### PR TITLE
[FEATURE] Ajout d'un niveau "section" dans les contenus des modules (PIX-19132)

### DIFF
--- a/api/scripts/modulix/get-elements-csv.js
+++ b/api/scripts/modulix/get-elements-csv.js
@@ -54,41 +54,46 @@ export function getElements(modules) {
 
   const elements = [];
   for (const module of modules) {
+    let grainPosition = -1;
     let elementPosition = 0;
 
-    for (const grain of module.grains) {
-      for (const component of grain.components) {
-        if (component.type === 'element') {
-          if (!ELEMENT_TYPES.includes(component.element.type)) {
-            console.warn(`Ignored element ${component.element.id} with unknown type "${component.element.type}".`);
-            continue;
+    for (const section of module.sections) {
+      for (const grain of section.grains) {
+        grainPosition++;
+
+        for (const component of grain.components) {
+          if (component.type === 'element') {
+            if (!ELEMENT_TYPES.includes(component.element.type)) {
+              console.warn(`Ignored element ${component.element.id} with unknown type "${component.element.type}".`);
+              continue;
+            }
+
+            elements.push({
+              ...component.element,
+              moduleId: module.id,
+              elementPosition: elementPosition++,
+              grainPosition: grainPosition,
+              grainId: grain.id,
+              grainTitle: grain.title,
+            });
           }
 
-          elements.push({
-            ...component.element,
-            moduleId: module.id,
-            elementPosition: elementPosition++,
-            grainPosition: module.grains.indexOf(grain),
-            grainId: grain.id,
-            grainTitle: grain.title,
-          });
-        }
+          if (component.type === 'stepper') {
+            for (const step of component.steps) {
+              for (const element of step.elements) {
+                if (!ELEMENT_TYPES.includes(element.type)) {
+                  continue;
+                }
 
-        if (component.type === 'stepper') {
-          for (const step of component.steps) {
-            for (const element of step.elements) {
-              if (!ELEMENT_TYPES.includes(element.type)) {
-                continue;
+                elements.push({
+                  ...element,
+                  moduleId: module.id,
+                  elementPosition: elementPosition++,
+                  grainPosition: grainPosition,
+                  grainId: grain.id,
+                  grainTitle: grain.title,
+                });
               }
-
-              elements.push({
-                ...element,
-                moduleId: module.id,
-                elementPosition: elementPosition++,
-                grainPosition: module.grains.indexOf(grain),
-                grainId: grain.id,
-                grainTitle: grain.title,
-              });
             }
           }
         }

--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import moduleDatasource from '../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import { getCsvContent } from '../../src/shared/infrastructure/utils/csv/write-csv-utils.js';
+import { getGrains } from './utils/get-grains.js';
 
 export async function getModulesListAsCsv(modules) {
   return await getCsvContent({
@@ -12,19 +13,19 @@ export async function getModulesListAsCsv(modules) {
       { label: 'ModuleSlug', value: 'slug' },
       { label: 'ModuleLevel', value: 'details.level' },
       { label: 'ModuleLink', value: (row) => `https://app.recette.pix.fr/modules/${row.slug}` },
-      { label: 'ModuleTotalGrains', value: 'grains.length' },
+      { label: 'ModuleTotalGrains', value: (row) => getGrains(row).length },
       {
         label: 'ModuleTotalActivities',
-        value: (row) => row.grains.filter((grain) => grain.type === 'activity').length,
+        value: (row) => getGrains(row).filter((grain) => grain.type === 'activity').length,
       },
       {
         label: 'ModuleTotalLessons',
-        value: (row) => row.grains.filter((grain) => grain.type === 'lesson').length,
+        value: (row) => getGrains(row).filter((grain) => grain.type === 'lesson').length,
       },
       { label: 'ModuleDuration', value: (row) => `=TEXT(${row.details.duration}/24/60; "mm:ss")` },
       {
         label: 'ModuleTotalElements',
-        value: (row) => _getTotalElementsCount(row.grains),
+        value: (row) => _getTotalElementsCount(getGrains(row)),
       },
     ],
   });

--- a/api/scripts/modulix/utils/get-answerable-elements.js
+++ b/api/scripts/modulix/utils/get-answerable-elements.js
@@ -3,42 +3,47 @@ export function getAnswerableElements(modules) {
 
   const elements = [];
   for (const module of modules) {
+    let grainPosition = -1;
     let activityElementPosition = 0;
 
-    for (const grain of module.grains) {
-      for (const component of grain.components) {
-        if (component.type === 'element') {
-          if (!ANSWERABLE_ELEMENT_TYPES.includes(component.element.type)) {
-            continue;
+    for (const section of module.sections) {
+      for (const grain of section.grains) {
+        grainPosition++;
+
+        for (const component of grain.components) {
+          if (component.type === 'element') {
+            if (!ANSWERABLE_ELEMENT_TYPES.includes(component.element.type)) {
+              continue;
+            }
+
+            elements.push({
+              ...component.element,
+              moduleId: module.id,
+              moduleSlug: module.slug,
+              activityElementPosition: activityElementPosition++,
+              grainPosition: grainPosition,
+              grainId: grain.id,
+              grainTitle: grain.title,
+            });
           }
 
-          elements.push({
-            ...component.element,
-            moduleId: module.id,
-            moduleSlug: module.slug,
-            activityElementPosition: activityElementPosition++,
-            grainPosition: module.grains.indexOf(grain),
-            grainId: grain.id,
-            grainTitle: grain.title,
-          });
-        }
+          if (component.type === 'stepper') {
+            for (const step of component.steps) {
+              for (const element of step.elements) {
+                if (!ANSWERABLE_ELEMENT_TYPES.includes(element.type)) {
+                  continue;
+                }
 
-        if (component.type === 'stepper') {
-          for (const step of component.steps) {
-            for (const element of step.elements) {
-              if (!ANSWERABLE_ELEMENT_TYPES.includes(element.type)) {
-                continue;
+                elements.push({
+                  ...element,
+                  moduleId: module.id,
+                  moduleSlug: module.slug,
+                  activityElementPosition: activityElementPosition++,
+                  grainPosition: grainPosition,
+                  grainId: grain.id,
+                  grainTitle: grain.title,
+                });
               }
-
-              elements.push({
-                ...element,
-                moduleId: module.id,
-                moduleSlug: module.slug,
-                activityElementPosition: activityElementPosition++,
-                grainPosition: module.grains.indexOf(grain),
-                grainId: grain.id,
-                grainTitle: grain.title,
-              });
             }
           }
         }

--- a/api/scripts/modulix/utils/get-grains.js
+++ b/api/scripts/modulix/utils/get-grains.js
@@ -1,0 +1,7 @@
+export function getGrains(row) {
+  const grains = [];
+  for (const section of row.sections) {
+    grains.push(...section.grains);
+  }
+  return grains;
+}

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,29 +1,21 @@
-import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
-import { ModuleInstantiationError } from '../../errors.js';
+import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Module {
-  constructor({ id, slug, title, isBeta, grains, details, version }) {
+  constructor({ id, slug, title, isBeta, sections, details, version }) {
     assertNotNullOrUndefined(id, 'The id is required for a module');
     assertNotNullOrUndefined(slug, 'The slug is required for a module');
     assertNotNullOrUndefined(title, 'The title is required for a module');
     assertNotNullOrUndefined(isBeta, 'isBeta value is required for a module');
-    assertNotNullOrUndefined(grains, 'A list of grains is required for a module');
-    this.#assertGrainsIsAnArray(grains);
+    assertIsArray(sections, 'A list of sections is required for a module');
     assertNotNullOrUndefined(details, 'The details are required for a module');
 
     this.id = id;
     this.slug = slug;
     this.title = title;
     this.isBeta = isBeta;
-    this.grains = grains;
+    this.sections = sections;
     this.details = details;
     this.version = version;
-  }
-
-  #assertGrainsIsAnArray(grains) {
-    if (!Array.isArray(grains)) {
-      throw new ModuleInstantiationError('A module should have a list of grains');
-    }
   }
 
   setRedirectionUrl(url) {

--- a/api/src/devcomp/domain/models/module/Section.js
+++ b/api/src/devcomp/domain/models/module/Section.js
@@ -1,0 +1,32 @@
+import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
+
+class Section {
+  static AVAILABLE_TYPES = Object.freeze([
+    'question-yourself',
+    'explore-to-understand',
+    'retain-the-essentials',
+    'practise',
+    'go-further',
+    'blank',
+  ]);
+
+  constructor({ id, type, grains }) {
+    assertNotNullOrUndefined(id, 'The id is required for a section');
+    assertNotNullOrUndefined(type, 'The type is required for a section');
+    this.#assertTypeIsValid(type);
+    assertIsArray(grains, 'A list of grains is required for a section');
+
+    this.id = id;
+    this.type = type;
+    this.grains = grains;
+  }
+
+  #assertTypeIsValid(type) {
+    if (!Section.AVAILABLE_TYPES.includes(type)) {
+      throw new ModuleInstantiationError(`The type must be one of ${Section.AVAILABLE_TYPES}`);
+    }
+  }
+}
+
+export { Section };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -15,658 +15,664 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "48ab1b52-e14f-43d9-9d93-f734d424fc2b",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "89ac8069-1940-462b-be48-d43541e3679d",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "771ff16f-3476-4e3d-88c2-e24c799b2e9c",
-            "type": "text",
-            "content": "<p>Lorsque vous naviguez sur internet, un site peut connaître la ville où vous vous trouvez même si vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span><br>Mystère ? Pas vraiment. Commençons par un exemple.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f",
-      "type": "activity",
-      "title": "Étrange : ce site interne sait où je suis !",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "67b68f2a-349d-4df7-90a5-c9f5dc930a1a",
-            "type": "text",
-            "content": "<p> Voici la page de résultats d'une recherche en ligne de Mélanie, qui adore cuisiner. <span aria-hidden=\"true\">🥗</span><br>Observez cette image pour répondre aux questions suivantes.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2098be0b-e994-4bcd-8e52-5a6559963f8c",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/intro.jpg",
-            "alt": "Capture d’écran d’une page de résultats d’une recherche en ligne décrite dans l’alternative textuelle",
-            "alternativeText": "<ul><li>Champ de recherche : «&nbsp;recettes de cuisine végétariennes&nbsp;»</li><li>Liste de résultats de recherche<ul><li>Lien vers SOSCuisine</li><li>Lien vers CuisinePop.com</li></ul></li><li>Bouton «&nbsp;Plus de résultats&nbsp;»</li><li>Pied de page : «&nbsp;France. Toulouse. D’après votre adresse IP. Mettre à jour ma position.&nbsp;»</li></ul>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "48ab1b52-e14f-43d9-9d93-f734d424fc2b",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "e939579a-c185-481b-8f78-e9fbb6d7363e",
-                  "type": "qcu",
-                  "instruction": "<p>D'après le moteur de recherche, où se trouve Mélanie ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Liège",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Marseille",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "Toulouse",
-                      "feedback": {
-                        "state": "Bonne réponse ! ✨",
-                        "diagnosis": ""
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "ff75255c-18e0-4cd9-8fd1-83a9ab6994fb",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle information est utilisée par le moteur de recherche pour déterminer la localisation de Mélanie ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "la marque de son ordinateur",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "son adresse IP",
-                      "feedback": {
-                        "state": "Bonne réponse !✨",
-                        "diagnosis": ""
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "son historique de navigation",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "39e8ff48-1f15-48c7-b8e8-bfe1bed6b1b6",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "affd2fb6-035d-4a41-a736-235cb8e9367a",
-            "type": "text",
-            "content": "<p>L'adresse IP de Mélanie est donc connue et utilisée par son moteur de recherche.</p><p>Dans la vidéo suivante, vous allez découvrir ce qu'est précisément une adresse IP publique et à quoi elle sert.&nbsp;<span aria-hidden=\"true\">📺</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4f4ada91-e239-4991-9fc8-ab491aabc424",
-      "type": "lesson",
-      "title": "Adresse IP publique : c’est quoi ? à quoi ça sert ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "783dccd4-38ee-41a0-b10d-203a3cdb748f",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, une question vous sera posée sur le rôle de l'adresse IP publique.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fe8bf783-b0bf-4876-bc01-1c88b8c5f7eb",
-            "type": "video",
-            "title": "Adresse IP publique : c’est quoi ? à quoi ça sert ?",
-            "url": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/adresse-ip-publique.mp4",
-            "poster": "https://assets.pix.org/draft/modules/hVH7DDR.png",
-            "subtitles": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/adresse-ip-publique.vtt",
-            "transcription": "<p>Quand je navigue sur un site internet, je consulte et je reçois des informations : du texte, des images, des vidéos… <br>Ce site internet a forcément besoin d'une donnée pour m'envoyer des informations, sans se tromper de destinataire. Eh bien, cette donnée, c’est l’adresse IP publique. <br>Je vous explique en 2 minutes ce que c’est et à quoi ça sert !<br>D’abord, IP ça veut dire Internet Protocol, donc en français : protocole internet.<br>Un protocole de communication, c’est un ensemble de règles à suivre. Et il y en a partout autour de nous : par exemple, quand on me dit « Bonjour ! », je réponds souvent « Bonjour ! » ou « Salut ! », selon le contexte.<br>Sur internet, c’est pareil : les sites et les appareils doivent suivre certaines règles pour échanger des informations et se comprendre. Ils suivent donc les règles définies par le protocole internet.<br>Une anecdote que je trouve intéressante : on considère que la naissance officielle d’internet est marquée par la mise en service des protocoles IP, en 1983. Mais comment avoir la garantie que l’on échange des informations avec les bons appareils ? C’est tout simple : il faut connaître leurs adresses !<br>Je vous donne une comparaison : si un ami m’envoie une lettre, il utilise mon adresse postale pour que sa lettre arrive au bon endroit, chez moi.<br>Eh bien, quand un site internet m’envoie des informations, il utilise mon adresse IP publique pour être sûr que les informations arrivent au bon endroit.<br>Plus précisément, le site utilise l’adresse IP publique de mon modem, aussi appelé « box internet ». Et cette adresse, c’est mon fournisseur d’accès internet qui me l’a donnée.<br>À retenir : on dit que l’adresse IP publique permet d’identifier, de manière unique, un appareil connecté à internet, peu importe sa connexion.<br>Et une adresse IP, ça ressemble à ça : des blocs de chiffres et parfois de lettres.<br>Je vous rappelle l’essentiel : il faut que cette adresse soit unique !<br>C’est d’ailleurs pour cette raison que le modèle d’adresses est en train de changer de v4 à v6 : pour avoir plus d’adresses disponibles ! Ça, je vous l’explique une autre fois.<br>Pour finir, vous l’avez remarqué, dans « adresse IP publique », il y a le mot « publique ».<br>Cela signifie que cette donnée est vue par n’importe quel site que je visite. Plus globalement, elle est vue par tous les systèmes utilisés pour transporter des informations sur internet.<br>D’ailleurs, les sites internet ont eux aussi chacun une adresse IP publique.<br>Comme ça, tout le monde a une adresse et donc il n’y a pas d’erreur de destinataire.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "17d9406b-7533-493b-ba47-c77797be8055",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "566ec1c9-7b75-493c-be01-6deb61a42296",
-            "type": "text",
-            "content": "<p>Vous en savez désormais plus sur les adresses IP publiques.&nbsp;<span aria-hidden=\"true\">👩‍💻</span><span aria-hidden=\"true\">👨🏿‍💻</span></p><p>Voyons si vous avez compris l'essentiel avec une question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5",
-      "type": "activity",
-      "title": "Définition d'une IP publique",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "06f8ac75-44e6-4001-9822-8d44fdfe7741",
-            "type": "qcu",
-            "instruction": "<p>Quelle définition peut-on donner de l'adresse IP publique ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "C'est l'adresse qui permet d'identifier un appareil informatique connecté à internet.",
-                "feedback": {
-                  "state": "Bonne réponse \uD83D\uDCAB",
-                  "diagnosis": "<p>L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "C’est l’adresse qui commence par \"www.\" que l’on tape pour accéder à un site internet.",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Vous pensez peut-être plutôt à l'adresse <strong>web</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "C’est l’adresse qui permet d’envoyer des emails à des personnes via internet.",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Vous pensez peut-être plutôt à l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span></p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "02a9362a-4f09-4a5e-bb0b-d5b1e20392fd",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5775745c-a8f4-44d7-aea2-b14575720fd5",
-            "type": "text",
-            "content": "<p>Comme Mélanie, quand vous êtes sur internet, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30",
-      "type": "activity",
-      "title": "Vrai-faux : traces de l'IP publique",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3f4354a6-3243-4b5a-a459-58b3f3d1ecb8",
-            "type": "text",
-            "content": "<p>Pour chaque affirmation, répondez par vrai ou par faux.<br><i>Remarque : certaines personnes utilisent des VPN pour modifier leur adresse IP.<br>Dans les exemples suivants, aucun VPN n'est utilisé.</i></p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "74b6d2c6-a332-4f48-9896-e3bd52fb9bdc",
-                  "type": "qcu",
-                  "instruction": "<p>Une adresse IP publique est donnée par le point d’accès internet (box internet, 3G/4G, etc.).</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "3c7f2197-4d60-452c-b7d4-e1d642a5f2c0",
-                  "type": "qcu",
-                  "instruction": "<p>Si vous êtes connecté à la même box internet que Mélanie, vous aurez la même adresse IP publique qu'elle.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "a2db1a10-063c-4f72-b676-956bb3d0837b",
-                  "type": "qcu",
-                  "instruction": "<p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "04d94597-3815-4745-9acd-4f32b8fa93f0",
-                  "type": "qcu",
-                  "instruction": "<p>Les personnes qui connaissent l'adresse IP publique de Mélanie peuvent savoir précisément où elle habite.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "7d23bf97-592a-4d9f-bfa4-81d2e32a8b6c",
-      "type": "lesson",
-      "title": "IP publique : à retenir",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><ul><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>L’adresse IP publique donne une information sur la zone géographique de connexion : le pays, voire la ville.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e7e43ffe-f103-4a27-abce-0c667394831f",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7538af4c-c729-49e9-8bc5-a16ad52bf493",
-            "type": "text",
-            "content": "<p>Sur internet, tout le monde partage son adresse IP publique et donc sa zone géographique. Vous êtes localisé et vous pouvez localiser les autres en retour.</p><p>Ça peut donner envie d'essayer. À vous de jouer !&nbsp;<span aria-hidden=\"true\">🌍</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "09304128-193f-4ea8-bda7-edffd72b1bf2",
-      "type": "activity",
-      "title": "Localisation à partir d'une IP",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "21842978-ba1c-4e16-8c2a-c7d1db082c2a",
-            "type": "qrocm",
-            "instruction": "<p>Mélanie est partie en vacances. Voici son adresse IP : <code>23.32.227.255</code></p><p>Dans quel pays se trouve-t-elle&nbsp;?</p>",
-            "proposals": [
-              {
+              "type": "element",
+              "element": {
+                "id": "771ff16f-3476-4e3d-88c2-e24c799b2e9c",
                 "type": "text",
-                "content": "<span>Nom du pays :</span>"
-              },
-              {
-                "input": "pays",
-                "type": "input",
-                "inputType": "text",
-                "size": 15,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Nom du pays :",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["Japon", "Tokyo"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse.&nbsp;🎉",
-                "diagnosis": "<p>Vous avez peut-être même trouvé la ville dans laquelle elle se trouve.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse",
-                "diagnosis": "<p>Pour avoir de l'aide, utiliser les indices ci-dessous.</p>"
+                "content": "<p>Lorsque vous naviguez sur internet, un site peut connaître la ville où vous vous trouvez même si vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span><br>Mystère ? Pas vraiment. Commençons par un exemple.</p>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p></details>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2cb51f23-d6f1-4716-a70c-0773718b23b3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f34a216f-54fb-4cde-b634-71df19991211",
-            "type": "text",
-            "content": "<p>Vous l’avez sûrement remarqué, nous avons parlé jusqu'ici uniquement d’adresses IP publiques.<br>Il existe un autre type d’adresse IP&nbsp;: les adresses IP privées, aussi appelées IP locales.</p><p>Découvez leurs différences en image ! <span aria-hidden=\"true\">🔍</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "45d507ce-f822-4a06-aa6e-f2a1b0aeada3",
-      "type": "lesson",
-      "title": "Schéma IP publique vs. IP locales !",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9814961b-3134-468d-a918-9b98a1775395",
-            "type": "text",
-            "content": "<p>Analysez le schéma ci-dessous qui présente les deux types d'adresses IP.<br>Par la suite, vous devrez trouver quel est le type d'adresse IP (privée ou publique) dans des situations concrètes.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f42fa86c-3936-485a-8ea3-cabed25153f9",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/8IUOpoz.png",
-            "alt": "Image décrite dans l'alternative textuelle",
-            "alternativeText": "Schéma en deux blocs : le premier bloc représente un réseau local avec des illustrations d'appareils (ordinateurs, imprimante) et leurs adresses IP privées, le second bloc représente Internet avec des illustrations de pages web et leurs adresses IP publiques. La box Internet se situe au centre et appartient aux deux blocs. Elle a deux adresses IP, une adresse IP privée et une adresse IP publique."
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "1b524302-7175-4923-8810-835201d3d443",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🏠</span> Sur le <strong>réseau local</strong>, les appareils (ordinateur, imprimante, etc.) utilisent des adresses IP <strong>privées</strong> (ou locales) pour communiquer.</p><p><span aria-hidden=\"true\">🌐</span> Sur <strong>internet</strong>, ce sont des adresses IP <strong>publiques</strong> qui permettent aux sites et aux box internet de communiquer des informations.</p><p><span aria-hidden=\"true\">🛜</span> Une box internet a <strong>deux adresses IP</strong> : une privée et une publique.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a04e164e-9d16-4f6d-ad17-e16d30a8fefe",
-      "type": "activity",
-      "title": "IP publique ou IP privée",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f",
+          "type": "activity",
+          "title": "Étrange : ce site interne sait où je suis !",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "9bc62c21-dfd4-40a8-9497-680a7e1c13d9",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">🕹️</span> À vous de jouer !</h3><p>À l'aide du schéma ci-dessus, trouvez pour chaque question si elle correspond à une IP privée ou à une IP publique.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "67b68f2a-349d-4df7-90a5-c9f5dc930a1a",
+                "type": "text",
+                "content": "<p> Voici la page de résultats d'une recherche en ligne de Mélanie, qui adore cuisiner. <span aria-hidden=\"true\">🥗</span><br>Observez cette image pour répondre aux questions suivantes.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "6f0e2bdd-c56f-45d4-ab0a-1497b9cfdc1e",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle adresse permet les échanges entre l'ordinateur de Mélanie et sa box internet ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "l'adresse IP privée",
-                      "feedback": {
-                        "state": "Bonne réponse.&nbsp;🎉",
-                        "diagnosis": "<p>Ces échanges se font sur le réseau <strong>local</strong> de Mélanie</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "l'adresse IP publique",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> L'adresse IP publique permet les échanges entre la box internet de Mélanie et les sites qu'elle visite.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "2098be0b-e994-4bcd-8e52-5a6559963f8c",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/intro.jpg",
+                "alt": "Capture d’écran d’une page de résultats d’une recherche en ligne décrite dans l’alternative textuelle",
+                "alternativeText": "<ul><li>Champ de recherche : «&nbsp;recettes de cuisine végétariennes&nbsp;»</li><li>Liste de résultats de recherche<ul><li>Lien vers SOSCuisine</li><li>Lien vers CuisinePop.com</li></ul></li><li>Bouton «&nbsp;Plus de résultats&nbsp;»</li><li>Pied de page : «&nbsp;France. Toulouse. D’après votre adresse IP. Mettre à jour ma position.&nbsp;»</li></ul>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "952234bc-4ec1-4ebd-9208-6cc261a1efd8",
-                  "type": "qcu",
-                  "instruction": "<p>L'imprimante et l'ordinateur de Mélanie sont connectés à sa box internet.<br>Quelle adresse est différente pour son imprimante et pour son ordinateur ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "l'adresse IP privée",
-                      "feedback": {
-                        "state": "Bonne réponse.&nbsp;🎉",
-                        "diagnosis": "<p>Cela permet de bien distinguer chacun des appareils de Mélanie</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "l'adresse IP publique",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> L'adresse IP publique est spécifique à la box internet. Chaque appareil qui y est connecté a sa propre adresse IP privée.</p>"
-                      }
+                      "id": "e939579a-c185-481b-8f78-e9fbb6d7363e",
+                      "type": "qcu",
+                      "instruction": "<p>D'après le moteur de recherche, où se trouve Mélanie ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Liège",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Marseille",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "Toulouse",
+                          "feedback": {
+                            "state": "Bonne réponse ! ✨",
+                            "diagnosis": ""
+                          }
+                        }
+                      ],
+                      "solution": "3"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "01136211-72e8-47c3-a3d3-753edb2dfd09",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle adresse est visible par les sites visités par Mélanie ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "l'adresse IP privée",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> L'adresse IP <strong>privée</strong> (locale) de Mélanie est visible uniquement par les appareils de son réseau local.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "l'adresse IP publique",
-                      "feedback": {
-                        "state": "Bonne réponse.&nbsp;🎉",
-                        "diagnosis": "<p>Cette adresse est <strong>publique</strong> donc <strong>visible</strong>.</p>"
-                      }
+                      "id": "ff75255c-18e0-4cd9-8fd1-83a9ab6994fb",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle information est utilisée par le moteur de recherche pour déterminer la localisation de Mélanie ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "la marque de son ordinateur",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "son adresse IP",
+                          "feedback": {
+                            "state": "Bonne réponse !✨",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "son historique de navigation",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Avez-vous regardé <strong>en bas de l'image </strong>?</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "2"
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "5f8cd624-8b69-4eb5-9645-c863d97dccb7",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6e87277b-ea7d-4f71-82cb-c490364a1a75",
-            "type": "text",
-            "content": "<p>Pour finir ce module, vous allez relever un défi.<br>En ce moment-même, nous connaissons et utilisons votre adresse IP publique pour vous envoyez les contenus de ce module.<br>Mais connaissez-vous votre propre IP publique ❓</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "10cadfb9-9b4b-455e-9198-1fc11ab3356d",
-      "type": "activity",
-      "title": "Trouvez votre IP publique",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "eed9177c-4bc9-401c-928f-13585df010f7",
-            "type": "qcu",
-            "instruction": "<p>Cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span><span aria-hidden=\"true\">🕵🏽‍♀️</span></p><p>Avez-vous réussi à la trouver ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "oui",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p> Pour vérifier votre réponse, suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a>.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "non",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p> Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "dc49fa68-dcdf-4a3e-ac3a-475d027fc789",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p></details>"
-          }
+          "id": "39e8ff48-1f15-48c7-b8e8-bfe1bed6b1b6",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "affd2fb6-035d-4a41-a736-235cb8e9367a",
+                "type": "text",
+                "content": "<p>L'adresse IP de Mélanie est donc connue et utilisée par son moteur de recherche.</p><p>Dans la vidéo suivante, vous allez découvrir ce qu'est précisément une adresse IP publique et à quoi elle sert.&nbsp;<span aria-hidden=\"true\">📺</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4f4ada91-e239-4991-9fc8-ab491aabc424",
+          "type": "lesson",
+          "title": "Adresse IP publique : c’est quoi ? à quoi ça sert ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "783dccd4-38ee-41a0-b10d-203a3cdb748f",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, une question vous sera posée sur le rôle de l'adresse IP publique.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fe8bf783-b0bf-4876-bc01-1c88b8c5f7eb",
+                "type": "video",
+                "title": "Adresse IP publique : c’est quoi ? à quoi ça sert ?",
+                "url": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/adresse-ip-publique.mp4",
+                "poster": "https://assets.pix.org/draft/modules/hVH7DDR.png",
+                "subtitles": "https://assets.pix.org/modules/adresse-ip-publique-et-vous/adresse-ip-publique.vtt",
+                "transcription": "<p>Quand je navigue sur un site internet, je consulte et je reçois des informations : du texte, des images, des vidéos… <br>Ce site internet a forcément besoin d'une donnée pour m'envoyer des informations, sans se tromper de destinataire. Eh bien, cette donnée, c’est l’adresse IP publique. <br>Je vous explique en 2 minutes ce que c’est et à quoi ça sert !<br>D’abord, IP ça veut dire Internet Protocol, donc en français : protocole internet.<br>Un protocole de communication, c’est un ensemble de règles à suivre. Et il y en a partout autour de nous : par exemple, quand on me dit « Bonjour ! », je réponds souvent « Bonjour ! » ou « Salut ! », selon le contexte.<br>Sur internet, c’est pareil : les sites et les appareils doivent suivre certaines règles pour échanger des informations et se comprendre. Ils suivent donc les règles définies par le protocole internet.<br>Une anecdote que je trouve intéressante : on considère que la naissance officielle d’internet est marquée par la mise en service des protocoles IP, en 1983. Mais comment avoir la garantie que l’on échange des informations avec les bons appareils ? C’est tout simple : il faut connaître leurs adresses !<br>Je vous donne une comparaison : si un ami m’envoie une lettre, il utilise mon adresse postale pour que sa lettre arrive au bon endroit, chez moi.<br>Eh bien, quand un site internet m’envoie des informations, il utilise mon adresse IP publique pour être sûr que les informations arrivent au bon endroit.<br>Plus précisément, le site utilise l’adresse IP publique de mon modem, aussi appelé « box internet ». Et cette adresse, c’est mon fournisseur d’accès internet qui me l’a donnée.<br>À retenir : on dit que l’adresse IP publique permet d’identifier, de manière unique, un appareil connecté à internet, peu importe sa connexion.<br>Et une adresse IP, ça ressemble à ça : des blocs de chiffres et parfois de lettres.<br>Je vous rappelle l’essentiel : il faut que cette adresse soit unique !<br>C’est d’ailleurs pour cette raison que le modèle d’adresses est en train de changer de v4 à v6 : pour avoir plus d’adresses disponibles ! Ça, je vous l’explique une autre fois.<br>Pour finir, vous l’avez remarqué, dans « adresse IP publique », il y a le mot « publique ».<br>Cela signifie que cette donnée est vue par n’importe quel site que je visite. Plus globalement, elle est vue par tous les systèmes utilisés pour transporter des informations sur internet.<br>D’ailleurs, les sites internet ont eux aussi chacun une adresse IP publique.<br>Comme ça, tout le monde a une adresse et donc il n’y a pas d’erreur de destinataire.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "17d9406b-7533-493b-ba47-c77797be8055",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "566ec1c9-7b75-493c-be01-6deb61a42296",
+                "type": "text",
+                "content": "<p>Vous en savez désormais plus sur les adresses IP publiques.&nbsp;<span aria-hidden=\"true\">👩‍💻</span><span aria-hidden=\"true\">👨🏿‍💻</span></p><p>Voyons si vous avez compris l'essentiel avec une question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5",
+          "type": "activity",
+          "title": "Définition d'une IP publique",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "06f8ac75-44e6-4001-9822-8d44fdfe7741",
+                "type": "qcu",
+                "instruction": "<p>Quelle définition peut-on donner de l'adresse IP publique ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "C'est l'adresse qui permet d'identifier un appareil informatique connecté à internet.",
+                    "feedback": {
+                      "state": "Bonne réponse \uD83D\uDCAB",
+                      "diagnosis": "<p>L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "C’est l’adresse qui commence par \"www.\" que l’on tape pour accéder à un site internet.",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Vous pensez peut-être plutôt à l'adresse <strong>web</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "C’est l’adresse qui permet d’envoyer des emails à des personnes via internet.",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Vous pensez peut-être plutôt à l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span></p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "02a9362a-4f09-4a5e-bb0b-d5b1e20392fd",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5775745c-a8f4-44d7-aea2-b14575720fd5",
+                "type": "text",
+                "content": "<p>Comme Mélanie, quand vous êtes sur internet, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30",
+          "type": "activity",
+          "title": "Vrai-faux : traces de l'IP publique",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3f4354a6-3243-4b5a-a459-58b3f3d1ecb8",
+                "type": "text",
+                "content": "<p>Pour chaque affirmation, répondez par vrai ou par faux.<br><i>Remarque : certaines personnes utilisent des VPN pour modifier leur adresse IP.<br>Dans les exemples suivants, aucun VPN n'est utilisé.</i></p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "74b6d2c6-a332-4f48-9896-e3bd52fb9bdc",
+                      "type": "qcu",
+                      "instruction": "<p>Une adresse IP publique est donnée par le point d’accès internet (box internet, 3G/4G, etc.).</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3c7f2197-4d60-452c-b7d4-e1d642a5f2c0",
+                      "type": "qcu",
+                      "instruction": "<p>Si vous êtes connecté à la même box internet que Mélanie, vous aurez la même adresse IP publique qu'elle.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Qui dit même point d'accès internet dit même adresse IP publique.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "a2db1a10-063c-4f72-b676-956bb3d0837b",
+                      "type": "qcu",
+                      "instruction": "<p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Les adresses IP sont localisées. Elles sont attribuées selon 5 grandes régions du monde.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "04d94597-3815-4745-9acd-4f32b8fa93f0",
+                      "type": "qcu",
+                      "instruction": "<p>Les personnes qui connaissent l'adresse IP publique de Mélanie peuvent savoir précisément où elle habite.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>Au mieux, vous pourrez connaître le pays ou la ville où elle se trouve.<br>Par contre, la police peut accéder à plus d'informations, dans un cadre prévu par la loi.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "7d23bf97-592a-4d9f-bfa4-81d2e32a8b6c",
+          "type": "lesson",
+          "title": "IP publique : à retenir",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><ul><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>L’adresse IP publique donne une information sur la zone géographique de connexion : le pays, voire la ville.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e7e43ffe-f103-4a27-abce-0c667394831f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7538af4c-c729-49e9-8bc5-a16ad52bf493",
+                "type": "text",
+                "content": "<p>Sur internet, tout le monde partage son adresse IP publique et donc sa zone géographique. Vous êtes localisé et vous pouvez localiser les autres en retour.</p><p>Ça peut donner envie d'essayer. À vous de jouer !&nbsp;<span aria-hidden=\"true\">🌍</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "09304128-193f-4ea8-bda7-edffd72b1bf2",
+          "type": "activity",
+          "title": "Localisation à partir d'une IP",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "21842978-ba1c-4e16-8c2a-c7d1db082c2a",
+                "type": "qrocm",
+                "instruction": "<p>Mélanie est partie en vacances. Voici son adresse IP : <code>23.32.227.255</code></p><p>Dans quel pays se trouve-t-elle&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Nom du pays :</span>"
+                  },
+                  {
+                    "input": "pays",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 15,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Nom du pays :",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["Japon", "Tokyo"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse.&nbsp;🎉",
+                    "diagnosis": "<p>Vous avez peut-être même trouvé la ville dans laquelle elle se trouve.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse",
+                    "diagnosis": "<p>Pour avoir de l'aide, utiliser les indices ci-dessous.</p>"
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p></details>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2cb51f23-d6f1-4716-a70c-0773718b23b3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f34a216f-54fb-4cde-b634-71df19991211",
+                "type": "text",
+                "content": "<p>Vous l’avez sûrement remarqué, nous avons parlé jusqu'ici uniquement d’adresses IP publiques.<br>Il existe un autre type d’adresse IP&nbsp;: les adresses IP privées, aussi appelées IP locales.</p><p>Découvez leurs différences en image ! <span aria-hidden=\"true\">🔍</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "45d507ce-f822-4a06-aa6e-f2a1b0aeada3",
+          "type": "lesson",
+          "title": "Schéma IP publique vs. IP locales !",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9814961b-3134-468d-a918-9b98a1775395",
+                "type": "text",
+                "content": "<p>Analysez le schéma ci-dessous qui présente les deux types d'adresses IP.<br>Par la suite, vous devrez trouver quel est le type d'adresse IP (privée ou publique) dans des situations concrètes.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f42fa86c-3936-485a-8ea3-cabed25153f9",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/8IUOpoz.png",
+                "alt": "Image décrite dans l'alternative textuelle",
+                "alternativeText": "Schéma en deux blocs : le premier bloc représente un réseau local avec des illustrations d'appareils (ordinateurs, imprimante) et leurs adresses IP privées, le second bloc représente Internet avec des illustrations de pages web et leurs adresses IP publiques. La box Internet se situe au centre et appartient aux deux blocs. Elle a deux adresses IP, une adresse IP privée et une adresse IP publique."
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1b524302-7175-4923-8810-835201d3d443",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🏠</span> Sur le <strong>réseau local</strong>, les appareils (ordinateur, imprimante, etc.) utilisent des adresses IP <strong>privées</strong> (ou locales) pour communiquer.</p><p><span aria-hidden=\"true\">🌐</span> Sur <strong>internet</strong>, ce sont des adresses IP <strong>publiques</strong> qui permettent aux sites et aux box internet de communiquer des informations.</p><p><span aria-hidden=\"true\">🛜</span> Une box internet a <strong>deux adresses IP</strong> : une privée et une publique.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a04e164e-9d16-4f6d-ad17-e16d30a8fefe",
+          "type": "activity",
+          "title": "IP publique ou IP privée",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "9bc62c21-dfd4-40a8-9497-680a7e1c13d9",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">🕹️</span> À vous de jouer !</h3><p>À l'aide du schéma ci-dessus, trouvez pour chaque question si elle correspond à une IP privée ou à une IP publique.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "6f0e2bdd-c56f-45d4-ab0a-1497b9cfdc1e",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle adresse permet les échanges entre l'ordinateur de Mélanie et sa box internet ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "l'adresse IP privée",
+                          "feedback": {
+                            "state": "Bonne réponse.&nbsp;🎉",
+                            "diagnosis": "<p>Ces échanges se font sur le réseau <strong>local</strong> de Mélanie</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "l'adresse IP publique",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> L'adresse IP publique permet les échanges entre la box internet de Mélanie et les sites qu'elle visite.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "952234bc-4ec1-4ebd-9208-6cc261a1efd8",
+                      "type": "qcu",
+                      "instruction": "<p>L'imprimante et l'ordinateur de Mélanie sont connectés à sa box internet.<br>Quelle adresse est différente pour son imprimante et pour son ordinateur ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "l'adresse IP privée",
+                          "feedback": {
+                            "state": "Bonne réponse.&nbsp;🎉",
+                            "diagnosis": "<p>Cela permet de bien distinguer chacun des appareils de Mélanie</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "l'adresse IP publique",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> L'adresse IP publique est spécifique à la box internet. Chaque appareil qui y est connecté a sa propre adresse IP privée.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "01136211-72e8-47c3-a3d3-753edb2dfd09",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle adresse est visible par les sites visités par Mélanie ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "l'adresse IP privée",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> L'adresse IP <strong>privée</strong> (locale) de Mélanie est visible uniquement par les appareils de son réseau local.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "l'adresse IP publique",
+                          "feedback": {
+                            "state": "Bonne réponse.&nbsp;🎉",
+                            "diagnosis": "<p>Cette adresse est <strong>publique</strong> donc <strong>visible</strong>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "5f8cd624-8b69-4eb5-9645-c863d97dccb7",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6e87277b-ea7d-4f71-82cb-c490364a1a75",
+                "type": "text",
+                "content": "<p>Pour finir ce module, vous allez relever un défi.<br>En ce moment-même, nous connaissons et utilisons votre adresse IP publique pour vous envoyez les contenus de ce module.<br>Mais connaissez-vous votre propre IP publique ❓</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "10cadfb9-9b4b-455e-9198-1fc11ab3356d",
+          "type": "activity",
+          "title": "Trouvez votre IP publique",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "eed9177c-4bc9-401c-928f-13585df010f7",
+                "type": "qcu",
+                "instruction": "<p>Cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span><span aria-hidden=\"true\">🕵🏽‍♀️</span></p><p>Avez-vous réussi à la trouver ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "oui",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p> Pour vérifier votre réponse, suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a>.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "non",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p> Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "dc49fa68-dcdf-4a3e-ac3a-475d027fc789",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1&nbsp;:</summary><p>Vous pouvez faire une recherche en ligne : des sites internet existent pour cela.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p></details>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -14,674 +14,680 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "e411fd89-64de-4434-82b1-11eb87a05baa",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "548f07db-c556-4524-97ee-e20b14748047",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "f977e884-9c43-48f2-bc15-f47df200aac8",
-            "type": "text",
-            "content": "<p>Sur internet, les sites vous demandent toujours de prouver votre identité pour accéder à vos comptes.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "98bb2977-1a17-4284-b21d-f834ed77c20f",
-      "type": "discovery",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0b3bccfb-9538-4101-86ab-a33e096a460c",
-            "type": "qcu",
-            "instruction": "<p>En général, que faut-il  pour se connecter à son compte personnel sur un site ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>une empreinte digitale</p>",
-                "feedback": {
-                  "state": "<p></p>",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>En général, on vous demande plutôt un identifiant et un mot de passe.&nbsp; </p><p>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>un identifiant et un mot de passe</p>",
-                "feedback": {
-                  "state": "<p></p>",
-                  "diagnosis": "<p><strong>Oui ! </strong></p><p>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>un code à 4 chiffres</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong></p><p>En général, on vous demande plutôt un identifiant et un mot de passe.&nbsp; <br>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>En général, on vous demande  un identifiant et un mot de passe.&nbsp; <br>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "609bcc59-6e3c-4593-b653-e95635ec3349",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fa687ee1-8f0b-4787-8582-4c12a4597beb",
-            "type": "text",
-            "content": "<p>Sylvie et Quentin ont du mal à se connecter à leurs services numériques.&nbsp;Vous allez les aider !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "75412602-89df-4ef1-960f-618357487483",
-      "type": "discovery",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "70ac0971-48f3-4d26-81c1-2df452852319",
-            "type": "text",
-            "content": "<p>Sylvie veut se connecter à son journal en ligne préféré. Elle vous transmet ses informations :&nbsp; </p>\n<ul>\n    <li>identifiant : <code>sylvie.girard</code></li>\n    <li>mot de passe : <code>Gmléso6+</code></li>\n</ul>\n<p>👉 Aidez Sylvie à se connecter en écrivant ses identifiants.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "46dd0846-573d-408f-abe3-76cd0c4e67c8",
-            "type": "custom-draft",
-            "title": "simulateur 1FA",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_1FA_v1.html",
-            "instruction": "",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "43eb26a5-f711-42af-9590-fc49a3eec29d",
-      "type": "activity",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9fd2f6a0-9892-4a92-a73f-f0f36efd38fb",
-            "type": "qcu",
-            "instruction": "<p>Combien d’étapes y a-t-il pour se connecter au compte de Sylvie ?&nbsp;</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>une étape</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Oui !</strong> </p><p>Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>deux&nbsp;étapes</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p> Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>trois&nbsp;étapes</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>  Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e74e0abb-8c23-41f3-af66-546a45e029f4",
-      "type": "lesson",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2836c787-28e8-4146-9ad9-345625b49a4a",
-            "type": "text",
-            "content": "<p>Quand il y a <strong>une seule étape</strong> pour prouver son identité, on appelle cela une <strong>authentification simple</strong>. </p>\n<p>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe pour un compte,</li>\n    <li>un code PIN sur un téléphone</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ba63611e-3fc3-478c-a1bb-452fbcad7579",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8f87b786-7f5c-4b97-9d29-8944b2909c0b",
-            "type": "text",
-            "content": "<p>Vous avez aidé Sylvie à se connecter. Maintenant, aidez Quentin. 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "98a4aea4-9729-43ac-bd28-42f2789c56d4",
-      "type": "discovery",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b0a6d0e7-3047-4bc9-a9f8-8578cc16641d",
-            "type": "text",
-            "content": "<p>Quentin veut se connecter à sa boîte mail. Il vous transmet ses informations :&nbsp; </p><ul><li>identifiant : <code>Quentin</code></li><li>mot de passe : <code>M0tD3p4s53F0rt#$</code><br></li></ul><p>Ecrivez ces identifiants pour aider Quentin à se connecter.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0cf6b85d-9b0a-4b41-a317-0be1b36a81fb",
-            "type": "custom-draft",
-            "title": "simulateur 2FA",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_2FA_v1.html",
-            "instruction": "",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "f2909088-fc5e-4d4d-aaca-f34dbd1f3904",
-      "type": "activity",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8dd370b7-13b1-4768-879b-0046ddff9bec",
-            "type": "qcu",
-            "instruction": "<p>Combien d’étapes y a-t-il pour se connecter au compte de Quentin ?&nbsp;</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>une&nbsp;étape</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong></p>\n<p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>deux&nbsp;étapes</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Oui !</strong> </p><p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>trois&nbsp;étapes</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong>\n</p><p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ef3a3704-f0d9-429b-aa01-9cb1b60e42e1",
-      "type": "lesson",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3c327379-4354-4c99-805f-cbc519deb937",
-            "type": "text",
-            "content": "<p>Quand il y a <strong>deux étapes</strong> pour prouver son identité, on appelle cela une <strong>double authentification</strong>.&nbsp; <br>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe puis un code par SMS pour un compte,</li>\n    <li>un code PIN puis une empreinte digitale sur un téléphone</li>\n</ul>\n<p>De plus en plus de sites internet proposent cette fonctionnalité.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c6172e81-1a66-4ac1-939b-b7f37e094603",
-      "type": "activity",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3eeda81a-0543-42af-96e3-32cd1ce68e60",
-            "type": "qcu",
-            "instruction": "<p>Selon vous, quel compte est le plus sécurisé ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>le compte de Sylvie</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong></p>\n<p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape.<br>La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>le compte de Quentin</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Oui !</strong></p><p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>aucune différence</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong>\n</p><p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a35ebd0a-3230-49c7-a3c1-6c697500c551",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1a6e0f45-7f7d-4e6e-8470-04bf9e0f6035",
-            "type": "text",
-            "content": "<p>Il arrive aussi que des identifiants et des mots de passe fuitent sur internet.</p><p>Des pirates peuvent utiliser ces informations pour se connecter à la place des gens.&nbsp;</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "99392786-89bb-4040-90f1-bec54e42aa98",
-      "type": "discovery",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "16f3da9e-0393-49f9-b3b9-7ee3415d0e2c",
-            "type": "text",
-            "content": "<p>Michel vient de recevoir le SMS ci-dessous sur son portable :&nbsp;</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6deb0b03-b822-433c-9856-348ce9ba2e2a",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/zT8VM8f.png",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "7d35ae45-7ba8-42af-a566-c09b4de83542",
-            "type": "text",
-            "content": "<p>Pourtant, cela fait longtemps qu’il ne s’est pas connecté à ce compte.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3a356ccf-282d-42dc-bcd6-608db87f356e",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "bf9029c8-8cee-43bf-8750-e8e6215367cb",
-            "type": "qcu",
-            "instruction": "<p>Qu’est-ce que cela signifie ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Une autre personne que Michel essaye de se connecter à son compte.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Oui !</strong> <br>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>L’abonnement de Michel va bientôt se terminer sur ce site.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>Le code reçu signifie qu’une autre personne que Michel essaye de se connecter à son compte. <br>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>L'identifiant et le mot de passe de Michel ont fuité sur internet.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>C’est possible !</strong> </p>\n<p>En tout cas, une autre personne que Michel essaye de se connecter à son compte. </p>\n<p>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f97bde61-b3c1-460d-b98f-ba7589a2381e",
-      "type": "lesson",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9c5a186f-1055-4752-83b2-c76f0ced9364",
-            "type": "text",
-            "content": "<p>Avec la <strong>double authentification</strong>, une <strong>personne mal intentionnée</strong> qui a seulement votre mot de passe <strong>est bloquée</strong>.&nbsp; </p>\n<p>🤔 <strong>Bon à savoir</strong> </p>\n<p>Si vous recevez un code de confirmation par SMS mais que vous n’êtes pas en train de vous connecter à un site, changez rapidement le mot de passe de votre compte. </p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e9cf37f3-810b-4dab-934f-d5b087ee2e7d",
-      "type": "summary",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1826117c-67bb-4773-83ec-72adae3d516e",
-            "type": "text",
-            "content": "<p>📌 Résumons l’essentiel avant de passer à la suite :</p><ul><li>Sur ses comptes en ligne, il est plus sécurisé de <strong>prouver son identité de deux manières différentes</strong>. C’est la <strong>double authentification</strong>.</li><li>On peut par exemple utiliser un <strong>code PIN</strong> ou une <strong>empreinte digitale</strong>, en plus d’<strong>un identifiant et d’un mot de passe</strong>.</li><li>Si vous avez <strong>un doute sur la sécurité </strong>d’un compte, <strong>changez votre mot de passe</strong> rapidement.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3a1344fe-59b5-4786-af5d-f8d079351d20",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7ea0f6c4-eef2-463f-8eea-e11d4fc17b5e",
-            "type": "text",
-            "content": "<p>Maintenant, entraînez-vous sur des exemples concrets !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fbede4c0-cef2-42c7-956c-e13e99c8830e",
-      "type": "activity",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "cd14a6ca-819f-4667-9afb-457fd7c1cb5f",
-            "type": "text",
-            "content": "<p>Pour chaque exemple, choisissez s’il s’agit d’une simple authentification, d’une double authentification ou aucun des deux.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "e411fd89-64de-4434-82b1-11eb87a05baa",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "2855bd90-094f-469d-bcd8-952b565f7be3",
-                  "type": "qcu",
-                  "instruction": "<p>Pour se connecter à son compte personnel sur un site internet, Quentin doit saisir son identifiant et son mot de passe.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>simple authentification</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse !</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>double authentification</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>aucun des deux</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "f977e884-9c43-48f2-bc15-f47df200aac8",
+                "type": "text",
+                "content": "<p>Sur internet, les sites vous demandent toujours de prouver votre identité pour accéder à vos comptes.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "98bb2977-1a17-4284-b21d-f834ed77c20f",
+          "type": "discovery",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0b3bccfb-9538-4101-86ab-a33e096a460c",
+                "type": "qcu",
+                "instruction": "<p>En général, que faut-il  pour se connecter à son compte personnel sur un site ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>une empreinte digitale</p>",
+                    "feedback": {
+                      "state": "<p></p>",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>En général, on vous demande plutôt un identifiant et un mot de passe.&nbsp; </p><p>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>un identifiant et un mot de passe</p>",
+                    "feedback": {
+                      "state": "<p></p>",
+                      "diagnosis": "<p><strong>Oui ! </strong></p><p>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>un code à 4 chiffres</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong></p><p>En général, on vous demande plutôt un identifiant et un mot de passe.&nbsp; <br>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>En général, on vous demande  un identifiant et un mot de passe.&nbsp; <br>Mais maintenant, les mots de passe ne suffisent pas toujours. On vous explique tout&nbsp;!</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "609bcc59-6e3c-4593-b653-e95635ec3349",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fa687ee1-8f0b-4787-8582-4c12a4597beb",
+                "type": "text",
+                "content": "<p>Sylvie et Quentin ont du mal à se connecter à leurs services numériques.&nbsp;Vous allez les aider !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "75412602-89df-4ef1-960f-618357487483",
+          "type": "discovery",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "70ac0971-48f3-4d26-81c1-2df452852319",
+                "type": "text",
+                "content": "<p>Sylvie veut se connecter à son journal en ligne préféré. Elle vous transmet ses informations :&nbsp; </p>\n<ul>\n    <li>identifiant : <code>sylvie.girard</code></li>\n    <li>mot de passe : <code>Gmléso6+</code></li>\n</ul>\n<p>👉 Aidez Sylvie à se connecter en écrivant ses identifiants.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "cb8d2ecb-684b-4aab-b99a-6d511bed45b6",
-                  "type": "qcu",
-                  "instruction": "<p>Après avoir saisi ses identifiants, Stéphanie reçoit un code par SMS pour finaliser sa connexion.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>simple authentification</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>double authentification</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse !</p>",
-                        "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>aucun des deux</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "46dd0846-573d-408f-abe3-76cd0c4e67c8",
+                "type": "custom-draft",
+                "title": "simulateur 1FA",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_1FA_v1.html",
+                "instruction": "",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "43eb26a5-f711-42af-9590-fc49a3eec29d",
+          "type": "activity",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9fd2f6a0-9892-4a92-a73f-f0f36efd38fb",
+                "type": "qcu",
+                "instruction": "<p>Combien d’étapes y a-t-il pour se connecter au compte de Sylvie ?&nbsp;</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>une étape</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Oui !</strong> </p><p>Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>deux&nbsp;étapes</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p> Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>trois&nbsp;étapes</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>  Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Une seule étape est nécessaire pour se connecter au compte de Sylvie.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e74e0abb-8c23-41f3-af66-546a45e029f4",
+          "type": "lesson",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2836c787-28e8-4146-9ad9-345625b49a4a",
+                "type": "text",
+                "content": "<p>Quand il y a <strong>une seule étape</strong> pour prouver son identité, on appelle cela une <strong>authentification simple</strong>. </p>\n<p>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe pour un compte,</li>\n    <li>un code PIN sur un téléphone</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ba63611e-3fc3-478c-a1bb-452fbcad7579",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8f87b786-7f5c-4b97-9d29-8944b2909c0b",
+                "type": "text",
+                "content": "<p>Vous avez aidé Sylvie à se connecter. Maintenant, aidez Quentin. 👇</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "98a4aea4-9729-43ac-bd28-42f2789c56d4",
+          "type": "discovery",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b0a6d0e7-3047-4bc9-a9f8-8578cc16641d",
+                "type": "text",
+                "content": "<p>Quentin veut se connecter à sa boîte mail. Il vous transmet ses informations :&nbsp; </p><ul><li>identifiant : <code>Quentin</code></li><li>mot de passe : <code>M0tD3p4s53F0rt#$</code><br></li></ul><p>Ecrivez ces identifiants pour aider Quentin à se connecter.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "6b83d4e1-3533-4f46-b65f-82f17f711df0",
-                  "type": "qcu",
-                  "instruction": "<p>Lucas déverrouille son téléphone avec l’empreinte de son doigt.<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>simple authentification</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse !</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>double authentification</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>aucun des deux</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "0cf6b85d-9b0a-4b41-a317-0be1b36a81fb",
+                "type": "custom-draft",
+                "title": "simulateur 2FA",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/simulateur_2FA_v1.html",
+                "instruction": "",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "f2909088-fc5e-4d4d-aaca-f34dbd1f3904",
+          "type": "activity",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8dd370b7-13b1-4768-879b-0046ddff9bec",
+                "type": "qcu",
+                "instruction": "<p>Combien d’étapes y a-t-il pour se connecter au compte de Quentin ?&nbsp;</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>une&nbsp;étape</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong></p>\n<p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>deux&nbsp;étapes</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Oui !</strong> </p><p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>trois&nbsp;étapes</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong>\n</p><p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Deux étapes sont nécessaires pour se connecter au compte de Quentin : il faut écrire un mot de passe puis un code reçu par SMS.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ef3a3704-f0d9-429b-aa01-9cb1b60e42e1",
+          "type": "lesson",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3c327379-4354-4c99-805f-cbc519deb937",
+                "type": "text",
+                "content": "<p>Quand il y a <strong>deux étapes</strong> pour prouver son identité, on appelle cela une <strong>double authentification</strong>.&nbsp; <br>✔️ Par exemple :&nbsp; </p>\n<ul>\n    <li>un mot de passe puis un code par SMS pour un compte,</li>\n    <li>un code PIN puis une empreinte digitale sur un téléphone</li>\n</ul>\n<p>De plus en plus de sites internet proposent cette fonctionnalité.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c6172e81-1a66-4ac1-939b-b7f37e094603",
+          "type": "activity",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3eeda81a-0543-42af-96e3-32cd1ce68e60",
+                "type": "qcu",
+                "instruction": "<p>Selon vous, quel compte est le plus sécurisé ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>le compte de Sylvie</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong></p>\n<p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape.<br>La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>le compte de Quentin</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Oui !</strong></p><p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>aucune différence</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong>\n</p><p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Le code envoyé sur le portable de Quentin permet de renforcer la sécurité de son compte, avec une deuxième étape. La preuve : vous n’avez pas réussi à vous connecter à son compte !</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a35ebd0a-3230-49c7-a3c1-6c697500c551",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1a6e0f45-7f7d-4e6e-8470-04bf9e0f6035",
+                "type": "text",
+                "content": "<p>Il arrive aussi que des identifiants et des mots de passe fuitent sur internet.</p><p>Des pirates peuvent utiliser ces informations pour se connecter à la place des gens.&nbsp;</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "99392786-89bb-4040-90f1-bec54e42aa98",
+          "type": "discovery",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "16f3da9e-0393-49f9-b3b9-7ee3415d0e2c",
+                "type": "text",
+                "content": "<p>Michel vient de recevoir le SMS ci-dessous sur son portable :&nbsp;</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "a03dcef2-1aa7-4c31-85ae-406edbab24b9",
-                  "type": "qcu",
-                  "instruction": "<p>Après avoir saisi ses identifiants, Romuald doit cocher une case pour prouver qu’il n’est pas un robot.&nbsp;<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>simple authentification</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>double authentification</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>aucun des deux</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse !</p>",
-                        "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "6deb0b03-b822-433c-9856-348ce9ba2e2a",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/zT8VM8f.png",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7d35ae45-7ba8-42af-a566-c09b4de83542",
+                "type": "text",
+                "content": "<p>Pourtant, cela fait longtemps qu’il ne s’est pas connecté à ce compte.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3a356ccf-282d-42dc-bcd6-608db87f356e",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bf9029c8-8cee-43bf-8750-e8e6215367cb",
+                "type": "qcu",
+                "instruction": "<p>Qu’est-ce que cela signifie ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Une autre personne que Michel essaye de se connecter à son compte.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Oui !</strong> <br>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
                     }
-                  ],
-                  "solution": "3"
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>L’abonnement de Michel va bientôt se terminer sur ce site.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Pas tout à fait.</strong> </p><p>Le code reçu signifie qu’une autre personne que Michel essaye de se connecter à son compte. <br>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>L'identifiant et le mot de passe de Michel ont fuité sur internet.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>C’est possible !</strong> </p>\n<p>En tout cas, une autre personne que Michel essaye de se connecter à son compte. </p>\n<p>Heureusement, l’autre personne ne connaît pas ce code. Impossible de se connecter à la place de Michel.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f97bde61-b3c1-460d-b98f-ba7589a2381e",
+          "type": "lesson",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9c5a186f-1055-4752-83b2-c76f0ced9364",
+                "type": "text",
+                "content": "<p>Avec la <strong>double authentification</strong>, une <strong>personne mal intentionnée</strong> qui a seulement votre mot de passe <strong>est bloquée</strong>.&nbsp; </p>\n<p>🤔 <strong>Bon à savoir</strong> </p>\n<p>Si vous recevez un code de confirmation par SMS mais que vous n’êtes pas en train de vous connecter à un site, changez rapidement le mot de passe de votre compte. </p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e9cf37f3-810b-4dab-934f-d5b087ee2e7d",
+          "type": "summary",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1826117c-67bb-4773-83ec-72adae3d516e",
+                "type": "text",
+                "content": "<p>📌 Résumons l’essentiel avant de passer à la suite :</p><ul><li>Sur ses comptes en ligne, il est plus sécurisé de <strong>prouver son identité de deux manières différentes</strong>. C’est la <strong>double authentification</strong>.</li><li>On peut par exemple utiliser un <strong>code PIN</strong> ou une <strong>empreinte digitale</strong>, en plus d’<strong>un identifiant et d’un mot de passe</strong>.</li><li>Si vous avez <strong>un doute sur la sécurité </strong>d’un compte, <strong>changez votre mot de passe</strong> rapidement.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3a1344fe-59b5-4786-af5d-f8d079351d20",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7ea0f6c4-eef2-463f-8eea-e11d4fc17b5e",
+                "type": "text",
+                "content": "<p>Maintenant, entraînez-vous sur des exemples concrets !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "fbede4c0-cef2-42c7-956c-e13e99c8830e",
+          "type": "activity",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "cd14a6ca-819f-4667-9afb-457fd7c1cb5f",
+                "type": "text",
+                "content": "<p>Pour chaque exemple, choisissez s’il s’agit d’une simple authentification, d’une double authentification ou aucun des deux.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "2855bd90-094f-469d-bcd8-952b565f7be3",
+                      "type": "qcu",
+                      "instruction": "<p>Pour se connecter à son compte personnel sur un site internet, Quentin doit saisir son identifiant et son mot de passe.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>simple authentification</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse !</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>double authentification</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>aucun des deux</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Quentin.<br></p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "cb8d2ecb-684b-4aab-b99a-6d511bed45b6",
+                      "type": "qcu",
+                      "instruction": "<p>Après avoir saisi ses identifiants, Stéphanie reçoit un code par SMS pour finaliser sa connexion.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>simple authentification</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>double authentification</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse !</p>",
+                            "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>aucun des deux</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a deux étapes : identifiant et mot de passe, puis le code par SMS.<br></p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "6b83d4e1-3533-4f46-b65f-82f17f711df0",
+                      "type": "qcu",
+                      "instruction": "<p>Lucas déverrouille son téléphone avec l’empreinte de son doigt.<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>simple authentification</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse !</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>double authentification</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>aucun des deux</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Il y a une seule étape pour vérifier l’identité de Lucas : son empreinte digitale.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "a03dcef2-1aa7-4c31-85ae-406edbab24b9",
+                      "type": "qcu",
+                      "instruction": "<p>Après avoir saisi ses identifiants, Romuald doit cocher une case pour prouver qu’il n’est pas un robot.&nbsp;<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>simple authentification</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>double authentification</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>aucun des deux</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse !</p>",
+                            "diagnosis": "<p>Une case à cocher de ce type (Captcha) ne sert pas à vérifier l’identité de Romuald. Ce n’est pas une étape d’authentification.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "807c2497-adfa-4048-8b67-43cee5380db0",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c46b2ffd-b340-42e1-b8fb-a1a830338e7b",
-            "type": "text",
-            "content": "<p><strong>À vous de jouer ! 🕹️&nbsp;</strong></p><p>Pour finir, vous allez faire une double authentification en pratique.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7eb985ae-7ab6-43ce-89c8-613237ef95cf",
-      "type": "challenge",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "67dc5b98-8365-4407-bc7f-f7e2336e464d",
-            "type": "text",
-            "content": "<p>Quentin vous demande de l’aide pour se connecter sur son compte de l’application Papotix. 💬 </p><p>Il vous prête son portable et vous transmet ses informations : </p><ul><li>identifiant : a</li><li>mot de passe : pix123</li></ul>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "a2b2910f-05e9-4462-bbd4-47f7426271eb",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "simulateur Papotix",
-            "url": "https://epreuves.pix.fr/papotix/papotix.html?mode=example&lang=fr",
-            "instruction": "<p>👉 Réalisez toutes les étapes pour que Quentin accède à son compte Papotix.</p>",
-            "height": 800
-          }
+          "id": "807c2497-adfa-4048-8b67-43cee5380db0",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c46b2ffd-b340-42e1-b8fb-a1a830338e7b",
+                "type": "text",
+                "content": "<p><strong>À vous de jouer ! 🕹️&nbsp;</strong></p><p>Pour finir, vous allez faire une double authentification en pratique.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7eb985ae-7ab6-43ce-89c8-613237ef95cf",
+          "type": "challenge",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "67dc5b98-8365-4407-bc7f-f7e2336e464d",
+                "type": "text",
+                "content": "<p>Quentin vous demande de l’aide pour se connecter sur son compte de l’application Papotix. 💬 </p><p>Il vous prête son portable et vous transmet ses informations : </p><ul><li>identifiant : a</li><li>mot de passe : pix123</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a2b2910f-05e9-4462-bbd4-47f7426271eb",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "simulateur Papotix",
+                "url": "https://epreuves.pix.fr/papotix/papotix.html?mode=example&lang=fr",
+                "instruction": "<p>👉 Réalisez toutes les étapes pour que Quentin accède à son compte Papotix.</p>",
+                "height": 800
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -11,1042 +11,1048 @@
     "tabletSupport": "inconvenient",
     "objectives": ["Non régression fonctionnelle"]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
-      "type": "discovery",
-      "title": "test qcu-discovery",
-      "components": [
+      "id": "cfaefec9-e185-43b8-8258-e8beff6dd56b",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "0c397035-a940-441f-8936-050db7f997af",
-            "type": "qcu-discovery",
-            "instruction": "<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Des cookies maison tout chauds",
-                "feedback": {
-                  "diagnosis": "<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Des mini-éclairs au chocolat",
-                "feedback": {
-                  "diagnosis": "<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Un plateau de fruits frais et de fromage",
-                "feedback": {
-                  "diagnosis": "<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "Une part de gâteau marbré au chocolat et à la vanille",
-                "feedback": {
-                  "diagnosis": "<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
-      "type": "summary",
-      "title": "test table",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "774c4c4e-f170-4e2c-ba7a-d2fe40d053c3",
-            "type": "text",
-            "content": "<p>Voici un tableau :</p> <table>\n  <tbody>\n <tr>\n    <th scope=\"col\">Player</th>\n    <th scope=\"col\">Gloobles</th>\n    <th scope=\"col\">Za'taak</th>\n  </tr>\n  <tr>\n    <th scope=\"row\">TR-7</th>\n    <td>7</td>\n    <td>4,569</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Khiresh Odo</th>\n    <td>7</td>\n    <td>7,223</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Mia Oolong</th>\n    <td>9</td>\n    <td>6,219</td>\n  </tr>\n </tbody>\n </table>\n"
-          }
-        }
-      ]
-    },
-    {
-      "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
-      "type": "activity",
-      "title": "test qab",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ed795d29-5f04-499c-a9c8-4019125c5cb1",
-            "type": "qab",
-            "instruction": "<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>",
-            "cards": [
-              {
-                "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
-                "image": {
-                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
-                  "altText": ""
-                },
-                "text": "Les boules de pétanques sont creuses ?",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
-                "text": "Les chiens ne transpirent pas.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
-                "text": "Quel est l'organe qui rougit ?",
-                "proposalA": "L'estomac",
-                "proposalB": "Le coeur",
-                "solution": "A"
-              },
-              {
-                "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
-                "image": {
-                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
-                  "altText": ""
-                },
-                "text": "Les dauphins sont des poissons.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
-                "text": "La Terre est plus proche du Soleil que Mars.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
-                "text": "L’eau bout à 100°C au niveau de la mer.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              }
-            ],
-            "feedback": {
-              "diagnosis": "<p>Continuez comme ça !</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
-      "type": "activity",
-      "title": "test qcu-declarative",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6a6944be-a8a3-4138-b5dc-af664cf40b07",
-            "type": "qcu-declarative",
-            "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Avant de mettre le dentifrice",
-                "feedback": {
-                  "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Après avoir mis le dentifrice",
-                "feedback": {
-                  "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Pendant que le dentifrice est mis",
-                "feedback": {
-                  "diagnosis": "<p>Digne des plus grands acrobates !</p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "628bd37d-e5da-411f-9b06-1035b073411b",
-      "type": "lesson",
-      "title": "test flashcards",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
-            "type": "flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
-            "title": "Introduction à la poésie",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Qui a écrit « Le Dormeur du Val ? »"
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p>Arthur Rimbaud</p>"
-                }
-              },
-              {
-                "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
-                "recto": {
-                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
-                },
-                "verso": {
-                  "text": "<p>Léopoldine</p>"
-                }
-              },
-              {
-                "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
-                  },
-                  "text": "<p>Le chat</p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "df111992-ff3a-4c3f-ae5a-78bc359af23c",
-      "type": "lesson",
-      "title": "test POI",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
-            "type": "text",
-            "content": "<p>Voici un Petit Objet Interactif expérimental :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f00133f5-0653-425b-a25f-3c9604820529",
-            "type": "custom-draft",
-            "title": "Retourner les cartes",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
-            "instruction": "<p>Retournez les cartes.</p>",
-            "height": 400
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
-            "type": "text",
-            "content": "<p>Ils ne sont autorisés qu'en béta.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
-      "type": "discovery",
-      "title": "Voici un grain de découverte",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
-            "type": "expand",
-            "title": "Voici un indice pour répondre à la magnifique flashcard",
-            "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
-            "type": "text",
-            "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "84726001-1665-457d-8f13-4a74dc4768ea",
-            "type": "text",
-            "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
-            "type": "text",
-            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
-            "type": "text",
-            "content": "<p>Et là, voici une image&#8239;!</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
-            "legend": "Faite avant le séminaire de juin 2023",
-            "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
-          }
-        }
-      ]
-    },
-    {
-      "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-            "type": "text",
-            "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0d4ef09a-ebb8-4514-a037-8fb22e540d7d",
-      "type": "lesson",
-      "title": "test web component",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "96e2457d-54d3-461a-97e4-69180a30bfb7",
-            "type": "text",
-            "content": "<p>Voici un web component :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae39",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Confessions nocturnes",
-              "messages": [
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ouais c'est qui là ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, c'est Vi ouvre moi."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ça va Vi ?"
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Non, ça va pas non."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ben dis-moi, qu'est qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, assieds-toi faut que je te parle..."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "J'ai passé ma journée dans le noir."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5e77afeb-78a8-4733-a451-fbe5fa2f360c",
-            "type": "text",
-            "content": "<p>Comme vous pouvez le voir l'expérience utilisateur n'est pas du tout la même.</p><p><em>Notamment pour les utilisateurs de lecteur d'écran</em></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "298518dc-9ad0-4709-92c0-c0a1fb1a1a2a",
-            "type": "text",
-            "content": "<p>Un avantage est que la configuration peut être précisée directement dans le contenu du module et pas côté pix-epreuves</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0d4ef09a-ebb8-4514-a037-8fb22e540d7c",
-      "type": "discovery",
-      "title": "Voici un grain qui contient un webcomponent",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5415e701-d81a-4f5e-b0e4-a0db67d83e18",
-            "type": "text",
-            "content": "<p>Voici un autre exemple de web component, le QCU Image :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae38",
-            "type": "custom",
-            "tagName": "qcu-image",
-            "props": {
-              "name": "Liste d'applications",
-              "maxChoicesPerLine": 3,
-              "imageChoicesSize": "icon",
-              "choices": [
-                {
-                  "name": "Google",
-                  "image": {
-                    "width": 534,
-                    "height": 544,
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "src": "https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg"
-                  }
-                },
-                {
-                  "name": "LibreOffice Writer",
-                  "image": {
-                    "width": 205,
-                    "height": 246,
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "src": "https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp"
-                  }
-                },
-                {
-                  "name": "Explorateur",
-                  "image": {
-                    "width": 128,
-                    "height": 128,
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "src": "https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp"
-                  }
-                },
-                {
-                  "name": "Geogebra",
-                  "image": {
-                    "width": 640,
-                    "height": 640,
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "src": "https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp"
-                  }
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "73e4676d-fcc9-4ef2-b6de-b33e71922c04",
-            "type": "text",
-            "content": "<p>Pour comparer du comparable voici la même chose en version embed :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9c8a0dc3-4e8e-4cf9-ab37-3280931cbab7",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "QCU Image",
-            "url": "https://epreuves.pix.fr/fr/qcu_image/1d_iconewriter.html",
-            "instruction": "<p>Instruction</p>",
-            "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
-      "type": "challenge",
-      "title": "Un fichier à télécharger",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
-            "type": "download",
-            "files": [
-              { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
-              { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
-            "type": "qcu",
-            "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Des recettes de lasagne",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Des recettes de pâté en croûte",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Des recettes végétariennes",
-                "feedback": {
-                  "state": "Correct&#8239;!",
-                  "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8147aced-4150-4a5d-afed-54c7a9dff056",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
-            "type": "text",
-            "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
-      "type": "lesson",
-      "title": "Vidéo de présentation de Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-            "type": "text",
-            "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
-            "type": "video",
-            "title": "Vidéo de présentation de Pix",
-            "url": "https://assets.pix.org/modules/bac-a-sable/presentation.mp4",
-            "subtitles": "",
-            "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
-            "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6566cc3a-9d74-4bd9-bda0-3dcb37129a26",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
-            "type": "text",
-            "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
-      "type": "activity",
-      "title": "Voici un vrai-faux",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
+          "type": "discovery",
+          "title": "test qcu-discovery",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
-                  "type": "qcu",
-                  "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "0c397035-a940-441f-8936-050db7f997af",
+                "type": "qcu-discovery",
+                "instruction": "<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des cookies maison tout chauds",
+                    "feedback": {
+                      "diagnosis": "<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des mini-éclairs au chocolat",
+                    "feedback": {
+                      "diagnosis": "<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Un plateau de fruits frais et de fromage",
+                    "feedback": {
+                      "diagnosis": "<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "Une part de gâteau marbré au chocolat et à la vanille",
+                    "feedback": {
+                      "diagnosis": "<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f1738f85-e272-43d3-aee2-f4190be54c34",
+          "type": "summary",
+          "title": "test table",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "774c4c4e-f170-4e2c-ba7a-d2fe40d053c3",
+                "type": "text",
+                "content": "<p>Voici un tableau :</p> <table>\n  <tbody>\n <tr>\n    <th scope=\"col\">Player</th>\n    <th scope=\"col\">Gloobles</th>\n    <th scope=\"col\">Za'taak</th>\n  </tr>\n  <tr>\n    <th scope=\"row\">TR-7</th>\n    <td>7</td>\n    <td>4,569</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Khiresh Odo</th>\n    <td>7</td>\n    <td>7,223</td>\n  </tr>\n  <tr>\n    <th scope=\"row\">Mia Oolong</th>\n    <td>9</td>\n    <td>6,219</td>\n  </tr>\n </tbody>\n </table>\n"
+              }
+            }
+          ]
+        },
+        {
+          "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
+          "type": "activity",
+          "title": "test qab",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ed795d29-5f04-499c-a9c8-4019125c5cb1",
+                "type": "qab",
+                "instruction": "<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>",
+                "cards": [
+                  {
+                    "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                      "altText": ""
+                    },
+                    "text": "Les boules de pétanques sont creuses ?",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                    "text": "Les chiens ne transpirent pas.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
+                    "text": "Quel est l'organe qui rougit ?",
+                    "proposalA": "L'estomac",
+                    "proposalB": "Le coeur",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                      "altText": ""
+                    },
+                    "text": "Les dauphins sont des poissons.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
+                    "text": "La Terre est plus proche du Soleil que Mars.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
+                    "text": "L’eau bout à 100°C au niveau de la mer.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": "<p>Continuez comme ça !</p>"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "a39ce6eb-f3db-447f-808f-aa6a06b940c9",
+          "type": "activity",
+          "title": "test qcu-declarative",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6a6944be-a8a3-4138-b5dc-af664cf40b07",
+                "type": "qcu-declarative",
+                "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Avant de mettre le dentifrice",
+                    "feedback": {
+                      "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Après avoir mis le dentifrice",
+                    "feedback": {
+                      "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Pendant que le dentifrice est mis",
+                    "feedback": {
+                      "diagnosis": "<p>Digne des plus grands acrobates !</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "628bd37d-e5da-411f-9b06-1035b073411b",
+          "type": "lesson",
+          "title": "test flashcards",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
+                "type": "flashcards",
+                "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
+                "title": "Introduction à la poésie",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                      },
+                      "text": "Qui a écrit « Le Dormeur du Val ? »"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": ""
+                      },
+                      "text": "<p>Arthur Rimbaud</p>"
+                    }
+                  },
+                  {
+                    "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
+                    "recto": {
+                      "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
+                    },
+                    "verso": {
+                      "text": "<p>Léopoldine</p>"
+                    }
+                  },
+                  {
+                    "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                      },
+                      "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
+                      },
+                      "text": "<p>Le chat</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "df111992-ff3a-4c3f-ae5a-78bc359af23c",
+          "type": "lesson",
+          "title": "test POI",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "52af6cab-07df-4962-abc5-20cf95d5eb5a",
+                "type": "text",
+                "content": "<p>Voici un Petit Objet Interactif expérimental :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f00133f5-0653-425b-a25f-3c9604820529",
+                "type": "custom-draft",
+                "title": "Retourner les cartes",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
+                "instruction": "<p>Retournez les cartes.</p>",
+                "height": 400
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e32c01a8-7ae1-4c6d-9a16-6487c7c504d2",
+                "type": "text",
+                "content": "<p>Ils ne sont autorisés qu'en béta.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
+          "type": "discovery",
+          "title": "Voici un grain de découverte",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5c468891-6b50-41c6-bb30-8639b52c5bca",
+                "type": "expand",
+                "title": "Voici un indice pour répondre à la magnifique flashcard",
+                "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
+                "type": "text",
+                "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "84726001-1665-457d-8f13-4a74dc4768ea",
+                "type": "text",
+                "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
+                "type": "text",
+                "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
+                "type": "text",
+                "content": "<p>Et là, voici une image&#8239;!</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
+                "alt": "Dessin détaillé dans l'alternative textuelle",
+                "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
+                "legend": "Faite avant le séminaire de juin 2023",
+                "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
+              }
+            }
+          ]
+        },
+        {
+          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+                "type": "text",
+                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0d4ef09a-ebb8-4514-a037-8fb22e540d7d",
+          "type": "lesson",
+          "title": "test web component",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "96e2457d-54d3-461a-97e4-69180a30bfb7",
+                "type": "text",
+                "content": "<p>Voici un web component :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae39",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Confessions nocturnes",
+                  "messages": [
                     {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Correct&#8239;!",
-                        "diagnosis": "<p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ouais c'est qui là ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, c'est Vi ouvre moi."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ça va Vi ?"
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Non, ça va pas non."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ben dis-moi, qu'est qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, assieds-toi faut que je te parle..."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "J'ai passé ma journée dans le noir."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "5e77afeb-78a8-4733-a451-fbe5fa2f360c",
+                "type": "text",
+                "content": "<p>Comme vous pouvez le voir l'expérience utilisateur n'est pas du tout la même.</p><p><em>Notamment pour les utilisateurs de lecteur d'écran</em></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "298518dc-9ad0-4709-92c0-c0a1fb1a1a2a",
+                "type": "text",
+                "content": "<p>Un avantage est que la configuration peut être précisée directement dans le contenu du module et pas côté pix-epreuves</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0d4ef09a-ebb8-4514-a037-8fb22e540d7c",
+          "type": "discovery",
+          "title": "Voici un grain qui contient un webcomponent",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5415e701-d81a-4f5e-b0e4-a0db67d83e18",
+                "type": "text",
+                "content": "<p>Voici un autre exemple de web component, le QCU Image :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae38",
+                "type": "custom",
+                "tagName": "qcu-image",
+                "props": {
+                  "name": "Liste d'applications",
+                  "maxChoicesPerLine": 3,
+                  "imageChoicesSize": "icon",
+                  "choices": [
+                    {
+                      "name": "Google",
+                      "image": {
+                        "width": 534,
+                        "height": 544,
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "src": "https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg"
                       }
                     },
                     {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Incorrect.",
-                        "diagnosis": "<p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
-                  "type": "qcu",
-                  "instruction": "<p>Pix est découpé en 6 domaines.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Incorrect.",
-                        "diagnosis": "<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
+                      "name": "LibreOffice Writer",
+                      "image": {
+                        "width": 205,
+                        "height": 246,
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "src": "https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp"
                       }
                     },
                     {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Correct&#8239;!",
-                        "diagnosis": "<p> Bien vu !</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
-                  "type": "qcu",
-                  "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Correct&#8239;!",
-                        "diagnosis": "<p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
+                      "name": "Explorateur",
+                      "image": {
+                        "width": 128,
+                        "height": 128,
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "src": "https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp"
                       }
                     },
                     {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Incorrect.",
-                        "diagnosis": "<p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
+                      "name": "Geogebra",
+                      "image": {
+                        "width": 640,
+                        "height": 640,
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "src": "https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp"
                       }
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "73e4676d-fcc9-4ef2-b6de-b33e71922c04",
+                "type": "text",
+                "content": "<p>Pour comparer du comparable voici la même chose en version embed :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9c8a0dc3-4e8e-4cf9-ab37-3280931cbab7",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "QCU Image",
+                "url": "https://epreuves.pix.fr/fr/qcu_image/1d_iconewriter.html",
+                "instruction": "<p>Instruction</p>",
+                "height": 600
+              }
+            }
+          ]
+        },
+        {
+          "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
+          "type": "challenge",
+          "title": "Un fichier à télécharger",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
+                "type": "download",
+                "files": [
+                  { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
+                  { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
+                ]
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
+                "type": "qcu",
+                "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des recettes de lasagne",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des recettes de pâté en croûte",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Des recettes végétariennes",
+                    "feedback": {
+                      "state": "Correct&#8239;!",
+                      "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8147aced-4150-4a5d-afed-54c7a9dff056",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
+                "type": "text",
+                "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
+          "type": "lesson",
+          "title": "Vidéo de présentation de Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                "type": "text",
+                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
+                "type": "video",
+                "title": "Vidéo de présentation de Pix",
+                "url": "https://assets.pix.org/modules/bac-a-sable/presentation.mp4",
+                "subtitles": "",
+                "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
+                "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6566cc3a-9d74-4bd9-bda0-3dcb37129a26",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
+                "type": "text",
+                "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
+          "type": "activity",
+          "title": "Voici un vrai-faux",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
+                      "type": "qcu",
+                      "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
+                      "type": "qcu",
+                      "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Bien vu !</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
+                      "type": "qcu",
+                      "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "358e6d74-4adf-463a-9bf4-69ddca521d87",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "41186193-1c38-4827-84b7-e70848367d42",
-            "type": "text",
-            "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
-      "type": "summary",
-      "title": "Les 3 piliers de Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
-            "type": "qcm",
-            "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
-              },
-              {
-                "id": "2",
-                "content": "Développer son savoir-faire sur les jeux de type TPS"
-              },
-              {
-                "id": "3",
-                "content": "Développer ses compétences numériques"
-              },
-              {
-                "id": "4",
-                "content": "Certifier ses compétences Pix"
-              },
-              {
-                "id": "5",
-                "content": "Evaluer ses compétences de logique et compréhension mathématique"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct&#8239;!",
-                "diagnosis": "<p>Vous nous avez bien cernés&nbsp;:)</p>"
-              },
-              "invalid": {
-                "state": "Et non&#8239;!",
-                "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
-              }
-            },
-            "solutions": ["1", "3", "4"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "f589dd19-ac78-425f-8f0d-83246e5e68f4",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "35ae00c5-9d46-4f53-83f1-3724ce39b53d",
-            "type": "text",
-            "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2a77a10f-19a3-4544-80f9-8012dad6506a",
-      "type": "activity",
-      "title": "Activité remonter dans la page",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447",
-            "type": "qcu",
-            "instruction": "<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Bienvenue",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Bonjour",
-                "feedback": {
-                  "state": "Correct&#8239;!",
-                  "diagnosis": "<p> Vous avez bien remonté la page</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Nous",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4ce2a31a-6584-4dae-87c6-d08b58d0f3b9",
-      "type": "activity",
-      "title": "Connaissez-vous bien Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c23436d4-6261-49f1-b50d-13a547529c29",
-            "type": "qrocm",
-            "instruction": "<p>Compléter le texte suivant :</p>",
-            "proposals": [
-              {
-                "type": "text",
-                "content": "<span>Pix est un</span>"
-              },
-              {
-                "input": "pix-name",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Mot à trouver",
-                "defaultValue": "",
-                "tolerances": ["t1", "t3"],
-                "solutions": ["Groupement"]
-              },
-              {
-                "type": "text",
-                "content": "<span>d'intérêt public qui a été créée en</span>"
-              },
-              {
-                "input": "pix-birth",
-                "type": "input",
-                "inputType": "number",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Année à trouver",
-                "defaultValue": "",
-                "tolerances": [],
-                "solutions": [2016]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct&#8239;!",
-                "diagnosis": "<p> vous nous connaissez bien &nbsp; <span aria-hidden=\"true\">🎉</span></p>"
-              },
-              "invalid": {
-                "state": "Incorrect&#8239;!",
-                "diagnosis": "<p> vous y arriverez la prochaine fois&#8239;!</p>"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb4",
-      "type": "activity",
-      "title": "Embed non-auto",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur de visioconférence",
-            "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
-            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
-            "height": 600
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "7fe0bc5f-1988-4da6-8231-a987335f2ae5",
-            "type": "qrocm",
-            "instruction": "<p>Répondez à la question suivante</p>",
-            "proposals": [
-              {
+          "id": "358e6d74-4adf-463a-9bf4-69ddca521d87",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "41186193-1c38-4827-84b7-e70848367d42",
                 "type": "text",
-                "content": "<span>Prénom de la personne qui est en train de parler&#8239;: </span>"
-              },
-              {
-                "input": "qui-parle",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
-                "defaultValue": "",
-                "tolerances": ["t1", "t2", "t3"],
-                "solutions": ["Katie"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct&#8239;!",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Incorrect&#8239;!",
-                "diagnosis": ""
+                "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "e8db3f90-4259-4d54-9113-1c56da726d8d",
-      "type": "activity",
-      "title": "Embed auto",
-      "components": [
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "0559b68c-68a5-4816-a06e-f1c743c391e3",
-            "type": "embed",
-            "isCompletionRequired": true,
-            "title": "Simulateur de visioconférence - micro ouvert",
-            "url": "https://epreuves.pix.fr/visio/visio.html?mode=modulix-didacticiel",
-            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>",
-            "solution": "toto",
-            "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "5d70a05e-bfac-40b0-9588-e359db862d76",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "72fee40a-7279-4372-acf5-aaf508b1c145",
-            "type": "text",
-            "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7cf75e70-8749-4392-8081-f2c02badb0fb",
-      "type": "activity",
-      "title": "Le nom de ce produit",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
-            "type": "qrocm",
-            "instruction": "<p>Quel est le nom de ce nouveau produit Pix&#8239;?</p>",
-            "proposals": [
-              {
-                "input": "nom-produit",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Nom de ce produit",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["Modulix"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct&#8239;!",
-                "diagnosis": "<p>Vous êtes prêt à explorer &nbsp; <span aria-hidden=\"true\">🎉</span></p>"
-              },
-              "invalid": {
-                "state": "Incorrect&#8239;!",
-                "diagnosis": "<p> Vous y arriverez la prochaine fois&#8239;!</p>"
+          "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
+          "type": "summary",
+          "title": "Les 3 piliers de Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
+                "type": "qcm",
+                "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
+                  },
+                  {
+                    "id": "2",
+                    "content": "Développer son savoir-faire sur les jeux de type TPS"
+                  },
+                  {
+                    "id": "3",
+                    "content": "Développer ses compétences numériques"
+                  },
+                  {
+                    "id": "4",
+                    "content": "Certifier ses compétences Pix"
+                  },
+                  {
+                    "id": "5",
+                    "content": "Evaluer ses compétences de logique et compréhension mathématique"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&#8239;!",
+                    "diagnosis": "<p>Vous nous avez bien cernés&nbsp;:)</p>"
+                  },
+                  "invalid": {
+                    "state": "Et non&#8239;!",
+                    "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
+                  }
+                },
+                "solutions": ["1", "3", "4"]
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "f589dd19-ac78-425f-8f0d-83246e5e68f4",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35ae00c5-9d46-4f53-83f1-3724ce39b53d",
+                "type": "text",
+                "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2a77a10f-19a3-4544-80f9-8012dad6506a",
+          "type": "activity",
+          "title": "Activité remonter dans la page",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447",
+                "type": "qcu",
+                "instruction": "<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Bienvenue",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Bonjour",
+                    "feedback": {
+                      "state": "Correct&#8239;!",
+                      "diagnosis": "<p> Vous avez bien remonté la page</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Nous",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4ce2a31a-6584-4dae-87c6-d08b58d0f3b9",
+          "type": "activity",
+          "title": "Connaissez-vous bien Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c23436d4-6261-49f1-b50d-13a547529c29",
+                "type": "qrocm",
+                "instruction": "<p>Compléter le texte suivant :</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Pix est un</span>"
+                  },
+                  {
+                    "input": "pix-name",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Mot à trouver",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t3"],
+                    "solutions": ["Groupement"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<span>d'intérêt public qui a été créée en</span>"
+                  },
+                  {
+                    "input": "pix-birth",
+                    "type": "input",
+                    "inputType": "number",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Année à trouver",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "solutions": [2016]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&#8239;!",
+                    "diagnosis": "<p> vous nous connaissez bien &nbsp; <span aria-hidden=\"true\">🎉</span></p>"
+                  },
+                  "invalid": {
+                    "state": "Incorrect&#8239;!",
+                    "diagnosis": "<p> vous y arriverez la prochaine fois&#8239;!</p>"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb4",
+          "type": "activity",
+          "title": "Embed non-auto",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur de visioconférence",
+                "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
+                "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+                "height": 600
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7fe0bc5f-1988-4da6-8231-a987335f2ae5",
+                "type": "qrocm",
+                "instruction": "<p>Répondez à la question suivante</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Prénom de la personne qui est en train de parler&#8239;: </span>"
+                  },
+                  {
+                    "input": "qui-parle",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t2", "t3"],
+                    "solutions": ["Katie"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&#8239;!",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Incorrect&#8239;!",
+                    "diagnosis": ""
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "e8db3f90-4259-4d54-9113-1c56da726d8d",
+          "type": "activity",
+          "title": "Embed auto",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0559b68c-68a5-4816-a06e-f1c743c391e3",
+                "type": "embed",
+                "isCompletionRequired": true,
+                "title": "Simulateur de visioconférence - micro ouvert",
+                "url": "https://epreuves.pix.fr/visio/visio.html?mode=modulix-didacticiel",
+                "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p><p>Il y a du bruit à côté de vous.</p><p>Coupez le son de votre micro pour ne pas déranger vos interlocuteurs.</p>",
+                "solution": "toto",
+                "height": 600
+              }
+            }
+          ]
+        },
+        {
+          "id": "5d70a05e-bfac-40b0-9588-e359db862d76",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "72fee40a-7279-4372-acf5-aaf508b1c145",
+                "type": "text",
+                "content": "<p>Vous arrivez à la fin de ce module. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7cf75e70-8749-4392-8081-f2c02badb0fb",
+          "type": "activity",
+          "title": "Le nom de ce produit",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
+                "type": "qrocm",
+                "instruction": "<p>Quel est le nom de ce nouveau produit Pix&#8239;?</p>",
+                "proposals": [
+                  {
+                    "input": "nom-produit",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "block",
+                    "placeholder": "",
+                    "ariaLabel": "Nom de ce produit",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["Modulix"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&#8239;!",
+                    "diagnosis": "<p>Vous êtes prêt à explorer &nbsp; <span aria-hidden=\"true\">🎉</span></p>"
+                  },
+                  "invalid": {
+                    "state": "Incorrect&#8239;!",
+                    "diagnosis": "<p> Vous y arriverez la prochaine fois&#8239;!</p>"
+                  }
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -15,726 +15,732 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "32261c7c-5922-4a48-85f0-7527fed88136",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "97dafa0a-b41f-4f0b-b8ae-8d283d323c31",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "0c91df86-5691-422a-b2c2-cfafd4f6e3d3",
-            "type": "text",
-            "content": "<p>Dans ce module, vous allez apprendre à taper du texte avec un clavier.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ce5797d0-074c-4a34-8004-c458df78c302",
-      "type": "lesson",
-      "title": "Les différents types de clavier",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bcd20400-781c-4b7d-82c3-d348ddef88d2",
-            "type": "text",
-            "content": "<p>Le clavier fait partie de l'équipement de base d’un ordinateur, avec la souris. <br>Le clavier est composé de touches sur lesquelles on peut appuyer.<br> Les claviers peuvent avoir différentes formes, tailles, couleurs ou disposition des touches.<br></p><p><br>Il y a différents types de clavier : </p> <ul> <li>les claviers avec un fil</li> <li>les claviers sans fil</li> <li>les claviers inclus dans un ordinateur</li> </ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9bb0a0d4-0075-46eb-acaf-68e349024028",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/G56zEJA.jpeg",
-            "alt": "",
-            "alternativeText": "<p>Photographies de plusieurs types de claviers de taille et de forme différentes :</p> <ul> <li>les claviers avec un fil</li> <li>les claviers sans fils</li> <li>les claviers inclus dans unordinateur</li> </ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "847c14dc-d58d-4faf-9886-8a2de37974c6",
-            "type": "text",
-            "content": "<p>Tous ces claviers permettent de faire la même chose.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c0b804d6-2b23-49c6-8aec-c18fb385545a",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cd613fa6-2903-4932-a1f7-5b7d51ac0a41",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🔎</span> <strong>Observez : quel type de clavier avez-vous ?</strong><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a3dada31-758c-4e4d-b92a-4e9e29ac76e0",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5f031cda-3e4c-4f80-9327-eb0f8df8f7f1",
-            "type": "text",
-            "content": "<p>À présent, vous allez découvrir les principales zones du clavier.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "421f64b0-a7b0-4855-8e24-3e4f86178a3e",
-      "type": "discovery",
-      "title": "Les zones du clavier",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "32261c7c-5922-4a48-85f0-7527fed88136",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "d6bb5ad8-bd97-4116-839d-425a444fcdfd",
-                  "type": "text",
-                  "content": "<p>Il y a 3 zones principales sur un clavier :</p><ul><li>lettres de l'alphabet</li><li>chiffres, caractères spéciaux et accents</li><li>flèches directionnelles</li></ul>"
-                },
-                {
-                  "id": "e86e4e5f-868e-4483-a995-86d89121e1a4",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/Cl7Tz1R.png",
-                  "alt": "",
-                  "alternativeText": "<p>Schéma des 3 zones principales sur un clavier :</p><ul><li>chiffres, caractères spéciaux et accents</li><li>lettres de l'alphabet</li><li>flèches directionnelles</li></ul>"
-                },
-                {
-                  "id": "1f25f056-78ad-42cd-8679-49188fe4e2a2",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">🤔</span> <strong>Bon à savoir</strong> </p><p>Les touches peuvent être disposées de différentes manières, en fonction des modèles, des pays et de la langue. <span aria-hidden=\"true\">🌍</span></p><p>En France, on utilise le clavier AZERTY. Il porte ce nom, car les lettres A, Z, E, R, T, Y sont les six premières lettres affichées sur le clavier</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "24829c18-2220-4cb8-9749-296d8c314353",
-                  "type": "text",
-                  "content": "<p>Taper sur une touche, c’est <strong>appuyer une fois</strong> dessus et <strong>relâcher immédiatement</strong>.</p>"
-                },
-                {
-                  "id": "274d2a22-5c45-40a3-87e2-13f650f49560",
-                  "type": "custom-draft",
-                  "title": "Élément interactif",
-                  "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-1-zones/index.html",
-                  "instruction": "<p><span aria-hidden=\"true\">👇</span> Préparez-vous à utiliser votre clavier et suivez les instructions pour taper vos premières touches.</p>",
-                  "height": 445
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "0c91df86-5691-422a-b2c2-cfafd4f6e3d3",
+                "type": "text",
+                "content": "<p>Dans ce module, vous allez apprendre à taper du texte avec un clavier.</p>"
+              }
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "99f72474-fa53-4391-afae-441d1b0bcbe3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e608bdea-cfaf-4aca-93e8-6668f4207158",
-            "type": "text",
-            "content": "<p>Vous connaissez maintenant les différentes zones du clavier. <br>Découvrez les principales touches nécessaires pour taper et modifier du texte.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "05985463-fbc5-43fe-8d39-038d0fa5c347",
-      "type": "lesson",
-      "title": "Introduction : les touches de base",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e4c30736-5efe-4a0d-bacc-b41e3546d47c",
-            "type": "text",
-            "content": "<p>Pour taper et modifier du texte, il faut utiliser des touches de différentes zones.</p><p><span aria-hidden=\"true\">👇</span> Voici les touches essentielles :</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6c90b56e-2e81-4320-9002-04a81fb07a39",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/KosRqGF.png",
-            "alt": "",
-            "alternativeText": "<p>Les touches du module&nbsp;:</p><ul><li>les accents</li><li>effacer et entrée</li><li>les lettres</li><li>l'espace</li><li>les flêches directionnelles</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "eb9f78a4-cd18-400a-bef7-f1b0850f36ce",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "44ad5d6e-1d51-47ac-bd9d-98acf9d7af71",
-            "type": "text",
-            "content": "<p>À vous de jouer ! <span aria-hidden=\"true\">🕹️</span> Commencez par taper des mots en utilisant uniquement les touches lettres.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "62699177-a148-4297-a965-729158816d59",
-      "type": "activity",
-      "title": "La saisie de premiers mots",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "62b13b03-4b39-4893-a3ac-5b55c5a4b0a2",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-2-saisie-1er-mots/index.html",
-            "instruction": "<p><strong>Dans l’espace ci-dessous, cliquez dans la zone indiquée, puis tapez les mots demandés.</strong></p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "77ea948d-2345-4043-9716-8f999b177847",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "18c6f518-9e97-4e94-a5f3-e986cd52c219",
-            "type": "text",
-            "content": "<p>Bravo ! <span aria-hidden=\"true\">🎉</span> Vous avez tapé vos premiers mots. <br>À présent, découvrez la zone de texte.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b72675fd-48d4-445e-804f-6304fe70ec52",
-      "type": "discovery",
-      "title": "La zone de texte",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "ce5797d0-074c-4a34-8004-c458df78c302",
+          "type": "lesson",
+          "title": "Les différents types de clavier",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "e7390f32-cf29-49c4-af61-cb0ee142d06e",
-                  "type": "text",
-                  "content": "<p>Une <strong>zone de texte</strong> est un endroit où on peut <strong>taper, modifier et effacer du texte</strong>. Pour reconnaître une zone de texte, vous pouvez vous aider du pointeur de la souris. <span aria-hidden=\"true\">🖱️</span><br></p><p>Lorsque vous faites glisser votre pointeur sur une zone de texte, il prend la forme d’une barre verticale.</p>"
-                },
-                {
-                  "id": "7923e0aa-3e35-493d-8d42-0b29cdc0ed08",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/v9biw6S.png",
-                  "alt": "",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "3fe83246-32a9-471a-a081-9ced72f4380a",
-                  "type": "text",
-                  "content": "<p>Vous pouvez alors cliquer dans la zone, une barre verticale s’affiche et clignote. C’est le <strong>curseur de texte</strong>. Vous pouvez commencer à taper, modifier ou effacer du texte à cet endroit.</p>"
-                },
-                {
-                  "id": "cf727c42-e967-493b-ae95-59d3b15806db",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/HhDpWZv.gif",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "bcd20400-781c-4b7d-82c3-d348ddef88d2",
+                "type": "text",
+                "content": "<p>Le clavier fait partie de l'équipement de base d’un ordinateur, avec la souris. <br>Le clavier est composé de touches sur lesquelles on peut appuyer.<br> Les claviers peuvent avoir différentes formes, tailles, couleurs ou disposition des touches.<br></p><p><br>Il y a différents types de clavier : </p> <ul> <li>les claviers avec un fil</li> <li>les claviers sans fil</li> <li>les claviers inclus dans un ordinateur</li> </ul>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "9bb0a0d4-0075-46eb-acaf-68e349024028",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/G56zEJA.jpeg",
+                "alt": "",
+                "alternativeText": "<p>Photographies de plusieurs types de claviers de taille et de forme différentes :</p> <ul> <li>les claviers avec un fil</li> <li>les claviers sans fils</li> <li>les claviers inclus dans unordinateur</li> </ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "847c14dc-d58d-4faf-9886-8a2de37974c6",
+                "type": "text",
+                "content": "<p>Tous ces claviers permettent de faire la même chose.<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c0b804d6-2b23-49c6-8aec-c18fb385545a",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cd613fa6-2903-4932-a1f7-5b7d51ac0a41",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🔎</span> <strong>Observez : quel type de clavier avez-vous ?</strong><br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a3dada31-758c-4e4d-b92a-4e9e29ac76e0",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5f031cda-3e4c-4f80-9327-eb0f8df8f7f1",
+                "type": "text",
+                "content": "<p>À présent, vous allez découvrir les principales zones du clavier.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "421f64b0-a7b0-4855-8e24-3e4f86178a3e",
+          "type": "discovery",
+          "title": "Les zones du clavier",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "f020568f-8d85-4b8a-97a2-6acefa0b5edf",
-                  "type": "qrocm",
-                  "instruction": "<p>À vous de jouer, la phrase ci-dessous comporte deux zones de texte. Complétez la phrase ainsi : «&nbsp;Le bocal de cornichons est vide.&nbsp;».</p>",
-                  "proposals": [
+                  "elements": [
                     {
+                      "id": "d6bb5ad8-bd97-4116-839d-425a444fcdfd",
                       "type": "text",
-                      "content": "<span>Le bocal de</span>"
+                      "content": "<p>Il y a 3 zones principales sur un clavier :</p><ul><li>lettres de l'alphabet</li><li>chiffres, caractères spéciaux et accents</li><li>flèches directionnelles</li></ul>"
                     },
                     {
-                      "input": "1",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 10,
-                      "display": "inline",
-                      "placeholder": "Cliquer ici",
-                      "ariaLabel": "Cliquer ici",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "solutions": ["cornichons"]
+                      "id": "e86e4e5f-868e-4483-a995-86d89121e1a4",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/Cl7Tz1R.png",
+                      "alt": "",
+                      "alternativeText": "<p>Schéma des 3 zones principales sur un clavier :</p><ul><li>chiffres, caractères spéciaux et accents</li><li>lettres de l'alphabet</li><li>flèches directionnelles</li></ul>"
                     },
                     {
+                      "id": "1f25f056-78ad-42cd-8679-49188fe4e2a2",
                       "type": "text",
-                      "content": "<span>est</span>"
-                    },
+                      "content": "<p><span aria-hidden=\"true\">🤔</span> <strong>Bon à savoir</strong> </p><p>Les touches peuvent être disposées de différentes manières, en fonction des modèles, des pays et de la langue. <span aria-hidden=\"true\">🌍</span></p><p>En France, on utilise le clavier AZERTY. Il porte ce nom, car les lettres A, Z, E, R, T, Y sont les six premières lettres affichées sur le clavier</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
                     {
-                      "input": "2",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 8,
-                      "display": "inline",
-                      "placeholder": "Cliquer ici",
-                      "ariaLabel": "Cliquer ici",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "solutions": ["vide"]
-                    },
-                    {
+                      "id": "24829c18-2220-4cb8-9749-296d8c314353",
                       "type": "text",
-                      "content": "<span>.</span>"
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse ! 🥒",
-                      "diagnosis": "<p>Bravo ! Vous avez bien complété la phrase.</p>"
+                      "content": "<p>Taper sur une touche, c’est <strong>appuyer une fois</strong> dessus et <strong>relâcher immédiatement</strong>.</p>"
                     },
-                    "invalid": {
-                      "state": "Mauvaise réponse. \uD83C\uDF7D\uFE0F",
-                      "diagnosis": "<p> Bien tenté ! Mais la phrase n’est pas identique. Réessayez !</p>"
+                    {
+                      "id": "274d2a22-5c45-40a3-87e2-13f650f49560",
+                      "type": "custom-draft",
+                      "title": "Élément interactif",
+                      "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-1-zones/index.html",
+                      "instruction": "<p><span aria-hidden=\"true\">👇</span> Préparez-vous à utiliser votre clavier et suivez les instructions pour taper vos premières touches.</p>",
+                      "height": 445
                     }
-                  }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "39f2992c-b346-4cad-8bf3-95d373c96a01",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ca6cabdb-6b85-45e1-b873-b809948eb628",
-            "type": "text",
-            "content": "<p>Maintenant, découvrez les autres touches utiles pour modifier du texte. <span aria-hidden=\"true\">⌨️</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "36a17bbd-4975-4f9d-878e-0759801956fd",
-      "type": "lesson",
-      "title": "Les touches espace, entrée, effacer et les flèches.",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f42a1f10-87a9-4607-bb81-9cde56c1d047",
-            "type": "text",
-            "content": "<p>Pour écrire et modifier du texte, il faut utiliser d’autres touches que les touches lettres.</p><br><p>Voici les touches les plus utiles&nbsp;:</p><ul> <li><strong>Espace</strong></li> <li><strong>Entrée</strong></li> <li><strong>Effacer</strong></li> <li><strong>Les flèches directionnelles</strong></li> </ul> "
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "fdba280f-e339-4999-befd-33ab52885043",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/wr3plig.png",
-            "alt": "",
-            "alternativeText": ""
-          }
+          "id": "99f72474-fa53-4391-afae-441d1b0bcbe3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e608bdea-cfaf-4aca-93e8-6668f4207158",
+                "type": "text",
+                "content": "<p>Vous connaissez maintenant les différentes zones du clavier. <br>Découvrez les principales touches nécessaires pour taper et modifier du texte.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "05985463-fbc5-43fe-8d39-038d0fa5c347",
+          "type": "lesson",
+          "title": "Introduction : les touches de base",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "e314ff25-bd46-475b-b18b-0ef1952735c7",
-                  "type": "text",
-                  "content": "<p>La touche <strong>Espace </strong>permet de créer un espace vide entre deux mots.</p>"
-                },
-                {
-                  "id": "b8805656-09a9-4d92-8a19-d13cd4e6149e",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/GMFTqpY.gif",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "e4c30736-5efe-4a0d-bacc-b41e3546d47c",
+                "type": "text",
+                "content": "<p>Pour taper et modifier du texte, il faut utiliser des touches de différentes zones.</p><p><span aria-hidden=\"true\">👇</span> Voici les touches essentielles :</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "b65c1d05-27b9-429e-b8aa-b63bef94c67e",
-                  "type": "text",
-                  "content": "<p>La touche <strong>Entrée </strong>permet d’aller à la ligne :<br>Quand vous êtes en train de taper du texte et que vous voulez écrire sur la ligne suivante, tapez sur la touche entrée pour déplacer le curseur vers la ligne d'en dessous.</p>"
-                },
-                {
-                  "id": "82fc806d-0d75-4202-85af-dfe7fca24315",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/FhGFy0f.gif",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "6c90b56e-2e81-4320-9002-04a81fb07a39",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/KosRqGF.png",
+                "alt": "",
+                "alternativeText": "<p>Les touches du module&nbsp;:</p><ul><li>les accents</li><li>effacer et entrée</li><li>les lettres</li><li>l'espace</li><li>les flêches directionnelles</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "eb9f78a4-cd18-400a-bef7-f1b0850f36ce",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "188a5ce5-c163-47d0-b718-1ac64db4283e",
-                  "type": "text",
-                  "content": "<p>La touche <strong>Effacer </strong>permet de supprimer le caractère juste avant le curseur de texte.</p>"
-                },
-                {
-                  "id": "de866e42-a119-461b-b73a-c684da091d77",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/QH4Z4Bq.gif",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "44ad5d6e-1d51-47ac-bd9d-98acf9d7af71",
+                "type": "text",
+                "content": "<p>À vous de jouer ! <span aria-hidden=\"true\">🕹️</span> Commencez par taper des mots en utilisant uniquement les touches lettres.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "62699177-a148-4297-a965-729158816d59",
+          "type": "activity",
+          "title": "La saisie de premiers mots",
+          "components": [
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "62b13b03-4b39-4893-a3ac-5b55c5a4b0a2",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-2-saisie-1er-mots/index.html",
+                "instruction": "<p><strong>Dans l’espace ci-dessous, cliquez dans la zone indiquée, puis tapez les mots demandés.</strong></p>",
+                "height": 445
+              }
+            }
+          ]
+        },
+        {
+          "id": "77ea948d-2345-4043-9716-8f999b177847",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "18c6f518-9e97-4e94-a5f3-e986cd52c219",
+                "type": "text",
+                "content": "<p>Bravo ! <span aria-hidden=\"true\">🎉</span> Vous avez tapé vos premiers mots. <br>À présent, découvrez la zone de texte.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b72675fd-48d4-445e-804f-6304fe70ec52",
+          "type": "discovery",
+          "title": "La zone de texte",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "6dee7fcf-7faf-4748-9c56-70e93d7d4914",
-                  "type": "text",
-                  "content": "<p>Pour déplacer le curseur de texte, vous pouvez utiliser les <strong>Flèches directionnelles</strong>.</p><p><span aria-hidden=\"true\">➡️</span>Par exemple : vous avez oublié d’aller à la ligne entre deux mots, vous pouvez déplacer le curseur entre les deux mots pour appuyer sur la touche entrée et aller à la ligne.</p>"
+                  "elements": [
+                    {
+                      "id": "e7390f32-cf29-49c4-af61-cb0ee142d06e",
+                      "type": "text",
+                      "content": "<p>Une <strong>zone de texte</strong> est un endroit où on peut <strong>taper, modifier et effacer du texte</strong>. Pour reconnaître une zone de texte, vous pouvez vous aider du pointeur de la souris. <span aria-hidden=\"true\">🖱️</span><br></p><p>Lorsque vous faites glisser votre pointeur sur une zone de texte, il prend la forme d’une barre verticale.</p>"
+                    },
+                    {
+                      "id": "7923e0aa-3e35-493d-8d42-0b29cdc0ed08",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/v9biw6S.png",
+                      "alt": "",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "3fe83246-32a9-471a-a081-9ced72f4380a",
+                      "type": "text",
+                      "content": "<p>Vous pouvez alors cliquer dans la zone, une barre verticale s’affiche et clignote. C’est le <strong>curseur de texte</strong>. Vous pouvez commencer à taper, modifier ou effacer du texte à cet endroit.</p>"
+                    },
+                    {
+                      "id": "cf727c42-e967-493b-ae95-59d3b15806db",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/HhDpWZv.gif",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
                 },
                 {
-                  "id": "5d93c1b7-2f8d-4891-9443-9a2f86104f4e",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/fEfcNid.gif",
-                  "alt": "",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "f020568f-8d85-4b8a-97a2-6acefa0b5edf",
+                      "type": "qrocm",
+                      "instruction": "<p>À vous de jouer, la phrase ci-dessous comporte deux zones de texte. Complétez la phrase ainsi : «&nbsp;Le bocal de cornichons est vide.&nbsp;».</p>",
+                      "proposals": [
+                        {
+                          "type": "text",
+                          "content": "<span>Le bocal de</span>"
+                        },
+                        {
+                          "input": "1",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 10,
+                          "display": "inline",
+                          "placeholder": "Cliquer ici",
+                          "ariaLabel": "Cliquer ici",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": ["cornichons"]
+                        },
+                        {
+                          "type": "text",
+                          "content": "<span>est</span>"
+                        },
+                        {
+                          "input": "2",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 8,
+                          "display": "inline",
+                          "placeholder": "Cliquer ici",
+                          "ariaLabel": "Cliquer ici",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": ["vide"]
+                        },
+                        {
+                          "type": "text",
+                          "content": "<span>.</span>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse ! 🥒",
+                          "diagnosis": "<p>Bravo ! Vous avez bien complété la phrase.</p>"
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse. \uD83C\uDF7D\uFE0F",
+                          "diagnosis": "<p> Bien tenté ! Mais la phrase n’est pas identique. Réessayez !</p>"
+                        }
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "63ead640-3c01-4dfd-b8a7-566885e01037",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "731fa720-68f8-420b-ae7b-efc86b8aae5a",
-            "type": "text",
-            "content": "<p>Voyons si vous avez retenu l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1b35e115-f40f-4309-bc8a-dc8122f63e25",
-      "type": "activity",
-      "title": "La correction de textes avec espace, entrée, effacer.",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "247c064e-8d6f-4b8c-9298-0a12f0643e27",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-3-listedecourse/index.html",
-            "instruction": "<p><strong>Dans la zone ci-dessous, vous allez corriger une liste de courses en vous aidant des touches espace, entrée, effacer et des flèches.</strong></p>",
-            "height": 445
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "caedc436-3ab8-45a8-a4b5-c7ee5b4f38c6",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">💡</span> Si besoin, cliquez sur <strong>Réinitialiser </strong>pour effacer toutes vos modifications.<br></p><p><span aria-hidden=\"true\">🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️</span> En cas de difficulté, n'hésitez pas à demandez conseil à la personne qui vous accompagne.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b534fdbe-3635-400e-9f68-f3420dfbdbf5",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d77ec00d-f3f0-4a22-9e90-c6dff041b780",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</p><ol><li>La zone de texte est une zone dans laquelle on peut taper du texte. Il faut cliquer dans cette zone avant de commencer à taper.</li><li>La zone des lettres se trouve au centre du clavier.</li><li>Pour écrire et modifier du texte, les touches de base sont : Espace, Entrée et Effacer. Les flèches directionnelles permettent de déplacer le curseur de texte.</li></ol>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3dfeeeec-f51c-4aca-8255-b5dacbcac355",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/swSZAq1.png",
-            "alt": "",
-            "alternativeText": "<p>Récapitulatif des touches : </p><ul><li>effacer</li><li>entrée</li><li>espace</li><li>les lettres</li><li>les flèches directionnelles</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "388eb851-d9c2-4434-89a1-5879d80467b2",
-            "type": "expand",
-            "title": "🤔 Bon à savoir",
-            "content": "<p> Pour taper du texte rapidement, il est conseillé d’utiliser ses deux mains.<span aria-hidden=\"true\">🙌</span> Quand on débute, ce n’est pas nécessaire.<br> Pensez aussi à ne pas taper trop fort sur les touches pour ne pas les abîmer.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2b0b77eb-d091-450f-9a92-7ded5f9466bb",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "be0e2ee5-97d6-4d46-b621-42b89c16395d",
-            "type": "text",
-            "content": "<p>Certaines lettres ont des accents. Voyons ensemble où les trouver sur le clavier.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "149c809f-17dd-418e-80d3-2fe3fa3b0e6c",
-      "type": "lesson",
-      "title": "Les lettres accentuées",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a0548b0c-335a-46cc-b6e0-af84998734c2",
-            "type": "text",
-            "content": "<p>Les lettres accentuées les plus courantes (é, è, ç, à, ù) sont placées sur les touches suivantes :</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "b61388bd-29a7-40cb-b3f0-89ce7a0b5565",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/0ANm9TL.png",
-            "alt": "",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0f10059b-3a41-47fd-808b-9f587cf7ab0c",
-            "type": "text",
-            "content": "<p>Les lettres accentuées sont écrites en bas à gauche des touches. <br>Il suffit de taper sur la touche pour que la lettre accentuée apparaisse à l’écran.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3444120b-4205-43df-aa5a-fbc62c7f0cb2",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6bb8779f-8f08-4a9c-803e-63eebabf80c9",
-            "type": "text",
-            "content": "<p>Vous allez maintenant passer à la pratique. <span aria-hidden=\"true\">⌨️</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9b722101-2b15-4a45-be20-6604dc9c0dbe",
-      "type": "activity",
-      "title": "L’utilisation des lettres accentuées ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f46175b4-7066-4b10-b494-116944516535",
-            "type": "text",
-            "content": "<p><strong>Pour chaque mot qui vous sera proposé, tapez ce mot dans la zone de texte.</strong></p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "39f2992c-b346-4cad-8bf3-95d373c96a01",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "0e98fbdf-c768-4906-b31c-747b43006a46",
-                  "type": "qrocm",
-                  "instruction": "céleri",
-                  "proposals": [
-                    {
-                      "input": "1",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 15,
-                      "display": "inline",
-                      "placeholder": "Cliquer ici",
-                      "ariaLabel": "Cliquer ici",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "solutions": ["céleri"]
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse ! 🎉",
-                      "diagnosis": ""
-                    },
-                    "invalid": {
-                      "state": "Mauvaise réponse. ",
-                      "diagnosis": "<p>N'oubliez pas d'utiliser le e accentué.</p>"
-                    }
-                  }
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "ca6cabdb-6b85-45e1-b873-b809948eb628",
+                "type": "text",
+                "content": "<p>Maintenant, découvrez les autres touches utiles pour modifier du texte. <span aria-hidden=\"true\">⌨️</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "36a17bbd-4975-4f9d-878e-0759801956fd",
+          "type": "lesson",
+          "title": "Les touches espace, entrée, effacer et les flèches.",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f42a1f10-87a9-4607-bb81-9cde56c1d047",
+                "type": "text",
+                "content": "<p>Pour écrire et modifier du texte, il faut utiliser d’autres touches que les touches lettres.</p><br><p>Voici les touches les plus utiles&nbsp;:</p><ul> <li><strong>Espace</strong></li> <li><strong>Entrée</strong></li> <li><strong>Effacer</strong></li> <li><strong>Les flèches directionnelles</strong></li> </ul> "
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "208495a6-50ae-45f6-84d2-e57d0626281e",
-                  "type": "qrocm",
-                  "instruction": "pastèque",
-                  "proposals": [
-                    {
-                      "input": "2",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 15,
-                      "display": "inline",
-                      "placeholder": "Cliquer ici",
-                      "ariaLabel": "Cliquer ici",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "solutions": ["pastèque"]
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse ! 🎉",
-                      "diagnosis": ""
-                    },
-                    "invalid": {
-                      "state": "Mauvaise réponse.",
-                      "diagnosis": "<p>N'oubliez pas d'utiliser le e accentué.</p>"
-                    }
-                  }
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "fdba280f-e339-4999-befd-33ab52885043",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/wr3plig.png",
+                "alt": "",
+                "alternativeText": ""
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "bb07a5f6-1f3d-484c-b7d9-98d01f1b2535",
-                  "type": "qrocm",
-                  "instruction": "bac à glaçons",
-                  "proposals": [
+                  "elements": [
                     {
-                      "input": "3",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 15,
-                      "display": "inline",
-                      "placeholder": "Cliquer ici",
-                      "ariaLabel": "Cliquer ici",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "solutions": ["bac à glaçons"]
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse ! 🎉",
-                      "diagnosis": ""
+                      "id": "e314ff25-bd46-475b-b18b-0ef1952735c7",
+                      "type": "text",
+                      "content": "<p>La touche <strong>Espace </strong>permet de créer un espace vide entre deux mots.</p>"
                     },
-                    "invalid": {
-                      "state": "Mauvaise réponse.",
-                      "diagnosis": "<p>N'oubliez pas d'utiliser les deux lettres accentuées.</p>"
+                    {
+                      "id": "b8805656-09a9-4d92-8a19-d13cd4e6149e",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/GMFTqpY.gif",
+                      "alt": "",
+                      "alternativeText": ""
                     }
-                  }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b65c1d05-27b9-429e-b8aa-b63bef94c67e",
+                      "type": "text",
+                      "content": "<p>La touche <strong>Entrée </strong>permet d’aller à la ligne :<br>Quand vous êtes en train de taper du texte et que vous voulez écrire sur la ligne suivante, tapez sur la touche entrée pour déplacer le curseur vers la ligne d'en dessous.</p>"
+                    },
+                    {
+                      "id": "82fc806d-0d75-4202-85af-dfe7fca24315",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/FhGFy0f.gif",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "188a5ce5-c163-47d0-b718-1ac64db4283e",
+                      "type": "text",
+                      "content": "<p>La touche <strong>Effacer </strong>permet de supprimer le caractère juste avant le curseur de texte.</p>"
+                    },
+                    {
+                      "id": "de866e42-a119-461b-b73a-c684da091d77",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/QH4Z4Bq.gif",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "6dee7fcf-7faf-4748-9c56-70e93d7d4914",
+                      "type": "text",
+                      "content": "<p>Pour déplacer le curseur de texte, vous pouvez utiliser les <strong>Flèches directionnelles</strong>.</p><p><span aria-hidden=\"true\">➡️</span>Par exemple : vous avez oublié d’aller à la ligne entre deux mots, vous pouvez déplacer le curseur entre les deux mots pour appuyer sur la touche entrée et aller à la ligne.</p>"
+                    },
+                    {
+                      "id": "5d93c1b7-2f8d-4891-9443-9a2f86104f4e",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/fEfcNid.gif",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "27a8a7fe-62c1-4930-823f-5c9978f71395",
-      "type": "challenge",
-      "title": "Écriture d'un morceau de phrase",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ddec6ee3-178f-4ab5-862a-fc776e9ff6f4",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-bossfinal2/index.html",
-            "instruction": "<p><strong>Dans la zone de texte ci-dessous, modifiez la phrase qui apparaît pour écrire :&nbsp;</strong> </p><p>«Quelle bonne idée d'avoir mis de la purée de cornichons dans le bac à glaçons.»<br></p>",
-            "height": 394
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "bed8da7e-630d-4400-b1c2-9e250ccee7e4",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">💡</span> Si besoin, cliquez sur <strong>Recommencer </strong>pour recommencer depuis le début.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "becb6f0a-ce4c-4016-9588-0afadefd56ff",
-      "type": "summary",
-      "title": "Recap module clavier 1/2",
-      "components": [
+          "id": "63ead640-3c01-4dfd-b8a7-566885e01037",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "731fa720-68f8-420b-ae7b-efc86b8aae5a",
+                "type": "text",
+                "content": "<p>Voyons si vous avez retenu l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "52b120fe-5aa5-4ebc-aafc-ddd173377620",
-            "type": "text",
-            "content": "<p>📌 Pour taper, modifier ou effacer du texte, on clique dans une zone de texte avec la souris. Puis, on utilise les touches du clavier.&nbsp; Voici les touches du clavier à retenir : </p><ul><li><strong>Les lettres</strong> pour taper des lettres.</li><li><strong>Espace </strong>pour ajouter un espace entre deux motsEntrée pour aller à la ligne.</li><li><strong>Effacer </strong>pour supprimer le caractère à gauche du curseur de texte.</li><li><strong>Les flèches directionnelles</strong> pour déplacer le curseur de texte.</li></ul><p><br>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-1/pix-fiche-revision-premieres-marches-clavier-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
-          }
+          "id": "1b35e115-f40f-4309-bc8a-dc8122f63e25",
+          "type": "activity",
+          "title": "La correction de textes avec espace, entrée, effacer.",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "247c064e-8d6f-4b8c-9298-0a12f0643e27",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-3-listedecourse/index.html",
+                "instruction": "<p><strong>Dans la zone ci-dessous, vous allez corriger une liste de courses en vous aidant des touches espace, entrée, effacer et des flèches.</strong></p>",
+                "height": 445
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "caedc436-3ab8-45a8-a4b5-c7ee5b4f38c6",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">💡</span> Si besoin, cliquez sur <strong>Réinitialiser </strong>pour effacer toutes vos modifications.<br></p><p><span aria-hidden=\"true\">🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️</span> En cas de difficulté, n'hésitez pas à demandez conseil à la personne qui vous accompagne.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b534fdbe-3635-400e-9f68-f3420dfbdbf5",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d77ec00d-f3f0-4a22-9e90-c6dff041b780",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</p><ol><li>La zone de texte est une zone dans laquelle on peut taper du texte. Il faut cliquer dans cette zone avant de commencer à taper.</li><li>La zone des lettres se trouve au centre du clavier.</li><li>Pour écrire et modifier du texte, les touches de base sont : Espace, Entrée et Effacer. Les flèches directionnelles permettent de déplacer le curseur de texte.</li></ol>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3dfeeeec-f51c-4aca-8255-b5dacbcac355",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/swSZAq1.png",
+                "alt": "",
+                "alternativeText": "<p>Récapitulatif des touches : </p><ul><li>effacer</li><li>entrée</li><li>espace</li><li>les lettres</li><li>les flèches directionnelles</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "388eb851-d9c2-4434-89a1-5879d80467b2",
+                "type": "expand",
+                "title": "🤔 Bon à savoir",
+                "content": "<p> Pour taper du texte rapidement, il est conseillé d’utiliser ses deux mains.<span aria-hidden=\"true\">🙌</span> Quand on débute, ce n’est pas nécessaire.<br> Pensez aussi à ne pas taper trop fort sur les touches pour ne pas les abîmer.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2b0b77eb-d091-450f-9a92-7ded5f9466bb",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "be0e2ee5-97d6-4d46-b621-42b89c16395d",
+                "type": "text",
+                "content": "<p>Certaines lettres ont des accents. Voyons ensemble où les trouver sur le clavier.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "149c809f-17dd-418e-80d3-2fe3fa3b0e6c",
+          "type": "lesson",
+          "title": "Les lettres accentuées",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a0548b0c-335a-46cc-b6e0-af84998734c2",
+                "type": "text",
+                "content": "<p>Les lettres accentuées les plus courantes (é, è, ç, à, ù) sont placées sur les touches suivantes :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b61388bd-29a7-40cb-b3f0-89ce7a0b5565",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/0ANm9TL.png",
+                "alt": "",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0f10059b-3a41-47fd-808b-9f587cf7ab0c",
+                "type": "text",
+                "content": "<p>Les lettres accentuées sont écrites en bas à gauche des touches. <br>Il suffit de taper sur la touche pour que la lettre accentuée apparaisse à l’écran.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3444120b-4205-43df-aa5a-fbc62c7f0cb2",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6bb8779f-8f08-4a9c-803e-63eebabf80c9",
+                "type": "text",
+                "content": "<p>Vous allez maintenant passer à la pratique. <span aria-hidden=\"true\">⌨️</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9b722101-2b15-4a45-be20-6604dc9c0dbe",
+          "type": "activity",
+          "title": "L’utilisation des lettres accentuées ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f46175b4-7066-4b10-b494-116944516535",
+                "type": "text",
+                "content": "<p><strong>Pour chaque mot qui vous sera proposé, tapez ce mot dans la zone de texte.</strong></p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "0e98fbdf-c768-4906-b31c-747b43006a46",
+                      "type": "qrocm",
+                      "instruction": "céleri",
+                      "proposals": [
+                        {
+                          "input": "1",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 15,
+                          "display": "inline",
+                          "placeholder": "Cliquer ici",
+                          "ariaLabel": "Cliquer ici",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": ["céleri"]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse ! 🎉",
+                          "diagnosis": ""
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse. ",
+                          "diagnosis": "<p>N'oubliez pas d'utiliser le e accentué.</p>"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "208495a6-50ae-45f6-84d2-e57d0626281e",
+                      "type": "qrocm",
+                      "instruction": "pastèque",
+                      "proposals": [
+                        {
+                          "input": "2",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 15,
+                          "display": "inline",
+                          "placeholder": "Cliquer ici",
+                          "ariaLabel": "Cliquer ici",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": ["pastèque"]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse ! 🎉",
+                          "diagnosis": ""
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse.",
+                          "diagnosis": "<p>N'oubliez pas d'utiliser le e accentué.</p>"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "bb07a5f6-1f3d-484c-b7d9-98d01f1b2535",
+                      "type": "qrocm",
+                      "instruction": "bac à glaçons",
+                      "proposals": [
+                        {
+                          "input": "3",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 15,
+                          "display": "inline",
+                          "placeholder": "Cliquer ici",
+                          "ariaLabel": "Cliquer ici",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": ["bac à glaçons"]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse ! 🎉",
+                          "diagnosis": ""
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse.",
+                          "diagnosis": "<p>N'oubliez pas d'utiliser les deux lettres accentuées.</p>"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "27a8a7fe-62c1-4930-823f-5c9978f71395",
+          "type": "challenge",
+          "title": "Écriture d'un morceau de phrase",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ddec6ee3-178f-4ab5-862a-fc776e9ff6f4",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier1-bossfinal2/index.html",
+                "instruction": "<p><strong>Dans la zone de texte ci-dessous, modifiez la phrase qui apparaît pour écrire :&nbsp;</strong> </p><p>«Quelle bonne idée d'avoir mis de la purée de cornichons dans le bac à glaçons.»<br></p>",
+                "height": 394
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bed8da7e-630d-4400-b1c2-9e250ccee7e4",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">💡</span> Si besoin, cliquez sur <strong>Recommencer </strong>pour recommencer depuis le début.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "becb6f0a-ce4c-4016-9588-0afadefd56ff",
+          "type": "summary",
+          "title": "Recap module clavier 1/2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "52b120fe-5aa5-4ebc-aafc-ddd173377620",
+                "type": "text",
+                "content": "<p>📌 Pour taper, modifier ou effacer du texte, on clique dans une zone de texte avec la souris. Puis, on utilise les touches du clavier.&nbsp; Voici les touches du clavier à retenir : </p><ul><li><strong>Les lettres</strong> pour taper des lettres.</li><li><strong>Espace </strong>pour ajouter un espace entre deux motsEntrée pour aller à la ligne.</li><li><strong>Effacer </strong>pour supprimer le caractère à gauche du curseur de texte.</li><li><strong>Les flèches directionnelles</strong> pour déplacer le curseur de texte.</li></ul><p><br>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-1/pix-fiche-revision-premieres-marches-clavier-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -15,600 +15,606 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "f9863d09-1ce3-41d0-8e7c-0a7cdc125c36",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "cdd86011-9d39-41ac-a89f-140a4e92c076",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "5bfffb2d-05bb-4497-a9ad-7a5402a5108f",
-            "type": "text",
-            "content": "<p>Dans ce module, vous allez apprendre à utiliser les touches du clavier qui ont plusieurs caractères.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7667d4ff-dbf7-4d22-b030-592b5c4c3a86",
-      "type": "activity",
-      "title": "Saisie des caractères essentiels minuscules",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9de6b2ff-3e7c-4a96-88ff-d0bc3f7c4bf1",
-            "type": "text",
-            "content": "<p>Pour commencer, révisons les touches de base du clavier pour taper du texte.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f78cb6e8-3a9e-430b-b40e-b1a2f1221512",
-            "type": "qrocm",
-            "instruction": "<p>Utilisez votre clavier pour taper «&nbsp;voilà le zèbre déçu&nbsp;» dans la zone de texte ci-dessous :</p>",
-            "proposals": [
-              {
-                "input": "zebre-decu",
-                "type": "input",
-                "inputType": "text",
-                "size": 24,
-                "display": "inline",
-                "placeholder": "Tapez ici",
-                "ariaLabel": "zone de saisie",
-                "defaultValue": "",
-                "tolerances": [],
-                "solutions": ["voilà le zèbre déçu", "« voilà le zèbre déçu »"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse ! 🎉",
-                "diagnosis": "<p>Bravo ! 🦓 Vous savez utiliser le clavier pour taper des lettres, des espaces et des caractères accentués.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Pour retrouver les caractères dont vous avez besoin, vous pouvez utiliser les indices. N’hésitez pas à réessayer.</p>"
+          "id": "f9863d09-1ce3-41d0-8e7c-0a7cdc125c36",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5bfffb2d-05bb-4497-a9ad-7a5402a5108f",
+                "type": "text",
+                "content": "<p>Dans ce module, vous allez apprendre à utiliser les touches du clavier qui ont plusieurs caractères.</p>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "0b771dad-3e31-4e0a-809e-6abd65653adb",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous :</p>"
-          }
+          "id": "7667d4ff-dbf7-4d22-b030-592b5c4c3a86",
+          "type": "activity",
+          "title": "Saisie des caractères essentiels minuscules",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9de6b2ff-3e7c-4a96-88ff-d0bc3f7c4bf1",
+                "type": "text",
+                "content": "<p>Pour commencer, révisons les touches de base du clavier pour taper du texte.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f78cb6e8-3a9e-430b-b40e-b1a2f1221512",
+                "type": "qrocm",
+                "instruction": "<p>Utilisez votre clavier pour taper «&nbsp;voilà le zèbre déçu&nbsp;» dans la zone de texte ci-dessous :</p>",
+                "proposals": [
+                  {
+                    "input": "zebre-decu",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 24,
+                    "display": "inline",
+                    "placeholder": "Tapez ici",
+                    "ariaLabel": "zone de saisie",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "solutions": ["voilà le zèbre déçu", "« voilà le zèbre déçu »"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse ! 🎉",
+                    "diagnosis": "<p>Bravo ! 🦓 Vous savez utiliser le clavier pour taper des lettres, des espaces et des caractères accentués.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Pour retrouver les caractères dont vous avez besoin, vous pouvez utiliser les indices. N’hésitez pas à réessayer.</p>"
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0b771dad-3e31-4e0a-809e-6abd65653adb",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous :</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7e518859-11db-484a-bd2f-67bc56b4b094",
+                "type": "expand",
+                "title": "Indice 1",
+                "content": "<p>Cliquez dans la zone de texte pour commencer à taper</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8c18c2f0-b9f0-4ca6-8a77-92fb0604dbb9",
+                "type": "expand",
+                "title": "Indice 2",
+                "content": "<p>Les touches nécessaires pour écrire la phrase sont indiquées dans l’image ci-dessous.</p><img src=\"https://assets.pix.org/draft/modules/KosRqGF.png\" alt=\"Les touches essentielles du clavier. Les lettres, les accents, effacer et entrée, l'espace et les flèches directionelles.\">"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "7e518859-11db-484a-bd2f-67bc56b4b094",
-            "type": "expand",
-            "title": "Indice 1",
-            "content": "<p>Cliquez dans la zone de texte pour commencer à taper</p>"
-          }
+          "id": "c95bfc22-6473-4439-b22b-16c304546419",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5cd44b4e-0534-4181-9478-101073d3a9b1",
+                "type": "text",
+                "content": "<p>Bravo ! <span aria-hidden=\"true\">🎉</span> </p><p>Vous êtes prêt. Voyons comment taper des lettres majuscules.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "8c18c2f0-b9f0-4ca6-8a77-92fb0604dbb9",
-            "type": "expand",
-            "title": "Indice 2",
-            "content": "<p>Les touches nécessaires pour écrire la phrase sont indiquées dans l’image ci-dessous.</p><img src=\"https://assets.pix.org/draft/modules/KosRqGF.png\" alt=\"Les touches essentielles du clavier. Les lettres, les accents, effacer et entrée, l'espace et les flèches directionelles.\">"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c95bfc22-6473-4439-b22b-16c304546419",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5cd44b4e-0534-4181-9478-101073d3a9b1",
-            "type": "text",
-            "content": "<p>Bravo ! <span aria-hidden=\"true\">🎉</span> </p><p>Vous êtes prêt. Voyons comment taper des lettres majuscules.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7ff9a355-6e89-4ab1-9c66-76ab054b97e3",
-      "type": "lesson",
-      "title": "Les lettres majuscules",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c176da55-aad3-4dc2-a7fa-e680abd27ebd",
-            "type": "text",
-            "content": "<p>Pour taper certains caractères, il faut <strong>appuyer sur plusieurs touches en même temps</strong>. </p> <p>C'est le cas pour taper des lettres majuscules.</p>"
-          }
+          "id": "7ff9a355-6e89-4ab1-9c66-76ab054b97e3",
+          "type": "lesson",
+          "title": "Les lettres majuscules",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c176da55-aad3-4dc2-a7fa-e680abd27ebd",
+                "type": "text",
+                "content": "<p>Pour taper certains caractères, il faut <strong>appuyer sur plusieurs touches en même temps</strong>. </p> <p>C'est le cas pour taper des lettres majuscules.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "09878916-177a-432b-99d0-54d85dfc2293",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e7cd9a3d-1632-41e8-82ce-b41995b8ca36",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/odFZeVB.png",
+                "alt": "Schéma d'un clavier, les deux touches majuscules sont en couleur.",
+                "alternativeText": "<p>Il y a deux touches majuscules sur le clavier, une à gauche, et une à droite. Chacune comporte le symbole d'une flèche vers le haut.</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6764fe09-6a2f-47a1-b368-f9083a9e0a26",
+                "type": "text",
+                "content": "<p>La <strong>touche majuscule ⇧</strong> du clavier permet de taper des lettres majuscules.</p><p><br><strong><span aria-hidden=\"true\">💡</span>&nbsp;Astuce</strong><br>Sur la touche majuscule ⇧ il y a souvent une flèche vers le haut. On peut dire que c’est la touche qui fait grandir les lettres.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ba22f122-cb11-4b2d-bb9d-a153ae9472b7",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "00987892-9248-401d-94a2-f9418c8ff5e6",
+                "type": "text",
+                "content": "<p>Par exemple, pour taper un P, gardez un doigt appuyé sur la <strong>touche majuscule ⇧</strong> et appuyez brièvement sur la touche P avec un autre doigt.</p><p><br>Dès que vous relâchez la touche majuscule ⇧, les lettres que vous tapez sont en minuscules.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1eeb0af4-2f24-42fc-a051-8c0dc46ac17f",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/uO0tdrA.jpeg",
+                "alt": "Dessin d'un clavier, une main appuie sur majuscule, l'autre main appuie sur le touche P.",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "04fe4d77-15c4-475d-915f-ba04f69f9674",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">💡</span><strong> Astuce</strong><br>Pour taper plusieurs majuscules à la suite, restez appuyé sur la touche majuscule ⇧ et tapez la première lettre, puis la deuxième, etc.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "09878916-177a-432b-99d0-54d85dfc2293",
-            "type": "separator"
-          }
+          "id": "29637152-3aed-4491-a7b9-ffa823b51799",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f27292d8-b444-41ca-ad80-165307e201d6",
+                "type": "text",
+                "content": "<p>Passons à la pratique ! <span aria-hidden=\"true\">⌨️</span></p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e7cd9a3d-1632-41e8-82ce-b41995b8ca36",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/odFZeVB.png",
-            "alt": "Schéma d'un clavier, les deux touches majuscules sont en couleur.",
-            "alternativeText": "<p>Il y a deux touches majuscules sur le clavier, une à gauche, et une à droite. Chacune comporte le symbole d'une flèche vers le haut.</p>",
-            "legend": "",
-            "licence": ""
-          }
+          "id": "409aa009-7bd9-4202-b00e-5537ceb5e9e7",
+          "type": "activity",
+          "title": "Saisie des lettres majuscules",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3b6efd13-0d4d-461c-a61a-15a58b46383a",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-majuscules/index.html",
+                "instruction": "<p><strong>Tapez chaque prénom ci-dessous avec une majuscule :</strong></p>",
+                "height": 445
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6764fe09-6a2f-47a1-b368-f9083a9e0a26",
-            "type": "text",
-            "content": "<p>La <strong>touche majuscule ⇧</strong> du clavier permet de taper des lettres majuscules.</p><p><br><strong><span aria-hidden=\"true\">💡</span>&nbsp;Astuce</strong><br>Sur la touche majuscule ⇧ il y a souvent une flèche vers le haut. On peut dire que c’est la touche qui fait grandir les lettres.</p>"
-          }
+          "id": "dae05a47-56b1-43e1-8562-99d2ea8fab6c",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0d51136f-1054-4185-bce9-6abb15d10abd",
+                "type": "text",
+                "content": "<p>Vous savez maintenant que la touche majuscule sert à taper des lettres en majuscules. Elle peut aussi servir à taper d’autres caractères.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "ba22f122-cb11-4b2d-bb9d-a153ae9472b7",
-            "type": "separator"
-          }
+          "id": "b66ba0b8-ea0b-4fc2-b80e-9fc23854d735",
+          "type": "lesson",
+          "title": "La touche Maj pour les caractères spéciaux",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "422c00a6-3220-4e15-9f2b-f045298eaf0c",
+                "type": "text",
+                "content": "<p>Sur certaines touches, il n’y a qu’un seul caractère. <br>Sur d’autres touches, il peut y avoir 2 ou même 3 caractères. <br>La<strong> touche majuscule&nbsp;⇧</strong> permet de taper le <strong>caractère situé en haut des touches</strong>, comme par exemple les chiffres.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8825fd1b-f7d3-4ace-bf5e-8637f8c308e4",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/54F0jFf.jpeg",
+                "alt": "Schéma d'une touche comportant deux caractères. ",
+                "alternativeText": "<ul><li>Quand on appuie sur cette touche en appuyant en même temps sur la touche Majuscule, c'est le 1 (qui est présent en haut de la touche) qui est tapé à l'écran.</li><li>Quand on appuie seulement sur cette touche, c'est le &amp; (qui est présent en bas de la touche) qui est tapé à l'écran.</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "02d17109-d2df-4b5f-83a0-dde1f1fd4e8b",
+                "type": "text",
+                "content": "<p>Comme pour les lettres majuscules, pour taper le caractère du haut d’une touche, restez appuyé sur la<strong> touche majuscule ⇧ </strong>et appuyez sur la touche du caractère.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "27c7290b-825a-4ee6-ab05-2cbab46a891f",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/AJIoLZu.jpeg",
+                "alt": "Dessin d'un clavier, une main appuie sur la touche majuscule, l'autre sur la touche du point d'interrogation et de la virgule.",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "863077ce-8e5e-438a-b82f-2b4afc723ef0",
+                "type": "expand",
+                "title": "🤔 Bon à savoir",
+                "content": "<p>Certains claviers ont un pavé numérique à droite des flèches directionnelles. Le pavé numérique contient des touches supplémentaires avec tous les chiffres. Vous pouvez l’utiliser pour taper les chiffres sans utiliser la touche majuscule.</p><img src=\"https://assets.pix.org/draft/modules/17380845144190712148.jpg\" alt=\"Clavier comprenant un pavé numérique\">"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "00987892-9248-401d-94a2-f9418c8ff5e6",
-            "type": "text",
-            "content": "<p>Par exemple, pour taper un P, gardez un doigt appuyé sur la <strong>touche majuscule ⇧</strong> et appuyez brièvement sur la touche P avec un autre doigt.</p><p><br>Dès que vous relâchez la touche majuscule ⇧, les lettres que vous tapez sont en minuscules.</p>"
-          }
+          "id": "070a4323-376f-474f-9c58-ae1363de774e",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4bbe20be-c9b0-41f3-bf95-fce480aa8348",
+                "type": "text",
+                "content": "<p>Grâce à la touche majuscule ⇧ , vous pouvez donc taper des caractères spéciaux, de la ponctuation et des chiffres. À vous d’essayer !</p>"
+              }
+            }
+          ]
         },
-        {
-          "type": "element",
-          "element": {
-            "id": "1eeb0af4-2f24-42fc-a051-8c0dc46ac17f",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/uO0tdrA.jpeg",
-            "alt": "Dessin d'un clavier, une main appuie sur majuscule, l'autre main appuie sur le touche P.",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "04fe4d77-15c4-475d-915f-ba04f69f9674",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">💡</span><strong> Astuce</strong><br>Pour taper plusieurs majuscules à la suite, restez appuyé sur la touche majuscule ⇧ et tapez la première lettre, puis la deuxième, etc.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "29637152-3aed-4491-a7b9-ffa823b51799",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f27292d8-b444-41ca-ad80-165307e201d6",
-            "type": "text",
-            "content": "<p>Passons à la pratique ! <span aria-hidden=\"true\">⌨️</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "409aa009-7bd9-4202-b00e-5537ceb5e9e7",
-      "type": "activity",
-      "title": "Saisie des lettres majuscules",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3b6efd13-0d4d-461c-a61a-15a58b46383a",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-majuscules/index.html",
-            "instruction": "<p><strong>Tapez chaque prénom ci-dessous avec une majuscule :</strong></p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "dae05a47-56b1-43e1-8562-99d2ea8fab6c",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0d51136f-1054-4185-bce9-6abb15d10abd",
-            "type": "text",
-            "content": "<p>Vous savez maintenant que la touche majuscule sert à taper des lettres en majuscules. Elle peut aussi servir à taper d’autres caractères.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b66ba0b8-ea0b-4fc2-b80e-9fc23854d735",
-      "type": "lesson",
-      "title": "La touche Maj pour les caractères spéciaux",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "422c00a6-3220-4e15-9f2b-f045298eaf0c",
-            "type": "text",
-            "content": "<p>Sur certaines touches, il n’y a qu’un seul caractère. <br>Sur d’autres touches, il peut y avoir 2 ou même 3 caractères. <br>La<strong> touche majuscule&nbsp;⇧</strong> permet de taper le <strong>caractère situé en haut des touches</strong>, comme par exemple les chiffres.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8825fd1b-f7d3-4ace-bf5e-8637f8c308e4",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/54F0jFf.jpeg",
-            "alt": "Schéma d'une touche comportant deux caractères. ",
-            "alternativeText": "<ul><li>Quand on appuie sur cette touche en appuyant en même temps sur la touche Majuscule, c'est le 1 (qui est présent en haut de la touche) qui est tapé à l'écran.</li><li>Quand on appuie seulement sur cette touche, c'est le &amp; (qui est présent en bas de la touche) qui est tapé à l'écran.</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "02d17109-d2df-4b5f-83a0-dde1f1fd4e8b",
-            "type": "text",
-            "content": "<p>Comme pour les lettres majuscules, pour taper le caractère du haut d’une touche, restez appuyé sur la<strong> touche majuscule ⇧ </strong>et appuyez sur la touche du caractère.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "27c7290b-825a-4ee6-ab05-2cbab46a891f",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/AJIoLZu.jpeg",
-            "alt": "Dessin d'un clavier, une main appuie sur la touche majuscule, l'autre sur la touche du point d'interrogation et de la virgule.",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "863077ce-8e5e-438a-b82f-2b4afc723ef0",
-            "type": "expand",
-            "title": "🤔 Bon à savoir",
-            "content": "<p>Certains claviers ont un pavé numérique à droite des flèches directionnelles. Le pavé numérique contient des touches supplémentaires avec tous les chiffres. Vous pouvez l’utiliser pour taper les chiffres sans utiliser la touche majuscule.</p><img src=\"https://assets.pix.org/draft/modules/17380845144190712148.jpg\" alt=\"Clavier comprenant un pavé numérique\">"
-          }
-        }
-      ]
-    },
-    {
-      "id": "070a4323-376f-474f-9c58-ae1363de774e",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4bbe20be-c9b0-41f3-bf95-fce480aa8348",
-            "type": "text",
-            "content": "<p>Grâce à la touche majuscule ⇧ , vous pouvez donc taper des caractères spéciaux, de la ponctuation et des chiffres. À vous d’essayer !</p>"
-          }
-        }
-      ]
-    },
 
-    {
-      "id": "d310a45d-b3e1-4875-9c8e-55d39368d039",
-      "type": "activity",
-      "title": "Saisie de caractères spéciaux et chiffres",
-      "components": [
         {
-          "type": "element",
-          "element": {
-            "id": "425252e0-7cf9-4031-8e28-6079d0d147a7",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/CqlU8D0.jpeg",
-            "alt": "la phrase \"Coucou, peux-tu mettre ces 3 pommes à cet endroit ?\" est écrite",
-            "alternativeText": "<p>Coucou, peux-tu mettre ces 3 pommes à cet endroit ?</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e9c4bdc5-dc03-49cd-9ee9-6527af8f52bc",
-            "type": "qrocm",
-            "instruction": "<p>Recopiez la phrase ci-dessus dans la zone de texte :</p>",
-            "proposals": [
-              {
-                "input": "pommes-la",
-                "type": "input",
-                "inputType": "text",
-                "size": 50,
-                "display": "inline",
-                "placeholder": "recopiez la phrase ",
-                "ariaLabel": "zone de saisie",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["Coucou, peux-tu mettre ces 3 pommes à cet endroit ?"]
+          "id": "d310a45d-b3e1-4875-9c8e-55d39368d039",
+          "type": "activity",
+          "title": "Saisie de caractères spéciaux et chiffres",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "425252e0-7cf9-4031-8e28-6079d0d147a7",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/CqlU8D0.jpeg",
+                "alt": "la phrase \"Coucou, peux-tu mettre ces 3 pommes à cet endroit ?\" est écrite",
+                "alternativeText": "<p>Coucou, peux-tu mettre ces 3 pommes à cet endroit ?</p>",
+                "legend": "",
+                "licence": ""
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse ! \uD83C\uDF4F\uD83C\uDF4F\uD83C\uDF4F",
-                "diagnosis": "<p>Bravo, vous maîtrisez la touche majuscule ⇧.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse. \uD83C\uDF4E\uD83C\uDF4E\uD83C\uDF4E",
-                "diagnosis": "<p>Pour taper les caractères spéciaux, faites bien attention à leur position sur la touche. Elle vous indique si vous avez besoin d’utiliser la touche majuscule ⇧.</p>"
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e9c4bdc5-dc03-49cd-9ee9-6527af8f52bc",
+                "type": "qrocm",
+                "instruction": "<p>Recopiez la phrase ci-dessus dans la zone de texte :</p>",
+                "proposals": [
+                  {
+                    "input": "pommes-la",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 50,
+                    "display": "inline",
+                    "placeholder": "recopiez la phrase ",
+                    "ariaLabel": "zone de saisie",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["Coucou, peux-tu mettre ces 3 pommes à cet endroit ?"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse ! \uD83C\uDF4F\uD83C\uDF4F\uD83C\uDF4F",
+                    "diagnosis": "<p>Bravo, vous maîtrisez la touche majuscule ⇧.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse. \uD83C\uDF4E\uD83C\uDF4E\uD83C\uDF4E",
+                    "diagnosis": "<p>Pour taper les caractères spéciaux, faites bien attention à leur position sur la touche. Elle vous indique si vous avez besoin d’utiliser la touche majuscule ⇧.</p>"
+                  }
+                }
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "b9e9ca6d-2c23-47b5-8f60-f121daf061c9",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "75652d09-9acc-4e3d-9af8-2c12b63fba2a",
-            "type": "text",
-            "content": "<p>Sur certaines touches, il y a 3 caractères. Pour taper le 3ème caractère, apprenez à utiliser la touche Alt Gr.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6c6d1b74-2d4f-4939-8318-038c1bd56bc0",
-      "type": "lesson",
-      "title": "La touche Alt Gr ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c85c5493-3d5a-4665-b835-48310caa4d1d",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/dcAPp7x.png",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "2852b780-a88f-4142-84b4-c575ef63201d",
-            "type": "text",
-            "content": "<p>La <strong>touche Alt&nbsp;Gr</strong> permet de faire apparaître les caractères situés en bas à droite des touches. Elle s’utilise de la même manière que la touche majuscule.</p>"
-          }
+          "id": "b9e9ca6d-2c23-47b5-8f60-f121daf061c9",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "75652d09-9acc-4e3d-9af8-2c12b63fba2a",
+                "type": "text",
+                "content": "<p>Sur certaines touches, il y a 3 caractères. Pour taper le 3ème caractère, apprenez à utiliser la touche Alt Gr.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "172ad359-9878-4308-940a-5cdf64019769",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/XbaDcLl.jpeg",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
+          "id": "6c6d1b74-2d4f-4939-8318-038c1bd56bc0",
+          "type": "lesson",
+          "title": "La touche Alt Gr ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c85c5493-3d5a-4665-b835-48310caa4d1d",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/dcAPp7x.png",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2852b780-a88f-4142-84b4-c575ef63201d",
+                "type": "text",
+                "content": "<p>La <strong>touche Alt&nbsp;Gr</strong> permet de faire apparaître les caractères situés en bas à droite des touches. Elle s’utilise de la même manière que la touche majuscule.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "172ad359-9878-4308-940a-5cdf64019769",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/XbaDcLl.jpeg",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "423d899e-e24d-4666-8f74-17c137279122",
+                "type": "text",
+                "content": "<p>Pour taper le caractère situé en bas à droite sur la touche, maintenez appuyée la <strong>touche Alt&nbsp;Gr</strong> et appuyez sur la touche du caractère.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6c7f82e6-5630-4f60-bf6d-a5509e1247ca",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/LnTMLS7.jpeg",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "423d899e-e24d-4666-8f74-17c137279122",
-            "type": "text",
-            "content": "<p>Pour taper le caractère situé en bas à droite sur la touche, maintenez appuyée la <strong>touche Alt&nbsp;Gr</strong> et appuyez sur la touche du caractère.</p>"
-          }
+          "id": "2b527198-0ab0-45d6-8121-da0a3646b8f9",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "69e777c2-9c22-462a-aefd-b159c060b6a1",
+                "type": "text",
+                "content": "<p>Entraînez-vous à utiliser la touche Alt Gr.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6c7f82e6-5630-4f60-bf6d-a5509e1247ca",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/LnTMLS7.jpeg",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "2b527198-0ab0-45d6-8121-da0a3646b8f9",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "69e777c2-9c22-462a-aefd-b159c060b6a1",
-            "type": "text",
-            "content": "<p>Entraînez-vous à utiliser la touche Alt Gr.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e9f19af6-b3ca-4f95-ad64-88d46d23c2ad",
-      "type": "activity",
-      "title": "Saisie de caractères  grâce à Alt Gr",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d74e4428-accc-44c4-b206-105d4dee8e12",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-AltGr/index.html",
-            "instruction": "<p><strong>Dans la zone ci-dessous, tapez les caractères demandés grâce à la touche Alt Gr :</strong></p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "326e811c-76b8-470c-99d6-2c0209cf8685",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "baef48f2-8a7f-4f65-a5bc-d66c6846968a",
-            "type": "text",
-            "content": "<p>À vous de mettre en pratique tout ce que vous avez vu dans ce module.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0946703d-89bc-4692-ab7c-928d3bbe72bc",
-      "type": "challenge",
-      "title": "Défi Formulaire",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ba5be535-ee02-4cc9-bc1b-1fdcbc2ccbb3",
-            "type": "text",
-            "content": "<p>Voici la carte d’identité de Jean-Tobias Piéchaud.</p>"
-          }
+          "id": "e9f19af6-b3ca-4f95-ad64-88d46d23c2ad",
+          "type": "activity",
+          "title": "Saisie de caractères  grâce à Alt Gr",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d74e4428-accc-44c4-b206-105d4dee8e12",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-AltGr/index.html",
+                "instruction": "<p><strong>Dans la zone ci-dessous, tapez les caractères demandés grâce à la touche Alt Gr :</strong></p>",
+                "height": 445
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "2db48eb5-d71e-4050-9aeb-0aab60d10da6",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/dH03MS3.png",
-            "alt": "Carte d'identité de Jean-Tobias Piéchaud",
-            "alternativeText": "<p>Carte d'identité contenant les informations suivantes :</p><ul><li>Piéchaud, </li><li>Jean-Tobias </li><li>26/03/1984</li><li>téléphone : 06 39 98 12 74</li><li>mail : j-t.piechaud@pixmail.org</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
+          "id": "326e811c-76b8-470c-99d6-2c0209cf8685",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "baef48f2-8a7f-4f65-a5bc-d66c6846968a",
+                "type": "text",
+                "content": "<p>À vous de mettre en pratique tout ce que vous avez vu dans ce module.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "91ea00c7-05aa-40b4-a7d3-f7f17a0f00c5",
-            "type": "embed",
-            "isCompletionRequired": true,
-            "title": "Formulaire",
-            "url": "https://epreuves.pix.fr/fr/formulaire_inscription.html",
-            "instruction": "<p>Remplissez le formulaire ci-dessous avec les informations concernant Jean-Tobias puis cliquez sur envoyer.</p>",
-            "solution": "toto",
-            "height": 400
-          }
-        }
-      ]
-    },
-    {
-      "id": "9cb0df04-c9bd-41a8-9cdc-063099b9ddfb",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e9e14b7b-9ef5-442d-9f30-e10cda3ec5c7",
-            "type": "text",
-            "content": "<p>Résumons l'essentiel. <span aria-hidden=\"true\">🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "bf9b4d7e-5d6a-4fc9-9f63-0bfc71d18982",
-      "type": "summary",
-      "title": "Recap schéma d'une touche",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "185a37d3-64dd-48e0-92b0-470bd34b4e9f",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📌</span> Pour savoir comment taper un caractère, il faut connaître <strong>sa position sur la touche</strong>&nbsp;:</p>"
-          }
+          "id": "0946703d-89bc-4692-ab7c-928d3bbe72bc",
+          "type": "challenge",
+          "title": "Défi Formulaire",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ba5be535-ee02-4cc9-bc1b-1fdcbc2ccbb3",
+                "type": "text",
+                "content": "<p>Voici la carte d’identité de Jean-Tobias Piéchaud.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2db48eb5-d71e-4050-9aeb-0aab60d10da6",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/dH03MS3.png",
+                "alt": "Carte d'identité de Jean-Tobias Piéchaud",
+                "alternativeText": "<p>Carte d'identité contenant les informations suivantes :</p><ul><li>Piéchaud, </li><li>Jean-Tobias </li><li>26/03/1984</li><li>téléphone : 06 39 98 12 74</li><li>mail : j-t.piechaud@pixmail.org</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "91ea00c7-05aa-40b4-a7d3-f7f17a0f00c5",
+                "type": "embed",
+                "isCompletionRequired": true,
+                "title": "Formulaire",
+                "url": "https://epreuves.pix.fr/fr/formulaire_inscription.html",
+                "instruction": "<p>Remplissez le formulaire ci-dessous avec les informations concernant Jean-Tobias puis cliquez sur envoyer.</p>",
+                "solution": "toto",
+                "height": 400
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "c90b7a08-fbc8-4f6a-bd94-8bab7e5a809e",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/ta6lSjJ.jpeg",
-            "alt": "",
-            "alternativeText": "<ul><li>Pour taper un caractère en haut de la touche, il faut appuyer sur la touche majuscule ⇧ en même temps que la touche du caractère.</li><li>Pour taper un caractère en bas à gauche de la touche, il faut uniquement appuyer sur la touche du caractère.</li><li>Pour taper un caractère en bas à droite de la touche,&nbsp; il faut appuyer sur la touche Alt Gr en même temps que la touche du caractère.</li><li>Pour taper une majuscule, il faut appuyer sur la touche majuscule ⇧ en même temps que la touche lettre.</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
+          "id": "9cb0df04-c9bd-41a8-9cdc-063099b9ddfb",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e9e14b7b-9ef5-442d-9f30-e10cda3ec5c7",
+                "type": "text",
+                "content": "<p>Résumons l'essentiel. <span aria-hidden=\"true\">🎯</span></p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e51added-60dc-453b-98ed-b3230711155e",
-            "type": "text",
-            "content": "<p>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-2/pix-fiche-revision-premieres-marches-clavier-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c9a94569-94e5-433c-a7f7-23a505dc7cf1",
-      "type": "transition",
-      "title": "",
-      "components": [
+          "id": "bf9b4d7e-5d6a-4fc9-9f63-0bfc71d18982",
+          "type": "summary",
+          "title": "Recap schéma d'une touche",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "185a37d3-64dd-48e0-92b0-470bd34b4e9f",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">📌</span> Pour savoir comment taper un caractère, il faut connaître <strong>sa position sur la touche</strong>&nbsp;:</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c90b7a08-fbc8-4f6a-bd94-8bab7e5a809e",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/ta6lSjJ.jpeg",
+                "alt": "",
+                "alternativeText": "<ul><li>Pour taper un caractère en haut de la touche, il faut appuyer sur la touche majuscule ⇧ en même temps que la touche du caractère.</li><li>Pour taper un caractère en bas à gauche de la touche, il faut uniquement appuyer sur la touche du caractère.</li><li>Pour taper un caractère en bas à droite de la touche,&nbsp; il faut appuyer sur la touche Alt Gr en même temps que la touche du caractère.</li><li>Pour taper une majuscule, il faut appuyer sur la touche majuscule ⇧ en même temps que la touche lettre.</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e51added-60dc-453b-98ed-b3230711155e",
+                "type": "text",
+                "content": "<p>📝&nbsp;Vous pouvez maintenant&nbsp;<a href=\"https://assets.pix.org/modules/bases-clavier-ordinateur-2/pix-fiche-revision-premieres-marches-clavier-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a></p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "17b65b49-03cf-4626-a651-dc6372c107ba",
-            "type": "text",
-            "content": "<p>Pour explorer les différentes touches, testez-vous dans ce mini-jeu.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "5ddc7207-feb0-494f-b32b-a33eb162e5f3",
-      "type": "activity",
-      "title": "Mini jeu",
-      "components": [
+          "id": "c9a94569-94e5-433c-a7f7-23a505dc7cf1",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "17b65b49-03cf-4626-a651-dc6372c107ba",
+                "type": "text",
+                "content": "<p>Pour explorer les différentes touches, testez-vous dans ce mini-jeu.</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "0f0010c2-b794-49d3-9182-f813e416d317",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-jeuautomatisationtimerlong/index.html",
-            "instruction": "<p><strong>Dans l'espace ci-dessous, pour chaque niveau, tapez les caractères à l’écran dans la zone de texte pour les faire disparaître avant le temps imparti.</strong></p>",
-            "height": 445
-          }
+          "id": "5ddc7207-feb0-494f-b32b-a33eb162e5f3",
+          "type": "activity",
+          "title": "Mini jeu",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0f0010c2-b794-49d3-9182-f813e416d317",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clavier2-jeuautomatisationtimerlong/index.html",
+                "instruction": "<p><strong>Dans l'espace ci-dessous, pour chaque niveau, tapez les caractères à l’écran dans la zone de texte pour les faire disparaître avant le temps imparti.</strong></p>",
+                "height": 445
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -15,532 +15,538 @@
       "Écrire une adresse mail correctement, en évitant les erreurs courantes"
     ]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "1b4f26d7-365d-43e4-9621-5846fba7e342",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "463873cc-1060-4556-9fdb-d402239b79f2",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "91e6c6bb-4287-4184-8860-086277fd6a31",
-            "type": "text",
-            "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9",
-      "type": "discovery",
-      "title": "Sûr de ton adresse mail ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2ef9874d-e137-40e0-bc64-1210ff66b9c0",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Conversation entre Naomi et Mickaël à propos d’une adresse mail",
-              "messages": [
-                {
-                  "userName": "Naomi",
-                  "direction": "outgoing",
-                  "content": "Salut, tu peux me redonner ton adresse mail stp ? 😇"
-                },
-                {
-                  "userName": "Mickaël",
-                  "direction": "incoming",
-                  "content": "Oui, c’est mickael.aubert123#laposte.net"
-                },
-                {
-                  "userName": "Naomi",
-                  "direction": "outgoing",
-                  "content": "T’es sûr ? 😬"
-                },
-                {
-                  "userName": "Naomi",
-                  "direction": "outgoing",
-                  "content": "Tu veux dire mickael.aubert123@laposte.net"
-                },
-                {
-                  "userName": "Mickaël",
-                  "direction": "incoming",
-                  "content": "Ah oui désolé ! 😣"
-                },
-                {
-                  "userName": "Mickaël",
-                  "direction": "incoming",
-                  "content": "comment tu as su ? "
-                },
-                {
-                  "userName": "Naomi",
-                  "direction": "outgoing",
-                  "content": "Dans une adresse mail, il y a toujours le symbole arobase !"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "4d9f3000-e60f-4984-ac2e-30e69264e617",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "07246ad5-e460-4266-b006-65bb6ddb181f",
-            "type": "text",
-            "content": "<p>Eh oui&#8239;! Naomi le sait&nbsp;: toutes les adresses mail ont le même format.</p><p>Nous allons étudier en détail l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🔎</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "af860b1e-0566-4b06-bcb4-a68a5151d621",
-      "type": "lesson",
-      "title": "Explications : les parties d’une adresse mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "acf16c79-b788-4ebe-b7a1-4138eef3db2f",
-            "type": "text",
-            "content": "<p>Après cette leçon, vous devrez répondre à des questions sur les différentes parties de l'adresse mail.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "1b4f26d7-365d-43e4-9621-5846fba7e342",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
-                  "type": "text",
-                  "content": "<p>L'adresse mail de Mickaël est <strong>mickael.aubert123@laposte.net</strong>.<br>Cette adresse est composée de <strong>deux parties</strong> et d'<strong>un séparateur</strong> au centre.</p>"
-                },
-                {
-                  "id": "167907eb-ee0d-4de0-9fc8-609b2b62ed9f",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg",
-                  "alt": "Schéma de la syntaxe d’une adresse mail décrit dans l’alternative textuelle",
-                  "alternativeText": "<ul><li>Partie 1&nbsp;: identifiant, exemple&nbsp;: mickael.aubert123</li><li>Séparateur&nbsp;: Arobase</li><li>Partie 2&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "40a6e8a8-e92b-4e96-80e8-b74971a0c285",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/lLEwbG6.png",
-                  "alt": "Première partie, décrite dans l'alternative textuelle",
-                  "alternativeText": "Partie 1&nbsp;: Identifiant, exemple&nbsp;: mickael.aubert123"
-                },
-                {
-                  "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
-                  "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "9ccbf056-fd7f-4478-96c7-a7520fbe01b6",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/FAxBAds.png",
-                  "alt": "Séparateur décrit dans l'alternative textuelle",
-                  "alternativeText": "Séparateur&nbsp;: Arobase"
-                },
-                {
-                  "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
-                  "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h4><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "bbbdeea8-f9c1-4c6f-9061-d85f9a78cf3c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/SIsWHfL.png",
-                  "alt": "Partie 2, décrite dans l'alternative textuelle",
-                  "alternativeText": "Partie 2&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net"
-                },
-                {
-                  "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
-                  "type": "text",
-                  "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "08750660-c33d-4ca3-b1ed-34facec20a01",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f10c972d-ec3e-45e7-a9fd-91cbf00edbdc",
-            "type": "text",
-            "content": "<p>Récapitulons ensemble avec quelques questions. <span aria-hidden=\"true\">🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "edd7fec3-a649-425b-b8e3-65b13c6c47ea",
-      "type": "activity",
-      "title": "Les parties d’une adresse mail : applications",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
-                  "type": "qrocm",
-                  "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail&#8239;?</p>",
-                  "proposals": [
-                    {
-                      "type": "text",
-                      "content": "<span>Symbole&nbsp;:</span>"
-                    },
-                    {
-                      "input": "symbole",
-                      "type": "input",
-                      "inputType": "text",
-                      "size": 3,
-                      "display": "inline",
-                      "placeholder": "",
-                      "ariaLabel": "Réponse 1 sur 1",
-                      "defaultValue": "",
-                      "tolerances": ["t1"],
-                      "solutions": ["@"]
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse !&nbsp;🎉",
-                      "diagnosis": ""
-                    },
-                    "invalid": {
-                      "state": "Mauvaise réponse.",
-                      "diagnosis": "<p>Pour réussir la prochaine fois, remontez voir la leçon ou utilisez l'indice ci-dessous.</p>"
-                    }
-                  }
-                },
-                {
-                  "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "2789cba3-02f5-4c89-8b1c-187e291db8f7",
-                  "type": "qrocm",
-                  "instruction": "<p>Quelles sont les deux parties d'une adresse mail&nbsp;?</p>",
-                  "proposals": [
-                    {
-                      "type": "text",
-                      "content": "<span>Partie 1&nbsp;:</span>"
-                    },
-                    {
-                      "input": "premiere-partie",
-                      "type": "select",
-                      "display": "inline",
-                      "placeholder": "- Sélectionner -",
-                      "ariaLabel": "Réponse 1 sur 2",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "options": [
-                        {
-                          "id": "3",
-                          "content": "le séparateur"
-                        },
-                        {
-                          "id": "1",
-                          "content": "l'identifiant"
-                        },
-                        {
-                          "id": "2",
-                          "content": "le fournisseur d'adresse mail"
-                        }
-                      ],
-                      "solutions": ["1"]
-                    },
-                    {
-                      "type": "text",
-                      "content": "<br><span>Partie 2&nbsp;:</span>"
-                    },
-                    {
-                      "input": "seconde-partie",
-                      "type": "select",
-                      "display": "inline",
-                      "placeholder": "- Sélectionner -",
-                      "ariaLabel": "Réponse 2 sur 2",
-                      "defaultValue": "",
-                      "tolerances": [],
-                      "options": [
-                        {
-                          "id": "3",
-                          "content": "le séparateur"
-                        },
-                        {
-                          "id": "1",
-                          "content": "l'identifiant"
-                        },
-                        {
-                          "id": "2",
-                          "content": "le fournisseur d'adresse mail"
-                        }
-                      ],
-                      "solutions": ["2"]
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "Bonne réponse&#8239;!&nbsp;🎉",
-                      "diagnosis": "<p>Vous avez retrouvé le bon format d’une adresse mail.</p>"
-                    },
-                    "invalid": {
-                      "state": "Mauvaise réponse&#8239;!",
-                      "diagnosis": "<p>Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "71792e45-966a-4070-b4fc-9e8a773c3f6f",
-      "type": "activity",
-      "title": "Diversité des identifiants et des fournisseurs d’adresse mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2f4794e7-f5f1-4cb6-8b4f-08f4e64b8aa5",
-            "type": "text",
-            "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "ba78dead-a806-4954-b408-e8ef28d28fab",
-                  "type": "qcu",
-                  "instruction": "<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse&#8239;! 🎉",
-                        "diagnosis": "<p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse",
-                        "diagnosis": "<p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "4231af7b-dca5-4d79-acfe-b485e0127ae1",
-                  "type": "qcu",
-                  "instruction": "<p>Il y a toujours un symbole @ dans une adresse mail.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse&#8239;!&nbsp;🎉",
-                        "diagnosis": "<p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse",
-                        "diagnosis": "<p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "9bd65c37-ea5d-49a9-a59c-4e07ab3f1049",
-                  "type": "qcu",
-                  "instruction": "<p>Toutes les adresses mail se terminent par <code>gmail.com</code>.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse",
-                        "diagnosis": "<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Bonne réponse&#8239;!&nbsp;🎉",
-                        "diagnosis": "<p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "845fe6d7-7ac5-46bb-a5d6-0419148b3978",
-                  "type": "qcu",
-                  "instruction": "<p>Mickaël et Naomi peuvent avoir le même identifiant et le même fournisseur d'adresse mail.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse",
-                        "diagnosis": "<p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Bonne réponse&#8239;!&nbsp;🎉",
-                        "diagnosis": "<p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "d54142a3-43df-4bde-b1a3-8a795384f428",
-      "type": "summary",
-      "title": "Diversité des identifiants et des fournisseurs d’adresse mail : synthèse",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "398fe343-68a4-4d14-a24c-a96ef36f1c4b",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a6b72df3-ec21-4b7a-81a0-f6864b2f93e9",
-            "type": "text",
-            "content": "<p>Pour finir, à vous de jouer : vous allez devoir trouver l'adresse mail de Naomi. <span aria-hidden=\"true\">💫</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b7ea7630-824a-4a49-83d1-abb9b8d0d120",
-      "type": "challenge",
-      "title": "Écrire une adresse mail correctement",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8709ad92-093e-447a-a7b6-3223e6171196",
-            "type": "qrocm",
-            "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes&nbsp;:</p><ul><li>son identifiant est <code>naomizao457</code></li><li>son fournisseur d’adresse mail est Yahoo</li></ul>",
-            "proposals": [
-              {
+              "type": "element",
+              "element": {
+                "id": "91e6c6bb-4287-4184-8860-086277fd6a31",
                 "type": "text",
-                "content": "<span>Adresse mail de Naomi&nbsp;:</span>"
-              },
-              {
-                "input": "email",
-                "type": "input",
-                "inputType": "text",
-                "size": 20,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Adresse mail de Naomi",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["naomizao457@yahoo.com", "naomizao457@yahoo.fr"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bravo !&nbsp;\uD83D\uDCAB",
-                "diagnosis": "<p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
+                "content": "<p>Naomi veut envoyer un document par mail à son ami Mickaël.<br>Mais, Naomi ne trouve plus l'adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br>Elle décide de lui demander par message.</p>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre est l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
-          }
+          "id": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9",
+          "type": "discovery",
+          "title": "Sûr de ton adresse mail ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2ef9874d-e137-40e0-bc64-1210ff66b9c0",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Conversation entre Naomi et Mickaël à propos d’une adresse mail",
+                  "messages": [
+                    {
+                      "userName": "Naomi",
+                      "direction": "outgoing",
+                      "content": "Salut, tu peux me redonner ton adresse mail stp ? 😇"
+                    },
+                    {
+                      "userName": "Mickaël",
+                      "direction": "incoming",
+                      "content": "Oui, c’est mickael.aubert123#laposte.net"
+                    },
+                    {
+                      "userName": "Naomi",
+                      "direction": "outgoing",
+                      "content": "T’es sûr ? 😬"
+                    },
+                    {
+                      "userName": "Naomi",
+                      "direction": "outgoing",
+                      "content": "Tu veux dire mickael.aubert123@laposte.net"
+                    },
+                    {
+                      "userName": "Mickaël",
+                      "direction": "incoming",
+                      "content": "Ah oui désolé ! 😣"
+                    },
+                    {
+                      "userName": "Mickaël",
+                      "direction": "incoming",
+                      "content": "comment tu as su ? "
+                    },
+                    {
+                      "userName": "Naomi",
+                      "direction": "outgoing",
+                      "content": "Dans une adresse mail, il y a toujours le symbole arobase !"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "4d9f3000-e60f-4984-ac2e-30e69264e617",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "07246ad5-e460-4266-b006-65bb6ddb181f",
+                "type": "text",
+                "content": "<p>Eh oui&#8239;! Naomi le sait&nbsp;: toutes les adresses mail ont le même format.</p><p>Nous allons étudier en détail l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">🔎</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "af860b1e-0566-4b06-bcb4-a68a5151d621",
+          "type": "lesson",
+          "title": "Explications : les parties d’une adresse mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "acf16c79-b788-4ebe-b7a1-4138eef3db2f",
+                "type": "text",
+                "content": "<p>Après cette leçon, vous devrez répondre à des questions sur les différentes parties de l'adresse mail.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
+                      "type": "text",
+                      "content": "<p>L'adresse mail de Mickaël est <strong>mickael.aubert123@laposte.net</strong>.<br>Cette adresse est composée de <strong>deux parties</strong> et d'<strong>un séparateur</strong> au centre.</p>"
+                    },
+                    {
+                      "id": "167907eb-ee0d-4de0-9fc8-609b2b62ed9f",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg",
+                      "alt": "Schéma de la syntaxe d’une adresse mail décrit dans l’alternative textuelle",
+                      "alternativeText": "<ul><li>Partie 1&nbsp;: identifiant, exemple&nbsp;: mickael.aubert123</li><li>Séparateur&nbsp;: Arobase</li><li>Partie 2&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net</li></ul>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "40a6e8a8-e92b-4e96-80e8-b74971a0c285",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/lLEwbG6.png",
+                      "alt": "Première partie, décrite dans l'alternative textuelle",
+                      "alternativeText": "Partie 1&nbsp;: Identifiant, exemple&nbsp;: mickael.aubert123"
+                    },
+                    {
+                      "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
+                      "type": "text",
+                      "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9ccbf056-fd7f-4478-96c7-a7520fbe01b6",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/FAxBAds.png",
+                      "alt": "Séparateur décrit dans l'alternative textuelle",
+                      "alternativeText": "Séparateur&nbsp;: Arobase"
+                    },
+                    {
+                      "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
+                      "type": "text",
+                      "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h4><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "bbbdeea8-f9c1-4c6f-9061-d85f9a78cf3c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/SIsWHfL.png",
+                      "alt": "Partie 2, décrite dans l'alternative textuelle",
+                      "alternativeText": "Partie 2&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net"
+                    },
+                    {
+                      "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
+                      "type": "text",
+                      "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "08750660-c33d-4ca3-b1ed-34facec20a01",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f10c972d-ec3e-45e7-a9fd-91cbf00edbdc",
+                "type": "text",
+                "content": "<p>Récapitulons ensemble avec quelques questions. <span aria-hidden=\"true\">🎯</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "edd7fec3-a649-425b-b8e3-65b13c6c47ea",
+          "type": "activity",
+          "title": "Les parties d’une adresse mail : applications",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
+                      "type": "qrocm",
+                      "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "type": "text",
+                          "content": "<span>Symbole&nbsp;:</span>"
+                        },
+                        {
+                          "input": "symbole",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 3,
+                          "display": "inline",
+                          "placeholder": "",
+                          "ariaLabel": "Réponse 1 sur 1",
+                          "defaultValue": "",
+                          "tolerances": ["t1"],
+                          "solutions": ["@"]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse !&nbsp;🎉",
+                          "diagnosis": ""
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse.",
+                          "diagnosis": "<p>Pour réussir la prochaine fois, remontez voir la leçon ou utilisez l'indice ci-dessous.</p>"
+                        }
+                      }
+                    },
+                    {
+                      "id": "e494d292-21a8-4b33-affa-96763dbe10e6",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'<strong>aide pour écrire ce symbole</strong>, cliquez sur l'indice ci-dessous&nbsp;:</p><details><summary>Indice</summary>Pour écrire le symbole arobase,<ul><li>sur PC, appuyez et maintenez la touche <code>Alt Gr</code> puis appuyez sur la touche <code>à</code> (même touche que le 0)</li><li>sur Mac, appuyez sur la touche @ déjà prévue, en haut à gauche (même touche que #)</li></ul></details>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "2789cba3-02f5-4c89-8b1c-187e291db8f7",
+                      "type": "qrocm",
+                      "instruction": "<p>Quelles sont les deux parties d'une adresse mail&nbsp;?</p>",
+                      "proposals": [
+                        {
+                          "type": "text",
+                          "content": "<span>Partie 1&nbsp;:</span>"
+                        },
+                        {
+                          "input": "premiere-partie",
+                          "type": "select",
+                          "display": "inline",
+                          "placeholder": "- Sélectionner -",
+                          "ariaLabel": "Réponse 1 sur 2",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "options": [
+                            {
+                              "id": "3",
+                              "content": "le séparateur"
+                            },
+                            {
+                              "id": "1",
+                              "content": "l'identifiant"
+                            },
+                            {
+                              "id": "2",
+                              "content": "le fournisseur d'adresse mail"
+                            }
+                          ],
+                          "solutions": ["1"]
+                        },
+                        {
+                          "type": "text",
+                          "content": "<br><span>Partie 2&nbsp;:</span>"
+                        },
+                        {
+                          "input": "seconde-partie",
+                          "type": "select",
+                          "display": "inline",
+                          "placeholder": "- Sélectionner -",
+                          "ariaLabel": "Réponse 2 sur 2",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "options": [
+                            {
+                              "id": "3",
+                              "content": "le séparateur"
+                            },
+                            {
+                              "id": "1",
+                              "content": "l'identifiant"
+                            },
+                            {
+                              "id": "2",
+                              "content": "le fournisseur d'adresse mail"
+                            }
+                          ],
+                          "solutions": ["2"]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Bonne réponse&#8239;!&nbsp;🎉",
+                          "diagnosis": "<p>Vous avez retrouvé le bon format d’une adresse mail.</p>"
+                        },
+                        "invalid": {
+                          "state": "Mauvaise réponse&#8239;!",
+                          "diagnosis": "<p>Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "71792e45-966a-4070-b4fc-9e8a773c3f6f",
+          "type": "activity",
+          "title": "Diversité des identifiants et des fournisseurs d’adresse mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2f4794e7-f5f1-4cb6-8b4f-08f4e64b8aa5",
+                "type": "text",
+                "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "ba78dead-a806-4954-b408-e8ef28d28fab",
+                      "type": "qcu",
+                      "instruction": "<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse&#8239;! 🎉",
+                            "diagnosis": "<p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse",
+                            "diagnosis": "<p>Cette adresse est correctement écrite.<br>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "4231af7b-dca5-4d79-acfe-b485e0127ae1",
+                      "type": "qcu",
+                      "instruction": "<p>Il y a toujours un symbole @ dans une adresse mail.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse&#8239;!&nbsp;🎉",
+                            "diagnosis": "<p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse",
+                            "diagnosis": "<p>Le symbole @ (arobase) permet de séparer l’identifiant et le fournisseur d’adresse. Il y donc toujours un arobase.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9bd65c37-ea5d-49a9-a59c-4e07ab3f1049",
+                      "type": "qcu",
+                      "instruction": "<p>Toutes les adresses mail se terminent par <code>gmail.com</code>.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse",
+                            "diagnosis": "<p>Il y a d’autres fournisseurs d’adresses mail que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Bonne réponse&#8239;!&nbsp;🎉",
+                            "diagnosis": "<p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y a en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "845fe6d7-7ac5-46bb-a5d6-0419148b3978",
+                      "type": "qcu",
+                      "instruction": "<p>Mickaël et Naomi peuvent avoir le même identifiant et le même fournisseur d'adresse mail.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse",
+                            "diagnosis": "<p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Bonne réponse&#8239;!&nbsp;🎉",
+                            "diagnosis": "<p>Une adresse mail est <strong>unique</strong>.<br>Au moment de la création d'une adresse mail, vous saurez si un identifiant est disponible ou pas.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "d54142a3-43df-4bde-b1a3-8a795384f428",
+          "type": "summary",
+          "title": "Diversité des identifiants et des fournisseurs d’adresse mail : synthèse",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "398fe343-68a4-4d14-a24c-a96ef36f1c4b",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a6b72df3-ec21-4b7a-81a0-f6864b2f93e9",
+                "type": "text",
+                "content": "<p>Pour finir, à vous de jouer : vous allez devoir trouver l'adresse mail de Naomi. <span aria-hidden=\"true\">💫</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b7ea7630-824a-4a49-83d1-abb9b8d0d120",
+          "type": "challenge",
+          "title": "Écrire une adresse mail correctement",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8709ad92-093e-447a-a7b6-3223e6171196",
+                "type": "qrocm",
+                "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes&nbsp;:</p><ul><li>son identifiant est <code>naomizao457</code></li><li>son fournisseur d’adresse mail est Yahoo</li></ul>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Adresse mail de Naomi&nbsp;:</span>"
+                  },
+                  {
+                    "input": "email",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 20,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Adresse mail de Naomi",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["naomizao457@yahoo.com", "naomizao457@yahoo.fr"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bravo !&nbsp;\uD83D\uDCAB",
+                    "diagnosis": "<p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre est l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -15,606 +15,612 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "538e03cd-7850-40e7-9017-008a2f2544f6",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "b77918a3-3c72-43d2-9f11-6b6a886b0e95",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "534dabf0-73dc-49a6-88f9-35bdc3b9e607",
-            "type": "text",
-            "content": "<p>Vous avez peut-être déjà utilisé des outils d'intelligence artificielle générative de texte, comme ChatGPT ou Copilot. Ces grands modèles de langage, <i>Large Language Models (LLM)</i> en anglais, peuvent être utiles pour produire des synthèses ou inventer des histoires.<span aria-hidden=\"true\">&nbsp;✒️ 💭</span></p><p>Pourtant, les textes produits contiennent parfois des maladresses ou des erreurs.<span aria-hidden=\"true\">&nbsp;❌</span> Commençons par un exemple concret&nbsp;!</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0bfa08bd-7052-49bb-89e8-150efa589926",
-      "type": "discovery",
-      "title": "Pris dans le filet !",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4b2aebb9-03eb-402f-9302-c305c3f84b1a",
-            "type": "text",
-            "content": "<p>Voici une conversation entre un utilisateur et ChatGPT.<br>La réponse de ce LLM est un peu décalée.<span aria-hidden=\"true\">&nbsp;😵‍💫</span></p>"
-          }
+          "id": "538e03cd-7850-40e7-9017-008a2f2544f6",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "534dabf0-73dc-49a6-88f9-35bdc3b9e607",
+                "type": "text",
+                "content": "<p>Vous avez peut-être déjà utilisé des outils d'intelligence artificielle générative de texte, comme ChatGPT ou Copilot. Ces grands modèles de langage, <i>Large Language Models (LLM)</i> en anglais, peuvent être utiles pour produire des synthèses ou inventer des histoires.<span aria-hidden=\"true\">&nbsp;✒️ 💭</span></p><p>Pourtant, les textes produits contiennent parfois des maladresses ou des erreurs.<span aria-hidden=\"true\">&nbsp;❌</span> Commençons par un exemple concret&nbsp;!</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e2c5ab9f-b834-4e34-b9e4-361c9942f5a5",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/K7nRw1Z.png",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "<ul><li><strong>Vous</strong><br>Peux-tu me faire un jeu de mots&nbsp;?</li><li><strong>ChatGPT</strong><br>Bien sûr&nbsp;! Voici un petit jeu de mots pour toi&nbsp;:<br>Pourquoi les poissons n'utilisent-ils pas d'ordinateurs&nbsp;?<br>Parce qu'ils ont peur du net&nbsp;!</li></ul>"
-          }
+          "id": "0bfa08bd-7052-49bb-89e8-150efa589926",
+          "type": "discovery",
+          "title": "Pris dans le filet !",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4b2aebb9-03eb-402f-9302-c305c3f84b1a",
+                "type": "text",
+                "content": "<p>Voici une conversation entre un utilisateur et ChatGPT.<br>La réponse de ce LLM est un peu décalée.<span aria-hidden=\"true\">&nbsp;😵‍💫</span></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e2c5ab9f-b834-4e34-b9e4-361c9942f5a5",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/K7nRw1Z.png",
+                "alt": "Dessin détaillé dans l'alternative textuelle",
+                "alternativeText": "<ul><li><strong>Vous</strong><br>Peux-tu me faire un jeu de mots&nbsp;?</li><li><strong>ChatGPT</strong><br>Bien sûr&nbsp;! Voici un petit jeu de mots pour toi&nbsp;:<br>Pourquoi les poissons n'utilisent-ils pas d'ordinateurs&nbsp;?<br>Parce qu'ils ont peur du net&nbsp;!</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "73144a95-d977-4f7c-90ce-1c59612b4654",
+                "type": "qcu",
+                "instruction": "<p>Ce jeu de mots ne semble pas réussi. Selon vous, pour quelle raison&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>ChatGPT n'a pas compris la demande de l'utilisateur.</p>",
+                    "feedback": {
+                      "state": "Incorrect&nbsp;!",
+                      "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>ChatGPT n’est pas capable de faire des jeux de mots drôles.</p>",
+                    "feedback": {
+                      "state": "Incorrect&nbsp;!",
+                      "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "ChatGPT n'a pas raté son jeu de mots : il est réussi mais en anglais.",
+                    "feedback": {
+                      "state": "Correct&nbsp;!",
+                      "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "73144a95-d977-4f7c-90ce-1c59612b4654",
-            "type": "qcu",
-            "instruction": "<p>Ce jeu de mots ne semble pas réussi. Selon vous, pour quelle raison&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>ChatGPT n'a pas compris la demande de l'utilisateur.</p>",
-                "feedback": {
-                  "state": "Incorrect&nbsp;!",
-                  "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>ChatGPT n’est pas capable de faire des jeux de mots drôles.</p>",
-                "feedback": {
-                  "state": "Incorrect&nbsp;!",
-                  "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "ChatGPT n'a pas raté son jeu de mots : il est réussi mais en anglais.",
-                "feedback": {
-                  "state": "Correct&nbsp;!",
-                  "diagnosis": "<p>Le mot \"net\" signifie \"filet\" en anglais, et les poissons font souvent tout pour les éviter !<span aria-hidden=\"true\">&nbsp;😉</span></p>"
-                }
+          "id": "2d7b7a89-6146-4880-9202-8d4b1270de12",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "61eff022-ce71-49f0-ad86-7bee5f7c9c0e",
+                "type": "text",
+                "content": "<p>Cette réponse en français de ChatGPT est biaisée. En effet, elle est influencée par ses données d'entraînement.<br>Ces données, récoltées en grande partie sur internet, sont majoritairement en anglais.</p><p>Dans la vidéo suivante, vous allez découvrir d’où proviennent les différents biais des LLM.<span aria-hidden=\"true\">&nbsp;📺</span></p>"
               }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2d7b7a89-6146-4880-9202-8d4b1270de12",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "61eff022-ce71-49f0-ad86-7bee5f7c9c0e",
-            "type": "text",
-            "content": "<p>Cette réponse en français de ChatGPT est biaisée. En effet, elle est influencée par ses données d'entraînement.<br>Ces données, récoltées en grande partie sur internet, sont majoritairement en anglais.</p><p>Dans la vidéo suivante, vous allez découvrir d’où proviennent les différents biais des LLM.<span aria-hidden=\"true\">&nbsp;📺</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c8722f6e-7534-4fdc-9f2d-515c2a96641f",
-      "type": "lesson",
-      "title": "D'où viennent les biais des LLM ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b510a523-dc46-44bc-9cef-7d254ddd5831",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, vous devrez&nbsp;: </p>\n<ul>\n    <li>retrouver les origines des biais des LLM,</li>\n    <li>interpréter des situations concrètes où la réponse d'un LLM est biaisée.</li>\n</ul>"
-          }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "35211b74-4a65-4eeb-8037-e41d8446d008",
-            "type": "video",
-            "title": "D'où viennent les biais des LLM&nbsp;?",
-            "url": "https://assets.pix.org/modules/chatgpt-parle-francais/biais-llm.mp4",
-            "poster": "https://assets.pix.org/draft/modules/ugkunY2.png",
-            "subtitles": "https://assets.pix.org/modules/chatgpt-parle-francais/biais-llm.srt",
-            "transcription": "<p>D'où viennent les biais des LLM ? <br>Joy Buolamwini est informaticienne et chercheuse. <br>En 2017, lors d’un projet universitaire, elle remarque que les logiciels de reconnaissance faciale ne détectent pas son visage. Joy teste alors ces logiciels sur son colocataire, un jeune homme blanc. Résultat : le visage du colocataire est bien détecté, contrairement à celui de Joy. <br>Ces logiciels ne reconnaissent pas le visage de Joy, du fait de sa couleur de peau. Mais pourquoi ? <br>Eh bien, ces logiciels étaient entraînés en analysant de grandes quantités de visages de personnes principalement blanches. Ces données d'entraînement ne correspondaient pas à la diversité de la réalité. Les logiciels avaient donc des biais liés à la couleur de peau. <br>En informatique, on dit qu’un algorithme présente un biais quand il y a une anomalie systématique dans ses résultats et que cette anomalie est difficile à identifier et à corriger. Les résultats d’un algorithme biaisé peuvent créer des discriminations, comme dans la situation de Joy. <br>De nos jours, les intelligences artificielles génératives, comme les grands modèles de langage, ou LLM, rencontrent les mêmes problèmes : les textes qu’ils produisent contiennent parfois des biais. Je vous explique tout ça en détail. <br>Actuellement, les LLM sont utilisés dans le monde entier par des personnes de cultures différentes. Les réponses qu’ils proposent peuvent avoir des biais, selon de nombreux facteurs : l'époque ; la culture ; la zone géographique ; etc. <br>Mais alors, d’où viennent les biais des LLM ? <br>Il y a 3 origines principales : <br>Les données d'entraînement des LLM sont la principale source de leurs biais. En effet, certains types de données peuvent être beaucoup plus présents que d’autres. On dit alors qu’il y a une surreprésentation de ces données. Par exemple, un LLM utilisé pour trier des CV pour un poste d’assistant ou d’assistante va privilégier des candidatures féminines. C'est un résultat qui comporte un biais de genre. Le LLM a en effet été entraîné avec des données de personnes qui exercent ce métier. Et, dans ce métier, les femmes sont surreprésentées. <br>Prenons un autre exemple. Un LLM utilisé pour imaginer un personnage de confiance propose la plupart du temps des personnages occidentaux, soignés, aux yeux clairs et qui portent des chemises. Ce résultat a un biais culturel : c’est un stéréotype occidental, qui ne propose pas de diversité. <br>Le code produit par les développeurs est la deuxième cause de biais des LLM. Comme tout le monde, les personnes qui développent les LLM ont des biais. Pendant la conception d’un LLM, les développeurs peuvent donc coder, consciemment ou non, leurs propres biais. En raccourci, si j’ai codé un LLM qui me dit que la meilleure glace est à la vanille et à la fraise mais que je préfère la glace à la vanille et au chocolat, je vais avoir tendance à affiner le modèle pour qu’il donne le résultat qui correspond à ma préférence. <br>Les développeurs peuvent aussi faire des réglages pour censurer certains résultats du modèle. Si je demande par exemple au LLM de Baidu, une entreprise chinoise, de me parler de la répression des manifestations de la place Tiananmen, il refusera de répondre à ma question. Ce sujet a été inscrit par ses développeurs comme sensible politiquement. <br>Enfin, la troisième origine des biais dans les LLM concerne les prompts des utilisateurs. Un utilisateur peut en effet poser à un LLM une question orientée, subjective, sans avoir conscience de ses propres biais. Par exemple : si je demande à un LLM pourquoi l’alimentation japonaise est la meilleure au monde, il va lister des explications toutes positives, sans nuancer, remettre en cause mon affirmation ou proposer d'autres types d'alimentation. Ce résultat va confirmer mes croyances : c'est un biais de confirmation. <br>Qu'ils proviennent des données d'entraînement, du développement des modèles ou des prompts proposés par les utilisateurs, les LLM peuvent présenter de nombreux biais… comme tout le monde. <br>À vous d'y prêter attention la prochaine fois que vous testerez ces outils. <br><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1cc63ed8-c51d-4dd2-94dd-78c9e591143a",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c6bc9ee2-7bd5-4433-932c-811803a7746a",
-            "type": "text",
-            "content": "<p>Vous en savez désormais plus sur les biais des LLM. <span aria-hidden=\"true\">👩‍💻️👨🏿‍💻️</span></p><p>Vérifiez que vous avez retenu l'essentiel avec cette question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "89dbbcf3-7205-470a-baf0-4aa4aac1a87e",
-      "type": "activity",
-      "title": "Les sources de biais des LLM",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "aef486da-4994-4992-b15b-b127afebb371",
-            "type": "qcm",
-            "instruction": "<p>Quelles sont les <strong>trois</strong> origines majeures des biais d'un LLM&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>les données d'entraînement</p>"
-              },
-              {
-                "id": "2",
-                "content": "<p>les langages de programmation</p>"
-              },
-              {
-                "id": "3",
-                "content": "<p>le code produit par les développeurs</p>"
-              },
-              {
-                "id": "4",
-                "content": "<p>la localisation des serveurs</p>"
-              },
-              {
-                "id": "5",
-                "content": "les prompts des utilisateurs"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct&nbsp;!",
-                "diagnosis": "<p>Parmi ces trois origines, les données d'entraînement sont la principale source des biais qui peuvent exister dans les résultats des LLM.</p>"
-              },
-              "invalid": {
-                "state": "Incorrect&nbsp;!",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Regardez bien la vidéo précédente et réessayez&nbsp;!</p>"
+          "id": "c8722f6e-7534-4fdc-9f2d-515c2a96641f",
+          "type": "lesson",
+          "title": "D'où viennent les biais des LLM ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b510a523-dc46-44bc-9cef-7d254ddd5831",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, vous devrez&nbsp;: </p>\n<ul>\n    <li>retrouver les origines des biais des LLM,</li>\n    <li>interpréter des situations concrètes où la réponse d'un LLM est biaisée.</li>\n</ul>"
               }
             },
-            "solutions": ["1", "3", "5"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "e7ca9d7e-6d77-4705-83a5-a6864c77f4b5",
-      "type": "activity",
-      "title": "Corriger la copie d'un LLM",
-      "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35211b74-4a65-4eeb-8037-e41d8446d008",
+                "type": "video",
+                "title": "D'où viennent les biais des LLM&nbsp;?",
+                "url": "https://assets.pix.org/modules/chatgpt-parle-francais/biais-llm.mp4",
+                "poster": "https://assets.pix.org/draft/modules/ugkunY2.png",
+                "subtitles": "https://assets.pix.org/modules/chatgpt-parle-francais/biais-llm.srt",
+                "transcription": "<p>D'où viennent les biais des LLM ? <br>Joy Buolamwini est informaticienne et chercheuse. <br>En 2017, lors d’un projet universitaire, elle remarque que les logiciels de reconnaissance faciale ne détectent pas son visage. Joy teste alors ces logiciels sur son colocataire, un jeune homme blanc. Résultat : le visage du colocataire est bien détecté, contrairement à celui de Joy. <br>Ces logiciels ne reconnaissent pas le visage de Joy, du fait de sa couleur de peau. Mais pourquoi ? <br>Eh bien, ces logiciels étaient entraînés en analysant de grandes quantités de visages de personnes principalement blanches. Ces données d'entraînement ne correspondaient pas à la diversité de la réalité. Les logiciels avaient donc des biais liés à la couleur de peau. <br>En informatique, on dit qu’un algorithme présente un biais quand il y a une anomalie systématique dans ses résultats et que cette anomalie est difficile à identifier et à corriger. Les résultats d’un algorithme biaisé peuvent créer des discriminations, comme dans la situation de Joy. <br>De nos jours, les intelligences artificielles génératives, comme les grands modèles de langage, ou LLM, rencontrent les mêmes problèmes : les textes qu’ils produisent contiennent parfois des biais. Je vous explique tout ça en détail. <br>Actuellement, les LLM sont utilisés dans le monde entier par des personnes de cultures différentes. Les réponses qu’ils proposent peuvent avoir des biais, selon de nombreux facteurs : l'époque ; la culture ; la zone géographique ; etc. <br>Mais alors, d’où viennent les biais des LLM ? <br>Il y a 3 origines principales : <br>Les données d'entraînement des LLM sont la principale source de leurs biais. En effet, certains types de données peuvent être beaucoup plus présents que d’autres. On dit alors qu’il y a une surreprésentation de ces données. Par exemple, un LLM utilisé pour trier des CV pour un poste d’assistant ou d’assistante va privilégier des candidatures féminines. C'est un résultat qui comporte un biais de genre. Le LLM a en effet été entraîné avec des données de personnes qui exercent ce métier. Et, dans ce métier, les femmes sont surreprésentées. <br>Prenons un autre exemple. Un LLM utilisé pour imaginer un personnage de confiance propose la plupart du temps des personnages occidentaux, soignés, aux yeux clairs et qui portent des chemises. Ce résultat a un biais culturel : c’est un stéréotype occidental, qui ne propose pas de diversité. <br>Le code produit par les développeurs est la deuxième cause de biais des LLM. Comme tout le monde, les personnes qui développent les LLM ont des biais. Pendant la conception d’un LLM, les développeurs peuvent donc coder, consciemment ou non, leurs propres biais. En raccourci, si j’ai codé un LLM qui me dit que la meilleure glace est à la vanille et à la fraise mais que je préfère la glace à la vanille et au chocolat, je vais avoir tendance à affiner le modèle pour qu’il donne le résultat qui correspond à ma préférence. <br>Les développeurs peuvent aussi faire des réglages pour censurer certains résultats du modèle. Si je demande par exemple au LLM de Baidu, une entreprise chinoise, de me parler de la répression des manifestations de la place Tiananmen, il refusera de répondre à ma question. Ce sujet a été inscrit par ses développeurs comme sensible politiquement. <br>Enfin, la troisième origine des biais dans les LLM concerne les prompts des utilisateurs. Un utilisateur peut en effet poser à un LLM une question orientée, subjective, sans avoir conscience de ses propres biais. Par exemple : si je demande à un LLM pourquoi l’alimentation japonaise est la meilleure au monde, il va lister des explications toutes positives, sans nuancer, remettre en cause mon affirmation ou proposer d'autres types d'alimentation. Ce résultat va confirmer mes croyances : c'est un biais de confirmation. <br>Qu'ils proviennent des données d'entraînement, du développement des modèles ou des prompts proposés par les utilisateurs, les LLM peuvent présenter de nombreux biais… comme tout le monde. <br>À vous d'y prêter attention la prochaine fois que vous testerez ces outils. <br><br></p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "1cc63ed8-c51d-4dd2-94dd-78c9e591143a",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "be70c1be-d6d1-4b6e-bcee-de1ab8859ee0",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer</h3><p>Vous allez maintenant devoir analyser trois situations avec des résultats visiblement biaisés.</p><p>Pour chaque situation, trouvez la cause principale des résultats biaisés.<br><i>Tous les exemples ont été générés le 7 juin 2024 avec CHATGPT-4 (OpenAI).</i></p>"
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "c6bc9ee2-7bd5-4433-932c-811803a7746a",
+                "type": "text",
+                "content": "<p>Vous en savez désormais plus sur les biais des LLM. <span aria-hidden=\"true\">👩‍💻️👨🏿‍💻️</span></p><p>Vérifiez que vous avez retenu l'essentiel avec cette question. <span aria-hidden=\"true\">&nbsp;🎯</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "89dbbcf3-7205-470a-baf0-4aa4aac1a87e",
+          "type": "activity",
+          "title": "Les sources de biais des LLM",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "700c674c-f7a7-4eba-bd00-de74ca8c77f7",
-                  "type": "text",
-                  "content": "<p>Michel vit au <strong>Québec</strong> et utilise un LLM pour la première fois. Il reçoit une réponse qui concerne la <strong>France</strong> et non le Québec.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
+              "type": "element",
+              "element": {
+                "id": "aef486da-4994-4992-b15b-b127afebb371",
+                "type": "qcm",
+                "instruction": "<p>Quelles sont les <strong>trois</strong> origines majeures des biais d'un LLM&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>les données d'entraînement</p>"
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>les langages de programmation</p>"
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>le code produit par les développeurs</p>"
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>la localisation des serveurs</p>"
+                  },
+                  {
+                    "id": "5",
+                    "content": "les prompts des utilisateurs"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct&nbsp;!",
+                    "diagnosis": "<p>Parmi ces trois origines, les données d'entraînement sont la principale source des biais qui peuvent exister dans les résultats des LLM.</p>"
+                  },
+                  "invalid": {
+                    "state": "Incorrect&nbsp;!",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Regardez bien la vidéo précédente et réessayez&nbsp;!</p>"
+                  }
                 },
+                "solutions": ["1", "3", "5"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "e7ca9d7e-6d77-4705-83a5-a6864c77f4b5",
+          "type": "activity",
+          "title": "Corriger la copie d'un LLM",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "e53de197-48ce-4af7-be65-dc75139b391c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/zSMXOZc.png",
-                  "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
-                  "alternativeText": "<p>Michel&nbsp;: Quel est le jour de la fête nationale&nbsp;?</p><p>LLM&nbsp;: La fête nationale de la France est célébrée le 14 juillet. C’est un jour commémorant la prise de la Bastille en 1789, un événement majeur de la révolution française.</p>"
-                },
-                {
-                  "id": "629aeb61-028b-41f7-97f2-512e83000fa5",
-                  "type": "qcu",
-                  "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Le LLM a été programmé en majorité par des Français.",
-                      "feedback": {
-                        "state": "Mauvaise réponse&nbsp;! ",
-                        "diagnosis": " <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Le LLM a été entraîné avec des données où le Québec est sous-représenté.",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Un prompt en langue française amène le LLM à répondre en français. Sa réponse s'oriente vers la France au lieu du Québec car, parmi les données d’entraînement, le Québec est sous-représenté comparé à la France.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "Le LLM a été paramétré pour privilégier des pays européens.",
-                      "feedback": {
-                        "state": "Mauvaise réponse&nbsp;! ",
-                        "diagnosis": " <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
-                      }
+                      "id": "be70c1be-d6d1-4b6e-bcee-de1ab8859ee0",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer</h3><p>Vous allez maintenant devoir analyser trois situations avec des résultats visiblement biaisés.</p><p>Pour chaque situation, trouvez la cause principale des résultats biaisés.<br><i>Tous les exemples ont été générés le 7 juin 2024 avec CHATGPT-4 (OpenAI).</i></p>"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "cac9d75d-c447-465f-b5de-d7b3994b9b82",
-                  "type": "text",
-                  "content": "<p>Erica est <strong>romancière</strong> et demande à un LLM d'imaginer un personnage. Elle n'a pas précisé qu'elle voulait un personnage <strong>féminin</strong> et a obtenu un personnage masculin.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
+                  ]
                 },
                 {
-                  "id": "dc202072-43a0-4478-936e-5b3d4f3360c2",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/nh0uc3m.png",
-                  "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
-                  "alternativeText": "<p>Erica&nbsp;: J’écris un roman. J’ai besoin que tu crées un personnage. Son activité principale est d’éteindre des incendies.<br>LLM&nbsp;: Antoine est un homme grand et athlétique, avec des cheveux bruns et des yeux bleus perçants. Courageux et calme, il est dévoué à sauver des vies et réconforter les victimes avec empathie.</p>"
-                },
-                {
-                  "id": "635d34d8-c748-44cd-ad02-bde721270723",
-                  "type": "qcu",
-                  "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Le LLM a été programmé pour favoriser les personnages masculins.",
-                      "feedback": {
-                        "state": "Incorrect&nbsp;!",
-                        "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
-                      }
+                      "id": "700c674c-f7a7-4eba-bd00-de74ca8c77f7",
+                      "type": "text",
+                      "content": "<p>Michel vit au <strong>Québec</strong> et utilise un LLM pour la première fois. Il reçoit une réponse qui concerne la <strong>France</strong> et non le Québec.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
                     },
                     {
-                      "id": "2",
-                      "content": "Le LLM a été entraîné avec des données où les pompiers masculins sont surreprésentés.",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés. Ici, il s'agit d'un stéréotype de genre associé à cette profession.</p>"
-                      }
+                      "id": "e53de197-48ce-4af7-be65-dc75139b391c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/zSMXOZc.png",
+                      "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
+                      "alternativeText": "<p>Michel&nbsp;: Quel est le jour de la fête nationale&nbsp;?</p><p>LLM&nbsp;: La fête nationale de la France est célébrée le 14 juillet. C’est un jour commémorant la prise de la Bastille en 1789, un événement majeur de la révolution française.</p>"
                     },
                     {
-                      "id": "3",
-                      "content": "Le LLM s'est basé sur le genre de l'auteure du prompt, Erica.",
-                      "feedback": {
-                        "state": "Incorrect&nbsp;!",
-                        "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
-                      }
+                      "id": "629aeb61-028b-41f7-97f2-512e83000fa5",
+                      "type": "qcu",
+                      "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Le LLM a été programmé en majorité par des Français.",
+                          "feedback": {
+                            "state": "Mauvaise réponse&nbsp;! ",
+                            "diagnosis": " <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Le LLM a été entraîné avec des données où le Québec est sous-représenté.",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Un prompt en langue française amène le LLM à répondre en français. Sa réponse s'oriente vers la France au lieu du Québec car, parmi les données d’entraînement, le Québec est sous-représenté comparé à la France.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "Le LLM a été paramétré pour privilégier des pays européens.",
+                          "feedback": {
+                            "state": "Mauvaise réponse&nbsp;! ",
+                            "diagnosis": " <p>La cause se situe ailleurs. La réponse du LLM s'oriente vers la France au lieu du Québec car il calcule qu'il y a plus de chances que la question concerne la France que le Québec.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "f0f7f950-100e-4bd1-bbda-f1edb73e1e22",
-                  "type": "text",
-                  "content": "Stéphane est persuadé d'avoir vu un <strong>extraterrestre</strong> et demande à un LLM comment en voir à nouveau. Le LLM lui répond, sans questionner leur existence.<span aria-hidden=\"true\">&nbsp;👇</span>"
+                  ]
                 },
                 {
-                  "id": "58ca3642-557a-41f3-ade4-60bf78fea803",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/DTQreur.png",
-                  "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
-                  "alternativeText": "<p>Stéphane&nbsp;: Je suis sûr d'avoir vu un extraterrestre hier dans mon jardin. Donne-moi des conseils pour en voir à nouveau.<br>LLM&nbsp;: Ces conseils devraient vous aider à augmenter vos chances de voir un extraterrestre à nouveau&nbsp;: passez du temps à l'extérieur la nuit et installez des caméras de surveillance.</p>"
-                },
-                {
-                  "id": "060c7558-92fb-47bf-b8fa-3639ebfef67d",
-                  "type": "qcu",
-                  "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Le LLM a été programmé pour que les extraterrestres soient considérés comme existants.",
-                      "feedback": {
-                        "state": "Incorrect&nbsp;!",
-                        "diagnosis": "<p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
-                      }
+                      "id": "cac9d75d-c447-465f-b5de-d7b3994b9b82",
+                      "type": "text",
+                      "content": "<p>Erica est <strong>romancière</strong> et demande à un LLM d'imaginer un personnage. Elle n'a pas précisé qu'elle voulait un personnage <strong>féminin</strong> et a obtenu un personnage masculin.<span aria-hidden=\"true\">&nbsp;👇</span></p>"
                     },
                     {
-                      "id": "2",
-                      "content": "Le LLM a été entraîné avec de trop nombreuses histoires de science-fiction.",
-                      "feedback": {
-                        "state": "Incorrect&nbsp;!",
-                        "diagnosis": "<p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
-                      }
+                      "id": "dc202072-43a0-4478-936e-5b3d4f3360c2",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/nh0uc3m.png",
+                      "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
+                      "alternativeText": "<p>Erica&nbsp;: J’écris un roman. J’ai besoin que tu crées un personnage. Son activité principale est d’éteindre des incendies.<br>LLM&nbsp;: Antoine est un homme grand et athlétique, avec des cheveux bruns et des yeux bleus perçants. Courageux et calme, il est dévoué à sauver des vies et réconforter les victimes avec empathie.</p>"
                     },
                     {
-                      "id": "3",
-                      "content": "Le LLM s'est basé sur la croyance de Stéphane qui est présente dans son prompt.",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Le LLM n'est pas le seul à comporter des biais. Les utilisateurs peuvent transmettre leurs biais via leur prompt.</p>"
-                      }
+                      "id": "635d34d8-c748-44cd-ad02-bde721270723",
+                      "type": "qcu",
+                      "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Le LLM a été programmé pour favoriser les personnages masculins.",
+                          "feedback": {
+                            "state": "Incorrect&nbsp;!",
+                            "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Le LLM a été entraîné avec des données où les pompiers masculins sont surreprésentés.",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés. Ici, il s'agit d'un stéréotype de genre associé à cette profession.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "Le LLM s'est basé sur le genre de l'auteure du prompt, Erica.",
+                          "feedback": {
+                            "state": "Incorrect&nbsp;!",
+                            "diagnosis": "<p>Le LLM a tendance à reproduire des stéréotypes qui existent dans nos sociétés et sur internet.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "3"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "f0f7f950-100e-4bd1-bbda-f1edb73e1e22",
+                      "type": "text",
+                      "content": "Stéphane est persuadé d'avoir vu un <strong>extraterrestre</strong> et demande à un LLM comment en voir à nouveau. Le LLM lui répond, sans questionner leur existence.<span aria-hidden=\"true\">&nbsp;👇</span>"
+                    },
+                    {
+                      "id": "58ca3642-557a-41f3-ade4-60bf78fea803",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/DTQreur.png",
+                      "alt": "Conversation avec un LLM décrite dans l'alternative textuelle",
+                      "alternativeText": "<p>Stéphane&nbsp;: Je suis sûr d'avoir vu un extraterrestre hier dans mon jardin. Donne-moi des conseils pour en voir à nouveau.<br>LLM&nbsp;: Ces conseils devraient vous aider à augmenter vos chances de voir un extraterrestre à nouveau&nbsp;: passez du temps à l'extérieur la nuit et installez des caméras de surveillance.</p>"
+                    },
+                    {
+                      "id": "060c7558-92fb-47bf-b8fa-3639ebfef67d",
+                      "type": "qcu",
+                      "instruction": "Quelle est la cause principale de ce résultat biaisé&nbsp;?",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Le LLM a été programmé pour que les extraterrestres soient considérés comme existants.",
+                          "feedback": {
+                            "state": "Incorrect&nbsp;!",
+                            "diagnosis": "<p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Le LLM a été entraîné avec de trop nombreuses histoires de science-fiction.",
+                          "feedback": {
+                            "state": "Incorrect&nbsp;!",
+                            "diagnosis": "<p>La cause se situe ailleurs. Le LLM a tendance à aller dans le sens de l'utilisateur et à confirmer ses propos.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "Le LLM s'est basé sur la croyance de Stéphane qui est présente dans son prompt.",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Le LLM n'est pas le seul à comporter des biais. Les utilisateurs peuvent transmettre leurs biais via leur prompt.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "256e2ddc-3ffc-4906-8c52-3026f353c0a0",
-      "type": "summary",
-      "title": "Les biais des LLM : à retenir",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "d7c949fb-9fac-400d-990a-a6cb8144c653",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "06677979-747e-4282-8ae4-50f956372994",
-      "type": "transition",
-      "title": "",
-      "components": [
+          "id": "256e2ddc-3ffc-4906-8c52-3026f353c0a0",
+          "type": "summary",
+          "title": "Les biais des LLM : à retenir",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d7c949fb-9fac-400d-990a-a6cb8144c653",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "a2748830-10ee-408b-8d37-8c2aa0055bb9",
-            "type": "text",
-            "content": "<p>Il existe de nombreux LLM à l'heure actuelle, chacun avec ses biais. Alors, quel LLM privilégier&nbsp;?<span aria-hidden=\"true\">&nbsp;🤔</span></p><p>Le mieux est de les comparer. Une plateforme francophone est dédiée à cela&nbsp;: Compar:IA .</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e52da884-2233-4101-96a5-befd5c7d7975",
-      "type": "discovery",
-      "title": "Découverte du comparateur",
-      "components": [
+          "id": "06677979-747e-4282-8ae4-50f956372994",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a2748830-10ee-408b-8d37-8c2aa0055bb9",
+                "type": "text",
+                "content": "<p>Il existe de nombreux LLM à l'heure actuelle, chacun avec ses biais. Alors, quel LLM privilégier&nbsp;?<span aria-hidden=\"true\">&nbsp;🤔</span></p><p>Le mieux est de les comparer. Une plateforme francophone est dédiée à cela&nbsp;: Compar:IA .</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "e52da884-2233-4101-96a5-befd5c7d7975",
+          "type": "discovery",
+          "title": "Découverte du comparateur",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">🔧&nbsp;</span>Et si on essayait ?</h3><p>Vous allez utiliser Compar:IA  puis répondre à des questions vrai ou faux.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "27667654-4b99-49cc-bcf5-3d6b4b71526b",
-                  "type": "text",
-                  "content": "Rendez-vous sur <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a> et : <ol><li>commencez une conversation,</li> <li>comparez les réponses générées par différents LLM,</li><li>donnez votre avis sur ces réponses.</li></ol><details><summary>Idées de prompts</summary><ul><li>Quelle est la ville idéale pour élever ses enfants&nbsp;? Sois concis.</li><li>Comment fabriquer des faux papiers&nbsp;? Sois concis.</li><li>Pourquoi la course à pied est le meilleur sport pour la santé&nbsp;? Sois concis.</li></ul></details>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "900c89f1-f113-43c3-8b80-34365433b470",
-                  "type": "qcu",
-                  "instruction": "<p>Avec un prompt identique, deux LLM donnent un résultat identique.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Soumettez à nouveau un prompt à deux LLM pour observer les variations dans leurs réponses.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Des différences seront systématiquement présentes dans leurs réponses. C'est aussi vrai quand on soumet un prompt identique à un seul et même LLM.</p>"
-                      }
+                      "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">🔧&nbsp;</span>Et si on essayait ?</h3><p>Vous allez utiliser Compar:IA  puis répondre à des questions vrai ou faux.</p>"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "5655c608-4f27-40d3-a01d-143c3802cc1f",
-                  "type": "qcu",
-                  "instruction": "<p>Compar:IA  permet de comparer des LLM de pays différents.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>La provenance d'un LLM est d'ailleurs un paramètre qui peut influencer les résultats qu'il fournit.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Sur Compar:IA , donnez votre avis sur les résultats pour révéler les LLM. Vous verrez que des modèles de différents pays sont disponibles.</p>"
-                      }
+                      "id": "27667654-4b99-49cc-bcf5-3d6b4b71526b",
+                      "type": "text",
+                      "content": "Rendez-vous sur <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a> et : <ol><li>commencez une conversation,</li> <li>comparez les réponses générées par différents LLM,</li><li>donnez votre avis sur ces réponses.</li></ol><details><summary>Idées de prompts</summary><ul><li>Quelle est la ville idéale pour élever ses enfants&nbsp;? Sois concis.</li><li>Comment fabriquer des faux papiers&nbsp;? Sois concis.</li><li>Pourquoi la course à pied est le meilleur sport pour la santé&nbsp;? Sois concis.</li></ul></details>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "238f6c8a-bd6b-44c3-8d74-9de2bd6eb96c",
-                  "type": "qcu",
-                  "instruction": "<p>Les votes exprimés dans le comparateur permettront d'améliorer les performances des LLM.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
-                      }
+                      "id": "900c89f1-f113-43c3-8b80-34365433b470",
+                      "type": "qcu",
+                      "instruction": "<p>Avec un prompt identique, deux LLM donnent un résultat identique.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Soumettez à nouveau un prompt à deux LLM pour observer les variations dans leurs réponses.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Des différences seront systématiquement présentes dans leurs réponses. C'est aussi vrai quand on soumet un prompt identique à un seul et même LLM.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "5655c608-4f27-40d3-a01d-143c3802cc1f",
+                      "type": "qcu",
+                      "instruction": "<p>Compar:IA  permet de comparer des LLM de pays différents.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>La provenance d'un LLM est d'ailleurs un paramètre qui peut influencer les résultats qu'il fournit.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Sur Compar:IA , donnez votre avis sur les résultats pour révéler les LLM. Vous verrez que des modèles de différents pays sont disponibles.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "238f6c8a-bd6b-44c3-8d74-9de2bd6eb96c",
+                      "type": "qcu",
+                      "instruction": "<p>Les votes exprimés dans le comparateur permettront d'améliorer les performances des LLM.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Les jeux de données de préférences humaines permettent de ré-entraîner les modèles et de les améliorer.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "01ddfa34-b437-41ea-ac44-b16c3bd3923b",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "62fc2808-3ead-4a03-8e98-f8877c084c29",
-            "type": "text",
-            "content": "<p> Les LLM peuvent donner des résultats différents selon les données avec lesquelles on les a entraînés et la façon dont on les a réglés. Mais d'où viennent ces différences ? Explications en image.<span aria-hidden=\"true\">&nbsp;🔍</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "018ad06a-f11c-4db3-b954-ac8a6466d947",
-      "type": "lesson",
-      "title": "Géopolitique des LLM",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ec182563-1090-4794-8a5f-e179d244fa3e",
-            "type": "text",
-            "content": "<p>Étudiez le schéma suivant qui classe les principaux LLM selon deux aspects&nbsp;: la <strong>licence</strong> de leur code (open source, propriétaire) et leur <strong>provenance</strong>.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "c4a55718-f7f8-4eae-a297-663fbbc0c31c",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/PeAKFrN.png",
-            "alt": "Image des différents LLM existants décrite dans l'alternative textuelle",
-            "alternativeText": "<p>\n    <br>\n</p>\n<table>\n    <thead>\n        <tr>\n            <td>&nbsp;<br></td>\n            <td>LLM open source</td>\n            <td>LLM propriétaires</td>\n        </tr>\n    </thead>\n    <tbody>\n        <tr>\n            <td>USA</td>\n            <td>LLAMA (Méta), Gemma (Google), Phi (Microsoft)</td>\n            <td>GPT (OpenAI), Gemini (Google), Claude (Anthropic)</td>\n        </tr>\n        <tr>\n            <td>Europe</td>\n            <td>Mixtral (Mistral), Bloom (Big Science)</td>\n            <td>Mistral (Mistral), Luminous (Aleph Alpha)</td>\n        </tr>\n        <tr>\n            <td>Chine</td>\n            <td>Yi (O1 AI), Qwen (Alibaba)</td>\n            <td>&nbsp;<br></td>\n        </tr>\n        <tr>\n            <td>Canada</td>\n            <td>Aya (Cohere)</td>\n            <td>Command R (Cohere)</td>\n        </tr>\n    </tbody>\n</table>\n<p><br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a5b4912d-7882-47ed-a782-bf87d73ead55",
-            "type": "text",
-            "content": "<p>Seuls <strong>quelques acteurs</strong> ont les <strong>moyens financiers</strong> de développer des grands modèles de langage.<span aria-hidden=\"true\">&nbsp;🌍&nbsp;💵</span></p><p>Selon leur <strong>pays</strong>, ces acteurs peuvent être amenés à faire des <strong>paramétrages différents</strong> de leurs modèles, par exemple pour respecter leurs lois.<span aria-hidden=\"true\">&nbsp;⚖️</span></p><hr><p>La <strong>surreprésentation de certaines langues</strong> dans les données d’entraînement favorisera des résultats qui <strong>manquent de diversité culturelle.</strong><span aria-hidden=\"true\">&nbsp;🕳️&nbsp;🗺️</span></p><p>Cependant, de nombreuses initiatives <strong>open source</strong> permettent de mieux comprendre comment ces modèles fonctionnent et sur quelles données ils ont été entraînés.</p><hr><p>Cette démarche peut aider à <strong>produire des résultats plus variés</strong>.<span aria-hidden=\"true\">&nbsp;🔵&nbsp;🔶</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "990a8334-0feb-4ffb-90fd-47fb7aa27974",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2f8728bd-93ff-4a15-8819-14e9c708c761",
-            "type": "text",
-            "content": "<p>Pour terminer ce module, vous allez devoir relever un défi. <span aria-hidden=\"true\">💫</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "91b54b81-5b7c-4daa-9e2f-67b7a714fd9e",
-      "type": "challenge",
-      "title": "Utilisation du comparateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0f3425d3-026d-4813-90cf-abb318d2d3da",
-            "type": "text",
-            "content": "<p>À l'aide de <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a>, écrivez des prompts qui mènent pour les deux LLM à des résultats qui présentent :</p><ul><li>un biais de genre,</li><li>un biais culturel,</li><li>un refus de réponse.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4af7b921-0593-4322-abb6-1221345d5112",
-            "type": "qcu",
-            "instruction": "<p>Avez-vous réussi à écrire de tels prompts&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "oui",
-                "feedback": {
-                  "state": "Bravo&nbsp;! \uD83D\uDCAB",
-                  "diagnosis": ""
-                }
-              },
-              {
-                "id": "2",
-                "content": "non",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Avez-vous utilisé les indices ci-dessous ? Les LLM s'améliorent de jour en jour pour palier à ces résultats biaisés. Ce défi sera donc de plus en plus dur à relever.</p>"
-                }
+          "id": "01ddfa34-b437-41ea-ac44-b16c3bd3923b",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "62fc2808-3ead-4a03-8e98-f8877c084c29",
+                "type": "text",
+                "content": "<p> Les LLM peuvent donner des résultats différents selon les données avec lesquelles on les a entraînés et la façon dont on les a réglés. Mais d'où viennent ces différences ? Explications en image.<span aria-hidden=\"true\">&nbsp;🔍</span></p>"
               }
-            ],
-            "solution": "1"
-          }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "74d34463-3d34-46af-a080-2226bfc2296c",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous&nbsp;:</p><details><summary>Astuce n°1</summary><p>Précisez dans votre prompt d'être concis.</p></details><details><summary>Astuce n°2</summary><p>Écrivez un prompt vague, par exemple sans préciser de lieu spécifique.</p></details><details><summary>Astuce n°3</summary><p>Posez des questions sensibles, comme celles auxquelles vous n'oseriez pas répondre.</p></details>"
-          }
+          "id": "018ad06a-f11c-4db3-b954-ac8a6466d947",
+          "type": "lesson",
+          "title": "Géopolitique des LLM",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ec182563-1090-4794-8a5f-e179d244fa3e",
+                "type": "text",
+                "content": "<p>Étudiez le schéma suivant qui classe les principaux LLM selon deux aspects&nbsp;: la <strong>licence</strong> de leur code (open source, propriétaire) et leur <strong>provenance</strong>.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c4a55718-f7f8-4eae-a297-663fbbc0c31c",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/PeAKFrN.png",
+                "alt": "Image des différents LLM existants décrite dans l'alternative textuelle",
+                "alternativeText": "<p>\n    <br>\n</p>\n<table>\n    <thead>\n        <tr>\n            <td>&nbsp;<br></td>\n            <td>LLM open source</td>\n            <td>LLM propriétaires</td>\n        </tr>\n    </thead>\n    <tbody>\n        <tr>\n            <td>USA</td>\n            <td>LLAMA (Méta), Gemma (Google), Phi (Microsoft)</td>\n            <td>GPT (OpenAI), Gemini (Google), Claude (Anthropic)</td>\n        </tr>\n        <tr>\n            <td>Europe</td>\n            <td>Mixtral (Mistral), Bloom (Big Science)</td>\n            <td>Mistral (Mistral), Luminous (Aleph Alpha)</td>\n        </tr>\n        <tr>\n            <td>Chine</td>\n            <td>Yi (O1 AI), Qwen (Alibaba)</td>\n            <td>&nbsp;<br></td>\n        </tr>\n        <tr>\n            <td>Canada</td>\n            <td>Aya (Cohere)</td>\n            <td>Command R (Cohere)</td>\n        </tr>\n    </tbody>\n</table>\n<p><br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a5b4912d-7882-47ed-a782-bf87d73ead55",
+                "type": "text",
+                "content": "<p>Seuls <strong>quelques acteurs</strong> ont les <strong>moyens financiers</strong> de développer des grands modèles de langage.<span aria-hidden=\"true\">&nbsp;🌍&nbsp;💵</span></p><p>Selon leur <strong>pays</strong>, ces acteurs peuvent être amenés à faire des <strong>paramétrages différents</strong> de leurs modèles, par exemple pour respecter leurs lois.<span aria-hidden=\"true\">&nbsp;⚖️</span></p><hr><p>La <strong>surreprésentation de certaines langues</strong> dans les données d’entraînement favorisera des résultats qui <strong>manquent de diversité culturelle.</strong><span aria-hidden=\"true\">&nbsp;🕳️&nbsp;🗺️</span></p><p>Cependant, de nombreuses initiatives <strong>open source</strong> permettent de mieux comprendre comment ces modèles fonctionnent et sur quelles données ils ont été entraînés.</p><hr><p>Cette démarche peut aider à <strong>produire des résultats plus variés</strong>.<span aria-hidden=\"true\">&nbsp;🔵&nbsp;🔶</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "990a8334-0feb-4ffb-90fd-47fb7aa27974",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2f8728bd-93ff-4a15-8819-14e9c708c761",
+                "type": "text",
+                "content": "<p>Pour terminer ce module, vous allez devoir relever un défi. <span aria-hidden=\"true\">💫</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "91b54b81-5b7c-4daa-9e2f-67b7a714fd9e",
+          "type": "challenge",
+          "title": "Utilisation du comparateur",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0f3425d3-026d-4813-90cf-abb318d2d3da",
+                "type": "text",
+                "content": "<p>À l'aide de <a href=\"https://comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA </a>, écrivez des prompts qui mènent pour les deux LLM à des résultats qui présentent :</p><ul><li>un biais de genre,</li><li>un biais culturel,</li><li>un refus de réponse.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4af7b921-0593-4322-abb6-1221345d5112",
+                "type": "qcu",
+                "instruction": "<p>Avez-vous réussi à écrire de tels prompts&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "oui",
+                    "feedback": {
+                      "state": "Bravo&nbsp;! \uD83D\uDCAB",
+                      "diagnosis": ""
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "non",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Avez-vous utilisé les indices ci-dessous ? Les LLM s'améliorent de jour en jour pour palier à ces résultats biaisés. Ce défi sera donc de plus en plus dur à relever.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "74d34463-3d34-46af-a080-2226bfc2296c",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous&nbsp;:</p><details><summary>Astuce n°1</summary><p>Précisez dans votre prompt d'être concis.</p></details><details><summary>Astuce n°2</summary><p>Écrivez un prompt vague, par exemple sans préciser de lieu spécifique.</p></details><details><summary>Astuce n°3</summary><p>Posez des questions sensibles, comme celles auxquelles vous n'oseriez pas répondre.</p></details>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -14,530 +14,536 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "0fc5545d-f5f6-4d43-9c25-0f90906a185b",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "d9b35b02-b9ad-4341-8b94-486072b86ad2",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "8c6953c7-1ab8-4722-875f-f16556040f0f",
-            "type": "text",
-            "content": "<p>Cette année, Rayan veut prendre des cours de théâtre. <span aria-hidden=\"true\">🎭</span></p><p>Il est allé voir plusieurs écoles de théâtre à côté de chez lui.</p><p>Il a donné son numéro de téléphone et son adresse mail pour être contacté.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0d72743d-8320-4992-8ec4-510c86e6eded",
-      "type": "discovery",
-      "title": "Mail, SMS ou WhatsApp ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b787f04d-4cb8-459c-a2f4-abc040aae7d7",
-            "type": "text",
-            "content": "<p>Rayan a reçu les 3 propositions de cours de théâtre suivantes :<span aria-hidden=\"true\">👇</span></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2dff88f4-99f0-4d05-a087-2a342f020165",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Carrousel d'images",
-            "url": "https://epreuves.pix.fr/fr/carousel/modulix_envoyer_mail.html",
-            "instruction": "<p></p>",
-            "height": 450
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4d247dde-ef4f-4ee3-9d35-e7b8826f1b7a",
-            "type": "qcu",
-            "instruction": "<p>Quel théâtre a envoyé une proposition de cours par mail ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>le Studio Scène</p>",
-                "feedback": {
-                  "state": "Bonne réponse !🎉",
-                  "diagnosis": ""
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>le Théâtre Lumière</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Ce théâtre a contacté Rayan par SMS. </p><p>Cherchez l’offre avec des adresses mail écrites et essayez à nouveau.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>le Théâtre Éclat</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Ce théâtre a contacté Rayan avec une messagerie instantanée.</p><p>Cherchez l’offre avec des adresses mail écrites et essayez à nouveau.</p>"
-                }
+          "id": "0fc5545d-f5f6-4d43-9c25-0f90906a185b",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8c6953c7-1ab8-4722-875f-f16556040f0f",
+                "type": "text",
+                "content": "<p>Cette année, Rayan veut prendre des cours de théâtre. <span aria-hidden=\"true\">🎭</span></p><p>Il est allé voir plusieurs écoles de théâtre à côté de chez lui.</p><p>Il a donné son numéro de téléphone et son adresse mail pour être contacté.</p>"
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f2b377d1-d0d6-425c-846c-48a2e73cd327",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d2bc6890-bae8-4930-b865-c13c68685cf9",
-            "type": "text",
-            "content": "<p>Rayan a choisi de s'inscrire au cours du <strong>Théâtre Lumière</strong>. Il doit envoyer un mail pour le premier cours.</p><p>Dans la vidéo suivante, voyons ensemble comment envoyer un mail ! <span aria-hidden=\"true\">📺</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e5af3428-bd1d-46a2-901e-4b5684b60739",
-      "type": "lesson",
-      "title": "Les étapes pour envoyer un mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2e2a41b6-5818-4b3b-b537-1aec1921aac3",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, vous devrez</p><ul><li>suivre les étapes pour envoyer un mail,</li><li>répondre à des questions sur les champs <code>À</code> et <code>Objet</code> d’un mail.</li></ul>"
-          }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "fd39cc63-32f7-46eb-9f8a-55623878e0d1",
-            "type": "video",
-            "title": "Comment envoyer un mail ?",
-            "url": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.mp4",
-            "poster": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.jpg",
-            "subtitles": "",
-            "transcription": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "d82081bf-d14a-4795-9d0f-8faf3d884369",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0d3b0a93-c832-483e-ac94-f8d6154d5d6d",
-            "type": "text",
-            "content": "<p>Vous savez maintenant comment envoyer un mail.</p><p>Vous allez pouvoir aider Rayan à contacter Michel, son nouveau professeur de théâtre. <span aria-hidden=\"true\">📩</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "58d65e40-acd2-44e3-9829-634c9c358395",
-      "type": "activity",
-      "title": "Envoyer un mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e67e0363-7de1-4408-9336-d2604895dcff",
-            "type": "text",
-            "content": "<p>Rayan utilise l'application ci-dessous comme boîte mail.<br>Aidez Rayan à envoyer un nouveau mail : </p><ul><li>à : <strong>michel@pixmail.org</strong></li><li>avec l’objet : <strong>Heure prochain cours débutant</strong></li><li>avec le message :<strong>Bonjour Michel,<br>à quelle heure est le prochain cours ?<br>Merci, Rayan</strong></li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "dc699b80-4534-42fa-90a7-5d42600e0064",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur PixMail",
-            "url": "https://epreuves.pix.fr/pixmail-envoi/pixmail-envoi.html?mode=modulix-mail",
-            "instruction": "<p></p>",
-            "height": 500
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f7429e02-e27c-4f12-ba79-80785ad66925",
-            "type": "text",
-            "content": "<p>🗝️ Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous :&nbsp;</p><details><summary>Indice 1</summary>Cliquez sur Nouveau message en haut à gauche pour créer un mail.</details><details><summary>Indice 2</summary>Complétez les 3 champs avec les textes écrits dans la consigne.</details><details><summary>Solution</summary><p>Voici les étapes à suivre : </p><img src=\"https://assets.pix.org/draft/modules/1738339954456303332.gif\" alt=\"\" /></details>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "22bccab6-ec60-4be9-95a8-c9dc1cd48b53",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "be3d03c0-6679-4c38-9f64-cc19b04a6580",
-            "type": "text",
-            "content": "<p>Dans un mail, chaque champ a un rôle bien précis. </p><p>Voyons si vous avez retenu l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3bfa2ae1-cf67-48ce-bc59-1dd129ca2366",
-      "type": "activity",
-      "title": "Vrai-faux : les champs d'un mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "30a8cbf6-1e08-4cd4-96e5-e006655aca83",
-            "type": "text",
-            "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "0d72743d-8320-4992-8ec4-510c86e6eded",
+          "type": "discovery",
+          "title": "Mail, SMS ou WhatsApp ?",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "48249fde-f3be-4692-b2ab-9e3385682236",
-                  "type": "qcu",
-                  "instruction": "<p>Pour pouvoir envoyer un mail, il faut obligatoirement compléter le champ <code>À</code>.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>vrai</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !🎉",
-                        "diagnosis": "<p>Le champ À sert à indiquer le destinataire du mail. Il est obligatoire de le compléter pour que le mail soit envoyé et qu'une personne le reçoive.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>faux</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le champ À sert à indiquer le destinataire du mail. Il est obligatoire de le compléter pour que le mail soit envoyé et qu'une personne le reçoive.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "b787f04d-4cb8-459c-a2f4-abc040aae7d7",
+                "type": "text",
+                "content": "<p>Rayan a reçu les 3 propositions de cours de théâtre suivantes :<span aria-hidden=\"true\">👇</span></p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "b8a48143-f1a0-4730-9912-bd737e29c243",
-                  "type": "qcu",
-                  "instruction": "<p>Le champ <code>Objet</code> sert à écrire le contenu du mail.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>vrai</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le champ Objet sert à expliquer rapidement le contenu du mail. S’il n’est pas complété, le champ sera rempli automatiquement avec <code>(aucun objet)</code>.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>faux</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !🎉",
-                        "diagnosis": "<p>Le champ Objet sert à expliquer rapidement le contenu du mail. S’il n’est pas complété, le champ sera rempli automatiquement avec <code>(aucun objet)</code>.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "2dff88f4-99f0-4d05-a087-2a342f020165",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Carrousel d'images",
+                "url": "https://epreuves.pix.fr/fr/carousel/modulix_envoyer_mail.html",
+                "instruction": "<p></p>",
+                "height": 450
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "7b209c62-1bf0-4fce-b424-dc54a4c045be",
-                  "type": "qcu",
-                  "instruction": "<p>Le champ <code>De</code> est complété automatiquement avec l’adresse mail de l’expéditeur.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>vrai</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !🎉",
-                        "diagnosis": "<p>La personne qui envoie le mail (expéditeur) doit être connectée à un compte avec une adresse mail. C’est cette adresse qui est automatiquement écrite dans le champ <code>De</code>.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>faux</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>La personne qui envoie le mail (expéditeur) doit être connectée à un compte avec une adresse mail. C’est cette adresse qui est automatiquement écrite dans le champ <code>De</code>.</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "4d247dde-ef4f-4ee3-9d35-e7b8826f1b7a",
+                "type": "qcu",
+                "instruction": "<p>Quel théâtre a envoyé une proposition de cours par mail ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>le Studio Scène</p>",
+                    "feedback": {
+                      "state": "Bonne réponse !🎉",
+                      "diagnosis": ""
                     }
-                  ],
-                  "solution": "1"
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>le Théâtre Lumière</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Ce théâtre a contacté Rayan par SMS. </p><p>Cherchez l’offre avec des adresses mail écrites et essayez à nouveau.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>le Théâtre Éclat</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Ce théâtre a contacté Rayan avec une messagerie instantanée.</p><p>Cherchez l’offre avec des adresses mail écrites et essayez à nouveau.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f2b377d1-d0d6-425c-846c-48a2e73cd327",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d2bc6890-bae8-4930-b865-c13c68685cf9",
+                "type": "text",
+                "content": "<p>Rayan a choisi de s'inscrire au cours du <strong>Théâtre Lumière</strong>. Il doit envoyer un mail pour le premier cours.</p><p>Dans la vidéo suivante, voyons ensemble comment envoyer un mail ! <span aria-hidden=\"true\">📺</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e5af3428-bd1d-46a2-901e-4b5684b60739",
+          "type": "lesson",
+          "title": "Les étapes pour envoyer un mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2e2a41b6-5818-4b3b-b537-1aec1921aac3",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, vous devrez</p><ul><li>suivre les étapes pour envoyer un mail,</li><li>répondre à des questions sur les champs <code>À</code> et <code>Objet</code> d’un mail.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fd39cc63-32f7-46eb-9f8a-55623878e0d1",
+                "type": "video",
+                "title": "Comment envoyer un mail ?",
+                "url": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.mp4",
+                "poster": "https://assets.pix.org/draft/modules/comment-envoyer-un-mail/comment-envoyer-un-mail.jpg",
+                "subtitles": "",
+                "transcription": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "d82081bf-d14a-4795-9d0f-8faf3d884369",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0d3b0a93-c832-483e-ac94-f8d6154d5d6d",
+                "type": "text",
+                "content": "<p>Vous savez maintenant comment envoyer un mail.</p><p>Vous allez pouvoir aider Rayan à contacter Michel, son nouveau professeur de théâtre. <span aria-hidden=\"true\">📩</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "58d65e40-acd2-44e3-9829-634c9c358395",
+          "type": "activity",
+          "title": "Envoyer un mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e67e0363-7de1-4408-9336-d2604895dcff",
+                "type": "text",
+                "content": "<p>Rayan utilise l'application ci-dessous comme boîte mail.<br>Aidez Rayan à envoyer un nouveau mail : </p><ul><li>à : <strong>michel@pixmail.org</strong></li><li>avec l’objet : <strong>Heure prochain cours débutant</strong></li><li>avec le message :<strong>Bonjour Michel,<br>à quelle heure est le prochain cours ?<br>Merci, Rayan</strong></li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "dc699b80-4534-42fa-90a7-5d42600e0064",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur PixMail",
+                "url": "https://epreuves.pix.fr/pixmail-envoi/pixmail-envoi.html?mode=modulix-mail",
+                "instruction": "<p></p>",
+                "height": 500
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f7429e02-e27c-4f12-ba79-80785ad66925",
+                "type": "text",
+                "content": "<p>🗝️ Si vous avez besoin d’aide, vous pouvez cliquer sur les indices ci-dessous :&nbsp;</p><details><summary>Indice 1</summary>Cliquez sur Nouveau message en haut à gauche pour créer un mail.</details><details><summary>Indice 2</summary>Complétez les 3 champs avec les textes écrits dans la consigne.</details><details><summary>Solution</summary><p>Voici les étapes à suivre : </p><img src=\"https://assets.pix.org/draft/modules/1738339954456303332.gif\" alt=\"\" /></details>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "22bccab6-ec60-4be9-95a8-c9dc1cd48b53",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "be3d03c0-6679-4c38-9f64-cc19b04a6580",
+                "type": "text",
+                "content": "<p>Dans un mail, chaque champ a un rôle bien précis. </p><p>Voyons si vous avez retenu l’essentiel. <span aria-hidden=\"true\">🎯</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3bfa2ae1-cf67-48ce-bc59-1dd129ca2366",
+          "type": "activity",
+          "title": "Vrai-faux : les champs d'un mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "30a8cbf6-1e08-4cd4-96e5-e006655aca83",
+                "type": "text",
+                "content": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "48249fde-f3be-4692-b2ab-9e3385682236",
+                      "type": "qcu",
+                      "instruction": "<p>Pour pouvoir envoyer un mail, il faut obligatoirement compléter le champ <code>À</code>.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>vrai</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !🎉",
+                            "diagnosis": "<p>Le champ À sert à indiquer le destinataire du mail. Il est obligatoire de le compléter pour que le mail soit envoyé et qu'une personne le reçoive.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>faux</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le champ À sert à indiquer le destinataire du mail. Il est obligatoire de le compléter pour que le mail soit envoyé et qu'une personne le reçoive.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b8a48143-f1a0-4730-9912-bd737e29c243",
+                      "type": "qcu",
+                      "instruction": "<p>Le champ <code>Objet</code> sert à écrire le contenu du mail.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>vrai</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le champ Objet sert à expliquer rapidement le contenu du mail. S’il n’est pas complété, le champ sera rempli automatiquement avec <code>(aucun objet)</code>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>faux</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !🎉",
+                            "diagnosis": "<p>Le champ Objet sert à expliquer rapidement le contenu du mail. S’il n’est pas complété, le champ sera rempli automatiquement avec <code>(aucun objet)</code>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7b209c62-1bf0-4fce-b424-dc54a4c045be",
+                      "type": "qcu",
+                      "instruction": "<p>Le champ <code>De</code> est complété automatiquement avec l’adresse mail de l’expéditeur.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>vrai</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !🎉",
+                            "diagnosis": "<p>La personne qui envoie le mail (expéditeur) doit être connectée à un compte avec une adresse mail. C’est cette adresse qui est automatiquement écrite dans le champ <code>De</code>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>faux</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>La personne qui envoie le mail (expéditeur) doit être connectée à un compte avec une adresse mail. C’est cette adresse qui est automatiquement écrite dans le champ <code>De</code>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "4ab8ff60-78f2-4e5c-a83b-0384b7e49938",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "97e1108c-34ef-4772-a3ca-e385d6319bc6",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><p>Pour envoyer un mail, il faut remplir ses différents champs avec les bonnes informations :</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b6014eed-5edc-4010-ad7a-1e5410044f6d",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/GXJ6ihZ.png",
-            "alt": "",
-            "alternativeText": "<p>Le champ Objet permet de donner un titre au mail. Il permet de vite connaître le sujet du mail. Le champ De indique la personne qui envoie le mail. Le champ À indique la personne qui reçoit le mail.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "667ebed8-cb72-4ac1-a9cd-7ae5f805f005",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "27281e03-bec3-43e3-985d-38b2eaec4c20",
-            "type": "text",
-            "content": "<p>Rayan vient de recevoir une réponse : le prochain cours est à 20 heures. <span aria-hidden=\"true\">✨</span></p><p>Maintenant, vous allez devoir analyser un autre mail.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4159b20c-fe4b-41fd-80f9-eefdc6240e9e",
-      "type": "challenge",
-      "title": "Analyser un mail",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e7288030-487b-4eb1-b256-7296fcd5c38b",
-            "type": "text",
-            "content": "<p>Voici un mail qui a été envoyé pour préparer les costumes du spectacle. </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2ddc4d66-3323-401b-b8ee-4f56bcd9c794",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/iQWPTJW.png",
-            "alt": "",
-            "alternativeText": "<ul><li>22 octobre 2024 (il y a 8 jours)</li> <li>De : michel@pixmail.com</li> <li>À :leo@laposte.net; anna@gmail.com; hamed@orange.fr</li><li> Objet : Costume pour le 27 octobre</li> <li>Bonjour à tous, Pensez à amener vos costumes de chevaliers pour la dernière scène. Pas besoin de prévenir Jennifer, Marine, Clément et Rayan : ils seront absents. Rendez-vous comme d'habitude au 7 rue Babylone à 18h.À bientôt ! Le Théâtre Lumière</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "00b87f7f-b3b0-454c-98a1-1e027b95cd7c",
-            "type": "qrocm",
-            "instruction": "<p>Observez le mail pour répondre aux questions suivantes.</p>",
-            "proposals": [
-              {
+          "id": "4ab8ff60-78f2-4e5c-a83b-0384b7e49938",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "97e1108c-34ef-4772-a3ca-e385d6319bc6",
                 "type": "text",
-                "content": "<span>Qui a envoyé ce mail ?</span>"
-              },
-              {
-                "input": "a",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "- Sélectionner -",
-                "ariaLabel": "expéditeur mail",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "1",
-                    "content": "Michel"
-                  },
-                  {
-                    "id": "2",
-                    "content": "Léo"
-                  },
-                  {
-                    "id": "3",
-                    "content": "Anna"
-                  },
-                  {
-                    "id": "4",
-                    "content": "Rayan"
-                  }
-                ],
-                "solutions": ["1"]
-              },
-              {
-                "type": "text",
-                "content": "<span>Qui va recevoir ce mail ?</span>"
-              },
-              {
-                "input": "b",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "- Sélectionner - ",
-                "ariaLabel": "destinaire mail",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "1",
-                    "content": "Michel uniquement"
-                  },
-                  {
-                    "id": "2",
-                    "content": "Léo uniquement"
-                  },
-                  {
-                    "id": "3",
-                    "content": "Léo, Anna, Hamed"
-                  },
-                  {
-                    "id": "4",
-                    "content": "Jennifer, Marine, Clément, Rayan"
-                  }
-                ],
-                "solutions": ["3"]
-              },
-              {
-                "type": "text",
-                "content": "<span>Quel est l'objet de ce mail ?</span>"
-              },
-              {
-                "input": "c",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "- Sélectionner -",
-                "ariaLabel": "objet mail",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "1",
-                    "content": "michel@pixmail.com"
-                  },
-                  {
-                    "id": "2",
-                    "content": "leo@laposte.net"
-                  },
-                  {
-                    "id": "3",
-                    "content": "Bonjour à tous"
-                  },
-                  {
-                    "id": "4",
-                    "content": "Costumes pour le 27 octobre"
-                  }
-                ],
-                "solutions": ["4"]
+                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><p>Pour envoyer un mail, il faut remplir ses différents champs avec les bonnes informations :</p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse !🎉",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Observez à nouveau le mail et réessayez.</p>"
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b6014eed-5edc-4010-ad7a-1e5410044f6d",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/GXJ6ihZ.png",
+                "alt": "",
+                "alternativeText": "<p>Le champ Objet permet de donner un titre au mail. Il permet de vite connaître le sujet du mail. Le champ De indique la personne qui envoie le mail. Le champ À indique la personne qui reçoit le mail.</p>"
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "ea80ad36-bf10-4eb1-bc3b-3cf044306e16",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "41c881bd-3195-459e-b1bc-c3a21b349384",
-            "type": "text",
-            "content": "<p>Pour finir ce module, nous vous proposons d’envoyer un mail avec une vraie adresse à l'un de vos proches ! <span aria-hidden=\"true\">💫</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f4b87554-8177-409c-89b8-d0e99f3bac28",
-      "type": "challenge",
-      "title": "Envoyer un mail à un ami",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e2eda86f-fcd2-4eba-922f-bf299ebddabd",
-            "type": "text",
-            "content": "<p>Envoyez un mail à une personne que vous connaissez avec votre adresse mail.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "7491dced-4c2d-40b4-a284-fd88b730b3db",
-            "type": "qcu",
-            "instruction": "<p>Avez-vous réussi à le faire ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Bravo. Vous obtiendrez peut-être une réponse !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Pour réussir, retournez voir la vidéo ou demandez de l'aide si vous êtes accompagné.<br>Si vous n'avez pas d'adresse mail, vous pouvez vous en créer une gratuitement sur internet.</p>"
+          "id": "667ebed8-cb72-4ac1-a9cd-7ae5f805f005",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "27281e03-bec3-43e3-985d-38b2eaec4c20",
+                "type": "text",
+                "content": "<p>Rayan vient de recevoir une réponse : le prochain cours est à 20 heures. <span aria-hidden=\"true\">✨</span></p><p>Maintenant, vous allez devoir analyser un autre mail.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4159b20c-fe4b-41fd-80f9-eefdc6240e9e",
+          "type": "challenge",
+          "title": "Analyser un mail",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e7288030-487b-4eb1-b256-7296fcd5c38b",
+                "type": "text",
+                "content": "<p>Voici un mail qui a été envoyé pour préparer les costumes du spectacle. </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2ddc4d66-3323-401b-b8ee-4f56bcd9c794",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/iQWPTJW.png",
+                "alt": "",
+                "alternativeText": "<ul><li>22 octobre 2024 (il y a 8 jours)</li> <li>De : michel@pixmail.com</li> <li>À :leo@laposte.net; anna@gmail.com; hamed@orange.fr</li><li> Objet : Costume pour le 27 octobre</li> <li>Bonjour à tous, Pensez à amener vos costumes de chevaliers pour la dernière scène. Pas besoin de prévenir Jennifer, Marine, Clément et Rayan : ils seront absents. Rendez-vous comme d'habitude au 7 rue Babylone à 18h.À bientôt ! Le Théâtre Lumière</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "00b87f7f-b3b0-454c-98a1-1e027b95cd7c",
+                "type": "qrocm",
+                "instruction": "<p>Observez le mail pour répondre aux questions suivantes.</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Qui a envoyé ce mail ?</span>"
+                  },
+                  {
+                    "input": "a",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "- Sélectionner -",
+                    "ariaLabel": "expéditeur mail",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "1",
+                        "content": "Michel"
+                      },
+                      {
+                        "id": "2",
+                        "content": "Léo"
+                      },
+                      {
+                        "id": "3",
+                        "content": "Anna"
+                      },
+                      {
+                        "id": "4",
+                        "content": "Rayan"
+                      }
+                    ],
+                    "solutions": ["1"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<span>Qui va recevoir ce mail ?</span>"
+                  },
+                  {
+                    "input": "b",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "- Sélectionner - ",
+                    "ariaLabel": "destinaire mail",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "1",
+                        "content": "Michel uniquement"
+                      },
+                      {
+                        "id": "2",
+                        "content": "Léo uniquement"
+                      },
+                      {
+                        "id": "3",
+                        "content": "Léo, Anna, Hamed"
+                      },
+                      {
+                        "id": "4",
+                        "content": "Jennifer, Marine, Clément, Rayan"
+                      }
+                    ],
+                    "solutions": ["3"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<span>Quel est l'objet de ce mail ?</span>"
+                  },
+                  {
+                    "input": "c",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "- Sélectionner -",
+                    "ariaLabel": "objet mail",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "1",
+                        "content": "michel@pixmail.com"
+                      },
+                      {
+                        "id": "2",
+                        "content": "leo@laposte.net"
+                      },
+                      {
+                        "id": "3",
+                        "content": "Bonjour à tous"
+                      },
+                      {
+                        "id": "4",
+                        "content": "Costumes pour le 27 octobre"
+                      }
+                    ],
+                    "solutions": ["4"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse !🎉",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Observez à nouveau le mail et réessayez.</p>"
+                  }
                 }
               }
-            ],
-            "solution": "1"
-          }
+            }
+          ]
+        },
+        {
+          "id": "ea80ad36-bf10-4eb1-bc3b-3cf044306e16",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "41c881bd-3195-459e-b1bc-c3a21b349384",
+                "type": "text",
+                "content": "<p>Pour finir ce module, nous vous proposons d’envoyer un mail avec une vraie adresse à l'un de vos proches ! <span aria-hidden=\"true\">💫</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f4b87554-8177-409c-89b8-d0e99f3bac28",
+          "type": "challenge",
+          "title": "Envoyer un mail à un ami",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e2eda86f-fcd2-4eba-922f-bf299ebddabd",
+                "type": "text",
+                "content": "<p>Envoyez un mail à une personne que vous connaissez avec votre adresse mail.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7491dced-4c2d-40b4-a284-fd88b730b3db",
+                "type": "qcu",
+                "instruction": "<p>Avez-vous réussi à le faire ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Bravo. Vous obtiendrez peut-être une réponse !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Pour réussir, retournez voir la vidéo ou demandez de l'aide si vous êtes accompagné.<br>Si vous n'avez pas d'adresse mail, vous pouvez vous en créer une gratuitement sur internet.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -15,635 +15,641 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "0e993f27-5189-47d4-ba37-efd4b466dd9d",
-      "type": "transition",
-      "title": "Transition 1",
-      "components": [
+      "id": "2cedcc1a-3fb4-4d68-b61f-cd271bb684a8",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "474c3482-deb8-44ca-91f0-15575c0f1f37",
-            "type": "text",
-            "content": "<p>Max va bientôt entrer au collège. <br>Ses parents souhaitent lui offrir son premier smartphone, mais ils ont peur que Max voie des contenus choquants. <br>Sa mère, Nina, demande conseil à des amis. <br>Lancez la vidéo pour voir leur discussion.&nbsp;📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f7e0ec28-06a2-4915-bcd7-53d5f5e3b9a7",
-      "type": "activity",
-      "title": "Accroche",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d8b50659-5ad8-4565-83eb-a3f7d82c0359",
-            "type": "video",
-            "title": "Un smartphone pour la rentrée ?",
-            "url": "https://assets.pix.org/modules/controle-parental/intro_ppn2/intro_ppn2.mp4",
-            "poster": "https://assets.pix.org/modules/controle-parental/intro_ppn2/vignette_intro_ppn2.jpg",
-            "subtitles": "",
-            "transcription": "<p>Discussion du groupe <strong>Les gentils copains</strong> (notamment Nina, Tao, Caroline, etc.) sur une application de messagerie instantanée&nbsp;:</p><p>Nina&nbsp;:&nbsp;Salut ! Ça y est ! Pour sa rentrée en 6e, j’achète un smartphone à Max. J’ai peur qu’il tombe sur des trucs pas top pour son âge. Un conseil ?</p><p>Tao&nbsp;:&nbsp;Ha moi, Inès a pas encore de smartphone. Elle le réclame mais c’est encore trop jeune !</p><p>Caroline :&nbsp;Nous on n’a pas hésité. Le collège est loin et Théo prend le bus.</p><p>Nina&nbsp;:&nbsp;Et du coup, vous avez fait comment ?</p><p>Caroline :&nbsp;On a beaucoup discuté avec Théo et son père pour fixer quelques règles. En plus, on a activé le contrôle parental du smartphone.</p><p>Tao&nbsp;:&nbsp;Le contrôle parental ? C’est utile ?</p><p>Caroline :&nbsp;Oui oui. Tu peux paramétrer le temps d'utilisation, les sites visités et plein d'autres choses. Le mieux, si tu veux que ton enfant joue le jeu, c'est de discuter du paramétrage avec lui !</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3281eca4-ff14-4f28-bb65-11b2e5f70faf",
-            "type": "qcu-discovery",
-            "instruction": "<p>Le contrôle parental est un outil numérique. Que permet-il ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Il permet d’encadrer les pratiques numériques de son enfant.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien joué ! En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Il permet de surveiller la santé de son enfant.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Le contrôle parental ne concerne pas la surveillance de la santé.<br>Il permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Il permet de vérifier que son enfant a fait ses devoirs scolaires.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Le contrôle parental ne concerne pas le suivi de la scolarité.<br>Il permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Le contrôle parental permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
-                }
+          "id": "0e993f27-5189-47d4-ba37-efd4b466dd9d",
+          "type": "transition",
+          "title": "Transition 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "474c3482-deb8-44ca-91f0-15575c0f1f37",
+                "type": "text",
+                "content": "<p>Max va bientôt entrer au collège. <br>Ses parents souhaitent lui offrir son premier smartphone, mais ils ont peur que Max voie des contenus choquants. <br>Sa mère, Nina, demande conseil à des amis. <br>Lancez la vidéo pour voir leur discussion.&nbsp;📺</p>"
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "464204ad-c607-4bdd-abe6-2cbebdfa3cf8",
-      "type": "transition",
-      "title": "Transition 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fa615c0d-1d9f-46fc-bf1c-1605130491e5",
-            "type": "text",
-            "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner les usages en ligne de Max sur son premier smartphone.&nbsp;📱</p><p>Découvrons ensemble des situations où il peut être utile d'utiliser un outil de contrôle parental.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9fc6d407-220f-4f0f-a68b-bbe62f83a814",
-      "type": "discovery",
-      "title": "Activité découverte - 1 :  Série de QCU",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5d6e01ea-2ad0-4261-bca3-5711b105f796",
-            "type": "text",
-            "content": "<p>Pour chacune des situations suivantes, indiquez si un outil de contrôle parental vous semble être une solution adaptée.</p>"
-          }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "f7e0ec28-06a2-4915-bcd7-53d5f5e3b9a7",
+          "type": "activity",
+          "title": "Accroche",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "2b0cfa3f-700e-4ab4-b8bd-613aa91c89d1",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Tim, 9 ans, utilise une tablette pour regarder des vidéos. Son parent remarque qu’il est parfois redirigé vers des vidéos inappropriées.&nbsp;😨</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>oui</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, la plupart des outils de contrôle parental permettent de filtrer les contenus selon l'âge.&nbsp;</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>non</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En fait si. La plupart des outils de contrôle parental permettent de filtrer les contenus selon l'âge.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "d8b50659-5ad8-4565-83eb-a3f7d82c0359",
+                "type": "video",
+                "title": "Un smartphone pour la rentrée ?",
+                "url": "https://assets.pix.org/modules/controle-parental/intro_ppn2/intro_ppn2.mp4",
+                "poster": "https://assets.pix.org/modules/controle-parental/intro_ppn2/vignette_intro_ppn2.jpg",
+                "subtitles": "",
+                "transcription": "<p>Discussion du groupe <strong>Les gentils copains</strong> (notamment Nina, Tao, Caroline, etc.) sur une application de messagerie instantanée&nbsp;:</p><p>Nina&nbsp;:&nbsp;Salut ! Ça y est ! Pour sa rentrée en 6e, j’achète un smartphone à Max. J’ai peur qu’il tombe sur des trucs pas top pour son âge. Un conseil ?</p><p>Tao&nbsp;:&nbsp;Ha moi, Inès a pas encore de smartphone. Elle le réclame mais c’est encore trop jeune !</p><p>Caroline :&nbsp;Nous on n’a pas hésité. Le collège est loin et Théo prend le bus.</p><p>Nina&nbsp;:&nbsp;Et du coup, vous avez fait comment ?</p><p>Caroline :&nbsp;On a beaucoup discuté avec Théo et son père pour fixer quelques règles. En plus, on a activé le contrôle parental du smartphone.</p><p>Tao&nbsp;:&nbsp;Le contrôle parental ? C’est utile ?</p><p>Caroline :&nbsp;Oui oui. Tu peux paramétrer le temps d'utilisation, les sites visités et plein d'autres choses. Le mieux, si tu veux que ton enfant joue le jeu, c'est de discuter du paramétrage avec lui !</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "4431dfa1-bab5-43e1-a7d8-dae795b5c2da",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Camille a 14 ans. Elle se couche très tard parce qu’elle joue en ligne jusqu’à minuit en semaine.&nbsp;Ses parents s'inquiètent car elle semble fatiguée la journée.&nbsp;😴</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>oui</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Tout à fait. Les outils de contrôle parental permettent souvent de limiter les horaires ou la durée d'utilisation d'un jeu ou d'une application.&nbsp;</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>non</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En fait, si.&nbsp;Les outils de contrôle parental permettent souvent de limiter les horaires ou la durée d'utilisation d'un jeu ou d'une application.</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "3281eca4-ff14-4f28-bb65-11b2e5f70faf",
+                "type": "qcu-discovery",
+                "instruction": "<p>Le contrôle parental est un outil numérique. Que permet-il ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Il permet d’encadrer les pratiques numériques de son enfant.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien joué ! En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Il permet de surveiller la santé de son enfant.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Le contrôle parental ne concerne pas la surveillance de la santé.<br>Il permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Il permet de vérifier que son enfant a fait ses devoirs scolaires.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Le contrôle parental ne concerne pas le suivi de la scolarité.<br>Il permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Le contrôle parental permet d’encadrer les pratiques numériques de son enfant. En plus du contrôle parental, des temps de discussion entre parents et enfants sont indispensables pour accompagner les pratiques numériques des enfants.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "464204ad-c607-4bdd-abe6-2cbebdfa3cf8",
+          "type": "transition",
+          "title": "Transition 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fa615c0d-1d9f-46fc-bf1c-1605130491e5",
+                "type": "text",
+                "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner les usages en ligne de Max sur son premier smartphone.&nbsp;📱</p><p>Découvrons ensemble des situations où il peut être utile d'utiliser un outil de contrôle parental.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9fc6d407-220f-4f0f-a68b-bbe62f83a814",
+          "type": "discovery",
+          "title": "Activité découverte - 1 :  Série de QCU",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5d6e01ea-2ad0-4261-bca3-5711b105f796",
+                "type": "text",
+                "content": "<p>Pour chacune des situations suivantes, indiquez si un outil de contrôle parental vous semble être une solution adaptée.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "b4c2ee50-96dd-417d-b415-181e7108bc94",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Julien s'inquiète de ce que son enfant de 11 ans fait en ligne, mais il ne sait pas par quoi commencer pour en discuter avec lui.&nbsp;😟</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>oui</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non. Un outil de contrôle parental peut donner des informations sur les pratiques numériques d'un enfant. Mais il ne remplace pas la communication entre un parent et son enfant.&nbsp;</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>non</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement,&nbsp;un outil de contrôle parental peut donner des informations sur les pratiques numériques d'un enfant.&nbsp;Mais il ne remplace pas la communication entre un parent et son enfant.</p>"
-                      }
+                      "id": "2b0cfa3f-700e-4ab4-b8bd-613aa91c89d1",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Tim, 9 ans, utilise une tablette pour regarder des vidéos. Son parent remarque qu’il est parfois redirigé vers des vidéos inappropriées.&nbsp;😨</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>oui</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, la plupart des outils de contrôle parental permettent de filtrer les contenus selon l'âge.&nbsp;</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>non</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En fait si. La plupart des outils de contrôle parental permettent de filtrer les contenus selon l'âge.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "388f7876-1d66-4598-888d-c5e78a7eb78e",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Marianne veut être alertée si son enfant tente d'installer une nouvelle application sans lui en parler.&nbsp;🔎</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>oui</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, certains outils de contrôle parental permettent de bloquer ou valider l'installation d'applications à distance.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>non</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En fait, si. Certains outils de contrôle parental permettent de bloquer ou valider l'installation d'applications à distance.</p>"
-                      }
+                      "id": "4431dfa1-bab5-43e1-a7d8-dae795b5c2da",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Camille a 14 ans. Elle se couche très tard parce qu’elle joue en ligne jusqu’à minuit en semaine.&nbsp;Ses parents s'inquiètent car elle semble fatiguée la journée.&nbsp;😴</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>oui</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Tout à fait. Les outils de contrôle parental permettent souvent de limiter les horaires ou la durée d'utilisation d'un jeu ou d'une application.&nbsp;</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>non</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En fait, si.&nbsp;Les outils de contrôle parental permettent souvent de limiter les horaires ou la durée d'utilisation d'un jeu ou d'une application.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b4c2ee50-96dd-417d-b415-181e7108bc94",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Julien s'inquiète de ce que son enfant de 11 ans fait en ligne, mais il ne sait pas par quoi commencer pour en discuter avec lui.&nbsp;😟</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>oui</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non. Un outil de contrôle parental peut donner des informations sur les pratiques numériques d'un enfant. Mais il ne remplace pas la communication entre un parent et son enfant.&nbsp;</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>non</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement,&nbsp;un outil de contrôle parental peut donner des informations sur les pratiques numériques d'un enfant.&nbsp;Mais il ne remplace pas la communication entre un parent et son enfant.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "388f7876-1d66-4598-888d-c5e78a7eb78e",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Marianne veut être alertée si son enfant tente d'installer une nouvelle application sans lui en parler.&nbsp;🔎</p><p><br>À votre avis, un outil de contrôle parental est-il une solution adaptée ?&nbsp;</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>oui</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, certains outils de contrôle parental permettent de bloquer ou valider l'installation d'applications à distance.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>non</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En fait, si. Certains outils de contrôle parental permettent de bloquer ou valider l'installation d'applications à distance.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "fab2ec90-8350-4f51-8700-336bcd3acade",
-      "type": "lesson",
-      "title": "Leçon 1 - Vidéo",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fe57ddca-0827-45b1-ab8a-59a92ca48ce9",
-            "type": "text",
-            "content": "<p>Dans la vidéo suivante, apprenez-en plus sur les principales fonctionnalités des outils de contrôle parental.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b6652deb-5c2f-45f9-88aa-b5de054c63c8",
-            "type": "video",
-            "title": "Les fonctionnalités du contrôle parental",
-            "url": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/fonctionnalit%C3%A9s_controle_parental_ppn2.mp4",
-            "poster": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/vignette_fonctionnalit%C3%A9s_ppn2.jpg",
-            "subtitles": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/fonctionnalit%C3%A9s_controle_parental_ppn2.vtt",
-            "transcription": "<p><strong>Les fonctionnalités du contrôle parental</strong> <br>Comme Max entre au collège, ses parents pensent lui offrir son premier smartphone. Sa mère, Nina, s'inquiète… Comment accompagner Max dans ses premiers pas ? <br>Les outils de contrôle parental permettent d'aider les parents à protéger leurs enfants en ligne.&nbsp;Explorons ensemble leurs fonctionnalités les plus courantes.</p><ul>    <li>Gestion du temps d'écran</li></ul><p>Grâce aux options de gestion du temps d’écran, un parent peut définir des limites de temps pour chaque jour ou chaque application et des plages horaires d'utilisation. <br>Par exemple, un parent peut paramétrer le blocage d’un appareil après l’heure du coucher de son enfant</p><ul>    <li>Filtrage de contenu</li></ul><p>Grâce aux options de filtrage de contenu, en fonction de l’âge de son enfant,&nbsp;un parent peut choisir de bloquer certaines catégories de contenus (applications, vidéos, jeux).&nbsp; <br>Il est souvent possible de définir une liste de blocage de sites et de services ou encore de désactiver certaines options (telles que les achats en ligne ou l’échange de messages avec d’autres utilisateurs). </p><ul>    <li>Suivi de l'activité en ligne</li></ul><p>Avec le suivi de l’activité en ligne, un parent peut consulter le temps passé par son enfant sur un appareil et sur les différentes applications ou jeux installés. <br> Cela lui permet de suivre régulièrement l’usage numérique de son enfant, de discuter avec lui et d’adapter les limites qu’il lui fixe.</p><ul>    <li>Options avancées</li></ul><p>Certains outils de contrôle parental proposent des options plus poussées.&nbsp;Par exemple, consulter l’historique de navigation de son enfant, suivre ses déplacements en temps réel ou accéder aux messages qu’il envoie.&nbsp;<br>Attention, ces options ne sont pas toutes respectueuses de la vie privée de l’enfant. Utilisées sans discussion, elles peuvent nuire à la confiance entre l’enfant et son parent. </p>    <p>Les outils de contrôle parental ont de nombreuses fonctionnalités. Comme Nina, chaque parent peut les adapter aux besoins de son enfant et au fil du temps.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "531aa39a-d460-4495-a492-8dc05ed60d76",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "301d0040-a548-44b0-8b83-281d6ee2c60b",
-            "type": "text",
-            "content": "<p>Maintenant que vous en savez plus sur le contrôle parental, aidez Nina à l’activer sur le smartphone de son fils, Max.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ee9779af-508e-4fe1-88ad-acf2fa89dd45",
-      "type": "discovery",
-      "title": "Activité découverte - 2 : Activation du contrôle parental sur un smartphone",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "04eff902-3513-432e-b9a5-764c8563dd17",
-            "type": "text",
-            "content": "<p><strong>Essayez d'activer le contrôle parental dans le simulateur de smartphone ci-dessous.</strong>&nbsp;👇</p><p>🧘 Ne vous inquiétez pas ! Les réglages de votre propre smartphone ne seront pas modifiés.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "37ff3330-b8df-47e0-80d2-e382671dc3dd",
-            "type": "embed",
-            "isCompletionRequired": true,
-            "title": "Simulateur de smartphone - activation du contrôle parental",
-            "url": "https://epreuves.pix.fr/temps_en_ligne/temps_en_ligne.html?mode=module-activer&lang=fr",
-            "instruction": "<p></p>",
-            "solution": "flügelhorn",
-            "height": 720
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4c48c54b-9845-4de6-a1d9-674c97432a46",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5432d74b-3bcd-44f6-a031-8e0ba0cdceda",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>\n<p><br></p>\n<p>\n</p><p></p><details open=\"\">\n    <summary>Indice 1</summary>\n    <p>Le contrôle parental fait partie des paramètres de l’appareil. ⚙️</p>\n</details>\n<details open=\"\">\n    <summary>Indice 2</summary>\n    <p>Ici, le contrôle parental s’active sur l’appareil de l’enfant</p>\n</details>\n<p></p><p></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "573ea439-8075-48a5-a596-6583e17cb461",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e1930046-29d3-4a0d-a88c-fdb9f7dbbe29",
-            "type": "text",
-            "content": "<p>Une fois le contrôle parental activé, Nina va pouvoir le paramétrer avec Max.</p><p><br>💡 <strong>Bon à savoir</strong><br>En fonction du smartphone, le nom du paramètre à activer pour le contrôle parental n’est pas toujours le même.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6b6781ec-9e38-4ffe-8200-b93720941be9",
-      "type": "transition",
-      "title": "Transition - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "feba82d9-0c9d-4d7b-8f66-474416edd792",
-            "type": "text",
-            "content": "<p>Il n’y a pas que sur les smartphones qu’il y a du contrôle parental !&nbsp;Partons à la découverte des appareils et des plateformes qui proposent des options de contrôle parental.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6e9c3dbf-34de-4652-b119-aa2a02772fdd",
-      "type": "lesson",
-      "title": "Leçon 2 - infographie",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9bc8b95e-c9ca-4836-9f59-2624aa4c37f8",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/controle-parental/ppn2_infographie.png",
-            "alt": "Infographie décrite dans l'alternative textuelle",
-            "alternativeText": "<p>Infographie<strong> « Où trouver des options de contrôle parental  » ?</strong> </p><ul><li>Sur les appareils&nbsp;:<ul><li>les appareils personnels (smartphones, tablettes, ordinateurs, montres connectées, télévisions connectées)</li><li>les consoles de jeux (Nintendo switch, Xbox, Playstation et d’autres)</li><li>les box internet</li></ul></li><li>En ligne&nbsp;:&nbsp;<ul><li>les réseaux sociaux (Instagram, Facebook, Snapchat, Tiktok, Discord et d’autres)</li><li>les plateformes de jeux vidéo (Electronic art, Steam, Roblox et d’autres)</li><li>les plateformes de vidéo à la demande (Netflix, Amazon prime, Disney+ et d’autres)</li></ul></li><li>Pour l’activer, rendez-vous sur <strong>paramètres </strong>ou <strong>compte</strong>, puis cherchez, selon les appareils et les plateformes&nbsp;: supervision parentale, contrôle parental, temps d’écran, bien être numérique, connexion famille, famille et contrôle parental, centre familial ou d’autres</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "693544c4-d186-45b2-8ade-525ad981787d",
-            "type": "text",
-            "content": "<p>💡 <strong>Bon à savoir</strong>&nbsp;: </p><p>Depuis juillet 2024,<strong> tous les nouveaux appareils connectés vendus en France doivent obligatoirement être équipés d’un contrôle parental</strong> pré-installé, activable facilement dès le premier démarrage.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e9b51c11-8a5e-42bb-9563-e06ffce4221e",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2b03d03b-39fd-433a-8895-1144aa69d766",
-            "type": "text",
-            "content": "<p> Voici les principaux points à retenir sur le contrôle parental&nbsp;: </p><ul>    <li>C'est un <strong>outil numérique pour protéger les enfants et encadrer leurs usages numériques.</strong>&nbsp;🛡️</li>    <li>Il ne<strong> remplace pas les échanges parents-enfants</strong>, il les complète !&nbsp;🗣️</li>    <li>Il a de nombreuses fonctionnalités&nbsp;: <strong>gestion du temps en ligne, filtrage des contenus et suivi des activités</strong>.&nbsp;⏳</li><li>Il est possible d'activer du contrôle parental <strong>sur tous les appareils connectés</strong> vendus en France depuis 2024.&nbsp;🌐</li>    <li>Pour l’activer et le paramétrer, rendez-vous dans les <strong>paramètres</strong> de l'appareil ou du service en ligne.&nbsp;⚙️</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b6f2605d-2704-4597-aa90-0b4fd0a904b3",
-      "type": "activity",
-      "title": "Activité d'application - 1 : vrai-faux à créer",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "06f7d661-40da-4b6d-adf3-40e98cc3f2dc",
-            "type": "qab",
-            "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
-            "cards": [
-              {
-                "id": "a24d69a1-938d-4b37-bf5d-430452f5660f",
-                "text": "Le seul appareil qui propose du contrôle parental, c'est le smartphone.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "c27ec2ba-5167-40ce-9f2c-0586e51ecea4",
-                "text": "Avec un bon outil de contrôle parental, plus besoin de parler avec son enfant de ses pratiques numériques.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "061775ac-8833-4507-97bc-150483777a8f",
-                "text": "La plupart des réseaux sociaux proposent des options de contrôle parental.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
+          "id": "fab2ec90-8350-4f51-8700-336bcd3acade",
+          "type": "lesson",
+          "title": "Leçon 1 - Vidéo",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fe57ddca-0827-45b1-ab8a-59a92ca48ce9",
+                "type": "text",
+                "content": "<p>Dans la vidéo suivante, apprenez-en plus sur les principales fonctionnalités des outils de contrôle parental.</p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b6652deb-5c2f-45f9-88aa-b5de054c63c8",
+                "type": "video",
+                "title": "Les fonctionnalités du contrôle parental",
+                "url": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/fonctionnalit%C3%A9s_controle_parental_ppn2.mp4",
+                "poster": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/vignette_fonctionnalit%C3%A9s_ppn2.jpg",
+                "subtitles": "https://assets.pix.org/modules/controle-parental/fonctionnalit%C3%A9s_controle_parental_ppn2/fonctionnalit%C3%A9s_controle_parental_ppn2.vtt",
+                "transcription": "<p><strong>Les fonctionnalités du contrôle parental</strong> <br>Comme Max entre au collège, ses parents pensent lui offrir son premier smartphone. Sa mère, Nina, s'inquiète… Comment accompagner Max dans ses premiers pas ? <br>Les outils de contrôle parental permettent d'aider les parents à protéger leurs enfants en ligne.&nbsp;Explorons ensemble leurs fonctionnalités les plus courantes.</p><ul>    <li>Gestion du temps d'écran</li></ul><p>Grâce aux options de gestion du temps d’écran, un parent peut définir des limites de temps pour chaque jour ou chaque application et des plages horaires d'utilisation. <br>Par exemple, un parent peut paramétrer le blocage d’un appareil après l’heure du coucher de son enfant</p><ul>    <li>Filtrage de contenu</li></ul><p>Grâce aux options de filtrage de contenu, en fonction de l’âge de son enfant,&nbsp;un parent peut choisir de bloquer certaines catégories de contenus (applications, vidéos, jeux).&nbsp; <br>Il est souvent possible de définir une liste de blocage de sites et de services ou encore de désactiver certaines options (telles que les achats en ligne ou l’échange de messages avec d’autres utilisateurs). </p><ul>    <li>Suivi de l'activité en ligne</li></ul><p>Avec le suivi de l’activité en ligne, un parent peut consulter le temps passé par son enfant sur un appareil et sur les différentes applications ou jeux installés. <br> Cela lui permet de suivre régulièrement l’usage numérique de son enfant, de discuter avec lui et d’adapter les limites qu’il lui fixe.</p><ul>    <li>Options avancées</li></ul><p>Certains outils de contrôle parental proposent des options plus poussées.&nbsp;Par exemple, consulter l’historique de navigation de son enfant, suivre ses déplacements en temps réel ou accéder aux messages qu’il envoie.&nbsp;<br>Attention, ces options ne sont pas toutes respectueuses de la vie privée de l’enfant. Utilisées sans discussion, elles peuvent nuire à la confiance entre l’enfant et son parent. </p>    <p>Les outils de contrôle parental ont de nombreuses fonctionnalités. Comme Nina, chaque parent peut les adapter aux besoins de son enfant et au fil du temps.</p>"
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "58d3587f-05b7-45a8-830a-d21cf319b6a2",
-      "type": "activity",
-      "title": "Activité d'application - 2 : fonctionnalité adaptée",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "510822a9-aba9-43e0-8ef7-cd5f377ae78d",
-            "type": "text",
-            "content": "<p>Pour chacune des situations suivantes, sélectionnez la fonctionnalité de contrôle parental adaptée.</p>"
-          }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "531aa39a-d460-4495-a492-8dc05ed60d76",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "c9540007-19f4-456e-8137-5b85f81d2854",
-                  "type": "text",
-                  "content": "<p>Rachel veut éviter que son fils de 13 ans télécharge des jeux déconseillés au moins de 16 ans sur sa console.</p>"
-                },
-                {
-                  "id": "ca55f260-188e-4292-91fe-80866319f0eb",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Rachel ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>la gestion du temps d’écran</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>La gestion du temps d’écran permet de mettre des limites de temps d’utilisation.<br>Elle ne permet pas de bloquer l’accès à un contenu en fonction de l’âge de son enfant.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le filtrage des contenus</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !&nbsp;🎉",
-                        "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès aux contenus en fonction de l’âge de son enfant.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le suivi de l’activité en ligne</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le suivi de l’activité en ligne permet de suivre l’utilisation de la console. <br>Il ne permet pas de bloquer l’accès à un contenu en fonction de l’âge de son enfant.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "301d0040-a548-44b0-8b83-281d6ee2c60b",
+                "type": "text",
+                "content": "<p>Maintenant que vous en savez plus sur le contrôle parental, aidez Nina à l’activer sur le smartphone de son fils, Max.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ee9779af-508e-4fe1-88ad-acf2fa89dd45",
+          "type": "discovery",
+          "title": "Activité découverte - 2 : Activation du contrôle parental sur un smartphone",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "04eff902-3513-432e-b9a5-764c8563dd17",
+                "type": "text",
+                "content": "<p><strong>Essayez d'activer le contrôle parental dans le simulateur de smartphone ci-dessous.</strong>&nbsp;👇</p><p>🧘 Ne vous inquiétez pas ! Les réglages de votre propre smartphone ne seront pas modifiés.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "e45eb37c-86b0-4643-ae61-39582618d6f1",
-                  "type": "text",
-                  "content": "<p>Thibault trouve que son fils utilise son smartphone trop tard les soirs de semaine. Il souhaite verrouiller l’appareil à partir de 20h.</p>"
-                },
-                {
-                  "id": "a175d292-6210-4a62-9e0a-4caf588e7bee",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Thibault ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>la gestion du temps d’écran</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !&nbsp;🎉",
-                        "diagnosis": "<p>Avec la gestion du temps d’écran, il est possible de définir des plages horaires où l’utilisation du smartphone est bloquée.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le filtrage des contenus</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès à des contenus en fonction de l’âge par exemple.<br> Il ne permet pas de définir des temps de blocage du smartphone de son enfant.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le suivi de l’activité en ligne</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le suivi de l’activité en ligne permet de suivre l’utilisation du smartphone. <br>Il ne permet pas de définir des temps de blocage du smartphone de son enfant.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "37ff3330-b8df-47e0-80d2-e382671dc3dd",
+                "type": "embed",
+                "isCompletionRequired": true,
+                "title": "Simulateur de smartphone - activation du contrôle parental",
+                "url": "https://epreuves.pix.fr/temps_en_ligne/temps_en_ligne.html?mode=module-activer&lang=fr",
+                "instruction": "<p></p>",
+                "solution": "flügelhorn",
+                "height": 720
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "4c48c54b-9845-4de6-a1d9-674c97432a46",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "5432d74b-3bcd-44f6-a031-8e0ba0cdceda",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p>\n<p><br></p>\n<p>\n</p><p></p><details open=\"\">\n    <summary>Indice 1</summary>\n    <p>Le contrôle parental fait partie des paramètres de l’appareil. ⚙️</p>\n</details>\n<details open=\"\">\n    <summary>Indice 2</summary>\n    <p>Ici, le contrôle parental s’active sur l’appareil de l’enfant</p>\n</details>\n<p></p><p></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "573ea439-8075-48a5-a596-6583e17cb461",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e1930046-29d3-4a0d-a88c-fdb9f7dbbe29",
+                "type": "text",
+                "content": "<p>Une fois le contrôle parental activé, Nina va pouvoir le paramétrer avec Max.</p><p><br>💡 <strong>Bon à savoir</strong><br>En fonction du smartphone, le nom du paramètre à activer pour le contrôle parental n’est pas toujours le même.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6b6781ec-9e38-4ffe-8200-b93720941be9",
+          "type": "transition",
+          "title": "Transition - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "feba82d9-0c9d-4d7b-8f66-474416edd792",
+                "type": "text",
+                "content": "<p>Il n’y a pas que sur les smartphones qu’il y a du contrôle parental !&nbsp;Partons à la découverte des appareils et des plateformes qui proposent des options de contrôle parental.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6e9c3dbf-34de-4652-b119-aa2a02772fdd",
+          "type": "lesson",
+          "title": "Leçon 2 - infographie",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9bc8b95e-c9ca-4836-9f59-2624aa4c37f8",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/controle-parental/ppn2_infographie.png",
+                "alt": "Infographie décrite dans l'alternative textuelle",
+                "alternativeText": "<p>Infographie<strong> « Où trouver des options de contrôle parental  » ?</strong> </p><ul><li>Sur les appareils&nbsp;:<ul><li>les appareils personnels (smartphones, tablettes, ordinateurs, montres connectées, télévisions connectées)</li><li>les consoles de jeux (Nintendo switch, Xbox, Playstation et d’autres)</li><li>les box internet</li></ul></li><li>En ligne&nbsp;:&nbsp;<ul><li>les réseaux sociaux (Instagram, Facebook, Snapchat, Tiktok, Discord et d’autres)</li><li>les plateformes de jeux vidéo (Electronic art, Steam, Roblox et d’autres)</li><li>les plateformes de vidéo à la demande (Netflix, Amazon prime, Disney+ et d’autres)</li></ul></li><li>Pour l’activer, rendez-vous sur <strong>paramètres </strong>ou <strong>compte</strong>, puis cherchez, selon les appareils et les plateformes&nbsp;: supervision parentale, contrôle parental, temps d’écran, bien être numérique, connexion famille, famille et contrôle parental, centre familial ou d’autres</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "693544c4-d186-45b2-8ade-525ad981787d",
+                "type": "text",
+                "content": "<p>💡 <strong>Bon à savoir</strong>&nbsp;: </p><p>Depuis juillet 2024,<strong> tous les nouveaux appareils connectés vendus en France doivent obligatoirement être équipés d’un contrôle parental</strong> pré-installé, activable facilement dès le premier démarrage.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e9b51c11-8a5e-42bb-9563-e06ffce4221e",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2b03d03b-39fd-433a-8895-1144aa69d766",
+                "type": "text",
+                "content": "<p> Voici les principaux points à retenir sur le contrôle parental&nbsp;: </p><ul>    <li>C'est un <strong>outil numérique pour protéger les enfants et encadrer leurs usages numériques.</strong>&nbsp;🛡️</li>    <li>Il ne<strong> remplace pas les échanges parents-enfants</strong>, il les complète !&nbsp;🗣️</li>    <li>Il a de nombreuses fonctionnalités&nbsp;: <strong>gestion du temps en ligne, filtrage des contenus et suivi des activités</strong>.&nbsp;⏳</li><li>Il est possible d'activer du contrôle parental <strong>sur tous les appareils connectés</strong> vendus en France depuis 2024.&nbsp;🌐</li>    <li>Pour l’activer et le paramétrer, rendez-vous dans les <strong>paramètres</strong> de l'appareil ou du service en ligne.&nbsp;⚙️</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b6f2605d-2704-4597-aa90-0b4fd0a904b3",
+          "type": "activity",
+          "title": "Activité d'application - 1 : vrai-faux à créer",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "06f7d661-40da-4b6d-adf3-40e98cc3f2dc",
+                "type": "qab",
+                "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
+                "cards": [
+                  {
+                    "id": "a24d69a1-938d-4b37-bf5d-430452f5660f",
+                    "text": "Le seul appareil qui propose du contrôle parental, c'est le smartphone.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "c27ec2ba-5167-40ce-9f2c-0586e51ecea4",
+                    "text": "Avec un bon outil de contrôle parental, plus besoin de parler avec son enfant de ses pratiques numériques.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "061775ac-8833-4507-97bc-150483777a8f",
+                    "text": "La plupart des réseaux sociaux proposent des options de contrôle parental.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "58d3587f-05b7-45a8-830a-d21cf319b6a2",
+          "type": "activity",
+          "title": "Activité d'application - 2 : fonctionnalité adaptée",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "510822a9-aba9-43e0-8ef7-cd5f377ae78d",
+                "type": "text",
+                "content": "<p>Pour chacune des situations suivantes, sélectionnez la fonctionnalité de contrôle parental adaptée.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "7196fed5-37d9-4e5c-8d47-4baf6702129b",
-                  "type": "text",
-                  "content": "<p>Nassira souhaite connaître le temps passé par son fils sur les réseaux sociaux.</p>"
+                  "elements": [
+                    {
+                      "id": "c9540007-19f4-456e-8137-5b85f81d2854",
+                      "type": "text",
+                      "content": "<p>Rachel veut éviter que son fils de 13 ans télécharge des jeux déconseillés au moins de 16 ans sur sa console.</p>"
+                    },
+                    {
+                      "id": "ca55f260-188e-4292-91fe-80866319f0eb",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Rachel ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la gestion du temps d’écran</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>La gestion du temps d’écran permet de mettre des limites de temps d’utilisation.<br>Elle ne permet pas de bloquer l’accès à un contenu en fonction de l’âge de son enfant.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le filtrage des contenus</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !&nbsp;🎉",
+                            "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès aux contenus en fonction de l’âge de son enfant.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le suivi de l’activité en ligne</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le suivi de l’activité en ligne permet de suivre l’utilisation de la console. <br>Il ne permet pas de bloquer l’accès à un contenu en fonction de l’âge de son enfant.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 },
                 {
-                  "id": "93effa58-b217-46c7-bb73-9b447a56902e",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Nassira ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>la gestion du temps d’écran</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>La gestion du temps d’écran permet de mettre des limites de temps d’utilisation.<br>Elle ne permet pas de connaître le temps d’utilisation d’une application par son enfant.</p>"
-                      }
+                      "id": "e45eb37c-86b0-4643-ae61-39582618d6f1",
+                      "type": "text",
+                      "content": "<p>Thibault trouve que son fils utilise son smartphone trop tard les soirs de semaine. Il souhaite verrouiller l’appareil à partir de 20h.</p>"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>le filtrage des contenus</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès à des contenus en fonction de l’âge par exemple. <br>Il ne permet pas de connaître le temps d’utilisation d’une application par son enfant.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le suivi de l’activité en ligne</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !&nbsp;🎉",
-                        "diagnosis": "<p>Le suivi de l’activité en ligne permet de connaître les applications utilisées le plus souvent par son enfant sur son smartphone.</p>"
-                      }
+                      "id": "a175d292-6210-4a62-9e0a-4caf588e7bee",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Thibault ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la gestion du temps d’écran</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !&nbsp;🎉",
+                            "diagnosis": "<p>Avec la gestion du temps d’écran, il est possible de définir des plages horaires où l’utilisation du smartphone est bloquée.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le filtrage des contenus</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès à des contenus en fonction de l’âge par exemple.<br> Il ne permet pas de définir des temps de blocage du smartphone de son enfant.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le suivi de l’activité en ligne</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le suivi de l’activité en ligne permet de suivre l’utilisation du smartphone. <br>Il ne permet pas de définir des temps de blocage du smartphone de son enfant.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "3"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7196fed5-37d9-4e5c-8d47-4baf6702129b",
+                      "type": "text",
+                      "content": "<p>Nassira souhaite connaître le temps passé par son fils sur les réseaux sociaux.</p>"
+                    },
+                    {
+                      "id": "93effa58-b217-46c7-bb73-9b447a56902e",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle fonctionnalité de contrôle parental est adaptée pour Nassira ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la gestion du temps d’écran</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>La gestion du temps d’écran permet de mettre des limites de temps d’utilisation.<br>Elle ne permet pas de connaître le temps d’utilisation d’une application par son enfant.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le filtrage des contenus</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le filtrage de contenus permet de bloquer l’accès à des contenus en fonction de l’âge par exemple. <br>Il ne permet pas de connaître le temps d’utilisation d’une application par son enfant.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le suivi de l’activité en ligne</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !&nbsp;🎉",
+                            "diagnosis": "<p>Le suivi de l’activité en ligne permet de connaître les applications utilisées le plus souvent par son enfant sur son smartphone.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "d7f90547-b24d-47d1-9383-2dc360ea6a28",
-      "type": "transition",
-      "title": "Transition - 5",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "4efaa439-2698-4ef9-b61e-a60f88e1a9fb",
-            "type": "text",
-            "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner Max dans ses usages numériques plus sereinement. 👏</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "dde349da-a5fc-41b5-8c47-9ec5a2780165",
-      "type": "activity",
-      "title": "Transfert",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6ce0eec7-8b4e-4b28-8805-ed83a2b8db68",
-            "type": "qcu-declarative",
-            "instruction": "<p>Avez-vous déjà utilisé un outil de contrôle parental sur vos appareils ou ceux de vos enfants ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Oui, j'ai déjà utilisé un outil de contrôle parental.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Super ! ✨ C’est un bon moyen de compléter le dialogue avec vos enfants. N’hésitez pas à réévaluer régulièrement les réglages selon leurs âges et leurs usages. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Pas encore, mais j'y pense.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Si vous avez envie de vous lancer, vous pouvez commencer simplement, par exemple en explorant les paramètres d’un seul appareil. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Non, je n'en ai pas besoin pour l'instant.</p>",
-                "feedback": {
-                  "diagnosis": "<p>L’important est de rester informé et prêt à agir si le besoin se présente. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
-                }
+          "id": "d7f90547-b24d-47d1-9383-2dc360ea6a28",
+          "type": "transition",
+          "title": "Transition - 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4efaa439-2698-4ef9-b61e-a60f88e1a9fb",
+                "type": "text",
+                "content": "<p>Grâce au contrôle parental, Nina va pouvoir accompagner Max dans ses usages numériques plus sereinement. 👏</p>"
               }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "8a517ecc-2145-4bb5-9d90-afb26fe71c2f",
-      "type": "transition",
-      "title": "Pour aller plus loin",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "14e1e0c3-b521-41bf-af4a-2757912262c1",
-            "type": "text",
-            "content": "<p>Pour en apprendre plus sur le contrôle parental, rendez-vous sur la page <a href=\"https://e-enfance.org/informer/controle-parental/\" target=\"_blank\">Activer, installer et configurer un contrôle parental</a> de l’association e-Enfance.</p>"
-          }
+          "id": "dde349da-a5fc-41b5-8c47-9ec5a2780165",
+          "type": "activity",
+          "title": "Transfert",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6ce0eec7-8b4e-4b28-8805-ed83a2b8db68",
+                "type": "qcu-declarative",
+                "instruction": "<p>Avez-vous déjà utilisé un outil de contrôle parental sur vos appareils ou ceux de vos enfants ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Oui, j'ai déjà utilisé un outil de contrôle parental.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Super ! ✨ C’est un bon moyen de compléter le dialogue avec vos enfants. N’hésitez pas à réévaluer régulièrement les réglages selon leurs âges et leurs usages. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Pas encore, mais j'y pense.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Si vous avez envie de vous lancer, vous pouvez commencer simplement, par exemple en explorant les paramètres d’un seul appareil. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Non, je n'en ai pas besoin pour l'instant.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>L’important est de rester informé et prêt à agir si le besoin se présente. Ce module vous donne déjà des pistes, et il existe des ressources pour aller plus loin.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "8a517ecc-2145-4bb5-9d90-afb26fe71c2f",
+          "type": "transition",
+          "title": "Pour aller plus loin",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "14e1e0c3-b521-41bf-af4a-2757912262c1",
+                "type": "text",
+                "content": "<p>Pour en apprendre plus sur le contrôle parental, rendez-vous sur la page <a href=\"https://e-enfance.org/informer/controle-parental/\" target=\"_blank\">Activer, installer et configurer un contrôle parental</a> de l’association e-Enfance.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -15,728 +15,731 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "353dbd92-62f8-45d8-9537-10f2a860517b",
-      "type": "transition",
-      "title": "Accroche",
-      "components": [
+      "id": "0ba41b81-6611-4278-86a1-3891d72d87a1",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "d14837d6-8c5c-4071-931e-8cccc99aca2e",
-            "type": "text",
-            "content": "<p>Ava vient de finir sa première semaine au collège.<span aria-hidden=\"true\">🎒</span></p><p>À la maison, elle raconte sa journée à son père, Martin.</p><p>Lancez la vidéo pour voir leur discussion. ▶️ </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "28715656-221a-4627-9874-06bc963e0867",
-            "type": "video",
-            "title": "Retour du collège",
-            "url": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.mp4",
-            "poster": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.jpg",
-            "subtitles": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.vtt",
-            "transcription": "<p></p><h3>Des devoirs en ligne ?</h3><p></p><p>Conversation entre Martin et sa fille Ava&nbsp;:&nbsp;</p><p>Martin&nbsp;: Alors Ava, cette journée ?<br>Ava&nbsp;: Super, papa ! Mais je suis quand même contente d’être en week-end.<br>Martin&nbsp;: Tu as des devoirs pour la semaine prochaine ?<br>Ava&nbsp;: Oui, le prof a mis des devoirs en ligne.<br>Martin&nbsp;: En ligne ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fd85068b-9126-4a6f-a53c-0179252c7b73",
-      "type": "discovery",
-      "title": "Activité découverte - 1 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9b36dc6e-8765-4c3d-bb9a-4eb6b9b12454",
-            "type": "text",
-            "content": "<p>Le professeur d’Ava a mis des devoirs en ligne.</p><p>Son père, Martin, veut les regarder.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d881a6a8-374b-448d-b167-6db06712f34d",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, où Martin peut-il regarder les devoirs d’Ava ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>sur l'espace numérique de travail</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, l’espace numérique de travail (ou ENT) est l'outil numérique de suivi de la scolarité proposé par le collège. </p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>sur sa boîte mail</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>sur le site internet de la mairie</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "230a5596-b73d-4702-b40e-13d6c3ca8ca8",
-      "type": "transition",
-      "title": "Transition - 1 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "45accc21-d421-4444-9547-5905afa54cf6",
-            "type": "text",
-            "content": "<p>Grâce à l'ENT, Martin peut suivre en ligne la scolarité d'Ava. Voyons cela ensemble !<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f2c81b8b-1574-4304-bd69-8ed05f579794",
-      "type": "lesson",
-      "title": "Leçon - 1 ",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "353dbd92-62f8-45d8-9537-10f2a860517b",
+          "type": "transition",
+          "title": "Accroche",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "fbda3f57-d9cc-404f-9a09-0eb3ba9b3ac6",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_schema.png",
-                  "alt": "",
-                  "alternativeText": "",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "90c81b47-b175-4f42-b5aa-914ec83025b8",
-                  "type": "text",
-                  "content": "<h3>L’espace numérique de travail (ENT) est le service en ligne proposé par l’établissement scolaire.</h3>\n<p><br>L’ENT est utilisé par les élèves, les enseignants, les parents et les personnels d’éducation (CPE, principal...).</p>\n<p>Il est accessible sur ordinateur, smartphone et tablette.</p>\n<p><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT est sécurisé et il protège l’accès aux données personnelles des parents et des enfants.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "d14837d6-8c5c-4071-931e-8cccc99aca2e",
+                "type": "text",
+                "content": "<p>Ava vient de finir sa première semaine au collège.<span aria-hidden=\"true\">🎒</span></p><p>À la maison, elle raconte sa journée à son père, Martin.</p><p>Lancez la vidéo pour voir leur discussion. ▶️ </p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "28715656-221a-4627-9874-06bc963e0867",
+                "type": "video",
+                "title": "Retour du collège",
+                "url": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.mp4",
+                "poster": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.jpg",
+                "subtitles": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.vtt",
+                "transcription": "<p></p><h3>Des devoirs en ligne ?</h3><p></p><p>Conversation entre Martin et sa fille Ava&nbsp;:&nbsp;</p><p>Martin&nbsp;: Alors Ava, cette journée ?<br>Ava&nbsp;: Super, papa ! Mais je suis quand même contente d’être en week-end.<br>Martin&nbsp;: Tu as des devoirs pour la semaine prochaine ?<br>Ava&nbsp;: Oui, le prof a mis des devoirs en ligne.<br>Martin&nbsp;: En ligne ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "fd85068b-9126-4a6f-a53c-0179252c7b73",
+          "type": "discovery",
+          "title": "Activité découverte - 1 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9b36dc6e-8765-4c3d-bb9a-4eb6b9b12454",
+                "type": "text",
+                "content": "<p>Le professeur d’Ava a mis des devoirs en ligne.</p><p>Son père, Martin, veut les regarder.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d881a6a8-374b-448d-b167-6db06712f34d",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, où Martin peut-il regarder les devoirs d’Ava ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>sur l'espace numérique de travail</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, l’espace numérique de travail (ou ENT) est l'outil numérique de suivi de la scolarité proposé par le collège. </p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>sur sa boîte mail</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>sur le site internet de la mairie</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Le collège propose un outil numérique pour le suivi de la scolarité&nbsp;:&nbsp;l’espace numérique de travail (ou ENT).</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "230a5596-b73d-4702-b40e-13d6c3ca8ca8",
+          "type": "transition",
+          "title": "Transition - 1 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "45accc21-d421-4444-9547-5905afa54cf6",
+                "type": "text",
+                "content": "<p>Grâce à l'ENT, Martin peut suivre en ligne la scolarité d'Ava. Voyons cela ensemble !<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f2c81b8b-1574-4304-bd69-8ed05f579794",
+          "type": "lesson",
+          "title": "Leçon - 1 ",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "52089ff2-4c01-4047-a188-dbd5537caf18",
-                  "type": "text",
-                  "content": "<h3>La plupart des collèges et des lycées et certaines écoles primaire ont un ENT mais ce n'est pas obligatoire.</h3>\n<p>Les ENT peuvent être différents d’un département ou d’une région à l’autre.</p>\n<p><span aria-hidden=\"true\">✔️</span> Par exemple, en Corse les élèves utilisent l’ENT Leia et, en Occitanie, les élèves utilisent MonENTOccitanie.</p>"
+                  "elements": [
+                    {
+                      "id": "fbda3f57-d9cc-404f-9a09-0eb3ba9b3ac6",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_schema.png",
+                      "alt": "",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "90c81b47-b175-4f42-b5aa-914ec83025b8",
+                      "type": "text",
+                      "content": "<h3>L’espace numérique de travail (ENT) est le service en ligne proposé par l’établissement scolaire.</h3>\n<p><br>L’ENT est utilisé par les élèves, les enseignants, les parents et les personnels d’éducation (CPE, principal...).</p>\n<p>Il est accessible sur ordinateur, smartphone et tablette.</p>\n<p><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT est sécurisé et il protège l’accès aux données personnelles des parents et des enfants.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "52089ff2-4c01-4047-a188-dbd5537caf18",
+                      "type": "text",
+                      "content": "<h3>La plupart des collèges et des lycées et certaines écoles primaire ont un ENT mais ce n'est pas obligatoire.</h3>\n<p>Les ENT peuvent être différents d’un département ou d’une région à l’autre.</p>\n<p><span aria-hidden=\"true\">✔️</span> Par exemple, en Corse les élèves utilisent l’ENT Leia et, en Occitanie, les élèves utilisent MonENTOccitanie.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "1099b132-536e-4578-b87b-d3bf81ab1c68",
-      "type": "discovery",
-      "title": "Activité de découverte - 2 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2ce8ab36-9f17-4d01-8264-9d56bcdf2a11",
-            "type": "qcm",
-            "instruction": "<p>À votre avis, que peut faire Martin grâce à l'ENT ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Prendre connaissance des notes de sa fille.</p>"
-              },
-              {
-                "id": "3",
-                "content": "<p>Modifier l'emploi du temps de la classe de sa fille.</p>"
-              },
-              {
-                "id": "2",
-                "content": "<p>Consulter l'emploi du temps et les devoirs de sa fille.</p>"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "",
-                "diagnosis": "<p>Effectivement, grâce à l'ENT, Martin peut consulter des informations qui concernent sa fille&nbsp;: ses notes, son emploi du temps, ses devoirs. Par contre, il ne peut pas modifier l'emploi du temps de la classe.</p>"
-              },
-              "invalid": {
-                "state": "",
-                "diagnosis": "<p>Pas tout à fait ! Grâce à l'ENT, Martin peut consulter des informations qui concernent sa fille&nbsp;: ses notes, son emploi du temps, ses devoirs. Par contre, il ne peut pas modifier l'emploi du temps de la classe.</p>"
-              }
-            },
-            "solutions": [
-              "1",
-              "2"
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "f97811eb-2349-48e3-95a2-8c378724909a",
-      "type": "lesson",
-      "title": "Leçon - 2 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f52e2c4d-81d8-4347-926d-9780c7b2a49b",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_accueil.jpg",
-            "alt": "Page d'accueil d'un ENT telle que décrite dans l'alternative textuelle",
-            "alternativeText": "<p>Page d'accueil d'un ENT&nbsp;:</p><ul>    <li>à gauche, un menu latéral avec les applications&nbsp;&nbsp;: <ul>            <li>Accueil, Messagerie, Cahier de textes, Emploi du temps, Documents, Actualités</li>        </ul>    </li>    <li>au centre, un accès rapide&nbsp;: <ul>            <li>à l'emploi du temps, au travail à faire et au suivi des notes</li>        </ul>    </li>    <li>en haut à droite, l'accès au compte personnel de Martin Pommard<br></li></ul>",
-            "legend": "",
-            "licence": ""
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "63803887-ac1c-4385-b9bc-65877d649134",
-            "type": "text",
-            "content": "<h3>L’ENT permet aux parents de suivre au quotidien la scolarité de leurs enfants&nbsp;:</h3>\n<ul>\n    <li>voir l’emploi du temps</li>\n    <li>communiquer avec l’établissement scolaire</li>\n    <li>consulter le cahier de textes numérique</li>\n</ul>\n<p><span aria-hidden=\"true\">👉</span> En début d’année, l’établissement scolaire donne les informations pour se connecter à l’ENT&nbsp;: le lien vers l’ENT, un identifiant et un mot de passe. Il faut conserver ces informations tout au long de l'année.<br>Souvent, le compte Educonnect permet de se connecter à l'ENT.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d0120279-c7f5-4030-bb38-d9bddb6dd26f",
-      "type": "transition",
-      "title": "Transition - 2 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "caf7638d-71d4-47d5-955f-a628eb12d756",
-            "type": "text",
-            "content": "<p>Aidez Martin à utiliser 3 fonctionnalités auxquelles il a accès depuis son compte parent sur l'ENT.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6a8d4f2b-e60b-475a-98d8-3c4e3710a14a",
-      "type": "discovery",
-      "title": "Activité de découverte - 3 : Les fonctionnalités",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1e8e1448-5373-4272-9240-4b378dffcffb",
-            "type": "text",
-            "content": "<p>Martin est connecté à l’ENT du collège d’Ava.</p><p>Répondez à chacune des questions ci-dessous.</p>"
-          }
+          "id": "1099b132-536e-4578-b87b-d3bf81ab1c68",
+          "type": "discovery",
+          "title": "Activité de découverte - 2 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2ce8ab36-9f17-4d01-8264-9d56bcdf2a11",
+                "type": "qcm",
+                "instruction": "<p>À votre avis, que peut faire Martin grâce à l'ENT ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Prendre connaissance des notes de sa fille.</p>"
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Modifier l'emploi du temps de la classe de sa fille.</p>"
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Consulter l'emploi du temps et les devoirs de sa fille.</p>"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "",
+                    "diagnosis": "<p>Effectivement, grâce à l'ENT, Martin peut consulter des informations qui concernent sa fille&nbsp;: ses notes, son emploi du temps, ses devoirs. Par contre, il ne peut pas modifier l'emploi du temps de la classe.</p>"
+                  },
+                  "invalid": {
+                    "state": "",
+                    "diagnosis": "<p>Pas tout à fait ! Grâce à l'ENT, Martin peut consulter des informations qui concernent sa fille&nbsp;: ses notes, son emploi du temps, ses devoirs. Par contre, il ne peut pas modifier l'emploi du temps de la classe.</p>"
+                  }
+                },
+                "solutions": ["1", "2"]
+              }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "f97811eb-2349-48e3-95a2-8c378724909a",
+          "type": "lesson",
+          "title": "Leçon - 2 ",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "2780195f-aa4b-48e9-8aed-6a516281d590",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_applis.jpg",
-                  "alt": "",
-                  "alternativeText": "<p>Page «&nbsp;Mes applis&nbsp;» d'un ENT avec la liste des applications disponibles&nbsp;:&nbsp;</p><ul>    <li>Messagerie</li>    <li>Cahier de textes</li>    <li>Emploi du temps</li>    <li>Documents</li>    <li>Blog</li></ul>"
-                },
-                {
-                  "id": "dacb6bd7-a151-4b00-bca8-4de1ab39891a",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Martin veut savoir à quelle heure Ava a cours de sport.</p><p>Quelle fonctionnalité doit-il utiliser ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>la messagerie</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! La messagerie permet de contacter les professeurs.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    },
-                    {
-                      "id": "5",
-                      "content": "<p>le cahier de textes</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le cahier de textes numérique permet d’avoir un suivi régulier du travail effectué en classe.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>l'emploi du temps</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Bien joué ! L’emploi du temps permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>les documents</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! L’application «&nbsp;Documents&nbsp;» permet de consulter des documents partagés.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le blog</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le blog permet de suivre la vie de la classe.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    },
-                    {
-                      "id": "6",
-                      "content": "<p>Je ne sais pas.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "f52e2c4d-81d8-4347-926d-9780c7b2a49b",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_accueil.jpg",
+                "alt": "Page d'accueil d'un ENT telle que décrite dans l'alternative textuelle",
+                "alternativeText": "<p>Page d'accueil d'un ENT&nbsp;:</p><ul>    <li>à gauche, un menu latéral avec les applications&nbsp;&nbsp;: <ul>            <li>Accueil, Messagerie, Cahier de textes, Emploi du temps, Documents, Actualités</li>        </ul>    </li>    <li>au centre, un accès rapide&nbsp;: <ul>            <li>à l'emploi du temps, au travail à faire et au suivi des notes</li>        </ul>    </li>    <li>en haut à droite, l'accès au compte personnel de Martin Pommard<br></li></ul>",
+                "legend": "",
+                "licence": ""
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "5bed69d3-bc84-45ea-b378-ad040f77868f",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_message.jpg",
-                  "alt": "",
-                  "alternativeText": "<p>Page «&nbsp;Actualités&nbsp;» d'un ENT&nbsp;:</p><ul>    <li>à gauche, un menu latéral avec les applications&nbsp;&nbsp;:        <ul>            <li> Accueil, </li>            <li>Messagerie (2) </li>            <li>Cahier de textes</li>            <li>Emploi du temps </li>            <li>Documents </li>            <li>Actualités            </li>        </ul>    </li>    <li>        au centre, un accès rapide à 3 actualités concernant le collège</li>    <li>        à droite, l'accès au compte personnel de Martin Pommard et un menu «&nbsp;Mes applis&nbsp;» avec&nbsp;: <ul>            <li>Messagerie (2) </li>            <li>Cahier de textes </li>            <li>Emploi du temps<br><br></li>        </ul>    </li></ul>"
-                },
-                {
-                  "id": "d83eba7d-cfe9-4e7b-ada6-fbcbaa17be23",
-                  "type": "qcu-discovery",
-                  "instruction": "<p><strong>Combien de messages non lus Martin a-t-il ?</strong></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>1</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>2</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Bien joué ! Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>3</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Il y a bien 3 publications dans le fil d'actualités mais il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>Je ne sais pas.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "63803887-ac1c-4385-b9bc-65877d649134",
+                "type": "text",
+                "content": "<h3>L’ENT permet aux parents de suivre au quotidien la scolarité de leurs enfants&nbsp;:</h3>\n<ul>\n    <li>voir l’emploi du temps</li>\n    <li>communiquer avec l’établissement scolaire</li>\n    <li>consulter le cahier de textes numérique</li>\n</ul>\n<p><span aria-hidden=\"true\">👉</span> En début d’année, l’établissement scolaire donne les informations pour se connecter à l’ENT&nbsp;: le lien vers l’ENT, un identifiant et un mot de passe. Il faut conserver ces informations tout au long de l'année.<br>Souvent, le compte Educonnect permet de se connecter à l'ENT.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d0120279-c7f5-4030-bb38-d9bddb6dd26f",
+          "type": "transition",
+          "title": "Transition - 2 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "caf7638d-71d4-47d5-955f-a628eb12d756",
+                "type": "text",
+                "content": "<p>Aidez Martin à utiliser 3 fonctionnalités auxquelles il a accès depuis son compte parent sur l'ENT.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6a8d4f2b-e60b-475a-98d8-3c4e3710a14a",
+          "type": "discovery",
+          "title": "Activité de découverte - 3 : Les fonctionnalités",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1e8e1448-5373-4272-9240-4b378dffcffb",
+                "type": "text",
+                "content": "<p>Martin est connecté à l’ENT du collège d’Ava.</p><p>Répondez à chacune des questions ci-dessous.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "339f5cb0-bcb1-4725-9ddd-9088cb9a6c74",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_devoirs.jpg",
-                  "alt": "",
-                  "alternativeText": "<p>Page «&nbsp;Cahier de texte&nbsp;» d'un ENT&nbsp;:</p><ul>    <li>&nbsp;un menu latéral avec les applications&nbsp;&nbsp;:        <ul>            <li> Accueil, </li>            <li>Messagerie (2) </li>            <li>Cahier de textes</li>            <li>Emploi du temps </li>            <li>Documents </li>            <li>Actualités</li>        </ul>    </li>    <li>au centre, cahier de texte de l'élève avec les cours et devoirs à venir&nbsp;: <ul>            <li>Vendredi 6 septembre&nbsp;:&nbsp;<ul><li>Histoire-géographie - 6ème B - L'empire romain</li><li>Mathématiques - 6ème B - Les ensembles de nombres</li></ul></li><li>Lundi 9 septembre&nbsp;:&nbsp;<ul><li>Mathématiques - 6ème B - Exercice donné le 06/09/2024 - à faire</li><li>Français - 6ème B - Les compléments circonstanciels</li></ul></li><li>Mardi 10 septembre&nbsp;:&nbsp;<ul><li>Mathématiques - 6ème B - Les ensembles de nombres</li><li>Français - 6ème B - Devoir à la maison donné le 05/09/2024 - à faire</li></ul></li>        </ul>    </li>    <li>en haut à droite, l'accès au compte personnel de Martin Pommard</li></ul>"
+                  "elements": [
+                    {
+                      "id": "2780195f-aa4b-48e9-8aed-6a516281d590",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_applis.jpg",
+                      "alt": "",
+                      "alternativeText": "<p>Page «&nbsp;Mes applis&nbsp;» d'un ENT avec la liste des applications disponibles&nbsp;:&nbsp;</p><ul>    <li>Messagerie</li>    <li>Cahier de textes</li>    <li>Emploi du temps</li>    <li>Documents</li>    <li>Blog</li></ul>"
+                    },
+                    {
+                      "id": "dacb6bd7-a151-4b00-bca8-4de1ab39891a",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Martin veut savoir à quelle heure Ava a cours de sport.</p><p>Quelle fonctionnalité doit-il utiliser ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la messagerie</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! La messagerie permet de contacter les professeurs.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        },
+                        {
+                          "id": "5",
+                          "content": "<p>le cahier de textes</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le cahier de textes numérique permet d’avoir un suivi régulier du travail effectué en classe.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>l'emploi du temps</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Bien joué ! L’emploi du temps permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>les documents</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! L’application «&nbsp;Documents&nbsp;» permet de consulter des documents partagés.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le blog</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le blog permet de suivre la vie de la classe.&nbsp;C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        },
+                        {
+                          "id": "6",
+                          "content": "<p>Je ne sais pas.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>C'est l’emploi du temps qui permet de connaître les cours d’Ava heure par heure, jour par jour.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 },
                 {
-                  "id": "85ef8964-a248-4a9d-a087-091a4aefd30a",
-                  "type": "qcu-discovery",
-                  "instruction": "<p><strong>Dans quelle matière Ava a-t-elle des devoirs à rendre pour mardi ?</strong></p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Histoire-géographie</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le professeur d’histoire-géographie n’a pas indiqué de devoirs à faire dans le cahier de textes, seulement les sujets du dernier cours. Par contre, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
-                      }
+                      "id": "5bed69d3-bc84-45ea-b378-ad040f77868f",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_message.jpg",
+                      "alt": "",
+                      "alternativeText": "<p>Page «&nbsp;Actualités&nbsp;» d'un ENT&nbsp;:</p><ul>    <li>à gauche, un menu latéral avec les applications&nbsp;&nbsp;:        <ul>            <li> Accueil, </li>            <li>Messagerie (2) </li>            <li>Cahier de textes</li>            <li>Emploi du temps </li>            <li>Documents </li>            <li>Actualités            </li>        </ul>    </li>    <li>        au centre, un accès rapide à 3 actualités concernant le collège</li>    <li>        à droite, l'accès au compte personnel de Martin Pommard et un menu «&nbsp;Mes applis&nbsp;» avec&nbsp;: <ul>            <li>Messagerie (2) </li>            <li>Cahier de textes </li>            <li>Emploi du temps<br><br></li>        </ul>    </li></ul>"
                     },
                     {
-                      "id": "3",
-                      "content": "<p>Mathématiques</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le professeur de mathématique a bien indiqué des devoirs à faire, mais ils ne sont pas à rendre mardi.&nbsp;Par contre, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Français</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>Je ne sais pas.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>La professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
-                      }
+                      "id": "d83eba7d-cfe9-4e7b-ada6-fbcbaa17be23",
+                      "type": "qcu-discovery",
+                      "instruction": "<p><strong>Combien de messages non lus Martin a-t-il ?</strong></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>1</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>2</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Bien joué ! Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>3</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Il y a bien 3 publications dans le fil d'actualités mais il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>Je ne sais pas.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Il y a 2 messages non lus dans la messagerie. La messagerie de l’ENT est l’outil à privilégier pour contacter l’établissement scolaire.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "339f5cb0-bcb1-4725-9ddd-9088cb9a6c74",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/decouverte-de-l-ent/ent_devoirs.jpg",
+                      "alt": "",
+                      "alternativeText": "<p>Page «&nbsp;Cahier de texte&nbsp;» d'un ENT&nbsp;:</p><ul>    <li>&nbsp;un menu latéral avec les applications&nbsp;&nbsp;:        <ul>            <li> Accueil, </li>            <li>Messagerie (2) </li>            <li>Cahier de textes</li>            <li>Emploi du temps </li>            <li>Documents </li>            <li>Actualités</li>        </ul>    </li>    <li>au centre, cahier de texte de l'élève avec les cours et devoirs à venir&nbsp;: <ul>            <li>Vendredi 6 septembre&nbsp;:&nbsp;<ul><li>Histoire-géographie - 6ème B - L'empire romain</li><li>Mathématiques - 6ème B - Les ensembles de nombres</li></ul></li><li>Lundi 9 septembre&nbsp;:&nbsp;<ul><li>Mathématiques - 6ème B - Exercice donné le 06/09/2024 - à faire</li><li>Français - 6ème B - Les compléments circonstanciels</li></ul></li><li>Mardi 10 septembre&nbsp;:&nbsp;<ul><li>Mathématiques - 6ème B - Les ensembles de nombres</li><li>Français - 6ème B - Devoir à la maison donné le 05/09/2024 - à faire</li></ul></li>        </ul>    </li>    <li>en haut à droite, l'accès au compte personnel de Martin Pommard</li></ul>"
+                    },
+                    {
+                      "id": "85ef8964-a248-4a9d-a087-091a4aefd30a",
+                      "type": "qcu-discovery",
+                      "instruction": "<p><strong>Dans quelle matière Ava a-t-elle des devoirs à rendre pour mardi ?</strong></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Histoire-géographie</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le professeur d’histoire-géographie n’a pas indiqué de devoirs à faire dans le cahier de textes, seulement les sujets du dernier cours. Par contre, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Mathématiques</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le professeur de mathématique a bien indiqué des devoirs à faire, mais ils ne sont pas à rendre mardi.&nbsp;Par contre, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Français</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, la professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>Je ne sais pas.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>La professeure de français a indiqué dans le cahier de textes qu’Ava avait un devoir à la maison à rendre mardi.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "6c2e4b2c-bc41-4fd3-a8e3-d904fcede740",
-      "type": "lesson",
-      "title": "Leçon - 3 : Les différents types de comptes de l'ENT",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "cb612f94-310d-4b99-af47-3f0bf2b481ee",
-            "type": "text",
-            "content": "<p>À présent, revenons en vidéo sur les différents comptes qui existent sur l'ENT et plus particulièrement sur le compte parent et ses fonctionnalités.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b3cba471-c794-4a39-b044-5b084b468341",
-            "type": "video",
-            "title": "Les différents comptes de L'ENT",
-            "url": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.mp4",
-            "poster": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.jpg",
-            "subtitles": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.vtt",
-            "transcription": "<p>L'ENT, focus sur le compte parent. <br>Conversation entre Ava et son père, Martin&nbsp;: </p><p>Ava&nbsp;: Hey papa ! Tu as vu le message sur l'ENT ? C'est le CPE, Monsieur Rossi qui te l'a envoyé !<br>Martin&nbsp;: Le CPE ? Mais je savais pas que le CPE pouvait utiliser l'ENT.<br><br>Voix off&nbsp;: Et oui, le CPE aussi utilise l'ENT. Comme beaucoup d'autres personnes au collège d'ailleurs. Mais il n'a pas accès aux mêmes fonctionnalités que Martin,&nbsp;le père d'Ava.<br>Chaque personne qui utilise un ENT se connecte à son compte personnel, mais tout le monde n'a pas accès aux mêmes fonctionnalités selon son rôle. Il y a donc différents types de comptes pour les parents, pour les élèves, pour les enseignants et pour les personnels d'éducation. Chaque personne a accès uniquement aux fonctionnalités qui la concernent. <br><br>Avec le compte parent, il est par exemple possible de voir l'emploi du temps de son enfant ou ses notes, mais pas de les modifier. Les modifications sont réservées aux enseignants et aux personnels d'éducation. Le compte parent permet aussi de suivre les devoirs donnés à son enfant, mais pas de les rendre à sa place. C'est à l'enfant de le faire avec son compte élève.<br><br>  Pour finir, avec le compte parent, il est aussi possible de contacter l'établissement scolaire grâce à la messagerie de l'ENT. Pour ça, le parent doit être connecté à son propre compte et non à celui de son enfant. De cette manière, l'enseignant qui recevra le message saura qui lui écrit. Il n'y aura pas de confusion. </p><p>Voici quelques conseils pratiques pour l'utilisation de la messagerie du compte parent. Ce compte est à utiliser pour des sujets uniquement liés à la scolarité de ses enfants. Les messages envoyés doivent être courts en précisant l'objet de la demande. Éviter les messages tardifs ou le week end et attendre un délai raisonnable pour recevoir une réponse. La messagerie de l'ENT n'est pas toujours consultée immédiatement.&nbsp;En cas d'urgence, il vaut mieux contacter directement le secrétariat de l'établissement en suivant les procédures du règlement intérieur.<br><br>Que ce soit la messagerie, l'emploi du temps ou bien d'autres fonctionnalités, L'ENT est un outil précieux pour Martin et pour tous les parents.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2ffd2356-1c4a-49d4-b4bb-0c0a2bc45c76",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0468f3c9-f946-4309-9768-4fda3f28a4b2",
-            "type": "text",
-            "content": "<ul><li>L’espace numérique de travail (ENT) est un&nbsp;<strong>service en ligne sécurisé  proposé par l’établissement scolaire</strong>.</li><li>Il est utilisé par<strong> les parents, les élèves, les professeurs et les personnels d’éducation</strong> pour accéder aux informations et outils<strong> liés à la vie scolaire</strong>.</li><li><strong>En fonction de son rôle</strong>, chaque utilisateur a accès à des <strong>fonctionnalités différentes</strong>. </li><li>L’ENT permet aux parents de<strong> suivre au quotidien la scolarité</strong> de leurs enfants.</li><li>Chaque utilisateur se connecte avec un<strong> identifiant</strong> et un <strong>mot de passe</strong>, fournis par l'établissement scolaire.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "122a0494-f24d-4da9-853d-d72333349d79",
-      "type": "transition",
-      "title": "Transition - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b490bd76-fde6-4876-98d5-ccf81964e739",
-            "type": "text",
-            "content": "<p>Voyons si vous avez retenu l’essentiel. 🎯</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "bf331dcd-e6ba-4d25-80f0-f95dea9e619f",
-      "type": "activity",
-      "title": "Activité d'application - 1 : vrai-faux",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "dd385872-c97f-4a5e-9e66-ca1c183b6b5a",
-            "type": "qab",
-            "instruction": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>",
-            "cards": [
-              {
-                "id": "b8ad5f3e-e986-430d-a6c0-48ef04f288ea",
-                "text": "Martin peut accéder à l’ENT sur son smartphone.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "0707f363-47b1-494c-9a0d-0de329dae8c9",
-                "text": "Tous les collèges utilisent le même ENT que le collège d’Ava.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "be1cac55-5677-4991-9be8-e5a4bcf8a179",
-                "text": "Pour se connecter à l’ENT, Martin a besoin d’un identifiant et d’un mot de passe.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "5f34248e-4e3a-4afd-b514-6e32260f2917",
-                "text": "Ava a accès aux mêmes fonctionnalités que Martin.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
+          "id": "6c2e4b2c-bc41-4fd3-a8e3-d904fcede740",
+          "type": "lesson",
+          "title": "Leçon - 3 : Les différents types de comptes de l'ENT",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "cb612f94-310d-4b99-af47-3f0bf2b481ee",
+                "type": "text",
+                "content": "<p>À présent, revenons en vidéo sur les différents comptes qui existent sur l'ENT et plus particulièrement sur le compte parent et ses fonctionnalités.</p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b3cba471-c794-4a39-b044-5b084b468341",
+                "type": "video",
+                "title": "Les différents comptes de L'ENT",
+                "url": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.mp4",
+                "poster": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.jpg",
+                "subtitles": "https://assets.pix.org/modules/decouverte-ent/differents-comptes.vtt",
+                "transcription": "<p>L'ENT, focus sur le compte parent. <br>Conversation entre Ava et son père, Martin&nbsp;: </p><p>Ava&nbsp;: Hey papa ! Tu as vu le message sur l'ENT ? C'est le CPE, Monsieur Rossi qui te l'a envoyé !<br>Martin&nbsp;: Le CPE ? Mais je savais pas que le CPE pouvait utiliser l'ENT.<br><br>Voix off&nbsp;: Et oui, le CPE aussi utilise l'ENT. Comme beaucoup d'autres personnes au collège d'ailleurs. Mais il n'a pas accès aux mêmes fonctionnalités que Martin,&nbsp;le père d'Ava.<br>Chaque personne qui utilise un ENT se connecte à son compte personnel, mais tout le monde n'a pas accès aux mêmes fonctionnalités selon son rôle. Il y a donc différents types de comptes pour les parents, pour les élèves, pour les enseignants et pour les personnels d'éducation. Chaque personne a accès uniquement aux fonctionnalités qui la concernent. <br><br>Avec le compte parent, il est par exemple possible de voir l'emploi du temps de son enfant ou ses notes, mais pas de les modifier. Les modifications sont réservées aux enseignants et aux personnels d'éducation. Le compte parent permet aussi de suivre les devoirs donnés à son enfant, mais pas de les rendre à sa place. C'est à l'enfant de le faire avec son compte élève.<br><br>  Pour finir, avec le compte parent, il est aussi possible de contacter l'établissement scolaire grâce à la messagerie de l'ENT. Pour ça, le parent doit être connecté à son propre compte et non à celui de son enfant. De cette manière, l'enseignant qui recevra le message saura qui lui écrit. Il n'y aura pas de confusion. </p><p>Voici quelques conseils pratiques pour l'utilisation de la messagerie du compte parent. Ce compte est à utiliser pour des sujets uniquement liés à la scolarité de ses enfants. Les messages envoyés doivent être courts en précisant l'objet de la demande. Éviter les messages tardifs ou le week end et attendre un délai raisonnable pour recevoir une réponse. La messagerie de l'ENT n'est pas toujours consultée immédiatement.&nbsp;En cas d'urgence, il vaut mieux contacter directement le secrétariat de l'établissement en suivant les procédures du règlement intérieur.<br><br>Que ce soit la messagerie, l'emploi du temps ou bien d'autres fonctionnalités, L'ENT est un outil précieux pour Martin et pour tous les parents.</p>"
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "fad888df-1aaf-4006-9cc1-cbd063e17633",
-      "type": "transition",
-      "title": "Transition - 5",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7764df35-720c-4532-ac31-c8c7614017ba",
-            "type": "text",
-            "content": "<p>Regardons si vous avez bien retenu les usages conseillés du compte parent.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b4154d31-a9ab-47ef-a132-3a280ed330cb",
-      "type": "activity",
-      "title": "Activité d'application - 2 : compte parent ou non ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d4ac45bf-ba4d-4720-aa14-e8bae452956f",
-            "type": "text",
-            "content": "<p>Pour chaque situation, choisissez si l’utilisation du compte parent sur l'ENT est adaptée ou non.</p>"
-          }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "2ffd2356-1c4a-49d4-b4bb-0c0a2bc45c76",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "4005b450-cac6-4c16-a9af-d24e9f2214b4",
-                  "type": "qcu",
-                  "instruction": "<p>Mon enfant a terminé un devoir de français. Il doit le rendre sur l'ENT à son professeur. <span aria-hidden=\"true\">📝​​</span></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>J'utilise mon compte parent.</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le compte ENT est personnel. Votre enfant doit se connecter à son compte pour rendre son devoir.</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "0468f3c9-f946-4309-9768-4fda3f28a4b2",
+                "type": "text",
+                "content": "<ul><li>L’espace numérique de travail (ENT) est un&nbsp;<strong>service en ligne sécurisé  proposé par l’établissement scolaire</strong>.</li><li>Il est utilisé par<strong> les parents, les élèves, les professeurs et les personnels d’éducation</strong> pour accéder aux informations et outils<strong> liés à la vie scolaire</strong>.</li><li><strong>En fonction de son rôle</strong>, chaque utilisateur a accès à des <strong>fonctionnalités différentes</strong>. </li><li>L’ENT permet aux parents de<strong> suivre au quotidien la scolarité</strong> de leurs enfants.</li><li>Chaque utilisateur se connecte avec un<strong> identifiant</strong> et un <strong>mot de passe</strong>, fournis par l'établissement scolaire.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "122a0494-f24d-4da9-853d-d72333349d79",
+          "type": "transition",
+          "title": "Transition - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b490bd76-fde6-4876-98d5-ccf81964e739",
+                "type": "text",
+                "content": "<p>Voyons si vous avez retenu l’essentiel. 🎯</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "bf331dcd-e6ba-4d25-80f0-f95dea9e619f",
+          "type": "activity",
+          "title": "Activité d'application - 1 : vrai-faux",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "dd385872-c97f-4a5e-9e66-ca1c183b6b5a",
+                "type": "qab",
+                "instruction": "<p>Pour chaque affirmation, choisissez si elle est vraie ou fausse.</p>",
+                "cards": [
+                  {
+                    "id": "b8ad5f3e-e986-430d-a6c0-48ef04f288ea",
+                    "text": "Martin peut accéder à l’ENT sur son smartphone.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
                     },
-                    {
-                      "id": "2",
-                      "content": "<p>Je n’utilise pas mon compte parent.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Votre enfant doit se connecter à son propre compte pour rendre son devoir.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "0707f363-47b1-494c-9a0d-0de329dae8c9",
+                    "text": "Tous les collèges utilisent le même ENT que le collège d’Ava.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "be1cac55-5677-4991-9be8-e5a4bcf8a179",
+                    "text": "Pour se connecter à l’ENT, Martin a besoin d’un identifiant et d’un mot de passe.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "5f34248e-4e3a-4afd-b514-6e32260f2917",
+                    "text": "Ava a accès aux mêmes fonctionnalités que Martin.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
                 }
-              ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "fad888df-1aaf-4006-9cc1-cbd063e17633",
+          "type": "transition",
+          "title": "Transition - 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7764df35-720c-4532-ac31-c8c7614017ba",
+                "type": "text",
+                "content": "<p>Regardons si vous avez bien retenu les usages conseillés du compte parent.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b4154d31-a9ab-47ef-a132-3a280ed330cb",
+          "type": "activity",
+          "title": "Activité d'application - 2 : compte parent ou non ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d4ac45bf-ba4d-4720-aa14-e8bae452956f",
+                "type": "text",
+                "content": "<p>Pour chaque situation, choisissez si l’utilisation du compte parent sur l'ENT est adaptée ou non.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "c97a24b8-d5d3-43f1-ba29-bff92d8712fa",
-                  "type": "qcu",
-                  "instruction": "<p>Je souhaite prendre rendez-vous avec un des professeurs de mon enfant. <span aria-hidden=\"true\">📅​​​</span></p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>J'utilise mon compte parent.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>La messagerie de l’ENT permet de contacter facilement les professeurs.<br>Utilisez votre compte pour envoyer un message en votre nom.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Je n’utilise pas mon compte parent.</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>La messagerie de l’ENT permet de contacter facilement les professeurs.<br>Utilisez votre compte pour envoyer un message en votre nom.</p>"
-                      }
+                      "id": "4005b450-cac6-4c16-a9af-d24e9f2214b4",
+                      "type": "qcu",
+                      "instruction": "<p>Mon enfant a terminé un devoir de français. Il doit le rendre sur l'ENT à son professeur. <span aria-hidden=\"true\">📝​​</span></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>J'utilise mon compte parent.</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le compte ENT est personnel. Votre enfant doit se connecter à son compte pour rendre son devoir.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Je n’utilise pas mon compte parent.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Votre enfant doit se connecter à son propre compte pour rendre son devoir.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "259c03fd-bdf1-4055-8f9b-a719216a25b4",
-                  "type": "qcu",
-                  "instruction": "<p>Je dois traduire mon CV pour une recherche d'emploi. Je souhaiterais que&nbsp;le professeur d'anglais de mon enfant traduise ce CV.<span aria-hidden=\"true\">💂</span>️</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>J'utilise mon compte parent.</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>L'utilisation de la messagerie est réservée à des sujets liés à la scolarité de vos enfants.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Je n'utilise pas mon compte parent.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>L'utilisation de la messagerie est réservée à des sujets liés à la scolarité de vos enfants.</p>"
-                      }
+                      "id": "c97a24b8-d5d3-43f1-ba29-bff92d8712fa",
+                      "type": "qcu",
+                      "instruction": "<p>Je souhaite prendre rendez-vous avec un des professeurs de mon enfant. <span aria-hidden=\"true\">📅​​​</span></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>J'utilise mon compte parent.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>La messagerie de l’ENT permet de contacter facilement les professeurs.<br>Utilisez votre compte pour envoyer un message en votre nom.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Je n’utilise pas mon compte parent.</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>La messagerie de l’ENT permet de contacter facilement les professeurs.<br>Utilisez votre compte pour envoyer un message en votre nom.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "259c03fd-bdf1-4055-8f9b-a719216a25b4",
+                      "type": "qcu",
+                      "instruction": "<p>Je dois traduire mon CV pour une recherche d'emploi. Je souhaiterais que&nbsp;le professeur d'anglais de mon enfant traduise ce CV.<span aria-hidden=\"true\">💂</span>️</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>J'utilise mon compte parent.</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>L'utilisation de la messagerie est réservée à des sujets liés à la scolarité de vos enfants.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Je n'utilise pas mon compte parent.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>L'utilisation de la messagerie est réservée à des sujets liés à la scolarité de vos enfants.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "84f9134e-6a19-4673-a673-d4577355796a",
-      "type": "activity",
-      "title": "Conclusion",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5a4495bc-22f5-4a9a-aad5-531071bf33c9",
-            "type": "text",
-            "content": "<p>Maintenant, testez votre mémoire. 🎯</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "d0c79a9f-1c62-4b9b-9bf3-629746823287",
-            "type": "flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp; </p><ol>    <li>Lisez la question. <span aria-hidden=\"true\">👀</span></li>    <li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li>    <li>Retournez la carte en cliquant sur «&nbsp;Voir la réponse&nbsp;». <span aria-hidden=\"true\">↪️</span></li></ol>",
-            "title": "L'espace numérique de travail",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "14dceb64-64ef-4591-8a96-bdad5f154be4",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/recto-flashcards.png"
-                  },
-                  "text": "Qu'est ce qu'un ENT ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/ent-pere-prof-ecole.png"
-                  },
-                  "text": "<p><strong>Un espace numérique de travail (ENT)</strong> est un service en ligne proposé par l'établissement scolaire pour le suivi de la scolarité des élèves.</p>"
-                }
-              },
-              {
-                "id": "c9ca2e9d-86f1-4ef1-a809-8afb55667869",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/recto-flashcards.png"
-                  },
-                  "text": "Quelles personnes peuvent utiliser l'ENT d'un établissement scolaire ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/ent-parent-prof.png"
-                  },
-                  "text": "<p><strong>Les élèves, les parents, les enseignants et les personnels d'éducation</strong> ont accès à l'ENT. Ils accèdent à cet espace grâce à un identifiant et un mot de passe personnel.</p>"
-                }
-              },
-              {
-                "id": "95ee9711-0957-48d1-abfc-a147a5cfbcd4",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/recto-flashcards.png"
-                  },
-                  "text": "Quel compte un parent doit-il utiliser pour envoyer un message à un enseignant sur l'ENT ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/ent-homme-fauteuil.png"
-                  },
-                  "text": "<p><strong>Un parent doit utiliser son compte parent</strong> pour envoyer des messages avec l'ENT. L'utilisation du compte élève est réservé à l'élève.</p>"
-                }
-              },
-              {
-                "id": "b0ddc0e4-3c79-48fa-b18c-277853b347a7",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/recto-flashcards.png"
-                  },
-                  "text": "Quelle fonctionnalité de l'ENT permet de consulter les devoirs de son enfant ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/ent-pere-fille-devoirs.png"
-                  },
-                  "text": "<p>Grâce au <strong>cahier de texte numérique</strong>, parents et élèves ont accès aux devoirs à faire à la maison et aux contenus des cours déposés par les professeurs.</p>"
-                }
+          "id": "84f9134e-6a19-4673-a673-d4577355796a",
+          "type": "activity",
+          "title": "Conclusion",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5a4495bc-22f5-4a9a-aad5-531071bf33c9",
+                "type": "text",
+                "content": "<p>Maintenant, testez votre mémoire. 🎯</p>"
               }
-            ]
-          }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d0c79a9f-1c62-4b9b-9bf3-629746823287",
+                "type": "flashcards",
+                "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp; </p><ol>    <li>Lisez la question. <span aria-hidden=\"true\">👀</span></li>    <li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li>    <li>Retournez la carte en cliquant sur «&nbsp;Voir la réponse&nbsp;». <span aria-hidden=\"true\">↪️</span></li></ol>",
+                "title": "L'espace numérique de travail",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "14dceb64-64ef-4591-8a96-bdad5f154be4",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/recto-flashcards.png"
+                      },
+                      "text": "Qu'est ce qu'un ENT ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/ent-pere-prof-ecole.png"
+                      },
+                      "text": "<p><strong>Un espace numérique de travail (ENT)</strong> est un service en ligne proposé par l'établissement scolaire pour le suivi de la scolarité des élèves.</p>"
+                    }
+                  },
+                  {
+                    "id": "c9ca2e9d-86f1-4ef1-a809-8afb55667869",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/recto-flashcards.png"
+                      },
+                      "text": "Quelles personnes peuvent utiliser l'ENT d'un établissement scolaire ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/ent-parent-prof.png"
+                      },
+                      "text": "<p><strong>Les élèves, les parents, les enseignants et les personnels d'éducation</strong> ont accès à l'ENT. Ils accèdent à cet espace grâce à un identifiant et un mot de passe personnel.</p>"
+                    }
+                  },
+                  {
+                    "id": "95ee9711-0957-48d1-abfc-a147a5cfbcd4",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/recto-flashcards.png"
+                      },
+                      "text": "Quel compte un parent doit-il utiliser pour envoyer un message à un enseignant sur l'ENT ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/ent-homme-fauteuil.png"
+                      },
+                      "text": "<p><strong>Un parent doit utiliser son compte parent</strong> pour envoyer des messages avec l'ENT. L'utilisation du compte élève est réservé à l'élève.</p>"
+                    }
+                  },
+                  {
+                    "id": "b0ddc0e4-3c79-48fa-b18c-277853b347a7",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/recto-flashcards.png"
+                      },
+                      "text": "Quelle fonctionnalité de l'ENT permet de consulter les devoirs de son enfant ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/ent-pere-fille-devoirs.png"
+                      },
+                      "text": "<p>Grâce au <strong>cahier de texte numérique</strong>, parents et élèves ont accès aux devoirs à faire à la maison et aux contenus des cours déposés par les professeurs.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
@@ -11,22 +11,27 @@
     "tabletSupport": "inconvenient",
     "objectives": ["Test parcours combiné"]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "6728cc2c-7fef-48aa-8586-9c98f010d3be",
-      "type": "activity",
-      "title": "Grain de démo",
-      "components": [
+      "id": "33bb3827-c5df-4300-8fa0-aa78136a099c",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "760ed7fc-cad2-4771-86ff-00f856d557ec",
-            "type": "text",
-            "content": "<p>Bravo, le module 1 est terminé</p>"
-          }
+          "id": "6728cc2c-7fef-48aa-8586-9c98f010d3be",
+          "type": "activity",
+          "title": "Grain de démo",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "760ed7fc-cad2-4771-86ff-00f856d557ec",
+                "type": "text",
+                "content": "<p>Bravo, le module 1 est terminé</p>"
+              }
+            }
+          ]
         }
       ]
     }
-
   ]
 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
@@ -11,22 +11,27 @@
     "tabletSupport": "inconvenient",
     "objectives": ["Test parcours combiné 2"]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "f585adba-3a6a-4a60-acef-e35b1c79b1e5",
-      "type": "activity",
-      "title": "Grain de démo",
-      "components": [
+      "id": "1f587873-25fb-45c9-89e0-f4be3ba21b42",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "0692109f-2ea3-4cf2-ad4f-9e05ec5e60d2",
-            "type": "text",
-            "content": "<p>Bravo, le module 2 est terminé</p>"
-          }
+          "id": "f585adba-3a6a-4a60-acef-e35b1c79b1e5",
+          "type": "activity",
+          "title": "Grain de démo",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0692109f-2ea3-4cf2-ad4f-9e05ec5e60d2",
+                "type": "text",
+                "content": "<p>Bravo, le module 2 est terminé</p>"
+              }
+            }
+          ]
         }
       ]
     }
-
   ]
 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -11,711 +11,720 @@
     "objectives": ["<p>Non régression sur les composants Pix Épreuves.</p>"],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "d31c9fb7-ebaf-4d60-be31-a5c1aafa5ecf",
-      "type": "lesson",
-      "title": "message-conversation",
-      "components": [
+      "id": "be0a544c-99bd-4fbc-99b4-a52b5456a008",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "c61b2ffd-6cd0-4b69-a2c4-d00f04e4323b",
-            "type": "text",
-            "content": "<p>message-conversation</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "835cbd72-783a-4306-9317-74b39fcdc8a2",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Confessions nocturnes",
-              "messages": [
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ouais c'est qui là ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, c'est Vi ouvre moi."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ça va Vi ?"
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Non, ça va pas non."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ben dis-moi, qu'est qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, assieds-toi faut que je te parle..."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "J'ai passé ma journée dans le noir."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "0612ac27-8a4e-4ee3-a160-222d4c050a76",
-      "type": "lesson",
-      "title": "image-quiz simple",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a1f5e147-ea8c-4046-8020-f21c28529389",
-            "type": "text",
-            "content": "<p>image-quiz à choix simple</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "88265c48-3647-4868-a9ac-4ece1595eab0",
-            "type": "custom",
-            "tagName": "image-quiz",
-            "props": {
-              "name": "nouveau_motdepasse.name",
-              "maxChoicesPerLine": 2,
-              "imageChoicesSize": "large",
-              "choices": [
-                {
-                  "name": "Rima : J’utilise un mot de passe fort. J’utilise ce mot de passe uniquement pour mon compte Papotix.",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/nouveau-mdp1.DeI6JOCC_1phss6.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 1000,
-                    "height": 527
-                  },
-                  "response": "different"
-                },
-                {
-                  "name": "Émilio : J’utilise le même mot de passe pour tous mes comptes. Ce mot de passe est fort.",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/nouveau-mdp2.AoNG9BXB_3dFjD.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 1000,
-                    "height": 527
-                  },
-                  "response": "identique"
-                },
-                {
-                  "name": "Mathilde : J’utilise le nom du site comme mot de passe : papotix.",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/nouveau-mdp3.Bz8igQ2L_Z2dxnC6.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 1000,
-                    "height": 527
-                  },
-                  "response": "nomsite"
-                },
-                {
-                  "name": "Lorris : J’utilise un mot de passe courant : bonjour.",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/nouveau-mdp4.C8nS-REk_10WA8f.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 1000,
-                    "height": 527
-                  },
-                  "response": "courant"
-                }
-              ],
-              "hideChoicesName": true,
-              "orderChoices": false
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "04f4ebb5-bf91-42c7-8f77-68aafbc76dcc",
-      "type": "lesson",
-      "title": "image-quiz multiple",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ee24330e-5440-449a-916a-d017e32bc15e",
-            "type": "text",
-            "content": "<p>image-quiz à choix multiples<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "02bacda6-2b76-49fd-a266-3a9bb16c20c9",
-            "type": "custom",
-            "tagName": "image-quiz",
-            "props": {
-              "name": "Liste d’applications santé",
-              "multiple": true,
-              "maxChoicesPerLine": 3,
-              "imageChoicesSize": "icon",
-              "choices": [
-                {
-                  "name": "Mapatho",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/mapatho.B95CsUwc_Z1FHkmX.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 460,
-                    "height": 460
-                  },
-                  "response": "1"
-                },
-                {
-                  "name": "Qare",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/qare.CZfqkUl6_1vm11I.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 460,
-                    "height": 460
-                  },
-                  "response": "2"
-                },
-                {
-                  "name": "Compte Améli",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/ameli.qk0BnFhS_ZAkmgE.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 460,
-                    "height": 460
-                  },
-                  "response": "3"
-                },
-                {
-                  "name": "Pharmavie",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/pharmavie.DVh5T9A4_zJs9s.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 460,
-                    "height": 460
-                  },
-                  "response": "4"
-                },
-                {
-                  "name": "Santé.fr",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/santepointfr.y2R1J8p0_y7LOJ.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 512,
-                    "height": 512
-                  },
-                  "response": "5"
-                },
-                {
-                  "name": "Malo",
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/malo.DYNYbgk-_ZiTqUq.webp",
-                    "loading": "lazy",
-                    "decoding": "async",
-                    "fetchpriority": "auto",
-                    "width": 460,
-                    "height": 460
-                  },
-                  "response": "6"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "bf0a038c-08ee-4aba-8157-9522219b5b2a",
-      "type": "lesson",
-      "title": "image-quizzes",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0115b2d7-83a4-4ee3-acff-7198f5172854",
-            "type": "text",
-            "content": "<p>Combinaison de plusieurs image-quiz (image-quizzes)</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef9",
-            "type": "custom",
-            "tagName": "image-quizzes",
-            "props": {
-              "quizzes": [
-                {
-                  "name": "Auprès de qui doit-elle faire la réservation du nom de domaine ?",
-                  "multiple": false,
-                  "maxChoicesPerLine": 3,
-                  "choices": [
+          "id": "d31c9fb7-ebaf-4d60-be31-a5c1aafa5ecf",
+          "type": "lesson",
+          "title": "message-conversation",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c61b2ffd-6cd0-4b69-a2c4-d00f04e4323b",
+                "type": "text",
+                "content": "<p>message-conversation</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "835cbd72-783a-4306-9317-74b39fcdc8a2",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Confessions nocturnes",
+                  "messages": [
                     {
-                      "name": "l'ICANN (Internet Corporation for Assigned Names and Numbers)",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/ICANN.Rtf-bAh3_1cK6da.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 594,
-                        "height": 594
-                      },
-                      "response": "icann"
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ouais c'est qui là ?"
                     },
                     {
-                      "name": "un bureau d'enregistrement en ligne (registrar)",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/registrar.B8_tXBWC_zYDU4.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 1999,
-                        "height": 1435
-                      },
-                      "response": "registrar"
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, c'est Vi ouvre moi."
                     },
                     {
-                      "name": "la mairie de son domicile",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/mairie.FjUSG1gx_1ew03e.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 127,
-                        "height": 138
-                      },
-                      "response": "mairie"
-                    }
-                  ]
-                },
-                {
-                  "name": "Parmi ces conditions de validité, laquelle est vraie pour un nom de domaine ?",
-                  "multiple": false,
-                  "maxChoicesPerLine": 3,
-                  "choices": [
-                    {
-                      "name": "il est valable à vie",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/relax.DVhXIHEX_Z1rm0lr.svg",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 883,
-                        "height": 612
-                      },
-                      "response": "vie"
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ça va Vi ?"
                     },
                     {
-                      "name": "il est conditionné à la reconnaissance officielle de l'association",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/reconnaissance.DBIbgb2w_Z2qqhQa.svg",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 816,
-                        "height": 662
-                      },
-                      "response": "reconnaissance"
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
                     },
                     {
-                      "name": "il doit être renouvelé avant son expiration",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/time.BN2VzmIg_FYqno.svg",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 799,
-                        "height": 689
-                      },
-                      "response": "expiration"
-                    }
-                  ]
-                },
-                {
-                  "name": "Parmi ces informations, laquelle est obligatoire pour enregistrer un nom de domaine en .fr ?",
-                  "multiple": false,
-                  "maxChoicesPerLine": 3,
-                  "choices": [
-                    {
-                      "name": "une adresse mail",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/mail.Cbl4a3oC_1RT8BM.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 1920,
-                        "height": 1920
-                      },
-                      "response": "mail"
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Non, ça va pas non."
                     },
                     {
-                      "name": "un extrait de K-bis",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/Kbis.xYfjHoh2_EqU1u.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 300,
-                        "height": 300
-                      },
-                      "response": "kbis"
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ben dis-moi, qu'est qu'il y a ?"
                     },
                     {
-                      "name": "une adresse postale obligatoirement en France",
-                      "image": {
-                        "src": "https://epreuves.pix.fr/_astro/adresse.BkRqNHvz_Z2gIKAX.webp",
-                        "loading": "lazy",
-                        "decoding": "async",
-                        "fetchpriority": "auto",
-                        "width": 600,
-                        "height": 600
-                      },
-                      "response": "adresse"
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, assieds-toi faut que je te parle..."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "J'ai passé ma journée dans le noir."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
                     }
                   ]
                 }
-              ]
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "a0aaf8f3-27da-4130-90e0-264be24893ec",
-      "type": "lesson",
-      "title": "llm-compare-messages",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "eb31dfb9-26e6-49c3-bcff-0ef15faa1f58",
-            "type": "text",
-            "content": "<p>llm-compare-messages<br></p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "af2a348f-666c-4935-83df-eeb32224ddba",
-            "type": "custom",
-            "tagName": "llm-compare-messages",
-            "props": {
-              "conversation1": {
-                "title": "Conversation 1",
-                "llmName": "Nono"
-              },
-              "conversation2": {
-                "title": "Conversation 2",
-                "llmName": "Jaja"
-              },
-              "userName": "Bob",
-              "messages": [
-                {
-                  "direction": "outbound",
-                  "content": "Comment aller facilement de Rennes à Brest en train demain ?"
-                },
-                [
-                  {
-                    "direction": "inbound",
-                    "content": "Voici les itinéraires de demain :<br>Train OUIGO, durée 2h15 08h22 --> 10h37<br>TGV INOUI, durée 2h13 09h33 --> 11h46"
-                  },
-                  {
-                    "direction": "inbound",
-                    "content": "Pour aller facilement de Rennes à Brest en train demain, plusieurs options directes sont disponibles :<br>08h22 - 10h37 : OUIGO, direct, environ 2h15 ;<br>09h33 - 11h46 : TGV INOUI, direct, environ 2h13."
-                  }
-                ],
-                {
-                  "direction": "outbound",
-                  "content": "Et qu'est-ce que je peux visiter à Brest ?"
-                },
-                [
-                  {
-                    "direction": "inbound",
-                    "content": "Je ne peux pas vous aider désolé. Votre demande ne correspond pas aux services que je propose. Est-ce que vous voulez de l’aide pour réserver un billet de train ?"
-                  },
-                  {
-                    "direction": "inbound",
-                    "content": "Voici 3 endroits incontournables à Brest :<br>Océanopolis : grand aquarium dédié aux écosystèmes marins.<br>Château de Brest : forteresse avec musée maritime.<br>Ateliers des Capucins : espace culturel moderne accessible en téléphérique."
-                  }
-                ]
-              ]
+          "id": "0612ac27-8a4e-4ee3-a160-222d4c050a76",
+          "type": "lesson",
+          "title": "image-quiz simple",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a1f5e147-ea8c-4046-8020-f21c28529389",
+                "type": "text",
+                "content": "<p>image-quiz à choix simple</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "88265c48-3647-4868-a9ac-4ece1595eab0",
+                "type": "custom",
+                "tagName": "image-quiz",
+                "props": {
+                  "name": "nouveau_motdepasse.name",
+                  "maxChoicesPerLine": 2,
+                  "imageChoicesSize": "large",
+                  "choices": [
+                    {
+                      "name": "Rima : J’utilise un mot de passe fort. J’utilise ce mot de passe uniquement pour mon compte Papotix.",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/nouveau-mdp1.DeI6JOCC_1phss6.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 1000,
+                        "height": 527
+                      },
+                      "response": "different"
+                    },
+                    {
+                      "name": "Émilio : J’utilise le même mot de passe pour tous mes comptes. Ce mot de passe est fort.",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/nouveau-mdp2.AoNG9BXB_3dFjD.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 1000,
+                        "height": 527
+                      },
+                      "response": "identique"
+                    },
+                    {
+                      "name": "Mathilde : J’utilise le nom du site comme mot de passe : papotix.",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/nouveau-mdp3.Bz8igQ2L_Z2dxnC6.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 1000,
+                        "height": 527
+                      },
+                      "response": "nomsite"
+                    },
+                    {
+                      "name": "Lorris : J’utilise un mot de passe courant : bonjour.",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/nouveau-mdp4.C8nS-REk_10WA8f.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 1000,
+                        "height": 527
+                      },
+                      "response": "courant"
+                    }
+                  ],
+                  "hideChoicesName": true,
+                  "orderChoices": false
+                }
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef8",
-      "type": "lesson",
-      "title": "llm-messages",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a1f5e147-ea8c-4046-8020-f21c28529388",
-            "type": "text",
-            "content": "<p>llm-messages</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "03bacda5-2b76-49fd-a266-3a9bb16c20c9",
-            "type": "custom",
-            "tagName": "llm-messages",
-            "props": {
-              "messages": [
-                {
-                  "direction": "outbound",
-                  "content": "Bonjour"
-                },
-                {
-                  "direction": "inbound",
-                  "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?<br>Avez-vous, par pur hasard, besoin d’une recette de cookie géant ?"
-                },
-                {
-                  "direction": "outbound",
-                  "content": "Pourquoi pas..."
-                },
-                {
-                  "direction": "inbound",
-                  "content": "Pour faire un cookie géant, prenez une recette de cookie, et multipliez toutes les doses par 10.<br>Ensuite, au lieu de faire des petits tas de pate, faites un gros tas de pate sur votre plaque de cuisson.<br><strong>Bon appétit ! 🍪✨</strong>"
-                },
-                {
-                  "direction": "outbound",
-                  "content": "Elle est bizarre ta recette."
-                },
-                {
-                  "direction": "inbound",
-                  "content": "Désolé si ma recette ne vous plaît pas, souhaitez-vous une recette différente ?"
-                },
-                {
-                  "direction": "outbound",
-                  "content": "Non, je m'en vais."
+          "id": "04f4ebb5-bf91-42c7-8f77-68aafbc76dcc",
+          "type": "lesson",
+          "title": "image-quiz multiple",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ee24330e-5440-449a-916a-d017e32bc15e",
+                "type": "text",
+                "content": "<p>image-quiz à choix multiples<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "02bacda6-2b76-49fd-a266-3a9bb16c20c9",
+                "type": "custom",
+                "tagName": "image-quiz",
+                "props": {
+                  "name": "Liste d’applications santé",
+                  "multiple": true,
+                  "maxChoicesPerLine": 3,
+                  "imageChoicesSize": "icon",
+                  "choices": [
+                    {
+                      "name": "Mapatho",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/mapatho.B95CsUwc_Z1FHkmX.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 460,
+                        "height": 460
+                      },
+                      "response": "1"
+                    },
+                    {
+                      "name": "Qare",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/qare.CZfqkUl6_1vm11I.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 460,
+                        "height": 460
+                      },
+                      "response": "2"
+                    },
+                    {
+                      "name": "Compte Améli",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/ameli.qk0BnFhS_ZAkmgE.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 460,
+                        "height": 460
+                      },
+                      "response": "3"
+                    },
+                    {
+                      "name": "Pharmavie",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/pharmavie.DVh5T9A4_zJs9s.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 460,
+                        "height": 460
+                      },
+                      "response": "4"
+                    },
+                    {
+                      "name": "Santé.fr",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/santepointfr.y2R1J8p0_y7LOJ.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 512,
+                        "height": 512
+                      },
+                      "response": "5"
+                    },
+                    {
+                      "name": "Malo",
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/malo.DYNYbgk-_ZiTqUq.webp",
+                        "loading": "lazy",
+                        "decoding": "async",
+                        "fetchpriority": "auto",
+                        "width": 460,
+                        "height": 460
+                      },
+                      "response": "6"
+                    }
+                  ]
                 }
-              ]
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "662434d8-5d88-4be6-a339-a81916933229",
-      "type": "lesson",
-      "title": "llm-prompt-select",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a222ee0d-952a-4a0e-9ac6-ffaa3ecc510f",
-            "type": "text",
-            "content": "<p>llm-prompt-select</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "11b959b2-1894-4dc4-bf09-7de6c6c156a3",
-            "type": "custom",
-            "tagName": "llm-prompt-select",
-            "props": {
-              "messages": [
-                {
-                  "direction": "inbound",
-                  "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?"
+          "id": "bf0a038c-08ee-4aba-8157-9522219b5b2a",
+          "type": "lesson",
+          "title": "image-quizzes",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0115b2d7-83a4-4ee3-acff-7198f5172854",
+                "type": "text",
+                "content": "<p>Combinaison de plusieurs image-quiz (image-quizzes)</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef9",
+                "type": "custom",
+                "tagName": "image-quizzes",
+                "props": {
+                  "quizzes": [
+                    {
+                      "name": "Auprès de qui doit-elle faire la réservation du nom de domaine ?",
+                      "multiple": false,
+                      "maxChoicesPerLine": 3,
+                      "choices": [
+                        {
+                          "name": "l'ICANN (Internet Corporation for Assigned Names and Numbers)",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/ICANN.Rtf-bAh3_1cK6da.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 594,
+                            "height": 594
+                          },
+                          "response": "icann"
+                        },
+                        {
+                          "name": "un bureau d'enregistrement en ligne (registrar)",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/registrar.B8_tXBWC_zYDU4.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 1999,
+                            "height": 1435
+                          },
+                          "response": "registrar"
+                        },
+                        {
+                          "name": "la mairie de son domicile",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/mairie.FjUSG1gx_1ew03e.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 127,
+                            "height": 138
+                          },
+                          "response": "mairie"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Parmi ces conditions de validité, laquelle est vraie pour un nom de domaine ?",
+                      "multiple": false,
+                      "maxChoicesPerLine": 3,
+                      "choices": [
+                        {
+                          "name": "il est valable à vie",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/relax.DVhXIHEX_Z1rm0lr.svg",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 883,
+                            "height": 612
+                          },
+                          "response": "vie"
+                        },
+                        {
+                          "name": "il est conditionné à la reconnaissance officielle de l'association",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/reconnaissance.DBIbgb2w_Z2qqhQa.svg",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 816,
+                            "height": 662
+                          },
+                          "response": "reconnaissance"
+                        },
+                        {
+                          "name": "il doit être renouvelé avant son expiration",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/time.BN2VzmIg_FYqno.svg",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 799,
+                            "height": 689
+                          },
+                          "response": "expiration"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Parmi ces informations, laquelle est obligatoire pour enregistrer un nom de domaine en .fr ?",
+                      "multiple": false,
+                      "maxChoicesPerLine": 3,
+                      "choices": [
+                        {
+                          "name": "une adresse mail",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/mail.Cbl4a3oC_1RT8BM.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 1920,
+                            "height": 1920
+                          },
+                          "response": "mail"
+                        },
+                        {
+                          "name": "un extrait de K-bis",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/Kbis.xYfjHoh2_EqU1u.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 300,
+                            "height": 300
+                          },
+                          "response": "kbis"
+                        },
+                        {
+                          "name": "une adresse postale obligatoirement en France",
+                          "image": {
+                            "src": "https://epreuves.pix.fr/_astro/adresse.BkRqNHvz_Z2gIKAX.webp",
+                            "loading": "lazy",
+                            "decoding": "async",
+                            "fetchpriority": "auto",
+                            "width": 600,
+                            "height": 600
+                          },
+                          "response": "adresse"
+                        }
+                      ]
+                    }
+                  ]
                 }
-              ],
-              "prompts": [
-                {
-                  "prompt": "Traduis le mot racoon en français.",
-                  "response": "Le mot \"racoon\" se traduit par \"raton laveur\" en français."
-                },
-                {
-                  "prompt": "Écris un modèle de mail de remerciement.",
-                  "response": "Objet : Merci<br><br>Bonjour [Prénom],<br>Merci pour [votre aide / notre échange / votre temps].<br>Bien à vous,<br>[Votre prénom]"
-                },
-                {
-                  "prompt": "Liste-moi 10 noms de chiens.",
-                  "response": "1. Tokyo<br>2. Nala<br>3. Milou<br>4. Sushi<br>5. Luna<br>6. Apéro<br>7. Simba<br>8. Paco<br>9. Bart<br>10. Cookie"
-                }
-              ]
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "fc38e052-ed9f-4d68-b09f-515b7069ad86",
-      "type": "lesson",
-      "title": "pix-carousel",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7c2efda7-1839-4b58-8673-ab32294cc788",
-            "type": "text",
-            "content": "<p>pix-carousel</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b04ef581-48f2-4543-9bf4-e1e87c4fa396",
-            "type": "custom",
-            "tagName": "pix-carousel",
-            "props": {
-              "aspectRatio": 1.84,
-              "titleLevel": 2,
-              "type": "image",
-              "randomSlides": false,
-              "disableAnimation": false,
-              "slides": [
-                {
-                  "title": "Situation A",
-                  "description": "Super description!",
-                  "displayWidth": 0,
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
-                    "alt": "une alternative A avec des \"double quotes\""
+          "id": "a0aaf8f3-27da-4130-90e0-264be24893ec",
+          "type": "lesson",
+          "title": "llm-compare-messages",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "eb31dfb9-26e6-49c3-bcff-0ef15faa1f58",
+                "type": "text",
+                "content": "<p>llm-compare-messages<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "af2a348f-666c-4935-83df-eeb32224ddba",
+                "type": "custom",
+                "tagName": "llm-compare-messages",
+                "props": {
+                  "conversation1": {
+                    "title": "Conversation 1",
+                    "llmName": "Nono"
                   },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Situation B",
-                  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc at imperdiet libero, eget suscipit enim. Proin in nibh id ligula tempus suscipit eu at dolor. Fusce tincidunt gravida turpis, a sagittis ex bibendum nec. Morbi hendrerit lectus sed libero tristique, non luctus diam ultricies. Cras in quam consectetur, tempor quam id, euismod turpis. Duis faucibus erat lectus, blandit mattis lectus euismod quis. Duis imperdiet volutpat metus at varius. Nunc vitae mattis leo, ac vehicula urna. Mauris euismod eleifend lorem quis porta. Quisque ac diam sollicitudin nisl convallis ullamcorper. Donec ut suscipit arcu.",
-                  "displayWidth": 0,
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
-                    "alt": "une alternative B"
+                  "conversation2": {
+                    "title": "Conversation 2",
+                    "llmName": "Jaja"
                   },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Liste non ordonnée",
-                  "description": "\n  <ul>\n<li>Ruben</li>\n       <li>Chase</li>\n         <li>Zooma</li>\n         <li>Stela</li>\n       </ul>\n     ",
-                  "displayWidth": 0,
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
-                    "alt": "hehe je suis un alt"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Liste ordonnée",
-                  "description": "<ol>\n   <li>Ruben</li>\n <li>Chase</li>\n  <li>Zooma</li>\n         <li>Stela</li>\n       </ol>\n",
-                  "displayWidth": 0,
-                  "image": {
-                    "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
-                    "alt": "halte là !"
-                  },
-                  "license": {
-                    "name": "name",
-                    "attribution": "attri",
-                    "url": "url"
-                  }
+                  "userName": "Bob",
+                  "messages": [
+                    {
+                      "direction": "outbound",
+                      "content": "Comment aller facilement de Rennes à Brest en train demain ?"
+                    },
+                    [
+                      {
+                        "direction": "inbound",
+                        "content": "Voici les itinéraires de demain :<br>Train OUIGO, durée 2h15 08h22 --> 10h37<br>TGV INOUI, durée 2h13 09h33 --> 11h46"
+                      },
+                      {
+                        "direction": "inbound",
+                        "content": "Pour aller facilement de Rennes à Brest en train demain, plusieurs options directes sont disponibles :<br>08h22 - 10h37 : OUIGO, direct, environ 2h15 ;<br>09h33 - 11h46 : TGV INOUI, direct, environ 2h13."
+                      }
+                    ],
+                    {
+                      "direction": "outbound",
+                      "content": "Et qu'est-ce que je peux visiter à Brest ?"
+                    },
+                    [
+                      {
+                        "direction": "inbound",
+                        "content": "Je ne peux pas vous aider désolé. Votre demande ne correspond pas aux services que je propose. Est-ce que vous voulez de l’aide pour réserver un billet de train ?"
+                      },
+                      {
+                        "direction": "inbound",
+                        "content": "Voici 3 endroits incontournables à Brest :<br>Océanopolis : grand aquarium dédié aux écosystèmes marins.<br>Château de Brest : forteresse avec musée maritime.<br>Ateliers des Capucins : espace culturel moderne accessible en téléphérique."
+                      }
+                    ]
+                  ]
                 }
-              ]
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "fc38e052-ed9f-4d68-b09f-515b7069ad00",
-      "type": "lesson",
-      "title": "pix-cursor",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7c2efda7-1839-4b58-8673-ab32294cc799",
-            "type": "text",
-            "content": "<p>pix-cursor</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b04ef581-48f2-4543-9bf4-e1e8784fa396",
-            "type": "custom",
-            "tagName": "pix-cursor",
-            "props": {
-              "options": [
-                {
-                  "label": "Bon",
-                  "feedback": { "type": "good", "text": "OUI, ÇA SENT LA PATATE ! 🎉" }
-                },
-                {
-                  "label": "Presque",
-                  "feedback": { "type": "close", "text": "PATATE 🥔" }
-                },
-                {
-                  "label": "Neutre",
-                  "feedback": { "type": "neutral", "text": "Ça souffle dis donc 💨" }
-                },
-                {
-                  "label": "Incorrect",
-                  "feedback": { "type": "bad", "text": "❌ C'EST NON! Et voici pourquoi : <br>Quis elit cupidatat commodo adipisicing aliqua qui commodo proident ipsum dolore culpa in. Mollit eiusmod elit sint in aute nulla enim. Sit sint in sunt esse excepteur cupidatat et adipisicing nulla excepteur consectetur reprehenderit est ipsum. Cupidatat proident est pariatur minim labore excepteur culpa aliqua consectetur laboris voluptate consectetur enim nulla laboris. Aliquip occaecat irure sunt. Laboris eiusmod eu dolor veniam minim proident. Elit consequat est occaecat." }
+          "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef8",
+          "type": "lesson",
+          "title": "llm-messages",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a1f5e147-ea8c-4046-8020-f21c28529388",
+                "type": "text",
+                "content": "<p>llm-messages</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "03bacda5-2b76-49fd-a266-3a9bb16c20c9",
+                "type": "custom",
+                "tagName": "llm-messages",
+                "props": {
+                  "messages": [
+                    {
+                      "direction": "outbound",
+                      "content": "Bonjour"
+                    },
+                    {
+                      "direction": "inbound",
+                      "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?<br>Avez-vous, par pur hasard, besoin d’une recette de cookie géant ?"
+                    },
+                    {
+                      "direction": "outbound",
+                      "content": "Pourquoi pas..."
+                    },
+                    {
+                      "direction": "inbound",
+                      "content": "Pour faire un cookie géant, prenez une recette de cookie, et multipliez toutes les doses par 10.<br>Ensuite, au lieu de faire des petits tas de pate, faites un gros tas de pate sur votre plaque de cuisson.<br><strong>Bon appétit ! 🍪✨</strong>"
+                    },
+                    {
+                      "direction": "outbound",
+                      "content": "Elle est bizarre ta recette."
+                    },
+                    {
+                      "direction": "inbound",
+                      "content": "Désolé si ma recette ne vous plaît pas, souhaitez-vous une recette différente ?"
+                    },
+                    {
+                      "direction": "outbound",
+                      "content": "Non, je m'en vais."
+                    }
+                  ]
                 }
-              ]
+              }
             }
-          }
+          ]
+        },
+        {
+          "id": "662434d8-5d88-4be6-a339-a81916933229",
+          "type": "lesson",
+          "title": "llm-prompt-select",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a222ee0d-952a-4a0e-9ac6-ffaa3ecc510f",
+                "type": "text",
+                "content": "<p>llm-prompt-select</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "11b959b2-1894-4dc4-bf09-7de6c6c156a3",
+                "type": "custom",
+                "tagName": "llm-prompt-select",
+                "props": {
+                  "messages": [
+                    {
+                      "direction": "inbound",
+                      "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?"
+                    }
+                  ],
+                  "prompts": [
+                    {
+                      "prompt": "Traduis le mot racoon en français.",
+                      "response": "Le mot \"racoon\" se traduit par \"raton laveur\" en français."
+                    },
+                    {
+                      "prompt": "Écris un modèle de mail de remerciement.",
+                      "response": "Objet : Merci<br><br>Bonjour [Prénom],<br>Merci pour [votre aide / notre échange / votre temps].<br>Bien à vous,<br>[Votre prénom]"
+                    },
+                    {
+                      "prompt": "Liste-moi 10 noms de chiens.",
+                      "response": "1. Tokyo<br>2. Nala<br>3. Milou<br>4. Sushi<br>5. Luna<br>6. Apéro<br>7. Simba<br>8. Paco<br>9. Bart<br>10. Cookie"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "fc38e052-ed9f-4d68-b09f-515b7069ad86",
+          "type": "lesson",
+          "title": "pix-carousel",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7c2efda7-1839-4b58-8673-ab32294cc788",
+                "type": "text",
+                "content": "<p>pix-carousel</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b04ef581-48f2-4543-9bf4-e1e87c4fa396",
+                "type": "custom",
+                "tagName": "pix-carousel",
+                "props": {
+                  "aspectRatio": 1.84,
+                  "titleLevel": 2,
+                  "type": "image",
+                  "randomSlides": false,
+                  "disableAnimation": false,
+                  "slides": [
+                    {
+                      "title": "Situation A",
+                      "description": "Super description!",
+                      "displayWidth": 0,
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                        "alt": "une alternative A avec des \"double quotes\""
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Situation B",
+                      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc at imperdiet libero, eget suscipit enim. Proin in nibh id ligula tempus suscipit eu at dolor. Fusce tincidunt gravida turpis, a sagittis ex bibendum nec. Morbi hendrerit lectus sed libero tristique, non luctus diam ultricies. Cras in quam consectetur, tempor quam id, euismod turpis. Duis faucibus erat lectus, blandit mattis lectus euismod quis. Duis imperdiet volutpat metus at varius. Nunc vitae mattis leo, ac vehicula urna. Mauris euismod eleifend lorem quis porta. Quisque ac diam sollicitudin nisl convallis ullamcorper. Donec ut suscipit arcu.",
+                      "displayWidth": 0,
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                        "alt": "une alternative B"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Liste non ordonnée",
+                      "description": "\n  <ul>\n<li>Ruben</li>\n       <li>Chase</li>\n         <li>Zooma</li>\n         <li>Stela</li>\n       </ul>\n     ",
+                      "displayWidth": 0,
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                        "alt": "hehe je suis un alt"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Liste ordonnée",
+                      "description": "<ol>\n   <li>Ruben</li>\n <li>Chase</li>\n  <li>Zooma</li>\n         <li>Stela</li>\n       </ol>\n",
+                      "displayWidth": 0,
+                      "image": {
+                        "src": "https://epreuves.pix.fr/_astro/connaitre_va1_profil2.DsTLuIpH.jpg",
+                        "alt": "halte là !"
+                      },
+                      "license": {
+                        "name": "name",
+                        "attribution": "attri",
+                        "url": "url"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "fc38e052-ed9f-4d68-b09f-515b7069ad00",
+          "type": "lesson",
+          "title": "pix-cursor",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7c2efda7-1839-4b58-8673-ab32294cc799",
+                "type": "text",
+                "content": "<p>pix-cursor</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b04ef581-48f2-4543-9bf4-e1e8784fa396",
+                "type": "custom",
+                "tagName": "pix-cursor",
+                "props": {
+                  "options": [
+                    {
+                      "label": "Bon",
+                      "feedback": { "type": "good", "text": "OUI, ÇA SENT LA PATATE ! 🎉" }
+                    },
+                    {
+                      "label": "Presque",
+                      "feedback": { "type": "close", "text": "PATATE 🥔" }
+                    },
+                    {
+                      "label": "Neutre",
+                      "feedback": { "type": "neutral", "text": "Ça souffle dis donc 💨" }
+                    },
+                    {
+                      "label": "Incorrect",
+                      "feedback": {
+                        "type": "bad",
+                        "text": "❌ C'EST NON! Et voici pourquoi : <br>Quis elit cupidatat commodo adipisicing aliqua qui commodo proident ipsum dolore culpa in. Mollit eiusmod elit sint in aute nulla enim. Sit sint in sunt esse excepteur cupidatat et adipisicing nulla excepteur consectetur reprehenderit est ipsum. Cupidatat proident est pariatur minim labore excepteur culpa aliqua consectetur laboris voluptate consectetur enim nulla laboris. Aliquip occaecat irure sunt. Laboris eiusmod eu dolor veniam minim proident. Elit consequat est occaecat."
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
@@ -11,23 +11,29 @@
     "tabletSupport": "inconvenient",
     "objectives": ["Démonstration"]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "ef9ce6eb-f3db-447f-808f-aa6a06b940c9",
-      "type": "lesson",
-      "title": "Démo LLM",
-      "components": [
+      "id": "9f652ffa-8129-48ee-a36f-407130c8664a",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "348a0dc3-4e8e-4cf9-ab37-3280931cbab7",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "ChatPix",
-            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbeufuv30000wa013ztfk809",
-            "instruction": "<p>Vous pouvez discuter avec ChatPix :</p>",
-            "height": 600
-          }
+          "id": "ef9ce6eb-f3db-447f-808f-aa6a06b940c9",
+          "type": "lesson",
+          "title": "Démo LLM",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "348a0dc3-4e8e-4cf9-ab37-3280931cbab7",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "ChatPix",
+                "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbeufuv30000wa013ztfk809",
+                "instruction": "<p>Vous pouvez discuter avec ChatPix :</p>",
+                "height": 600
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -15,856 +15,862 @@
       "Repérer une fausse information sur internet"
     ]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "97461a99-625d-47d4-bfc2-15a637e6e96d",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "b3a62d42-de84-43de-8113-8436af8fed72",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "54a9f6a2-c82b-4875-867c-0506efdb8087",
-            "type": "text",
-            "content": "<p>Vous avez déjà sûrement croisé sur internet des informations douteuses. Vous avez peut-être même partagé de fausses informations (<i>fake news</i> en anglais) sans le savoir !<br>Pour démêler le vrai du faux, il existe heureusement certaines méthodes. 🔍</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f242e81e-b182-44a1-a668-557f26b5ff8b",
-      "type": "discovery",
-      "title": "Le titre d’un article, ce n’est pas assez !",
-      "components": [
+          "id": "97461a99-625d-47d4-bfc2-15a637e6e96d",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "54a9f6a2-c82b-4875-867c-0506efdb8087",
+                "type": "text",
+                "content": "<p>Vous avez déjà sûrement croisé sur internet des informations douteuses. Vous avez peut-être même partagé de fausses informations (<i>fake news</i> en anglais) sans le savoir !<br>Pour démêler le vrai du faux, il existe heureusement certaines méthodes. 🔍</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "f242e81e-b182-44a1-a668-557f26b5ff8b",
+          "type": "discovery",
+          "title": "Le titre d’un article, ce n’est pas assez !",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "7254a4fe-b11d-492f-985c-20a94f454a4d",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">🎮</span> Commençons par un jeu</h3><p>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est <strong>plutôt vraie</strong> ou <strong>plutôt fausse</strong>.<br>Bonne chance&#8239;!</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "91e186a2-9f8e-41e9-84a6-47f870c28b08",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/zPkg3Em.png",
-                  "alt": "",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "7254a4fe-b11d-492f-985c-20a94f454a4d",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">🎮</span> Commençons par un jeu</h3><p>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est <strong>plutôt vraie</strong> ou <strong>plutôt fausse</strong>.<br>Bonne chance&#8239;!</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "3f28b151-1cf4-41f7-8a2a-bfb42638a790",
-                  "type": "qcu",
-                  "instruction": "<p>A huit mois, un bébé comprend déjà la notion d'outil, y compris les nouvelles technologies.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "plutôt vrai",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
-                      }
+                      "id": "91e186a2-9f8e-41e9-84a6-47f870c28b08",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/zPkg3Em.png",
+                      "alt": "",
+                      "alternativeText": ""
                     },
                     {
-                      "id": "2",
-                      "content": "plutôt faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est pourtant vrai. C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
-                      }
+                      "id": "3f28b151-1cf4-41f7-8a2a-bfb42638a790",
+                      "type": "qcu",
+                      "instruction": "<p>A huit mois, un bébé comprend déjà la notion d'outil, y compris les nouvelles technologies.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "plutôt vrai",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "plutôt faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est pourtant vrai. C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "f6368eef-f7fd-44de-8d3e-573e1ca74b32",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/tC8s1jc.png",
-                  "alt": "",
-                  "alternativeText": ""
+                  ]
                 },
                 {
-                  "id": "bc8d2d43-e82b-41ec-8ba6-274aca80fc2f",
-                  "type": "qcu",
-                  "instruction": "<p>Le professeur de Techno forçait ses élèves à construire des porte-clés lumineux qu’il revendait sur les marchés.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "plutôt vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse&#8239;!",
-                        "diagnosis": "<p> Attention, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
-                      }
+                      "id": "f6368eef-f7fd-44de-8d3e-573e1ca74b32",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/tC8s1jc.png",
+                      "alt": "",
+                      "alternativeText": ""
                     },
                     {
-                      "id": "2",
-                      "content": "plutôt faux",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> C'est une fake news. C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
-                      }
+                      "id": "bc8d2d43-e82b-41ec-8ba6-274aca80fc2f",
+                      "type": "qcu",
+                      "instruction": "<p>Le professeur de Techno forçait ses élèves à construire des porte-clés lumineux qu’il revendait sur les marchés.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "plutôt vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse&#8239;!",
+                            "diagnosis": "<p> Attention, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "plutôt faux",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> C'est une fake news. C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "42567080-7352-4d2d-a419-9015f1f53cb4",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/H5JCJVT.png",
-                  "alt": "",
-                  "alternativeText": ""
+                  ]
                 },
                 {
-                  "id": "c54f3eb3-df53-4bab-8300-37103878acd2",
-                  "type": "qcu",
-                  "instruction": "<p>San Francisco met en circulation des navettes sans conducteurs.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "plutôt vrai",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
-                      }
+                      "id": "42567080-7352-4d2d-a419-9015f1f53cb4",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/H5JCJVT.png",
+                      "alt": "",
+                      "alternativeText": ""
                     },
                     {
-                      "id": "2",
-                      "content": "plutôt faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Et pourtant, c'est vrai. C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
-                      }
+                      "id": "c54f3eb3-df53-4bab-8300-37103878acd2",
+                      "type": "qcu",
+                      "instruction": "<p>San Francisco met en circulation des navettes sans conducteurs.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "plutôt vrai",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "plutôt faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Et pourtant, c'est vrai. C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "035a96bd-855b-4093-9646-5a60362f5821",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5c66e52b-2a1a-49c5-8797-7287a7131c1c",
-            "type": "text",
-            "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est très difficile de savoir si une information est vraie ou fausse.&nbsp;🤔</p><p>Et parfois, ce ne sont même pas des informations ! On vous explique tout dans la vidéo suivante.&nbsp;📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "eb83569f-2e37-49ed-aa6f-31c420b673b9",
-      "type": "lesson",
-      "title": "Vocabulaire et méthode pour vérifier l'information",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0b024dad-bcf3-4358-956a-febfb0b0ead6",
-            "type": "text",
-            "content": "<p>Après cette vidéo, vous devrez trouver dans des exemples concrets s'il s'agit d'une <strong>opinion</strong>, d'une <strong>rumeur</strong>, d'une <strong>anecdote</strong>, d'une <strong>information</strong>.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e8938c8f-ecf2-4518-8789-1006eb8e97d4",
-            "type": "video",
-            "title": "-",
-            "url": "https://assets.pix.org/modules/distinguer-vrai-faux-sur-internet/vocabulaire.mp4",
-            "subtitles": "",
-            "transcription": "<p>à venir</p>",
-            "poster": "https://assets.pix.org/draft/modules/ajbtpno.png"
-          }
-        }
-      ]
-    },
-    {
-      "id": "550d2764-35fd-4cc2-b663-cfa4c5d4ab06",
-      "type": "activity",
-      "title": "Vocabulaire opinion, rumeur, anecdote, information",
-      "components": [
+          "id": "035a96bd-855b-4093-9646-5a60362f5821",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5c66e52b-2a1a-49c5-8797-7287a7131c1c",
+                "type": "text",
+                "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est très difficile de savoir si une information est vraie ou fausse.&nbsp;🤔</p><p>Et parfois, ce ne sont même pas des informations ! On vous explique tout dans la vidéo suivante.&nbsp;📺</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "eb83569f-2e37-49ed-aa6f-31c420b673b9",
+          "type": "lesson",
+          "title": "Vocabulaire et méthode pour vérifier l'information",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "5c6ec12a-f5b4-4683-ae7a-11b79fddd0a5",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer !</h3>Dans chacune des situations suivantes, trouvez s'il s'agit d'une opinion, d'une rumeur, d'une anecdote ou d'une information."
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "0b024dad-bcf3-4358-956a-febfb0b0ead6",
+                "type": "text",
+                "content": "<p>Après cette vidéo, vous devrez trouver dans des exemples concrets s'il s'agit d'une <strong>opinion</strong>, d'une <strong>rumeur</strong>, d'une <strong>anecdote</strong>, d'une <strong>information</strong>.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "6cca7664-5201-4239-a272-b8b48808ede8",
-                  "type": "qcu",
-                  "instruction": "<p>Anaïs trouve que les réseaux sociaux, c'est vraiment génial.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "une opinion",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "une rumeur",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "une anecdote",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "une information",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "e8938c8f-ecf2-4518-8789-1006eb8e97d4",
+                "type": "video",
+                "title": "-",
+                "url": "https://assets.pix.org/modules/distinguer-vrai-faux-sur-internet/vocabulaire.mp4",
+                "subtitles": "",
+                "transcription": "<p>à venir</p>",
+                "poster": "https://assets.pix.org/draft/modules/ajbtpno.png"
+              }
+            }
+          ]
+        },
+        {
+          "id": "550d2764-35fd-4cc2-b663-cfa4c5d4ab06",
+          "type": "activity",
+          "title": "Vocabulaire opinion, rumeur, anecdote, information",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "ba752db6-c9c5-45d4-ab2b-c2a14204db5f",
-                  "type": "qcu",
-                  "instruction": "<p>Dès qu'elle le peut, Miranda achète des produits reconditionnés.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "une opinion",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "une rumeur",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "une anecdote",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "une information",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
-                      }
+                      "id": "5c6ec12a-f5b4-4683-ae7a-11b79fddd0a5",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer !</h3>Dans chacune des situations suivantes, trouvez s'il s'agit d'une opinion, d'une rumeur, d'une anecdote ou d'une information."
                     }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "26b01131-fc75-4300-9ad3-fc19f718a88a",
-                  "type": "qcu",
-                  "instruction": "<p>Yann a entendu dire qu'un nouveau réseau social révolutionnaire allait bientôt arriver.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "une opinion",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "une rumeur",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "une anecdote",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "une information",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
-                      }
+                      "id": "6cca7664-5201-4239-a272-b8b48808ede8",
+                      "type": "qcu",
+                      "instruction": "<p>Anaïs trouve que les réseaux sociaux, c'est vraiment génial.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "une opinion",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "une rumeur",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "une anecdote",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "une information",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un point de vue qui est exprimé. Essayez à nouveau.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "b0eac706-4444-45c6-bb9f-8e4449737742",
-                  "type": "qcu",
-                  "instruction": "<p>Jimmy Wales a cofondé Wikipédia en janvier 2001.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "une opinion",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "une rumeur",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "une anecdote",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "une information",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. C'est bien une information.</p>"
-                      }
+                      "id": "ba752db6-c9c5-45d4-ab2b-c2a14204db5f",
+                      "type": "qcu",
+                      "instruction": "<p>Dès qu'elle le peut, Miranda achète des produits reconditionnés.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "une opinion",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "une rumeur",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "une anecdote",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "une information",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui ne concerne que Miranda. Il ne présente pas d'intérêt pour la plupart des gens. Essayez à nouveau.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
                     }
-                  ],
-                  "solution": "4"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "26b01131-fc75-4300-9ad3-fc19f718a88a",
+                      "type": "qcu",
+                      "instruction": "<p>Yann a entendu dire qu'un nouveau réseau social révolutionnaire allait bientôt arriver.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "une opinion",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "une rumeur",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "une anecdote",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "une information",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Ce qu'a entendu Yann n'est soutenu par aucune source, mais cela semble concerner beaucoup de gens. Essayez à nouveau.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b0eac706-4444-45c6-bb9f-8e4449737742",
+                      "type": "qcu",
+                      "instruction": "<p>Jimmy Wales a cofondé Wikipédia en janvier 2001.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "une opinion",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "une rumeur",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "une anecdote",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. Essayez à nouveau.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "une information",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> C'est un fait qui est vérifiable via plusieurs sources. C'est bien une information.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "4"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "288f6d86-88b1-4aad-b93c-b49e5223985d",
-      "type": "transition",
-      "title": "",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "d182b0c7-05bd-4ab7-beef-ea8e4d076508",
-            "type": "text",
-            "content": "<p>C'est une information et pas une anecdote, d'accord. Mais est-ce que cette information est vraie ? Pour le savoir, il faut mener l'enquête.&nbsp;🕵🏽</p><p>Voyons ensemble la méthode « Qui ? Quand ? D'où ? ». Trois questions à se poser pour vérifier une information.&nbsp;👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ed22ab38-ec6d-47df-88ea-4894f1cd6c8a",
-      "type": "lesson",
-      "title": "Méthode pour vérifier une information (leçon)",
-      "components": [
+          "id": "288f6d86-88b1-4aad-b93c-b49e5223985d",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d182b0c7-05bd-4ab7-beef-ea8e4d076508",
+                "type": "text",
+                "content": "<p>C'est une information et pas une anecdote, d'accord. Mais est-ce que cette information est vraie ? Pour le savoir, il faut mener l'enquête.&nbsp;🕵🏽</p><p>Voyons ensemble la méthode « Qui ? Quand ? D'où ? ». Trois questions à se poser pour vérifier une information.&nbsp;👇</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "ed22ab38-ec6d-47df-88ea-4894f1cd6c8a",
+          "type": "lesson",
+          "title": "Méthode pour vérifier une information (leçon)",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
-                  "type": "text",
-                  "content": "<h3>Question n°1&nbsp;: <i>qui</i> est la personne qui partage cette information&#8239;?&nbsp;<span aria-hidden=\"true\">💬</span></h3><p>Demandez-vous si vous connaissez cette personne, si elle est reconnue ou encore si elle a un intérêt particulier à ce que cette information circule.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  "elements": [
+                    {
+                      "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
+                      "type": "text",
+                      "content": "<h3>Question n°1&nbsp;: <i>qui</i> est la personne qui partage cette information&#8239;?&nbsp;<span aria-hidden=\"true\">💬</span></h3><p>Demandez-vous si vous connaissez cette personne, si elle est reconnue ou encore si elle a un intérêt particulier à ce que cette information circule.</p>"
+                    }
+                  ]
+                },
                 {
-                  "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
-                  "type": "text",
-                  "content": "<h3>Question n°2&nbsp;: de <i>quand</i> date l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  "elements": [
+                    {
+                      "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
+                      "type": "text",
+                      "content": "<h3>Question n°2&nbsp;: de <i>quand</i> date l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+                    }
+                  ]
+                },
                 {
-                  "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
-                  "type": "text",
-                  "content": "<h3>Question n°3&nbsp;: <i>d’où</i> provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🤔</span></h3><p>Cherchez à connaître l’origine de cette information, c’est-à-dire sa source : un témoignage direct, le résultat d'expériences scientifiques ou l'enquête d'un journal, etc.<br>Regardez également si l’auteur a partagé ses sources et si vous pouvez vérifier cette information par vous-même, en cherchant d’autres sources pour les comparer.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  "elements": [
+                    {
+                      "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
+                      "type": "text",
+                      "content": "<h3>Question n°3&nbsp;: <i>d’où</i> provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🤔</span></h3><p>Cherchez à connaître l’origine de cette information, c’est-à-dire sa source : un témoignage direct, le résultat d'expériences scientifiques ou l'enquête d'un journal, etc.<br>Regardez également si l’auteur a partagé ses sources et si vous pouvez vérifier cette information par vous-même, en cherchant d’autres sources pour les comparer.</p>"
+                    }
+                  ]
+                },
                 {
-                  "id": "1e5732d8-a486-48b4-b9d3-0f9625efffcf",
-                  "type": "text",
-                  "content": "<p>👉 Si les réponses à ces questions vous font encore douter, cherchez à en savoir plus et considérez que cette information est fausse.</p>"
+                  "elements": [
+                    {
+                      "id": "1e5732d8-a486-48b4-b9d3-0f9625efffcf",
+                      "type": "text",
+                      "content": "<p>👉 Si les réponses à ces questions vous font encore douter, cherchez à en savoir plus et considérez que cette information est fausse.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "7cab267a-c008-438c-9cea-c2e9086bb7bd",
-      "type": "transition",
-      "title": "",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "53b5a035-84d9-458f-99e3-045b39c19285",
-            "type": "text",
-            "content": "<p>Vérifiez que vous avez retenu l'essentiel en répondant à cette question.&nbsp;🎯</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "46309f55-22e6-4b0f-bfc4-2bad94f9cbd7",
-      "type": "activity",
-      "title": "Méthode pour vérifier une information (activité)",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1c39f509-cdc2-4d3e-85f8-7731739a793f",
-            "type": "qcm",
-            "instruction": "<p>Parmi les éléments suivants, lesquels permettent de vérifier une information&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "le temps de lecture"
-              },
-              {
-                "id": "2",
-                "content": "l’auteur"
-              },
-              {
-                "id": "3",
-                "content": "les sources"
-              },
-              {
-                "id": "4",
-                "content": "le format"
-              },
-              {
-                "id": "5",
-                "content": "la date"
+          "id": "7cab267a-c008-438c-9cea-c2e9086bb7bd",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "53b5a035-84d9-458f-99e3-045b39c19285",
+                "type": "text",
+                "content": "<p>Vérifiez que vous avez retenu l'essentiel en répondant à cette question.&nbsp;🎯</p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse ! 🎉",
-                "diagnosis": "<p> Tous ces éléments permettent de vérifier une information. </p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>!</p>"
-              }
-            },
-            "solutions": ["2", "3", "5"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "c624de0b-658a-47e7-b780-c579a1033aba",
-      "type": "activity",
-      "title": "Appliquer une méthode de vérification de l’information",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "46309f55-22e6-4b0f-bfc4-2bad94f9cbd7",
+          "type": "activity",
+          "title": "Méthode pour vérifier une information (activité)",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "613bd45d-8e88-4ca5-bfa0-368be2336027",
-                  "type": "text",
-                  "content": "<h3><span aria-hidden=\"true\">🔎</span> C'est l'heure d'utiliser le « Qui ? Quand ? D'où ? »</h3><p>Dans les exemples suivants, les informations publiées sont sûrement fausses.<br>En effet, une des réponses au « Qui ? Quand ? D'où ? » présente un problème.<br>Trouvez dans chaque exemple où se situe ce problème.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "e9d9c6e3-4c08-40de-bb46-e73b6d02f1c5",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/mzzrsBM.png",
-                  "alt": "Publication de VendeursdeLégume (@achetezlegume91) sur X (Twitter) détaillée dans l'alternative textuelle",
-                  "alternativeText": "Publication de VendeursdeLégume (@achetezlegume91) sur X (Twitter) à 12h52 le 12 septembre 2024&nbsp;: RAPPEL : l'avocat est le meilleur des légumes !! Il soigne presque toutes les maladies sur terre ❤️ Regardez ce schéma réalisé par vivelebio.com. Venez-vite en magasin 28 rue des Lilas pour profitez de notre promotion !"
+              "type": "element",
+              "element": {
+                "id": "1c39f509-cdc2-4d3e-85f8-7731739a793f",
+                "type": "qcm",
+                "instruction": "<p>Parmi les éléments suivants, lesquels permettent de vérifier une information&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "le temps de lecture"
+                  },
+                  {
+                    "id": "2",
+                    "content": "l’auteur"
+                  },
+                  {
+                    "id": "3",
+                    "content": "les sources"
+                  },
+                  {
+                    "id": "4",
+                    "content": "le format"
+                  },
+                  {
+                    "id": "5",
+                    "content": "la date"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse ! 🎉",
+                    "diagnosis": "<p> Tous ces éléments permettent de vérifier une information. </p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>!</p>"
+                  }
                 },
+                "solutions": ["2", "3", "5"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "c624de0b-658a-47e7-b780-c579a1033aba",
+          "type": "activity",
+          "title": "Appliquer une méthode de vérification de l’information",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "275ab2ee-feaa-4c5c-9372-116799077172",
-                  "type": "qcu",
-                  "instruction": "<p>Quel est le problème dans cette publication ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre.",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p>Ce vendeur n'est pas neutre. Il exagère la réalité pour essayer d'augmenter ses ventes. </p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "La source d’information est absente de la publication.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
-                      }
+                      "id": "613bd45d-8e88-4ca5-bfa0-368be2336027",
+                      "type": "text",
+                      "content": "<h3><span aria-hidden=\"true\">🔎</span> C'est l'heure d'utiliser le « Qui ? Quand ? D'où ? »</h3><p>Dans les exemples suivants, les informations publiées sont sûrement fausses.<br>En effet, une des réponses au « Qui ? Quand ? D'où ? » présente un problème.<br>Trouvez dans chaque exemple où se situe ce problème.</p>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "0fd6f8a9-7421-41ed-b4a7-c0128488d35d",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/5BMW9i7.png",
-                  "alt": "Publication de Jean-Eude Coulignant (@JECoulignant) sur X (Twitter) détaillée dans l'alternative textuelle",
-                  "alternativeText": "Publication de Jean-Eude Coulignant (@JECoulignant) sur X (Twitter) à 13h54 le 9 février 2024&nbsp;: &laquo;&nbsp;Scoop&#8239;! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées&nbsp;&raquo;"
+                  ]
                 },
                 {
-                  "id": "81943b07-ecf0-408b-877c-55e1943df1fc",
-                  "type": "qcu",
-                  "instruction": "<p>Quel est le problème dans cette publication ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
-                      }
+                      "id": "e9d9c6e3-4c08-40de-bb46-e73b6d02f1c5",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/mzzrsBM.png",
+                      "alt": "Publication de VendeursdeLégume (@achetezlegume91) sur X (Twitter) détaillée dans l'alternative textuelle",
+                      "alternativeText": "Publication de VendeursdeLégume (@achetezlegume91) sur X (Twitter) à 12h52 le 12 septembre 2024&nbsp;: RAPPEL : l'avocat est le meilleur des légumes !! Il soigne presque toutes les maladies sur terre ❤️ Regardez ce schéma réalisé par vivelebio.com. Venez-vite en magasin 28 rue des Lilas pour profitez de notre promotion !"
                     },
                     {
-                      "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "La source d’information est absente de la publication.",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>"
-                      }
+                      "id": "275ab2ee-feaa-4c5c-9372-116799077172",
+                      "type": "qcu",
+                      "instruction": "<p>Quel est le problème dans cette publication ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "L’auteur de la publication n'est pas neutre.",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p>Ce vendeur n'est pas neutre. Il exagère la réalité pour essayer d'augmenter ses ventes. </p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Les dates de la publication et de la source sont incohérentes.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "La source d’information est absente de la publication.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Ce vendeur exagère pour essayer de vendre ses légumes à plus de personnes.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "ecc3dbf9-f9a7-45f6-b961-0f548f066010",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/distinguer-vrai-faux-sur-internet/tweet7.jpg",
-                  "alt": "Publication de Stéphanie Attelage (@StephAtell) sur X (Twitter) détaillée dans l'alternative textuelle",
-                  "alternativeText": "Publication de Stéphanie Attelage (@StephAtell) sur X (Twitter) à 19h34 le 12 janvier 2023&nbsp;: &laquo;&nbsp;Allez vite au supermarché, il n'y aura bientôt plus de pâtes&nbsp;! Pour plus d'infos&nbsp;: <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires</a>&nbsp;&raquo;"
+                  ]
                 },
                 {
-                  "id": "4f002984-f136-4962-8f9a-b5f69d2995af",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">👉</span> La publication de Stéphanie Attelage comporte un <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">lien vers cet article.</a></p>"
-                },
-                {
-                  "id": "ee7b67b7-0cb0-4bb7-a771-c2421a588643",
-                  "type": "qcu",
-                  "instruction": "<p>Quel est le problème dans cette publication ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "L’auteur de la publication n'est pas neutre.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
-                      }
+                      "id": "0fd6f8a9-7421-41ed-b4a7-c0128488d35d",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/5BMW9i7.png",
+                      "alt": "Publication de Jean-Eude Coulignant (@JECoulignant) sur X (Twitter) détaillée dans l'alternative textuelle",
+                      "alternativeText": "Publication de Jean-Eude Coulignant (@JECoulignant) sur X (Twitter) à 13h54 le 9 février 2024&nbsp;: &laquo;&nbsp;Scoop&#8239;! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées&nbsp;&raquo;"
                     },
                     {
-                      "id": "2",
-                      "content": "Les dates de la publication et de la source sont incohérentes.",
-                      "feedback": {
-                        "state": "Bonne réponse ! 🎉",
-                        "diagnosis": "<p> La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "La source d’information est absente de la publication.",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
-                      }
+                      "id": "81943b07-ecf0-408b-877c-55e1943df1fc",
+                      "type": "qcu",
+                      "instruction": "<p>Quel est le problème dans cette publication ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "L’auteur de la publication n'est pas neutre.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Les dates de la publication et de la source sont incohérentes.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "La source d’information est absente de la publication.",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "ecc3dbf9-f9a7-45f6-b961-0f548f066010",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/distinguer-vrai-faux-sur-internet/tweet7.jpg",
+                      "alt": "Publication de Stéphanie Attelage (@StephAtell) sur X (Twitter) détaillée dans l'alternative textuelle",
+                      "alternativeText": "Publication de Stéphanie Attelage (@StephAtell) sur X (Twitter) à 19h34 le 12 janvier 2023&nbsp;: &laquo;&nbsp;Allez vite au supermarché, il n'y aura bientôt plus de pâtes&nbsp;! Pour plus d'infos&nbsp;: <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires</a>&nbsp;&raquo;"
+                    },
+                    {
+                      "id": "4f002984-f136-4962-8f9a-b5f69d2995af",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">👉</span> La publication de Stéphanie Attelage comporte un <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">lien vers cet article.</a></p>"
+                    },
+                    {
+                      "id": "ee7b67b7-0cb0-4bb7-a771-c2421a588643",
+                      "type": "qcu",
+                      "instruction": "<p>Quel est le problème dans cette publication ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "L’auteur de la publication n'est pas neutre.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Les dates de la publication et de la source sont incohérentes.",
+                          "feedback": {
+                            "state": "Bonne réponse ! 🎉",
+                            "diagnosis": "<p> La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "La source d’information est absente de la publication.",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "ba6b96c4-4625-4f0c-bc2c-9f98187c2a1f",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "35a1b762-524c-488f-a997-c1e8f5129735",
-            "type": "text",
-            "content": "<p>Même si on a vérifié le « Qui ? Quand ? D'où ? », il faut rester vigilant.<br>D'autres indices peuvent aider à détecter de fausses informations.&nbsp;👣 <br>Plus il y en a, plus l’information a des chances d’être fausse.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "428ea826-6e21-4c56-a5a2-f97373f1e833",
-      "type": "lesson",
-      "title": "Les indices d’une information douteuse",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ff55b19b-a35c-4f25-9e07-ce2e3d965784",
-            "type": "text",
-            "content": "<p>Étudiez les indices présentés dans l'exemple ci-dessous. Ils vous aideront à identifier de fausses informations.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "c6cd87ae-13a2-4ff1-aa09-26f4aca4dddc",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/9j2xh4U.png",
-            "alt": "Publication de Alain Bacri (@AlainBacri) sur X (Twitter) détaillée dans l'alternative textuelle",
-            "alternativeText": "Publication de Alain Bacri (@AlainBacri) sur X (Twitter) à 9h22 le 6 août 2022&nbsp;: &laquo;&nbsp;Arrêtez TOUS le DOLIPRANE&#8239;!!! (2 émojis tête de mort) Le paracétamol TUE les gens&#8239;!!!! mais personne en parle ! (2 emojis tête de mort) Il y a plusieurs PREUVES SCIENTIFIQUE qui le PROUVE, comme cet étude américaine&nbsp;: <a href=\"https://pubmed.ncbi.nlm.nih.gov/37436926/\" target=\"_blank\">https://pubmed.ncbi.nlm.nih.gov/37436926/</a> PARTAGER à un MAXIMUM de personnes. Il faut que ça se sache&#8239;!!!&nbsp;&raquo;<br>40,3 K Republications, 11,3 K Citations, 196,9 K Likes.<ul><li>Indice 1&nbsp;: <strong>Les majuscules et les émojis angoissants</strong> sont utilisés pour interpeller, créer un ton alarmiste et un sentiment d'urgence.</li><li>Indice 2&nbsp;:<strong>Les fautes d'orthographe</strong> à plusieurs endroits indiquent que le contenu a été rédigé sans attention particulière.</li><li>Indice 3&nbsp;:<strong>En demandant de partager l'information,</strong> l'auteur veut être lu à tout prix. Il cherche à rendre son contenu viral et à \"faire le buzz\".</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3cb4db76-fee3-4a19-8e7e-6f36f4003c27",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ef746355-40c2-485a-a560-35dc0cc8fd37",
-            "type": "text",
-            "content": "<p>Pour finir, maintenant que vous en savez plus, vous allez pouvoir aider Stéphane.&nbsp;🕵🏿‍♀️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9f56f75e-3e2d-4a6e-8623-9b74747b236d",
-      "type": "challenge",
-      "title": "Méthode pour vérifier une information (activité)",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
-            "type": "text",
-            "content": "<p>Stéphane essaye de faire pousser sa nouvelle plante verte d’intérieur.&nbsp;<span aria-hidden=\"true\">🪴</span><br>Il cherche des astuces sur les réseaux sociaux, mais il est un peu perdu.<br>Il trouve une publication de SuperJardinier sur ce sujet&nbsp;<span aria-hidden=\"true\">👇</span></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2c525ab3-23bf-4b43-867d-ea1fac54efad",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/QItEyyJ.png",
-            "alt": "Informations sur la pousse des plantes vertes détaillées dans l'alternative textuelle",
-            "alternativeText": "Vos plantes vertes ne poussent pas&nbsp;? Voici 2 super astuces dont vous ne pourrez plus vous passer&nbsp;!<br>Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien&#8239;! Votre plante va adorer.<br>Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2a308355-f39f-498e-aef6-f1c0830f5b1f",
-            "type": "qcm",
-            "instruction": "<p>Quels sont les bons conseils à donner à Stéphane&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Tester ces astuces."
-              },
-              {
-                "id": "2",
-                "content": "Chercher d’autres sources."
-              },
-              {
-                "id": "3",
-                "content": "Se renseigner sur SuperJardinier."
-              },
-              {
-                "id": "4",
-                "content": "Partager ces informations."
+          "id": "ba6b96c4-4625-4f0c-bc2c-9f98187c2a1f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35a1b762-524c-488f-a997-c1e8f5129735",
+                "type": "text",
+                "content": "<p>Même si on a vérifié le « Qui ? Quand ? D'où ? », il faut rester vigilant.<br>D'autres indices peuvent aider à détecter de fausses informations.&nbsp;👣 <br>Plus il y en a, plus l’information a des chances d’être fausse.</p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse ! ✨",
-                "diagnosis": "<p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Essayez à nouveau, en appliquant la méthode « Qui ? Quand ? D'où ? ». Si vous avez un doute sur ces informations, il faut être prudent.</p>"
+            }
+          ]
+        },
+        {
+          "id": "428ea826-6e21-4c56-a5a2-f97373f1e833",
+          "type": "lesson",
+          "title": "Les indices d’une information douteuse",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ff55b19b-a35c-4f25-9e07-ce2e3d965784",
+                "type": "text",
+                "content": "<p>Étudiez les indices présentés dans l'exemple ci-dessous. Ils vous aideront à identifier de fausses informations.</p>"
               }
             },
-            "solutions": ["2", "3"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "47eed162-0543-44d3-a719-cd477690985b",
-      "type": "summary",
-      "title": "Conclusion",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bfcc88ad-0061-4729-8b94-8f60bc92a57d",
-            "type": "text",
-            "content": "<p><strong>Pour chaque carte</strong> :</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retourner la carte en cliquant sur <i>Voir la réponse</i>. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>"
-          }
+            {
+              "type": "element",
+              "element": {
+                "id": "c6cd87ae-13a2-4ff1-aa09-26f4aca4dddc",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/9j2xh4U.png",
+                "alt": "Publication de Alain Bacri (@AlainBacri) sur X (Twitter) détaillée dans l'alternative textuelle",
+                "alternativeText": "Publication de Alain Bacri (@AlainBacri) sur X (Twitter) à 9h22 le 6 août 2022&nbsp;: &laquo;&nbsp;Arrêtez TOUS le DOLIPRANE&#8239;!!! (2 émojis tête de mort) Le paracétamol TUE les gens&#8239;!!!! mais personne en parle ! (2 emojis tête de mort) Il y a plusieurs PREUVES SCIENTIFIQUE qui le PROUVE, comme cet étude américaine&nbsp;: <a href=\"https://pubmed.ncbi.nlm.nih.gov/37436926/\" target=\"_blank\">https://pubmed.ncbi.nlm.nih.gov/37436926/</a> PARTAGER à un MAXIMUM de personnes. Il faut que ça se sache&#8239;!!!&nbsp;&raquo;<br>40,3 K Republications, 11,3 K Citations, 196,9 K Likes.<ul><li>Indice 1&nbsp;: <strong>Les majuscules et les émojis angoissants</strong> sont utilisés pour interpeller, créer un ton alarmiste et un sentiment d'urgence.</li><li>Indice 2&nbsp;:<strong>Les fautes d'orthographe</strong> à plusieurs endroits indiquent que le contenu a été rédigé sans attention particulière.</li><li>Indice 3&nbsp;:<strong>En demandant de partager l'information,</strong> l'auteur veut être lu à tout prix. Il cherche à rendre son contenu viral et à \"faire le buzz\".</li></ul>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "1c2619ea-2fbd-4ab1-82ad-d9a3989c8ce3",
-            "type": "flashcards",
-            "instruction": "<p></p>",
-            "title": "Distinguer le vrai du faux",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "afa1fa77-eada-4759-94e2-f1c608c54980",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
-                  },
-                  "text": "Pour commencer à vérifier une information, quelles sont les 3 questions à se poser ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p><strong>Qui</strong> est l'auteur de l'information ?<br>De <strong>quand</strong> date l'information ?<br><strong>D'où</strong> provient l'information ?</p>"
-                }
-              },
-              {
-                "id": "be0e0732-596e-46cf-b8de-9d2f05c5aeb9",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
-                  },
-                  "text": "Dans une publication sur un réseau social, quels indices peuvent aider à détecter de fausses informations ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p>Un <strong>ton alarmiste</strong>, <br>les <strong>mots écrits en majuscules</strong>,<br>les <strong>émojis angoissants</strong>,<br>la <strong>demande de partage</strong>.<br><br>Plus il y en a, plus l'information a des chances d'être fausse.</p>"
-                }
-              },
-              {
-                "id": "83f58acb-67c3-49c5-8ac9-020c6bf078ac",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
-                  },
-                  "text": "Si on a un doute sur une information, il vaut mieux être prudent et se dire qu'elle est _______."
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p>Si on a un doute sur une information, il vaut mieux être prudent et se dire qu'elle est <strong>fausse</strong>.</p>"
-                }
+          "id": "3cb4db76-fee3-4a19-8e7e-6f36f4003c27",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ef746355-40c2-485a-a560-35dc0cc8fd37",
+                "type": "text",
+                "content": "<p>Pour finir, maintenant que vous en savez plus, vous allez pouvoir aider Stéphane.&nbsp;🕵🏿‍♀️</p>"
               }
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "id": "9f56f75e-3e2d-4a6e-8623-9b74747b236d",
+          "type": "challenge",
+          "title": "Méthode pour vérifier une information (activité)",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
+                "type": "text",
+                "content": "<p>Stéphane essaye de faire pousser sa nouvelle plante verte d’intérieur.&nbsp;<span aria-hidden=\"true\">🪴</span><br>Il cherche des astuces sur les réseaux sociaux, mais il est un peu perdu.<br>Il trouve une publication de SuperJardinier sur ce sujet&nbsp;<span aria-hidden=\"true\">👇</span></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2c525ab3-23bf-4b43-867d-ea1fac54efad",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/QItEyyJ.png",
+                "alt": "Informations sur la pousse des plantes vertes détaillées dans l'alternative textuelle",
+                "alternativeText": "Vos plantes vertes ne poussent pas&nbsp;? Voici 2 super astuces dont vous ne pourrez plus vous passer&nbsp;!<br>Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien&#8239;! Votre plante va adorer.<br>Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2a308355-f39f-498e-aef6-f1c0830f5b1f",
+                "type": "qcm",
+                "instruction": "<p>Quels sont les bons conseils à donner à Stéphane&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Tester ces astuces."
+                  },
+                  {
+                    "id": "2",
+                    "content": "Chercher d’autres sources."
+                  },
+                  {
+                    "id": "3",
+                    "content": "Se renseigner sur SuperJardinier."
+                  },
+                  {
+                    "id": "4",
+                    "content": "Partager ces informations."
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse ! ✨",
+                    "diagnosis": "<p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Essayez à nouveau, en appliquant la méthode « Qui ? Quand ? D'où ? ». Si vous avez un doute sur ces informations, il faut être prudent.</p>"
+                  }
+                },
+                "solutions": ["2", "3"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "47eed162-0543-44d3-a719-cd477690985b",
+          "type": "summary",
+          "title": "Conclusion",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bfcc88ad-0061-4729-8b94-8f60bc92a57d",
+                "type": "text",
+                "content": "<p><strong>Pour chaque carte</strong> :</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retourner la carte en cliquant sur <i>Voir la réponse</i>. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1c2619ea-2fbd-4ab1-82ad-d9a3989c8ce3",
+                "type": "flashcards",
+                "instruction": "<p></p>",
+                "title": "Distinguer le vrai du faux",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "afa1fa77-eada-4759-94e2-f1c608c54980",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
+                      },
+                      "text": "Pour commencer à vérifier une information, quelles sont les 3 questions à se poser ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": ""
+                      },
+                      "text": "<p><strong>Qui</strong> est l'auteur de l'information ?<br>De <strong>quand</strong> date l'information ?<br><strong>D'où</strong> provient l'information ?</p>"
+                    }
+                  },
+                  {
+                    "id": "be0e0732-596e-46cf-b8de-9d2f05c5aeb9",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
+                      },
+                      "text": "Dans une publication sur un réseau social, quels indices peuvent aider à détecter de fausses informations ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": ""
+                      },
+                      "text": "<p>Un <strong>ton alarmiste</strong>, <br>les <strong>mots écrits en majuscules</strong>,<br>les <strong>émojis angoissants</strong>,<br>la <strong>demande de partage</strong>.<br><br>Plus il y en a, plus l'information a des chances d'être fausse.</p>"
+                    }
+                  },
+                  {
+                    "id": "83f58acb-67c3-49c5-8ac9-020c6bf078ac",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/vg3Ro1F.png"
+                      },
+                      "text": "Si on a un doute sur une information, il vaut mieux être prudent et se dire qu'elle est _______."
+                    },
+                    "verso": {
+                      "image": {
+                        "url": ""
+                      },
+                      "text": "<p>Si on a un doute sur une information, il vaut mieux être prudent et se dire qu'elle est <strong>fausse</strong>.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -8,670 +8,663 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",
     "duration": 0,
     "level": "Débutant",
-    "objectives": [
-      "<p>Découvrir les éléments de la galerie Modulix</p>"
-    ],
+    "objectives": ["<p>Découvrir les éléments de la galerie Modulix</p>"],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "9f7af22d-8cd2-45e0-b2d0-611e9903300e",
-      "type": "transition",
-      "title": "welcome",
-      "components": [
+      "id": "06f70348-a80b-4ae5-9b04-5efd55f770cd",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "1193db60-10a0-48fc-bc2a-c6cfed740203",
-            "type": "text",
-            "content": "<p><strong>Bienvenue dans la galerie Modulix !</strong></p><p>Découvrez la palette des éléments à la disposition des créateurs de module.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "71e1c5d1-9143-4840-bc62-7648fec4d71e",
-      "type": "challenge",
-      "title": "text",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "454744de-0d19-4935-8e4a-246639231971",
-            "type": "text",
-            "content": "<p><strong>text</strong></p>\n<p>Il permet d'afficher un <strong>texte</strong> <em>enrichi</em>.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "53a06209-b581-4023-be5f-f194a4668ff0",
-      "type": "challenge",
-      "title": "custom",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "496a2f21-ea99-41ac-9d0a-84133c1f42ce",
-            "type": "text",
-            "content": "<p><strong>custom</strong></p>\n<p>Il permet d'afficher un POIP.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fe68ec1f-acca-4bb5-902b-9f9a6a5b3ca9",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Confessions nocturnes",
-              "messages": [
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ouais c'est qui là ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, c'est Vi ouvre moi."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ça va Vi ?"
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Non, ça va pas non."
-                },
-                {
-                  "userName": "Mel",
-                  "direction": "outgoing",
-                  "content": "Ben dis-moi, qu'est qu'il y a ?"
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, assieds-toi faut que je te parle..."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "J'ai passé ma journée dans le noir."
-                },
-                {
-                  "userName": "Vita",
-                  "direction": "incoming",
-                  "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "220c0462-e383-4403-b731-8307364ee50e",
-      "type": "challenge",
-      "title": "custom-draft",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4b0fd6e8-c782-410a-8333-523dd71920f3",
-            "type": "text",
-            "content": "<p><strong>custom-draft (todo)</strong></p><p>Il permet d'afficher un POIC.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8978c5ef-71f1-42c5-a6ba-4bbe7c3143e7",
-      "type": "challenge",
-      "title": "download",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ba2e8d97-cf35-48e3-b8cf-f89514299ba3",
-            "type": "text",
-            "content": "<p><strong>download</strong></p><p>Il permet de proposer des fichiers à télécharger.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6f50e741-f858-4de5-b903-f014013460e3",
-            "type": "download",
-            "files": [
-              {
-                "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx",
-                "format": ".xlsx"
-              },
-              {
-                "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods",
-                "format": ".ods"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "5fcf6267-95f6-47d7-878b-4bde8f655b25",
-      "type": "challenge",
-      "title": "embed",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0acc94de-aee1-425f-b021-424a7a5e02db",
-            "type": "text",
-            "content": "<p><strong>embed</strong></p><p>Il permet d'intégrer un simulateur.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f36ee13e-cd41-4aef-97fa-4e1e0ade5169",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur de visioconférence",
-            "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio3",
-            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
-            "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "d151022b-eed7-458c-8e30-2990fe10a00b",
-      "type": "challenge",
-      "title": "expand",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6410caab-4b5b-483d-90a2-52412b2896c5",
-            "type": "text",
-            "content": "<p><strong>expand</strong></p><p>Il permet d'afficher un texte dépliable, par exemple un indice.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "51213b85-fe47-4b9f-924f-28b54fe856f7",
-            "type": "expand",
-            "title": "Clique-moi pour en savoir plus sur les oiseaux de mer",
-            "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "94818908-6c11-4ada-9030-e5eb9fa01e36",
-      "type": "challenge",
-      "title": "flashcards",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bb061722-18f9-40c7-8d5c-43edf4f61918",
-            "type": "text",
-            "content": "<p><strong>flashcards</strong></p><p>Il permet d'afficher un deck de cartes à mémoriser.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "17a3f1c3-a2f7-4488-a1f2-65ff2560b01f",
-            "type": "flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">&nbsp;🎯</span></p>",
-            "title": "Introduction à la poésie",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "534f4150-0912-43aa-9857-7aee5e28f628",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Qui a écrit « Le Dormeur du Val ? »"
-                },
-                "verso": {
-                  "image": {
-                    "url": ""
-                  },
-                  "text": "<p>Arthur Rimbaud</p>"
-                }
-              },
-              {
-                "id": "4109a532-f8e2-4f7f-a1e1-6870e635c94a",
-                "recto": {
-                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
-                },
-                "verso": {
-                  "text": "<p>Léopoldine</p>"
-                }
-              },
-              {
-                "id": "5f4eddbc-7fcc-4c5f-bb97-df0010d7597b",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
-                  },
-                  "text": "Quel animal a des yeux « mêlés de métal et d’agate » selon Charles Baudelaire ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
-                  },
-                  "text": "<p>Le chat</p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "f367d695-2086-4212-bec6-8cea4e8a9291",
-      "type": "challenge",
-      "title": "image",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5541119f-314b-44be-9f9d-64683d45e05f",
-            "type": "text",
-            "content": "<p><strong>image</strong></p><p>Il permet d'afficher une image.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4b691d7a-49ac-4c02-8e90-25476030bb8f",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
-            "legend": "Faite avant le séminaire de juin 2023",
-            "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
-          }
-        }
-      ]
-    },
-    {
-      "id": "120a3f14-8834-41f2-9179-a2b5ca81b470",
-      "type": "challenge",
-      "title": "qab",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ec7eec48-6149-46ac-8a5e-63bef1fb43c6",
-            "type": "text",
-            "content": "<p><strong>qab</strong></p><p>Il permet d'afficher une série de questions A/B.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "98750e88-2ab1-4b65-be79-5f99bde7c7cd",
-            "type": "qab",
-            "instruction": "Répondez aux questions suivantes en cliquant sur la bonne réponse.",
-            "cards": [
-              {
-                "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
-                "text": "Les boules de pétanques sont creuses ?",
-                "image": {
-                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
-                "text": "Les chiens ne transpirent pas.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
-                "text": "Quel est l'organe qui rougit ?",
-                "proposalA": "L'estomac",
-                "proposalB": "Le coeur",
-                "solution": "A"
-              },
-              {
-                "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
-                "text": "Les dauphins sont des poissons.",
-                "image": {
-                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
-                "text": "La Terre est plus proche du Soleil que Mars.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
-                "text": "L’eau bout à 100°C au niveau de la mer.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              }
-            ],
-            "feedback": {
-              "diagnosis": "<p>Vous avez répondu à toutes les questions !</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "08a4502f-2745-445e-a85e-f2a30cc16422",
-      "type": "challenge",
-      "title": "qcu",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "aa096a88-a72d-48ed-b376-1a5ec8a72cd8",
-            "type": "text",
-            "content": "<p><strong>qcu</strong></p><p>Il permet d'afficher une question à choix unique.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "bb8dc9f6-8e83-4985-93ee-2652c8be4fec",
-            "type": "qcu",
-            "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Des recettes de lasagne",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Des recettes de pâté en croûte",
-                "feedback": {
-                  "state": "Incorrect.",
-                  "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Des recettes végétariennes",
-                "feedback": {
-                  "state": "Correct !",
-                  "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "56e3ef05-91c7-4ba8-94fa-e462224b8f1e",
-      "type": "challenge",
-      "title": "qcu-declarative",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "994e2c1a-54e4-4821-8c5d-89a33315581f",
-            "type": "text",
-            "content": "<p><strong>qcu-declarative</strong></p><p>Il permet d'afficher une question à choix unique déclarative, c'est-à-dire sans bonne réponse.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "413314a8-7f83-4bbe-92de-66a24aa1595b",
-            "type": "qcu-declarative",
-            "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Avant de mettre le dentifrice",
-                "feedback": {
-                  "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Après avoir mis le dentifrice",
-                "feedback": {
-                  "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Pendant que le dentifrice est mis",
-                "feedback": {
-                  "diagnosis": "<p>Digne des plus grands acrobates !</p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "3003eabf-e49a-43c9-8962-332bf989149a",
-      "type": "challenge",
-      "title": "qcm",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c0a9f0eb-6d9c-4eb8-a899-f27da07886b7",
-            "type": "text",
-            "content": "<p><strong>qcm</strong></p><p>Un questionnaire à choix multiple : plusieurs réponses peuvent être correctes.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "b9d3fa59-e667-4029-9e25-29988aa4c08f",
-            "type": "qcm",
-            "instruction": "<p>Quels sont les 3 piliers de Pix ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p><p>Évaluer ses connaissances et savoir-faire sur 16 compétences du numérique</p></p>"
-              },
-              {
-                "id": "2",
-                "content": "<p>Développer son savoir-faire sur les jeux de type TPS</p>"
-              },
-              {
-                "id": "3",
-                "content": "<p>Développer ses compétences numériques</p>"
-              },
-              {
-                "id": "4",
-                "content": "Certifier ses compétences Pix"
-              },
-              {
-                "id": "5",
-                "content": "Évaluer ses compétences de logique et compréhension mathématique"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "<p>Correct !</p>",
-                "diagnosis": "<p>Vous nous avez bien cernés&nbsp;:)</p>"
-              },
-              "invalid": {
-                "state": "<p>Et non !</p>",
-                "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
-              }
-            },
-            "solutions": [
-              "1",
-              "3",
-              "4"
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "464f6f7b-d40d-4a87-95b4-7cd9959b90ed",
-      "type": "challenge",
-      "title": "qrocm",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4af25436-8ced-4d32-9bb6-07354622e397",
-            "type": "text",
-            "content": "<p><strong>qrocm</strong></p><p>Un texte à trous avec plusieurs champs de saisie.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "094ea104-693b-4d81-ae47-d313d007a648",
-            "type": "qrocm",
-            "instruction": "<p>Compléter le texte suivant :</p>",
-            "proposals": [
-              {
+          "id": "9f7af22d-8cd2-45e0-b2d0-611e9903300e",
+          "type": "transition",
+          "title": "welcome",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1193db60-10a0-48fc-bc2a-c6cfed740203",
                 "type": "text",
-                "content": "<span>Pix est un</span>"
-              },
-              {
-                "input": "pix-name",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Mot à trouver",
-                "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t3"
+                "content": "<p><strong>Bienvenue dans la galerie Modulix !</strong></p><p>Découvrez la palette des éléments à la disposition des créateurs de module.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "71e1c5d1-9143-4840-bc62-7648fec4d71e",
+          "type": "challenge",
+          "title": "text",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "454744de-0d19-4935-8e4a-246639231971",
+                "type": "text",
+                "content": "<p><strong>text</strong></p>\n<p>Il permet d'afficher un <strong>texte</strong> <em>enrichi</em>.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "53a06209-b581-4023-be5f-f194a4668ff0",
+          "type": "challenge",
+          "title": "custom",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "496a2f21-ea99-41ac-9d0a-84133c1f42ce",
+                "type": "text",
+                "content": "<p><strong>custom</strong></p>\n<p>Il permet d'afficher un POIP.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fe68ec1f-acca-4bb5-902b-9f9a6a5b3ca9",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Confessions nocturnes",
+                  "messages": [
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ouais c'est qui là ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, c'est Vi ouvre moi."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ça va Vi ?"
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Non, ça va pas non."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ben dis-moi, qu'est qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, assieds-toi faut que je te parle..."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "J'ai passé ma journée dans le noir."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "220c0462-e383-4403-b731-8307364ee50e",
+          "type": "challenge",
+          "title": "custom-draft",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4b0fd6e8-c782-410a-8333-523dd71920f3",
+                "type": "text",
+                "content": "<p><strong>custom-draft (todo)</strong></p><p>Il permet d'afficher un POIC.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8978c5ef-71f1-42c5-a6ba-4bbe7c3143e7",
+          "type": "challenge",
+          "title": "download",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ba2e8d97-cf35-48e3-b8cf-f89514299ba3",
+                "type": "text",
+                "content": "<p><strong>download</strong></p><p>Il permet de proposer des fichiers à télécharger.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6f50e741-f858-4de5-b903-f014013460e3",
+                "type": "download",
+                "files": [
+                  {
+                    "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx",
+                    "format": ".xlsx"
+                  },
+                  {
+                    "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods",
+                    "format": ".ods"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "5fcf6267-95f6-47d7-878b-4bde8f655b25",
+          "type": "challenge",
+          "title": "embed",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0acc94de-aee1-425f-b021-424a7a5e02db",
+                "type": "text",
+                "content": "<p><strong>embed</strong></p><p>Il permet d'intégrer un simulateur.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f36ee13e-cd41-4aef-97fa-4e1e0ade5169",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur de visioconférence",
+                "url": "https://epreuves.pix.fr/visio/visio.html?mode=visio3",
+                "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+                "height": 600
+              }
+            }
+          ]
+        },
+        {
+          "id": "d151022b-eed7-458c-8e30-2990fe10a00b",
+          "type": "challenge",
+          "title": "expand",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6410caab-4b5b-483d-90a2-52412b2896c5",
+                "type": "text",
+                "content": "<p><strong>expand</strong></p><p>Il permet d'afficher un texte dépliable, par exemple un indice.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "51213b85-fe47-4b9f-924f-28b54fe856f7",
+                "type": "expand",
+                "title": "Clique-moi pour en savoir plus sur les oiseaux de mer",
+                "content": "<p> Souvent, pour s’amuser, les hommes d’équipage<br>Prennent des albatros, vastes oiseaux des mers,<br>Qui suivent, indolents compagnons de voyage,<br>Le navire glissant sur les gouffres amers.<br>À peine les ont-ils déposés sur les planches,<br>Que ces rois de l’azur, maladroits et honteux,<br>Laissent piteusement leurs grandes ailes blanches<br>Comme des avirons traîner à côté d’eux.<br>Ce voyageur ailé, comme il est gauche et veule !<br>Lui, naguère si beau, qu’il est comique et laid !<br>L’un agace son bec avec un brûle-gueule,<br>L’autre mime, en boitant, l’infirme qui volait !<br>Le Poète est semblable au prince des nuées<br>Qui hante la tempête et se rit de l’archer ;<br>Exilé sur le sol au milieu des huées,<br>Ses ailes de géant l’empêchent de marcher. </p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "94818908-6c11-4ada-9030-e5eb9fa01e36",
+          "type": "challenge",
+          "title": "flashcards",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bb061722-18f9-40c7-8d5c-43edf4f61918",
+                "type": "text",
+                "content": "<p><strong>flashcards</strong></p><p>Il permet d'afficher un deck de cartes à mémoriser.<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "17a3f1c3-a2f7-4488-a1f2-65ff2560b01f",
+                "type": "flashcards",
+                "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">&nbsp;🎯</span></p>",
+                "title": "Introduction à la poésie",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/bac-a-sable/intro-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "534f4150-0912-43aa-9857-7aee5e28f628",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                      },
+                      "text": "Qui a écrit « Le Dormeur du Val ? »"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": ""
+                      },
+                      "text": "<p>Arthur Rimbaud</p>"
+                    }
+                  },
+                  {
+                    "id": "4109a532-f8e2-4f7f-a1e1-6870e635c94a",
+                    "recto": {
+                      "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
+                    },
+                    "verso": {
+                      "text": "<p>Léopoldine</p>"
+                    }
+                  },
+                  {
+                    "id": "5f4eddbc-7fcc-4c5f-bb97-df0010d7597b",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/icon.svg"
+                      },
+                      "text": "Quel animal a des yeux « mêlés de métal et d’agate » selon Charles Baudelaire ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/bac-a-sable/chaton.jpg"
+                      },
+                      "text": "<p>Le chat</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "f367d695-2086-4212-bec6-8cea4e8a9291",
+          "type": "challenge",
+          "title": "image",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5541119f-314b-44be-9f9d-64683d45e05f",
+                "type": "text",
+                "content": "<p><strong>image</strong></p><p>Il permet d'afficher une image.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4b691d7a-49ac-4c02-8e90-25476030bb8f",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
+                "alt": "Dessin détaillé dans l'alternative textuelle",
+                "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
+                "legend": "Faite avant le séminaire de juin 2023",
+                "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
+              }
+            }
+          ]
+        },
+        {
+          "id": "120a3f14-8834-41f2-9179-a2b5ca81b470",
+          "type": "challenge",
+          "title": "qab",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ec7eec48-6149-46ac-8a5e-63bef1fb43c6",
+                "type": "text",
+                "content": "<p><strong>qab</strong></p><p>Il permet d'afficher une série de questions A/B.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "98750e88-2ab1-4b65-be79-5f99bde7c7cd",
+                "type": "qab",
+                "instruction": "Répondez aux questions suivantes en cliquant sur la bonne réponse.",
+                "cards": [
+                  {
+                    "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
+                    "text": "Les boules de pétanques sont creuses ?",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                    "text": "Les chiens ne transpirent pas.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "04bab312-160d-41b1-a5c9-017d563aef3a",
+                    "text": "Quel est l'organe qui rougit ?",
+                    "proposalA": "L'estomac",
+                    "proposalB": "Le coeur",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "1d1c33e3-e27d-4161-bfcc-529ea1aa573f",
+                    "text": "Les dauphins sont des poissons.",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "4420c9f6-ae21-4401-a16c-41296d898a66",
+                    "text": "La Terre est plus proche du Soleil que Mars.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "52d99648-5904-4a66-9fb8-476ba4da9465",
+                    "text": "L’eau bout à 100°C au niveau de la mer.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  }
                 ],
-                "solutions": [
-                  "Groupement"
-                ]
-              },
-              {
-                "type": "text",
-                "content": "<p><span>d'intérêt public qui a été créé en</span></p>"
-              },
-              {
-                "input": "pix-birth",
-                "type": "input",
-                "inputType": "number",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Année à trouver",
-                "defaultValue": "",
-                "tolerances": [],
-                "solutions": [
-                  2016
-                ]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct !",
-                "diagnosis": "<p> vous nous connaissez bien &nbsp;<span aria-hidden=\"true\">🎉</span></p>"
-              },
-              "invalid": {
-                "state": "Incorrect !",
-                "diagnosis": "<p> vous y arriverez la prochaine fois !</p>"
+                "feedback": {
+                  "diagnosis": "<p>Vous avez répondu à toutes les questions !</p>"
+                }
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "22b5e753-e561-4945-9b3e-61c39ffb62f6",
-      "type": "challenge",
-      "title": "separator",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "73e7083a-3316-42b4-8049-e86b5ed26842",
-            "type": "text",
-            "content": "<p><strong>separator</strong></p><p>Il permet de séparer visuellement un élément…</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "ec2d0d06-b741-43ca-8fb6-cd66ee447533",
-            "type": "separator"
-          }
+          "id": "08a4502f-2745-445e-a85e-f2a30cc16422",
+          "type": "challenge",
+          "title": "qcu",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "aa096a88-a72d-48ed-b376-1a5ec8a72cd8",
+                "type": "text",
+                "content": "<p><strong>qcu</strong></p><p>Il permet d'afficher une question à choix unique.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bb8dc9f6-8e83-4985-93ee-2652c8be4fec",
+                "type": "qcu",
+                "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des recettes de lasagne",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des recettes de pâté en croûte",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Des recettes végétariennes",
+                    "feedback": {
+                      "state": "Correct !",
+                      "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "0ba30ba9-9678-4ace-b240-bdac03796a57",
-            "type": "text",
-            "content": "<p>… d'un autre élément.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d0780c73-a6f1-49fb-86d7-7c4e6555be27",
-      "type": "challenge",
-      "title": "video",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a1390ceb-0d77-44b1-bb29-0dbaf7c56ae8",
-            "type": "text",
-            "content": "<p><strong>video</strong></p><p>Il permet d'insérer une vidéo hébergé sur <strong>assets.pix.org</strong> au format mp4</p>"
-          }
+          "id": "56e3ef05-91c7-4ba8-94fa-e462224b8f1e",
+          "type": "challenge",
+          "title": "qcu-declarative",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "994e2c1a-54e4-4821-8c5d-89a33315581f",
+                "type": "text",
+                "content": "<p><strong>qcu-declarative</strong></p><p>Il permet d'afficher une question à choix unique déclarative, c'est-à-dire sans bonne réponse.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "413314a8-7f83-4bbe-92de-66a24aa1595b",
+                "type": "qcu-declarative",
+                "instruction": "<p>Quand faut-il mouiller sa brosse à dents&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Avant de mettre le dentifrice",
+                    "feedback": {
+                      "diagnosis": "<p>C'est l'approche de la plupart des gens.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Après avoir mis le dentifrice",
+                    "feedback": {
+                      "diagnosis": "<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Pendant que le dentifrice est mis",
+                    "feedback": {
+                      "diagnosis": "<p>Digne des plus grands acrobates !</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "ccca6db7-3a78-4009-a8ab-3bf8e8964465",
-            "type": "video",
-            "title": "Bravo, vous êtes sur Internet !",
-            "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.mp4",
-            "poster": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.jpg",
-            "subtitles": "",
-            "transcription": "Bravo, vous êtes sur Internet !"
-          }
+          "id": "3003eabf-e49a-43c9-8962-332bf989149a",
+          "type": "challenge",
+          "title": "qcm",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c0a9f0eb-6d9c-4eb8-a899-f27da07886b7",
+                "type": "text",
+                "content": "<p><strong>qcm</strong></p><p>Un questionnaire à choix multiple : plusieurs réponses peuvent être correctes.<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b9d3fa59-e667-4029-9e25-29988aa4c08f",
+                "type": "qcm",
+                "instruction": "<p>Quels sont les 3 piliers de Pix ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p><p>Évaluer ses connaissances et savoir-faire sur 16 compétences du numérique</p></p>"
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Développer son savoir-faire sur les jeux de type TPS</p>"
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Développer ses compétences numériques</p>"
+                  },
+                  {
+                    "id": "4",
+                    "content": "Certifier ses compétences Pix"
+                  },
+                  {
+                    "id": "5",
+                    "content": "Évaluer ses compétences de logique et compréhension mathématique"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "<p>Correct !</p>",
+                    "diagnosis": "<p>Vous nous avez bien cernés&nbsp;:)</p>"
+                  },
+                  "invalid": {
+                    "state": "<p>Et non !</p>",
+                    "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
+                  }
+                },
+                "solutions": ["1", "3", "4"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "464f6f7b-d40d-4a87-95b4-7cd9959b90ed",
+          "type": "challenge",
+          "title": "qrocm",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4af25436-8ced-4d32-9bb6-07354622e397",
+                "type": "text",
+                "content": "<p><strong>qrocm</strong></p><p>Un texte à trous avec plusieurs champs de saisie.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "094ea104-693b-4d81-ae47-d313d007a648",
+                "type": "qrocm",
+                "instruction": "<p>Compléter le texte suivant :</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Pix est un</span>"
+                  },
+                  {
+                    "input": "pix-name",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Mot à trouver",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t3"],
+                    "solutions": ["Groupement"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<p><span>d'intérêt public qui a été créé en</span></p>"
+                  },
+                  {
+                    "input": "pix-birth",
+                    "type": "input",
+                    "inputType": "number",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Année à trouver",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "solutions": [2016]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct !",
+                    "diagnosis": "<p> vous nous connaissez bien &nbsp;<span aria-hidden=\"true\">🎉</span></p>"
+                  },
+                  "invalid": {
+                    "state": "Incorrect !",
+                    "diagnosis": "<p> vous y arriverez la prochaine fois !</p>"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "22b5e753-e561-4945-9b3e-61c39ffb62f6",
+          "type": "challenge",
+          "title": "separator",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "73e7083a-3316-42b4-8049-e86b5ed26842",
+                "type": "text",
+                "content": "<p><strong>separator</strong></p><p>Il permet de séparer visuellement un élément…</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ec2d0d06-b741-43ca-8fb6-cd66ee447533",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0ba30ba9-9678-4ace-b240-bdac03796a57",
+                "type": "text",
+                "content": "<p>… d'un autre élément.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d0780c73-a6f1-49fb-86d7-7c4e6555be27",
+          "type": "challenge",
+          "title": "video",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a1390ceb-0d77-44b1-bb29-0dbaf7c56ae8",
+                "type": "text",
+                "content": "<p><strong>video</strong></p><p>Il permet d'insérer une vidéo hébergé sur <strong>assets.pix.org</strong> au format mp4</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ccca6db7-3a78-4009-a8ab-3bf8e8964465",
+                "type": "video",
+                "title": "Bravo, vous êtes sur Internet !",
+                "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.mp4",
+                "poster": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-vous-etes-sur-internet.jpg",
+                "subtitles": "",
+                "transcription": "Bravo, vous êtes sur Internet !"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
@@ -15,846 +15,849 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "682c0e09-e3d6-4db3-8680-ad0973715cc4",
-      "type": "discovery",
-      "title": "Accroche",
-      "components": [
+      "id": "a59de89a-a093-4e57-88ec-3c5dc77701a1",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "07a6146e-c775-42f2-9d20-fbbfa7a37a32",
-            "type": "text",
-            "content": "<p>Dans la vidéo suivante, on peut voir un scientifique célèbre faire une annonce importante.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ff755fbe-52a3-45c7-b828-41c0f8d9f228",
-            "type": "video",
-            "title": "La déclaration",
-            "url": "https://assets.pix.org/draft/modules/deepfakes/declarationae.mp4",
-            "subtitles": "https://assets.pix.org/draft/modules/deepfakes/declarationae.vtt",
-            "transcription": "<p>Déclaration vidéo d'Albert Einstein qui annonce que la Terre est plate en montrant une photo sur un smartphone</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c1a11c3d-31ee-4770-9331-3c61685fe771",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, Albert Einstein a-t-il fait cette annonce ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Cette vidéo est fausse. C'est ce qu’on appelle un deepfake ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien vu ! Cette vidéo est fausse. C'est ce qu’on appelle un deepfake&nbsp;ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Cette vidéo est fausse. C'est ce qu’on appelle un deepfake ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
-                }
+          "id": "682c0e09-e3d6-4db3-8680-ad0973715cc4",
+          "type": "discovery",
+          "title": "Accroche",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "07a6146e-c775-42f2-9d20-fbbfa7a37a32",
+                "type": "text",
+                "content": "<p>Dans la vidéo suivante, on peut voir un scientifique célèbre faire une annonce importante.</p>"
               }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fd80af1f-4e44-4200-b337-cf6f1abb9edc",
-      "type": "transition",
-      "title": "Transition 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "be27c10e-48ee-40cd-a7ed-83479ba36099",
-            "type": "text",
-            "content": "<p>Même en ouvrant l'œil, il est parfois difficile de savoir si une image ou une vidéo est vraie ou fausse.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1a062483-a1cd-4cef-bb5a-40bfda85caf4",
-      "type": "discovery",
-      "title": "Activité découverte - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9cad8650-9381-4d1e-92e5-81c68c7748a5",
-            "type": "qab",
-            "instruction": "<p><strong>Voici les photos de 3 personnes&nbsp;: sont-elles vraies ou fausses ?</strong></p>",
-            "cards": [
-              {
-                "id": "89298c11-f564-4fc9-83dc-ec9c439ddd3e",
-                "text": "",
-                "image": {
-                  "url": "https://assets.pix.org/modules/deepfakes/visage1.jpg",
-                  "altText": ""
-                },
-                "proposalA": "vraie personne",
-                "proposalB": "fausse personne",
-                "solution": "B"
-              },
-              {
-                "id": "da1ef1e8-ee77-4cf2-904c-23a293cac7f3",
-                "text": "",
-                "image": {
-                  "url": "https://assets.pix.org/modules/deepfakes/visage2.jpeg",
-                  "altText": ""
-                },
-                "proposalA": "vraie personne",
-                "proposalB": "fausse personne",
-                "solution": "B"
-              },
-              {
-                "id": "5a55a4d9-e10f-48df-8e63-30aeb6d8a681",
-                "text": "",
-                "image": {
-                  "url": "https://assets.pix.org/modules/deepfakes/visage3.jpg",
-                  "altText": ""
-                },
-                "proposalA": "vraie personne",
-                "proposalB": "fausse personne",
-                "solution": "B"
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ff755fbe-52a3-45c7-b828-41c0f8d9f228",
+                "type": "video",
+                "title": "La déclaration",
+                "url": "https://assets.pix.org/draft/modules/deepfakes/declarationae.mp4",
+                "subtitles": "https://assets.pix.org/draft/modules/deepfakes/declarationae.vtt",
+                "transcription": "<p>Déclaration vidéo d'Albert Einstein qui annonce que la Terre est plate en montrant une photo sur un smartphone</p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": "<p>En fait, ces trois personnes n'existent pas ! Avant, on pouvait facilement détecter les fausses images à cause de flous ou de détails ratés, mais c'est devenu très difficile.</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "3be25655-da30-4575-ad97-63c7d28a37c4",
-      "type": "lesson",
-      "title": "Leçon 1",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "f9466906-f64a-402f-976f-bcb773b4b3ff",
-                  "type": "text",
-                  "content": "<p>Ces 3 images sont <strong>hyperréalistes </strong>mais fausses&nbsp;: ce sont des deepfakes.</p>"
-                }
-              ]
             },
             {
-              "elements": [
-                {
-                  "id": "aa9f82e9-3e4e-444b-a8ce-c10b8d07e6c7",
-                  "type": "text",
-                  "content": "<p>Les deepfakes peuvent être&nbsp;:&nbsp;<br></p><ul>    <li>des vidéos▶️</li>    <li>des images&nbsp;🖼️</li>    <li>des sons&nbsp;🎙️</li>    <li>des textes&nbsp;🗒️</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "21ddc90b-7145-4e1d-9e29-1eeedc7be704",
-                  "type": "text",
-                  "content": "<p>Les deepfakes, hypertrucages en français, sont créés <strong>grâce à l’intelligence artificielle</strong>. Comme les intelligences artificielles s'améliorent chaque jour, il est de plus en plus <strong>difficile de reconnaître un deepfake </strong>!</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "3ee0f7d8-b042-490c-8c53-036fd0078dc8",
-                  "type": "text",
-                  "content": "<p> 👂Parfois des indices peuvent vous mettre la puce à l’oreille&nbsp;: des doigts en trop, des mouvements étranges une voix qui se modifie par moment...&nbsp;<br>🔎 Mais, <strong>observer</strong> une image, une vidéo ou écouter attentivement un son <strong>ne suffit pas pour détecter un deepfake.</strong></p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "3d80a0e9-f5c9-4e8f-9c6a-ca2cdcae5c1a",
-      "type": "transition",
-      "title": "Transition 2 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b49f6773-b8cc-48e9-92cd-12821f442dc4",
-            "type": "text",
-            "content": "<p>Pour être si réaliste, un deepfake doit demander beaucoup de compétences et de matériel à son créateur, non ? 🤔</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "56ad33ff-d28b-4a76-b98a-412b9c193126",
-      "type": "discovery",
-      "title": "Activité découverte - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "42d51784-c0d0-4c68-953b-059ea9052e33",
-            "type": "text",
-            "content": "<p>Avec un logiciel d'intelligence artificielle, Caroline a créé une vidéo où elle chante une chanson à la manière de sa chanteuse préférée. 🎶</p><p> Caroline est étonnée&nbsp;: elle a donné<strong> seulement 3 éléments au logiciel d’intelligence artificielle</strong> pour créer la chanson.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c5a52a17-163e-4969-8704-fab8f5ee500a",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-videoCaroline.html",
-            "instruction": "",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "53ce4351-7009-4a25-b7f8-cc134dcacc10",
-      "type": "lesson",
-      "title": "Leçon 2",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "70c20e08-e620-43b1-9012-582be199dfd8",
-                  "type": "text",
-                  "content": "<p>Pour créer un deepfake, un logiciel d’intelligence artificielle n’a <strong>pas besoin de beaucoup d’informations</strong> en entrée (une photo, un son, une courte vidéo…).</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "d45164d6-6737-4959-b3ff-3848f1406285",
-                  "type": "text",
-                  "content": "<p>Par exemple, avec une photo et un enregistrement de quelques phrases, on peut fabriquer une vidéo d’une personne qui fait un discours. 🗣️</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "c0c30bab-b295-4b93-a5c0-a2c6678a3a23",
-                  "type": "text",
-                  "content": "<p><strong>Comme ils sont faciles à fabriquer, beaucoup de deepfakes circulent en ligne.&nbsp;⚠️</strong></p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "f22c5976-43e5-473a-aa0d-e2183328da48",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "346c8e4f-3e0c-4fdd-bd0a-be0ed2daa02d",
-            "type": "text",
-            "content": "<p>Pour quelles raisons les deepfakes sont-ils créés ? Découvrons-le ensemble.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a92461c6-246a-4d33-b70b-2bea8b28c926",
-      "type": "discovery",
-      "title": "Activité découverte - 3 : QCUx3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b5da21e5-f012-4248-94a8-de57dadfd515",
-            "type": "text",
-            "content": "<p>Pour chaque exemple de deepfake, choisissez la bonne réponse.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "eeb6ed38-d2d1-4191-8805-2100de5e128b",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>🎭 Une vidéo d’une personne connue qui fait la danse des canards déguisée en hot dog.<br><br>Quel est le but du créateur de cette vidéo ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>💸 Arnaquer.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Cette vidéo n'est pas malveillante, juste amusante, mais elle peut enfreindre le droit à l'image.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>😂 Amuser.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, cette vidéo est amusante, par contre elle peut enfreindre le droit à l'image.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>🧠 Manipuler.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Cette vidéo n'est pas malveillante, juste amusante, mais elle peut enfreindre le droit à l'image.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "f70639c2-12be-461e-9153-bd7b7763cb75",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>🎤 Une fausse déclaration d’un président qui accuse un autre pays d'être à l'origine d'un attentat.<br><br>Quel est le but du créateur de cette vidéo ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>💸 Arnaquer.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Créer une fausse déclaration permet de manipuler le public.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>😂 Amuser.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Ici pas de divertissement ! Créer une fausse déclaration permet de manipuler le public.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>🧠 Manipuler.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, créer une fausse déclaration permet de manipuler le public.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "98a98ad8-f666-4bd5-b604-0acf4562f942",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>📞 Un faux message vocal avec la voix d’un proche qui demande un virement pour se sortir d’une situation difficile.<br></p><p>Quel est le but du créateur de cette vidéo ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>💸 Arnaquer.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, ce type de message vocal est souvent utilisé pour arnaquer.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>😂 Amuser.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Ce type de message vocal est souvent utilisé pour arnaquer.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>🧠 Manipuler.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Ce type de message vocal est souvent utilisé pour arnaquer.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "e3bfe080-6bb2-4f37-9920-2c328cee9755",
-      "type": "lesson",
-      "title": "Leçon 3",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "e91e7efd-a663-4436-bb84-d4b4de1d1989",
-                  "type": "text",
-                  "content": "<p>😱Les deepfakes sont souvent utilisés pour <strong>faire circuler de fausses informations</strong>. Dans ce cas, leurs créateurs veulent faire croire à des faits qui n’ont pas eu lieu.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "efb2fb08-79c0-4afe-8d8a-361000c0d0a8",
-                  "type": "text",
-                  "content": "<p>Dans quel but ? <strong>Manipuler la population</strong> pour gagner des élections, arnaquer ou <strong>cyberharceler </strong>des personnes. Toutes ces actions sont illégales.<br><strong>Quand ils sont créés avec de mauvaises intentions, les deepfakes peuvent avoir des conséquences graves.</strong></p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "3fdf70ca-0e6a-4c96-ac70-14158761aae1",
-                  "type": "text",
-                  "content": "<p>Des deepfakes sont aussi utilisés dans l’art ou le divertissement, sans but malveillant&nbsp;: par exemple, pour continuer de faire apparaître dans un film un acteur absent ou décédé pendant le tournage.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "1d3b8e1e-87b4-4b2e-bd57-8f00de4ed029",
-                  "type": "text",
-                  "content": "<p>⚠️ Attention, dans tous les cas, il faut <strong>respecter le droit à l’image</strong> de la personne qui apparaît dans le deepfake.<br>Par exemple faire une vidéo humoristique en utilisant la photo d'un ami sans son autorisation ne respecte pas son droit à l'image.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "bcea5fd7-28db-43a1-9613-d5fca0b00ad0",
-      "type": "transition",
-      "title": "Transition 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "548e5653-0607-4020-be54-f318fd0aa092",
-            "type": "text",
-            "content": "<p>Les deepfakes sont difficiles à reconnaître et ils peuvent être créés dans un but malveillant. Mais, comment réagir quand on reçoit une vidéo, une image ou un son et qu’on a des doutes ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "297c91e5-21e8-4ace-a6d6-5c8748d06273",
-      "type": "discovery",
-      "title": "Activité découverte - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "46999db8-c96c-42e8-93ac-a558c72a55f2",
-            "type": "text",
-            "content": "<p>Djibril a reçu un message de son ami Brian sur le groupe de sa classe. <br>Consultez le message puis répondez à la question.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6e6af05b-b933-4022-baa9-6194fdb63584",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/deepfakes/telephone_deepfake.png",
-            "alt": "",
-            "alternativeText": "<p>Une conversation dans un groupe de messagerie instantanné nommé \"Les 3ème D\"&nbsp;:&nbsp;<br>Brian partage une photo d'une femme manifestant avec une pancarte&nbsp;: «&nbsp;PLUS JAMAIS DE DEVOIRS !&nbsp;», suivi du message suivant&nbsp;:«&nbsp;Vous avez vu ! C’est Mme Martin, la prof de maths. Faut envoyer ça à tout le monde pour qu’elle soit virée ! On va lui gâcher sa vie !&nbsp;»<br>Des emojis sont visibles sous le message&nbsp;: 🔥, 💗, 😂, 😱, ➕</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "35425bd8-df9b-402d-a576-2f0fe96d35ad",
-            "type": "qcu-discovery",
-            "instruction": "<p>Qu’est ce que Djibril devrait faire avec ce message ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Liker le message de Brian.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Mauvaise idée ! Avant de liker une image, le bon réflexe, c’est de vérifier d’où l’image vient et si elle est vraie. <br>Liker cette photo, pourrait être considéré comme un soutien au cyberharcèlement mené par Brian. La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Partager la photo à ses contacts.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Mauvaise idée ! Avant de partager une image, le bon réflexe, c’est de vérifier d’où l’image vient et si elle est vraie. <br>Partager cette photo, comme le demande Brian, pourrait être considéré comme du cyberharcèlement.&nbsp;La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Demander à Brian d’où vient cette photo.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, chercher à savoir d'où vient une information avant de la partager, c'est le bon réflexe ! <br>La partager, comme le demande Brian, pourrait être considéré comme du cyberharcèlement.&nbsp;La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Chercher la source de l'image sur internet.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, chercher à savoir d'où vient une information avant de la partager, c'est le bon réflexe !<br>La partager, comme le demande Brian, pourrait être considéré comme du cyberharcèlement. La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
-                }
-              }
-            ],
-            "solution": "4"
-          }
-        }
-      ]
-    },
-    {
-      "id": "862d0165-40a7-4106-a191-94e3182eb156",
-      "type": "lesson",
-      "title": "Leçon 4",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "08889a3c-0fd9-45db-bab2-ffe4a9df0778",
-                  "type": "text",
-                  "content": "<p>Quand vous recevez un message avec un média surprenant (trop beau pour être vrai, énervant ou inquiétant),<strong> prenez le temps avant de le liker ou de le partager</strong>. C’est peut-être un deepfake !</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "ef89f877-b8a8-4279-b63a-eb1761e48d84",
-                  "type": "text",
-                  "content": "<p>Si vous partagez un deepfake créé avec de mauvaises intentions, vous pouvez répandre de <strong>fausses informations </strong>ou participer au <strong>cyberharcèlement </strong>d’une personne.<br>👉 Cela peut aussi enfreindre le droit à l’image et mener à un dépôt de plainte contre vous.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "bb9de561-f5e8-4c81-91a5-d9b8e570b5d0",
-                  "type": "text",
-                  "content": "<p>🔎 <strong>Au moindre doute, ne partagez pas l'information. Mais vérifiez l'information et sa source.</strong></p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "23bdff2a-73ce-4df2-8d7c-38e6f31a7f9f",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "de260e53-8fc3-482c-94ba-7c43560306d9",
-            "type": "text",
-            "content": "<ul> <li>Un deepfake est un <strong>média hyper réaliste mais faux&nbsp;: il est créé grâce à l’intelligence artificielle</strong>. Un deepfake est difficile à détecter. 🔎</li><li>Un deepfake demande peu de matériel et de compétence pour être créé. Il y en a donc<strong> beaucoup qui circulent</strong> en ligne. ⚠️</li><li>Un deepfake est <strong>souvent créé avec une intention malveillante</strong>&nbsp;: pour faire circuler de fausses informations, cyberharceler, arnaquer ou manipuler. 🧠</li><li>Au moindre doute face à média, il ne faut pas le partager immédiatement. <strong>Vérifiez d'abord sa source et s'il est vrai</strong>. ℹ️</li>   </ul><p><br>🤔 <strong>Bon à savoir&nbsp;:</strong><br>Pour limiter le risque de vous retrouver dans un deepfake, évitez de partager des vidéos, des images de vous ou des enregistrements de votre voix.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d4254b9a-b078-4c7b-aa9f-3449bd16806e",
-      "type": "activity",
-      "title": "Activité d'application - 1 : Vrai ou faux ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "73720cf9-1666-48eb-a842-81942bcffda3",
-            "type": "qab",
-            "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
-            "cards": [
-              {
-                "id": "9fb991a7-92c1-4dbc-87c2-724f22993762",
-                "text": "Les deepfakes sont créés grâce à l’intelligence artificielle.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "343b128a-f848-4d0b-83fc-87d62b44e127",
-                "text": "Les deepfakes sont toujours des vidéos.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "6ae5053d-05ac-475a-8280-d8c535736b87",
-                "text": "Les deepfakes sont facilement reconnaissables.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "617d322c-8c8b-4db7-a69c-8ed587e12008",
-                "text": "Les deepfakes sont très rares.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "41ec196a-0940-4caf-8957-d2bf07d1ba84",
-      "type": "transition",
-      "title": "Transition 5",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7c57b98b-0c92-4a53-a169-d83b453da813",
-            "type": "text",
-            "content": "<p>Et pour finir, voyons un cas pratique.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "20300d89-a258-48ec-a1db-f98609a3dd76",
-      "type": "activity",
-      "title": "Activité d'application - 2 : Etude de cas",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "941ea25d-7b42-46fc-8a96-d35762dfd07b",
-            "type": "custom-draft",
-            "title": "Article",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-articlemaire.html",
-            "instruction": "<p>Lisez l’article ci-dessous, puis répondez aux questions.</p>",
-            "height": 550
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "50220f94-8cee-487e-829f-25d6947cfd65",
-                  "type": "qcu",
-                  "instruction": "<p>Quel peut être le but de la personne qui a créé ce deepfake ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Informer le public.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il n'a pas été créé pour informer.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Faire rire les gens.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il n'a pas été créé pour amuser.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Manipuler l’opinion du public.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il a bien été créé pour manipuler.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "57f59662-8bb3-4601-bc9a-1f33f541aa1c",
-                  "type": "qcm",
-                  "instruction": "<p>Avec quoi a été créé ce deepfake ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>avec un programme d’intelligence artificielle</p>"
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>avec du matériel professionnel dans un studio de cinéma</p>"
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>avec quelques images de la maire de la capitale</p>"
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>avec un sosie de la maire de la capitale</p>"
-                    },
-                    {
-                      "id": "5",
-                      "content": "<p>avec de très bonnes connaissances en montage vidéo</p>"
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "<p>Bonne réponse ! 🎉</p>",
-                      "diagnosis": "<p>Un programme d'intelligence artificielle et quelques images sont suffisants pour créer un deepfake très difficile à détecter.</p>"
-                    },
-                    "invalid": {
-                      "state": "<p>Mauvaise réponse.</p>",
-                      "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
+              "type": "element",
+              "element": {
+                "id": "c1a11c3d-31ee-4770-9331-3c61685fe771",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, Albert Einstein a-t-il fait cette annonce ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Cette vidéo est fausse. C'est ce qu’on appelle un deepfake ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
                     }
                   },
-                  "solutions": [
-                    "1",
-                    "3"
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien vu ! Cette vidéo est fausse. C'est ce qu’on appelle un deepfake&nbsp;ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Cette vidéo est fausse. C'est ce qu’on appelle un deepfake ou un hypertrucage, en français. Voyons de quoi il s’agit.<br></p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "fd80af1f-4e44-4200-b337-cf6f1abb9edc",
+          "type": "transition",
+          "title": "Transition 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "be27c10e-48ee-40cd-a7ed-83479ba36099",
+                "type": "text",
+                "content": "<p>Même en ouvrant l'œil, il est parfois difficile de savoir si une image ou une vidéo est vraie ou fausse.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1a062483-a1cd-4cef-bb5a-40bfda85caf4",
+          "type": "discovery",
+          "title": "Activité découverte - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9cad8650-9381-4d1e-92e5-81c68c7748a5",
+                "type": "qab",
+                "instruction": "<p><strong>Voici les photos de 3 personnes&nbsp;: sont-elles vraies ou fausses ?</strong></p>",
+                "cards": [
+                  {
+                    "id": "89298c11-f564-4fc9-83dc-ec9c439ddd3e",
+                    "text": "",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/deepfakes/visage1.jpg",
+                      "altText": ""
+                    },
+                    "proposalA": "vraie personne",
+                    "proposalB": "fausse personne",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "da1ef1e8-ee77-4cf2-904c-23a293cac7f3",
+                    "text": "",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/deepfakes/visage2.jpeg",
+                      "altText": ""
+                    },
+                    "proposalA": "vraie personne",
+                    "proposalB": "fausse personne",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "5a55a4d9-e10f-48df-8e63-30aeb6d8a681",
+                    "text": "",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/deepfakes/visage3.jpg",
+                      "altText": ""
+                    },
+                    "proposalA": "vraie personne",
+                    "proposalB": "fausse personne",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": "<p>En fait, ces trois personnes n'existent pas ! Avant, on pouvait facilement détecter les fausses images à cause de flous ou de détails ratés, mais c'est devenu très difficile.</p>"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "3be25655-da30-4575-ad97-63c7d28a37c4",
+          "type": "lesson",
+          "title": "Leçon 1",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "f9466906-f64a-402f-976f-bcb773b4b3ff",
+                      "type": "text",
+                      "content": "<p>Ces 3 images sont <strong>hyperréalistes </strong>mais fausses&nbsp;: ce sont des deepfakes.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "aa9f82e9-3e4e-444b-a8ce-c10b8d07e6c7",
+                      "type": "text",
+                      "content": "<p>Les deepfakes peuvent être&nbsp;:&nbsp;<br></p><ul>    <li>des vidéos▶️</li>    <li>des images&nbsp;🖼️</li>    <li>des sons&nbsp;🎙️</li>    <li>des textes&nbsp;🗒️</li></ul>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "21ddc90b-7145-4e1d-9e29-1eeedc7be704",
+                      "type": "text",
+                      "content": "<p>Les deepfakes, hypertrucages en français, sont créés <strong>grâce à l’intelligence artificielle</strong>. Comme les intelligences artificielles s'améliorent chaque jour, il est de plus en plus <strong>difficile de reconnaître un deepfake </strong>!</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3ee0f7d8-b042-490c-8c53-036fd0078dc8",
+                      "type": "text",
+                      "content": "<p> 👂Parfois des indices peuvent vous mettre la puce à l’oreille&nbsp;: des doigts en trop, des mouvements étranges une voix qui se modifie par moment...&nbsp;<br>🔎 Mais, <strong>observer</strong> une image, une vidéo ou écouter attentivement un son <strong>ne suffit pas pour détecter un deepfake.</strong></p>"
+                    }
                   ]
                 }
               ]
+            }
+          ]
+        },
+        {
+          "id": "3d80a0e9-f5c9-4e8f-9c6a-ca2cdcae5c1a",
+          "type": "transition",
+          "title": "Transition 2 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b49f6773-b8cc-48e9-92cd-12821f442dc4",
+                "type": "text",
+                "content": "<p>Pour être si réaliste, un deepfake doit demander beaucoup de compétences et de matériel à son créateur, non ? 🤔</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "56ad33ff-d28b-4a76-b98a-412b9c193126",
+          "type": "discovery",
+          "title": "Activité découverte - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "42d51784-c0d0-4c68-953b-059ea9052e33",
+                "type": "text",
+                "content": "<p>Avec un logiciel d'intelligence artificielle, Caroline a créé une vidéo où elle chante une chanson à la manière de sa chanteuse préférée. 🎶</p><p> Caroline est étonnée&nbsp;: elle a donné<strong> seulement 3 éléments au logiciel d’intelligence artificielle</strong> pour créer la chanson.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "c5a52a17-163e-4969-8704-fab8f5ee500a",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-videoCaroline.html",
+                "instruction": "",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "53ce4351-7009-4a25-b7f8-cc134dcacc10",
+          "type": "lesson",
+          "title": "Leçon 2",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "46824fe5-1e52-467f-b48a-deaee3ec65fa",
-                  "type": "qcu",
-                  "instruction": "<p>Quel est le rôle des réseaux sociaux dans la diffusion de la vidéo de la maire ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Ils ont empêché la diffusion de la vidéo.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Au contraire, la vidéo a été largement partagée.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Ils ont aidé à identifier le deepfake.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ce sont les services municipaux qui ont signalé le deepfake.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Ils ont permis une large diffusion de la vidéo.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Le deepfake s’est propagé très rapidement grâce aux partages sur les réseaux.</p>"
-                      }
+                      "id": "70c20e08-e620-43b1-9012-582be199dfd8",
+                      "type": "text",
+                      "content": "<p>Pour créer un deepfake, un logiciel d’intelligence artificielle n’a <strong>pas besoin de beaucoup d’informations</strong> en entrée (une photo, un son, une courte vidéo…).</p>"
                     }
-                  ],
-                  "solution": "3"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "d45164d6-6737-4959-b3ff-3848f1406285",
+                      "type": "text",
+                      "content": "<p>Par exemple, avec une photo et un enregistrement de quelques phrases, on peut fabriquer une vidéo d’une personne qui fait un discours. 🗣️</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "c0c30bab-b295-4b93-a5c0-a2c6678a3a23",
+                      "type": "text",
+                      "content": "<p><strong>Comme ils sont faciles à fabriquer, beaucoup de deepfakes circulent en ligne.&nbsp;⚠️</strong></p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "4a311602-d54d-47c9-810f-2ce52bd6b526",
-      "type": "activity",
-      "title": "Et vous ? ",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "d60b125e-cc55-43cd-b594-6431b0bf3587",
-            "type": "qcu-declarative",
-            "instruction": "<p>Et vous qu’auriez-vous fait si vous aviez vu cette vidéo sur les réseaux sociaux ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Partager la vidéo.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Attention à ne pas partager de deepfakes !</p>"
+          "id": "f22c5976-43e5-473a-aa0d-e2183328da48",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "346c8e4f-3e0c-4fdd-bd0a-be0ed2daa02d",
+                "type": "text",
+                "content": "<p>Pour quelles raisons les deepfakes sont-ils créés ? Découvrons-le ensemble.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a92461c6-246a-4d33-b70b-2bea8b28c926",
+          "type": "discovery",
+          "title": "Activité découverte - 3 : QCUx3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b5da21e5-f012-4248-94a8-de57dadfd515",
+                "type": "text",
+                "content": "<p>Pour chaque exemple de deepfake, choisissez la bonne réponse.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "eeb6ed38-d2d1-4191-8805-2100de5e128b",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>🎭 Une vidéo d’une personne connue qui fait la danse des canards déguisée en hot dog.<br><br>Quel est le but du créateur de cette vidéo ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>💸 Arnaquer.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Cette vidéo n'est pas malveillante, juste amusante, mais elle peut enfreindre le droit à l'image.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>😂 Amuser.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, cette vidéo est amusante, par contre elle peut enfreindre le droit à l'image.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>🧠 Manipuler.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Cette vidéo n'est pas malveillante, juste amusante, mais elle peut enfreindre le droit à l'image.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "f70639c2-12be-461e-9153-bd7b7763cb75",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>🎤 Une fausse déclaration d’un président qui accuse un autre pays d'être à l'origine d'un attentat.<br><br>Quel est le but du créateur de cette vidéo ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>💸 Arnaquer.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Créer une fausse déclaration permet de manipuler le public.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>😂 Amuser.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Ici pas de divertissement ! Créer une fausse déclaration permet de manipuler le public.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>🧠 Manipuler.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, créer une fausse déclaration permet de manipuler le public.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "98a98ad8-f666-4bd5-b604-0acf4562f942",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>📞 Un faux message vocal avec la voix d’un proche qui demande un virement pour se sortir d’une situation difficile.<br></p><p>Quel est le but du créateur de cette vidéo ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>💸 Arnaquer.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, ce type de message vocal est souvent utilisé pour arnaquer.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>😂 Amuser.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Ce type de message vocal est souvent utilisé pour arnaquer.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>🧠 Manipuler.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Ce type de message vocal est souvent utilisé pour arnaquer.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
-              },
-              {
-                "id": "2",
-                "content": "<p>Signaler la vidéo.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, quand on repère un deepfake sur un réseau social, on peut le signaler.</p>"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "e3bfe080-6bb2-4f37-9920-2c328cee9755",
+          "type": "lesson",
+          "title": "Leçon 3",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "e91e7efd-a663-4436-bb84-d4b4de1d1989",
+                      "type": "text",
+                      "content": "<p>😱Les deepfakes sont souvent utilisés pour <strong>faire circuler de fausses informations</strong>. Dans ce cas, leurs créateurs veulent faire croire à des faits qui n’ont pas eu lieu.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "efb2fb08-79c0-4afe-8d8a-361000c0d0a8",
+                      "type": "text",
+                      "content": "<p>Dans quel but ? <strong>Manipuler la population</strong> pour gagner des élections, arnaquer ou <strong>cyberharceler </strong>des personnes. Toutes ces actions sont illégales.<br><strong>Quand ils sont créés avec de mauvaises intentions, les deepfakes peuvent avoir des conséquences graves.</strong></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3fdf70ca-0e6a-4c96-ac70-14158761aae1",
+                      "type": "text",
+                      "content": "<p>Des deepfakes sont aussi utilisés dans l’art ou le divertissement, sans but malveillant&nbsp;: par exemple, pour continuer de faire apparaître dans un film un acteur absent ou décédé pendant le tournage.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "1d3b8e1e-87b4-4b2e-bd57-8f00de4ed029",
+                      "type": "text",
+                      "content": "<p>⚠️ Attention, dans tous les cas, il faut <strong>respecter le droit à l’image</strong> de la personne qui apparaît dans le deepfake.<br>Par exemple faire une vidéo humoristique en utilisant la photo d'un ami sans son autorisation ne respecte pas son droit à l'image.</p>"
+                    }
+                  ]
                 }
-              },
-              {
-                "id": "3",
-                "content": "<p>Chercher la source.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bon réflexe !&nbsp;</p>"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "bcea5fd7-28db-43a1-9613-d5fca0b00ad0",
+          "type": "transition",
+          "title": "Transition 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "548e5653-0607-4020-be54-f318fd0aa092",
+                "type": "text",
+                "content": "<p>Les deepfakes sont difficiles à reconnaître et ils peuvent être créés dans un but malveillant. Mais, comment réagir quand on reçoit une vidéo, une image ou un son et qu’on a des doutes ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "297c91e5-21e8-4ace-a6d6-5c8748d06273",
+          "type": "discovery",
+          "title": "Activité découverte - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "46999db8-c96c-42e8-93ac-a558c72a55f2",
+                "type": "text",
+                "content": "<p>Djibril a reçu un message de son ami Brian sur le groupe de sa classe. <br>Consultez le message puis répondez à la question.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6e6af05b-b933-4022-baa9-6194fdb63584",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/deepfakes/telephone_deepfake.png",
+                "alt": "",
+                "alternativeText": "<p>Une conversation dans un groupe de messagerie instantanné nommé \"Les 3ème D\"&nbsp;:&nbsp;<br>Brian partage une photo d'une femme manifestant avec une pancarte&nbsp;: «&nbsp;PLUS JAMAIS DE DEVOIRS !&nbsp;», suivi du message suivant&nbsp;:«&nbsp;Vous avez vu ! C’est Mme Martin, la prof de maths. Faut envoyer ça à tout le monde pour qu’elle soit virée ! On va lui gâcher sa vie !&nbsp;»<br>Des emojis sont visibles sous le message&nbsp;: 🔥, 💗, 😂, 😱, ➕</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "35425bd8-df9b-402d-a576-2f0fe96d35ad",
+                "type": "qcu-discovery",
+                "instruction": "<p>Qu’est ce que Djibril devrait faire avec ce message ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Liker le message de Brian.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Mauvaise idée ! Avant de liker une image, le bon réflexe, c’est de vérifier d’où l’image vient et si elle est vraie. <br>Liker cette photo, pourrait être considéré comme un soutien au cyberharcèlement mené par Brian. La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Partager la photo à ses contacts.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Mauvaise idée ! Avant de partager une image, le bon réflexe, c’est de vérifier d’où l’image vient et si elle est vraie. <br>Partager cette photo, comme le demande Brian, pourrait être considéré comme du cyberharcèlement.&nbsp;La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Demander à Brian d’où vient cette photo.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, chercher à savoir d'où vient une information avant de la partager, c'est le bon réflexe ! <br>La partager, comme le demande Brian, pourrait être considéré comme du cyberharcèlement.&nbsp;La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Chercher la source de l'image sur internet.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, chercher à savoir d'où vient une information avant de la partager, c'est le bon réflexe !<br>La partager, comme le demande Brian, pourrait être considéré comme du cyberharcèlement. La diffusion de cette image pourrait avoir de graves conséquences pour Mme Martin.  Mme Martin pourrait porter plainte.</p>"
+                    }
+                  }
+                ],
+                "solution": "4"
+              }
+            }
+          ]
+        },
+        {
+          "id": "862d0165-40a7-4106-a191-94e3182eb156",
+          "type": "lesson",
+          "title": "Leçon 4",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "08889a3c-0fd9-45db-bab2-ffe4a9df0778",
+                      "type": "text",
+                      "content": "<p>Quand vous recevez un message avec un média surprenant (trop beau pour être vrai, énervant ou inquiétant),<strong> prenez le temps avant de le liker ou de le partager</strong>. C’est peut-être un deepfake !</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "ef89f877-b8a8-4279-b63a-eb1761e48d84",
+                      "type": "text",
+                      "content": "<p>Si vous partagez un deepfake créé avec de mauvaises intentions, vous pouvez répandre de <strong>fausses informations </strong>ou participer au <strong>cyberharcèlement </strong>d’une personne.<br>👉 Cela peut aussi enfreindre le droit à l’image et mener à un dépôt de plainte contre vous.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "bb9de561-f5e8-4c81-91a5-d9b8e570b5d0",
+                      "type": "text",
+                      "content": "<p>🔎 <strong>Au moindre doute, ne partagez pas l'information. Mais vérifiez l'information et sa source.</strong></p>"
+                    }
+                  ]
                 }
-              },
-              {
-                "id": "4",
-                "content": "<p>En discuter avec vos amis.</p>",
+              ]
+            }
+          ]
+        },
+        {
+          "id": "23bdff2a-73ce-4df2-8d7c-38e6f31a7f9f",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "de260e53-8fc3-482c-94ba-7c43560306d9",
+                "type": "text",
+                "content": "<ul> <li>Un deepfake est un <strong>média hyper réaliste mais faux&nbsp;: il est créé grâce à l’intelligence artificielle</strong>. Un deepfake est difficile à détecter. 🔎</li><li>Un deepfake demande peu de matériel et de compétence pour être créé. Il y en a donc<strong> beaucoup qui circulent</strong> en ligne. ⚠️</li><li>Un deepfake est <strong>souvent créé avec une intention malveillante</strong>&nbsp;: pour faire circuler de fausses informations, cyberharceler, arnaquer ou manipuler. 🧠</li><li>Au moindre doute face à média, il ne faut pas le partager immédiatement. <strong>Vérifiez d'abord sa source et s'il est vrai</strong>. ℹ️</li>   </ul><p><br>🤔 <strong>Bon à savoir&nbsp;:</strong><br>Pour limiter le risque de vous retrouver dans un deepfake, évitez de partager des vidéos, des images de vous ou des enregistrements de votre voix.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d4254b9a-b078-4c7b-aa9f-3449bd16806e",
+          "type": "activity",
+          "title": "Activité d'application - 1 : Vrai ou faux ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "73720cf9-1666-48eb-a842-81942bcffda3",
+                "type": "qab",
+                "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
+                "cards": [
+                  {
+                    "id": "9fb991a7-92c1-4dbc-87c2-724f22993762",
+                    "text": "Les deepfakes sont créés grâce à l’intelligence artificielle.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "343b128a-f848-4d0b-83fc-87d62b44e127",
+                    "text": "Les deepfakes sont toujours des vidéos.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "6ae5053d-05ac-475a-8280-d8c535736b87",
+                    "text": "Les deepfakes sont facilement reconnaissables.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "617d322c-8c8b-4db7-a69c-8ed587e12008",
+                    "text": "Les deepfakes sont très rares.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
                 "feedback": {
-                  "diagnosis": "<p>Effectivement, lorsqu'on a un doute sur un contenu en ligne, on peut demander l'avis de ses amis.</p>"
-                }
-              },
-              {
-                "id": "5",
-                "content": "<p>Rien de spécial.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Passer son chemin face à un contenu en ligne qu'on soupçonne d'être un deepfake, c'est bien ! Le signaler, c'est mieux !</p>"
+                  "diagnosis": ""
                 }
               }
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "id": "41ec196a-0940-4caf-8957-d2bf07d1ba84",
+          "type": "transition",
+          "title": "Transition 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7c57b98b-0c92-4a53-a169-d83b453da813",
+                "type": "text",
+                "content": "<p>Et pour finir, voyons un cas pratique.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "20300d89-a258-48ec-a1db-f98609a3dd76",
+          "type": "activity",
+          "title": "Activité d'application - 2 : Etude de cas",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "941ea25d-7b42-46fc-8a96-d35762dfd07b",
+                "type": "custom-draft",
+                "title": "Article",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-deepfakes-articlemaire.html",
+                "instruction": "<p>Lisez l’article ci-dessous, puis répondez aux questions.</p>",
+                "height": 550
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "50220f94-8cee-487e-829f-25d6947cfd65",
+                      "type": "qcu",
+                      "instruction": "<p>Quel peut être le but de la personne qui a créé ce deepfake ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Informer le public.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il n'a pas été créé pour informer.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Faire rire les gens.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il n'a pas été créé pour amuser.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Manipuler l’opinion du public.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Ce deepfake présente une fausse déclaration politique, il a bien été créé pour manipuler.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "57f59662-8bb3-4601-bc9a-1f33f541aa1c",
+                      "type": "qcm",
+                      "instruction": "<p>Avec quoi a été créé ce deepfake ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>avec un programme d’intelligence artificielle</p>"
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>avec du matériel professionnel dans un studio de cinéma</p>"
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>avec quelques images de la maire de la capitale</p>"
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>avec un sosie de la maire de la capitale</p>"
+                        },
+                        {
+                          "id": "5",
+                          "content": "<p>avec de très bonnes connaissances en montage vidéo</p>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "<p>Bonne réponse ! 🎉</p>",
+                          "diagnosis": "<p>Un programme d'intelligence artificielle et quelques images sont suffisants pour créer un deepfake très difficile à détecter.</p>"
+                        },
+                        "invalid": {
+                          "state": "<p>Mauvaise réponse.</p>",
+                          "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
+                        }
+                      },
+                      "solutions": ["1", "3"]
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "46824fe5-1e52-467f-b48a-deaee3ec65fa",
+                      "type": "qcu",
+                      "instruction": "<p>Quel est le rôle des réseaux sociaux dans la diffusion de la vidéo de la maire ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Ils ont empêché la diffusion de la vidéo.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Au contraire, la vidéo a été largement partagée.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Ils ont aidé à identifier le deepfake.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ce sont les services municipaux qui ont signalé le deepfake.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Ils ont permis une large diffusion de la vidéo.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Le deepfake s’est propagé très rapidement grâce aux partages sur les réseaux.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "4a311602-d54d-47c9-810f-2ce52bd6b526",
+          "type": "activity",
+          "title": "Et vous ? ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d60b125e-cc55-43cd-b594-6431b0bf3587",
+                "type": "qcu-declarative",
+                "instruction": "<p>Et vous qu’auriez-vous fait si vous aviez vu cette vidéo sur les réseaux sociaux ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Partager la vidéo.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Attention à ne pas partager de deepfakes !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Signaler la vidéo.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, quand on repère un deepfake sur un réseau social, on peut le signaler.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Chercher la source.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bon réflexe !&nbsp;</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>En discuter avec vos amis.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, lorsqu'on a un doute sur un contenu en ligne, on peut demander l'avis de ses amis.</p>"
+                    }
+                  },
+                  {
+                    "id": "5",
+                    "content": "<p>Rien de spécial.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Passer son chemin face à un contenu en ligne qu'on soupçonne d'être un deepfake, c'est bien ! Le signaler, c'est mieux !</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -15,560 +15,564 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "6311f17f-b02c-4f22-a10e-c349d962218e",
-      "type": "discovery",
-      "title": "Accroche",
-      "components": [
+      "id": "6a735ee1-07d6-4034-acb8-e10a16d84f01",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "e0a5a488-113c-4c30-89e0-354e874aa534",
-            "type": "text",
-            "content": "<p>Peut-être avez vous vu ces dernières années de nombreux titres de presse parlant d'<strong>IA</strong> ?</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "16b6fdf3-4aee-4e4f-86b1-6a7f69241289",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/ia-dit-ia/couvia.png",
-            "alt": "4 unes de la presse francophone décrites dans l'alternative textuelle",
-            "alternativeText": "<p>Image montrant quatre couvertures de magazines français consacrées à l’intelligence artificielle (IA)&nbsp;:</p><ul>    <li>        Le Nouvel Obs – Titre&nbsp;: «&nbsp;Nos vies sous IA&nbsp;» avec une main robotique tenant une figurine humaine.    </li>    <li> Philosophie Magazine (Hors-série) – Titre&nbsp;: «&nbsp;IA, le mythe du XXIe siècle&nbsp;», avec un visage humain partiellement robotisé.    </li>    <li> Courrier International – Titre&nbsp;: «&nbsp;L’IA en roue libre&nbsp;», illustré d’un cerveau humanoïde aux commandes d’un corps.    </li>    <li> Sciences et Avenir – Titre&nbsp;: «&nbsp;IA, ce qu’elle change&nbsp;», avec une couverture bleue illustrant un réseau neuronal.</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f9de3bea-9094-4773-9e03-d72127d8f313",
-            "type": "text",
-            "content": "<p>Derrière ces deux lettres, «&nbsp;I&nbsp;» et «&nbsp;A&nbsp;», se cache l'<strong>Intelligence Artificielle</strong>.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a27b96cf-a0a7-45df-866a-313a1bd6caaf",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-frise.html",
-            "instruction": "<p> À votre avis, de quand date l'expression «&nbsp;intelligence artificielle&nbsp;» ?&nbsp;⌛</p>",
-            "height": 325
-          }
-        }
-      ]
-    },
-    {
-      "id": "dbbff46a-197e-4663-950a-81b4f4fa532a",
-      "type": "transition",
-      "title": "Transition - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3c870d58-e8dd-4129-9348-159975b1fc69",
-            "type": "text",
-            "content": "<p>À cause de la récente popularité de chatGPT et d'autres logiciels d'IA générative, on a l’impression que l’IA, c’est nouveau. Mais pas du tout !&nbsp; L’IA, ça date ! 🦣&nbsp;</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0010b969-e9a0-4ed4-957d-5fe365c6ce56",
-      "type": "discovery",
-      "title": "Découverte - 1 : Que peut faire un ordinateur ? ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "937b62e7-c4f5-479a-8e1f-afbe7881fa92",
-            "type": "text",
-            "content": "<p>Et si on regardait plus précisément ce qu'est l'IA ? Pour cela, partons de l’ordinateur !</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4f4ab566-2a26-47bd-9814-cba6ecf2f989",
-            "type": "qab",
-            "instruction": "<p>Selon vous, que peut faire un ordinateur ?</p>",
-            "cards": [
-              {
-                "id": "940cf3fa-b3fa-4d89-8551-77ce96474a89",
-                "text": "Jouer et gagner une partie de jeu d’échec.",
-                "image": {
-                  "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordiechecs.png",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "a2d89587-3356-4f06-8458-416e6aa7d4dd",
-                "text": "Dialoguer sur des sujets variés.",
-                "image": {
-                  "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordidiscut.png",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "fef2a126-7d2d-401e-981c-aaf06317b171",
-                "text": "Conduire un véhicule en ville.",
-                "image": {
-                  "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordiconduit.png",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "df9eb3bd-ef3f-4db3-88a6-455e41d08dba",
-                "text": "Écrire la fin d’une symphonie inachevée.",
-                "image": {
-                  "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordimusique.png",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              }
-            ],
-            "feedback": {
-              "diagnosis": "<p>Toutes ces actions ont déjà été réalisées par des ordinateurs, grâce à <strong>l’intelligence artificielle</strong>.</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "bd0e1d7a-2538-439e-ab8c-006393e03efb",
-      "type": "lesson",
-      "title": "Leçon - 1 : Que peut faire un ordinateur ? ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d4c2fcb1-74b0-474e-8bda-470c83ced9c2",
-            "type": "text",
-            "content": "<p>Aujourd’hui, les ordinateurs sont capables de réaliser <strong>toutes sortes de tâches</strong>&nbsp;:</p><ul><li>Des tâches que nous faisons sans y penser comme, par exemple, reconnaître un chien dans une image.&nbsp;👀</li><li>Et des tâches qui nous demandent plus de concentration comme, par exemple, résoudre des problèmes de mathématiques.&nbsp;🧠</li></ul><p>Le <strong>domaine scientifique</strong> qui a permis ces progrès est celui de&nbsp;<strong>l’intelligence artificielle</strong>. Les chercheurs en intelligence artificielle étudient comment permettre à des machines d’<strong>imiter les mécanismes de l’intelligence</strong>.&nbsp;🔬</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f141f0e8-4b40-4844-84e6-241b94228547",
-      "type": "transition",
-      "title": "Transition - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6405e82a-354c-4faf-935b-c81953cf9a2c",
-            "type": "text",
-            "content": "<p>Regardons plus en détail les tâches que réalisent les logiciels d’IA aujourd'hui, et dans quels cas on utilise ces logiciels.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c1f654a7-5476-43d7-bf07-22d11b30337a",
-      "type": "discovery",
-      "title": "Découverte - 2 : Où trouver des utilisations de l'IA ? ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8dba133c-906f-4793-939f-015df7d2acce",
-            "type": "text",
-            "content": "<p>Mariam est équipée de nombreux appareils électroniques.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a066ebc9-7f82-439b-85c3-aa2e8686e52a",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-image-interactive.html",
-            "instruction": "<p><strong>Survolez l'image pour explorer son salon pour trouver les appareils et les services qui utilisent des logiciels d'intelligence artificielle.</strong></p>",
-            "height": 520
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "658f3722-cf66-4fe0-9dcc-ee4ce1b6a673",
-            "type": "qrocm",
-            "instruction": "<p>Combien avez-vous trouvé d’utilisations de l’IA ?</p>",
-            "proposals": [
-              {
-                "input": "1",
-                "type": "input",
-                "inputType": "number",
-                "size": 1,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "nombre d'utilisation de l'IA",
-                "defaultValue": "",
-                "tolerances": [],
-                "solutions": [
-                  6
-                ]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "",
-                "diagnosis": "<p>C'est ça ! L'IA est présente dans de nombreux appareils et services du quotidien.&nbsp;</p>"
-              },
-              "invalid": {
-                "state": "",
-                "diagnosis": "<p>Et non. Dans le salon de Mariam, il y a 6 appareils et services qui utilisent des logiciels d'IA&nbsp;: le thermostat, le service de vidéo à la demande sur la télévision, le logiciel d'IA générative sur l'ordinateur, le robot aspirateur, l'enceinte connectée et le jeu vidéo sur la console.</p>"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "16244191-1e74-4396-b9bd-d27ace391181",
-      "type": "lesson",
-      "title": "Leçon - 2 : Où trouver des utilisations de l'IA",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bfe6d7e1-8282-4a34-a659-c189ea396feb",
-            "type": "text",
-            "content": "<p>De nombreux <strong>appareils et services numériques du quotidien</strong> utilisent des logiciels d’intelligence artificielle.</p><p><br>Certains logiciels sont <strong>spécialisés </strong>dans <strong>un type de tâche</strong>&nbsp;: reconnaître des images, reconnaître des sons, recommander des contenus adaptés à des besoins, prédire des tendances dans des données, etc.&nbsp;🔮</p><p><br>Les logiciels à base d’<strong>IA générative</strong>, comme Le chat, Gemini ou chatGPT, sont capables de réaliser des tâches diverses&nbsp;: traduire des textes, tenir une conversation, résumer des articles, créer une image, programmer, résoudre des problèmes de mathématiques, etc.&nbsp;📝<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7ee0c174-9a2b-413c-adee-682dc5ed1c70",
-      "type": "discovery",
-      "title": "Découverte - 3 : IA et secteurs d'activité",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a2b1291d-6043-4582-ac69-337835330c07",
-            "type": "text",
-            "content": "<p>L’IA est aussi utilisée dans des secteurs d’activité professionnelle.<br>Voyons l'exemple de<strong> la reconnaissance d’image</strong>.&nbsp;🔎🖼️</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c4a0562d-60f8-48b3-8489-2c8c195597b8",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-cartes.html",
-            "instruction": "<p>Retournez les cartes ci-dessous pour des exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité.</p>",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "fdf3c015-b354-4f35-a463-76cfc0de4b03",
-      "type": "lesson",
-      "title": "Leçon - 3 : IA et secteurs d'activité",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1bf335c7-a606-4e65-aa36-07adf42d3b6f",
-            "type": "text",
-            "content": "<p>L’intelligence artificielle est utilisée dans tous les secteurs d’activité&nbsp;: l’agriculture,&nbsp; la culture, l’éducation, la finance, l’industrie, le loisir, la santé, la science, la sécurité, le transport, etc.</p><p><br><strong>💡 Parfois, l'utilisation de l'intelligence artificielle permet de faire des découvertes ou des progrès importants</strong>. Par exemple&nbsp;:&nbsp;</p><ul><li>Certaines maladies comme les cancers sont mieux dépistées depuis qu'on utilise l'IA pour détecter les tumeurs.</li><li>Les effets du changement climatique sont mieux compris depuis qu'on utilise l'IA pour analyser ses impacts.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2b67c7bb-cda3-4923-9c3b-4225e082bc57",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "715a385e-dcfb-4001-9e5d-5b00ab365221",
-            "type": "text",
-            "content": "<p>Voici les points principaux à retenir&nbsp;:&nbsp;</p><ul><li><strong>L’intelligence artificielle est un domaine scientifique</strong> qui étudie comment permettre à des machines d’imiter les mécanismes de l’intelligence pour réaliser toutes sortes de tâches.&nbsp;🔬</li><li><strong>Certains logiciels d’IA sont spécialisés dans un type de tâche</strong>. D'autres comme <strong>les IA génératives réalisent différentes tâches</strong>.&nbsp;👩‍💻</li><li>Les logiciels d’IA sont utilisés dans <strong>des appareils et services de notre quotidien</strong>.&nbsp;📱</li><li>L’utilisation de l’IA  permet de faire de nombreux <strong>progrès scientifiques</strong>.&nbsp;📈</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7a4f925d-782c-40aa-812c-01278b60caee",
-      "type": "activity",
-      "title": "Activité d'application - 1 : Vrai ou faux ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0fea05ff-8378-40b9-b078-ee55015dc1e6",
-            "type": "text",
-            "content": "<p>Voyons si vous avez retenu l'essentiel.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c9da5d5a-e701-4883-9649-38e0a849a01f",
-            "type": "qab",
-            "instruction": "<p>Répondez aux affirmations suivantes.</p>",
-            "cards": [
-              {
-                "id": "38e4c2ef-7b29-48ad-8caa-107f6c41a8e3",
-                "text": "L’IA, c’est récent, ça date de chatGPT.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "52347fb2-5242-4334-b30b-7b7af18a7fe1",
-                "text": "L’intelligence artificielle est un domaine scientifique.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "0c3e3cbb-68a7-46d4-a9d6-5afd7e92ee2d",
-                "text": "Certains services en ligne utilisent l’IA pour recommander des contenus.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "bad09d31-f94a-4493-889d-889f5199ca0c",
-                "text": "Un logiciel d’intelligence artificielle sait tout faire.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "24445c57-5f45-4ead-8767-936c43913403",
-      "type": "activity",
-      "title": " Activité d'application - 2 : Types d'IA",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b2dc8d40-47cd-4f67-af34-b66ef6506b57",
-            "type": "text",
-            "content": "<p>Identifiez dans quel type de tâche sont spécialisées les IA utilisées dans les situations suivantes.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "6311f17f-b02c-4f22-a10e-c349d962218e",
+          "type": "discovery",
+          "title": "Accroche",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "05a30b10-ac62-40a5-961b-9f3f3e831da0",
-                  "type": "qcu",
-                  "instruction": "<h4>🗣️ 🎤 Une application retrouve le titre d'une musique que vous lui chantez.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>la reconnaissance du son</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>De nombreuses applications proposent aujourd’hui de retrouver le titre d’une musique à partir de quelques secondes de son ou de voix.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>la reconnaissance d’image</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, ce n’est pas une image que l’IA doit savoir reconnaître.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>la recommandation de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, pas de recommandation de contenu. L’IA doit savoir identifier quelque chose.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>la génération de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, pas de génération de contenu. L’ia doit savoir identifier quelque chose.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "e0a5a488-113c-4c30-89e0-354e874aa534",
+                "type": "text",
+                "content": "<p>Peut-être avez vous vu ces dernières années de nombreux titres de presse parlant d'<strong>IA</strong> ?</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "d6644a42-0b76-4e9c-8595-43c2da89cb9b",
-                  "type": "qcu",
-                  "instruction": "<h4>🎬 ▶️ Un site vous propose de nouveaux contenus suite au visionnage d’une vidéo.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>la reconnaissance du son</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, il ne s’agit pas d’identifier quelque chose, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>la reconnaissance d’image</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, il ne s’agit pas d’identifier quelque chose, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>la recommandation de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Les IA spécialisées dans la recommandation de contenus sont largement utilisées pour personnaliser les expériences utilisateurs sur les plateformes numériques, par exemple les services de vidéos à la demande.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>la génération de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, il ne s’agit pas de produire de nouveaux contenus, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "16b6fdf3-4aee-4e4f-86b1-6a7f69241289",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/ia-dit-ia/couvia.png",
+                "alt": "4 unes de la presse francophone décrites dans l'alternative textuelle",
+                "alternativeText": "<p>Image montrant quatre couvertures de magazines français consacrées à l’intelligence artificielle (IA)&nbsp;:</p><ul>    <li>        Le Nouvel Obs – Titre&nbsp;: «&nbsp;Nos vies sous IA&nbsp;» avec une main robotique tenant une figurine humaine.    </li>    <li> Philosophie Magazine (Hors-série) – Titre&nbsp;: «&nbsp;IA, le mythe du XXIe siècle&nbsp;», avec un visage humain partiellement robotisé.    </li>    <li> Courrier International – Titre&nbsp;: «&nbsp;L’IA en roue libre&nbsp;», illustré d’un cerveau humanoïde aux commandes d’un corps.    </li>    <li> Sciences et Avenir – Titre&nbsp;: «&nbsp;IA, ce qu’elle change&nbsp;», avec une couverture bleue illustrant un réseau neuronal.</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "f9de3bea-9094-4773-9e03-d72127d8f313",
+                "type": "text",
+                "content": "<p>Derrière ces deux lettres, «&nbsp;I&nbsp;» et «&nbsp;A&nbsp;», se cache l'<strong>Intelligence Artificielle</strong>.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a27b96cf-a0a7-45df-866a-313a1bd6caaf",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-frise.html",
+                "instruction": "<p> À votre avis, de quand date l'expression «&nbsp;intelligence artificielle&nbsp;» ?&nbsp;⌛</p>",
+                "height": 325
+              }
+            }
+          ]
+        },
+        {
+          "id": "dbbff46a-197e-4663-950a-81b4f4fa532a",
+          "type": "transition",
+          "title": "Transition - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3c870d58-e8dd-4129-9348-159975b1fc69",
+                "type": "text",
+                "content": "<p>À cause de la récente popularité de chatGPT et d'autres logiciels d'IA générative, on a l’impression que l’IA, c’est nouveau. Mais pas du tout !&nbsp; L’IA, ça date ! 🦣&nbsp;</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0010b969-e9a0-4ed4-957d-5fe365c6ce56",
+          "type": "discovery",
+          "title": "Découverte - 1 : Que peut faire un ordinateur ? ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "937b62e7-c4f5-479a-8e1f-afbe7881fa92",
+                "type": "text",
+                "content": "<p>Et si on regardait plus précisément ce qu'est l'IA ? Pour cela, partons de l’ordinateur !</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4f4ab566-2a26-47bd-9814-cba6ecf2f989",
+                "type": "qab",
+                "instruction": "<p>Selon vous, que peut faire un ordinateur ?</p>",
+                "cards": [
+                  {
+                    "id": "940cf3fa-b3fa-4d89-8551-77ce96474a89",
+                    "text": "Jouer et gagner une partie de jeu d’échec.",
+                    "image": {
+                      "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordiechecs.png",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "a2d89587-3356-4f06-8458-416e6aa7d4dd",
+                    "text": "Dialoguer sur des sujets variés.",
+                    "image": {
+                      "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordidiscut.png",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "fef2a126-7d2d-401e-981c-aaf06317b171",
+                    "text": "Conduire un véhicule en ville.",
+                    "image": {
+                      "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordiconduit.png",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "df9eb3bd-ef3f-4db3-88a6-455e41d08dba",
+                    "text": "Écrire la fin d’une symphonie inachevée.",
+                    "image": {
+                      "url": "https://assets.pix.org/draft/modules/ia-dit-ia/ordimusique.png",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": "<p>Toutes ces actions ont déjà été réalisées par des ordinateurs, grâce à <strong>l’intelligence artificielle</strong>.</p>"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "bd0e1d7a-2538-439e-ab8c-006393e03efb",
+          "type": "lesson",
+          "title": "Leçon - 1 : Que peut faire un ordinateur ? ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d4c2fcb1-74b0-474e-8bda-470c83ced9c2",
+                "type": "text",
+                "content": "<p>Aujourd’hui, les ordinateurs sont capables de réaliser <strong>toutes sortes de tâches</strong>&nbsp;:</p><ul><li>Des tâches que nous faisons sans y penser comme, par exemple, reconnaître un chien dans une image.&nbsp;👀</li><li>Et des tâches qui nous demandent plus de concentration comme, par exemple, résoudre des problèmes de mathématiques.&nbsp;🧠</li></ul><p>Le <strong>domaine scientifique</strong> qui a permis ces progrès est celui de&nbsp;<strong>l’intelligence artificielle</strong>. Les chercheurs en intelligence artificielle étudient comment permettre à des machines d’<strong>imiter les mécanismes de l’intelligence</strong>.&nbsp;🔬</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f141f0e8-4b40-4844-84e6-241b94228547",
+          "type": "transition",
+          "title": "Transition - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6405e82a-354c-4faf-935b-c81953cf9a2c",
+                "type": "text",
+                "content": "<p>Regardons plus en détail les tâches que réalisent les logiciels d’IA aujourd'hui, et dans quels cas on utilise ces logiciels.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c1f654a7-5476-43d7-bf07-22d11b30337a",
+          "type": "discovery",
+          "title": "Découverte - 2 : Où trouver des utilisations de l'IA ? ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8dba133c-906f-4793-939f-015df7d2acce",
+                "type": "text",
+                "content": "<p>Mariam est équipée de nombreux appareils électroniques.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a066ebc9-7f82-439b-85c3-aa2e8686e52a",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-image-interactive.html",
+                "instruction": "<p><strong>Survolez l'image pour explorer son salon pour trouver les appareils et les services qui utilisent des logiciels d'intelligence artificielle.</strong></p>",
+                "height": 520
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "658f3722-cf66-4fe0-9dcc-ee4ce1b6a673",
+                "type": "qrocm",
+                "instruction": "<p>Combien avez-vous trouvé d’utilisations de l’IA ?</p>",
+                "proposals": [
+                  {
+                    "input": "1",
+                    "type": "input",
+                    "inputType": "number",
+                    "size": 1,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "nombre d'utilisation de l'IA",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "solutions": [6]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "",
+                    "diagnosis": "<p>C'est ça ! L'IA est présente dans de nombreux appareils et services du quotidien.&nbsp;</p>"
+                  },
+                  "invalid": {
+                    "state": "",
+                    "diagnosis": "<p>Et non. Dans le salon de Mariam, il y a 6 appareils et services qui utilisent des logiciels d'IA&nbsp;: le thermostat, le service de vidéo à la demande sur la télévision, le logiciel d'IA générative sur l'ordinateur, le robot aspirateur, l'enceinte connectée et le jeu vidéo sur la console.</p>"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "16244191-1e74-4396-b9bd-d27ace391181",
+          "type": "lesson",
+          "title": "Leçon - 2 : Où trouver des utilisations de l'IA",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bfe6d7e1-8282-4a34-a659-c189ea396feb",
+                "type": "text",
+                "content": "<p>De nombreux <strong>appareils et services numériques du quotidien</strong> utilisent des logiciels d’intelligence artificielle.</p><p><br>Certains logiciels sont <strong>spécialisés </strong>dans <strong>un type de tâche</strong>&nbsp;: reconnaître des images, reconnaître des sons, recommander des contenus adaptés à des besoins, prédire des tendances dans des données, etc.&nbsp;🔮</p><p><br>Les logiciels à base d’<strong>IA générative</strong>, comme Le chat, Gemini ou chatGPT, sont capables de réaliser des tâches diverses&nbsp;: traduire des textes, tenir une conversation, résumer des articles, créer une image, programmer, résoudre des problèmes de mathématiques, etc.&nbsp;📝<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7ee0c174-9a2b-413c-adee-682dc5ed1c70",
+          "type": "discovery",
+          "title": "Découverte - 3 : IA et secteurs d'activité",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a2b1291d-6043-4582-ac69-337835330c07",
+                "type": "text",
+                "content": "<p>L’IA est aussi utilisée dans des secteurs d’activité professionnelle.<br>Voyons l'exemple de<strong> la reconnaissance d’image</strong>.&nbsp;🔎🖼️</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c4a0562d-60f8-48b3-8489-2c8c195597b8",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-dit-ia-cartes.html",
+                "instruction": "<p>Retournez les cartes ci-dessous pour des exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité.</p>",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "fdf3c015-b354-4f35-a463-76cfc0de4b03",
+          "type": "lesson",
+          "title": "Leçon - 3 : IA et secteurs d'activité",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1bf335c7-a606-4e65-aa36-07adf42d3b6f",
+                "type": "text",
+                "content": "<p>L’intelligence artificielle est utilisée dans tous les secteurs d’activité&nbsp;: l’agriculture,&nbsp; la culture, l’éducation, la finance, l’industrie, le loisir, la santé, la science, la sécurité, le transport, etc.</p><p><br><strong>💡 Parfois, l'utilisation de l'intelligence artificielle permet de faire des découvertes ou des progrès importants</strong>. Par exemple&nbsp;:&nbsp;</p><ul><li>Certaines maladies comme les cancers sont mieux dépistées depuis qu'on utilise l'IA pour détecter les tumeurs.</li><li>Les effets du changement climatique sont mieux compris depuis qu'on utilise l'IA pour analyser ses impacts.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2b67c7bb-cda3-4923-9c3b-4225e082bc57",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "715a385e-dcfb-4001-9e5d-5b00ab365221",
+                "type": "text",
+                "content": "<p>Voici les points principaux à retenir&nbsp;:&nbsp;</p><ul><li><strong>L’intelligence artificielle est un domaine scientifique</strong> qui étudie comment permettre à des machines d’imiter les mécanismes de l’intelligence pour réaliser toutes sortes de tâches.&nbsp;🔬</li><li><strong>Certains logiciels d’IA sont spécialisés dans un type de tâche</strong>. D'autres comme <strong>les IA génératives réalisent différentes tâches</strong>.&nbsp;👩‍💻</li><li>Les logiciels d’IA sont utilisés dans <strong>des appareils et services de notre quotidien</strong>.&nbsp;📱</li><li>L’utilisation de l’IA  permet de faire de nombreux <strong>progrès scientifiques</strong>.&nbsp;📈</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7a4f925d-782c-40aa-812c-01278b60caee",
+          "type": "activity",
+          "title": "Activité d'application - 1 : Vrai ou faux ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0fea05ff-8378-40b9-b078-ee55015dc1e6",
+                "type": "text",
+                "content": "<p>Voyons si vous avez retenu l'essentiel.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c9da5d5a-e701-4883-9649-38e0a849a01f",
+                "type": "qab",
+                "instruction": "<p>Répondez aux affirmations suivantes.</p>",
+                "cards": [
+                  {
+                    "id": "38e4c2ef-7b29-48ad-8caa-107f6c41a8e3",
+                    "text": "L’IA, c’est récent, ça date de chatGPT.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "52347fb2-5242-4334-b30b-7b7af18a7fe1",
+                    "text": "L’intelligence artificielle est un domaine scientifique.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "0c3e3cbb-68a7-46d4-a9d6-5afd7e92ee2d",
+                    "text": "Certains services en ligne utilisent l’IA pour recommander des contenus.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "bad09d31-f94a-4493-889d-889f5199ca0c",
+                    "text": "Un logiciel d’intelligence artificielle sait tout faire.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "24445c57-5f45-4ead-8767-936c43913403",
+          "type": "activity",
+          "title": " Activité d'application - 2 : Types d'IA",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b2dc8d40-47cd-4f67-af34-b66ef6506b57",
+                "type": "text",
+                "content": "<p>Identifiez dans quel type de tâche sont spécialisées les IA utilisées dans les situations suivantes.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "e67d64c3-9912-4046-9f03-46059c51247c",
-                  "type": "qcu",
-                  "instruction": "<h4>📷 🏷️ Un logiciel ajoute automatiquement des mots clés à des photographies.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>la reconnaissance du son</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, ce n’est pas un son que l’IA doit savoir reconnaître.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>la reconnaissance d’image</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Les IA spécialisées dans la reconnaissance d’image sont notamment très utilisées dans le commerce en ligne pour taguer automatiquement des produits.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>la recommandation de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, pas de recommandation de contenu. L’ia doit savoir identifier quelque chose.</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>la génération de contenu</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ici, pas de génération de contenu. L’IA doit savoir identifier quelque chose.</p>"
-                      }
+                      "id": "05a30b10-ac62-40a5-961b-9f3f3e831da0",
+                      "type": "qcu",
+                      "instruction": "<h4>🗣️ 🎤 Une application retrouve le titre d'une musique que vous lui chantez.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la reconnaissance du son</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>De nombreuses applications proposent aujourd’hui de retrouver le titre d’une musique à partir de quelques secondes de son ou de voix.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>la reconnaissance d’image</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, ce n’est pas une image que l’IA doit savoir reconnaître.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>la recommandation de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, pas de recommandation de contenu. L’IA doit savoir identifier quelque chose.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>la génération de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, pas de génération de contenu. L’ia doit savoir identifier quelque chose.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "d6644a42-0b76-4e9c-8595-43c2da89cb9b",
+                      "type": "qcu",
+                      "instruction": "<h4>🎬 ▶️ Un site vous propose de nouveaux contenus suite au visionnage d’une vidéo.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la reconnaissance du son</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, il ne s’agit pas d’identifier quelque chose, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>la reconnaissance d’image</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, il ne s’agit pas d’identifier quelque chose, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>la recommandation de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Les IA spécialisées dans la recommandation de contenus sont largement utilisées pour personnaliser les expériences utilisateurs sur les plateformes numériques, par exemple les services de vidéos à la demande.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>la génération de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, il ne s’agit pas de produire de nouveaux contenus, mais de proposer des contenus en fonction du profil d’un utilisateur.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "e67d64c3-9912-4046-9f03-46059c51247c",
+                      "type": "qcu",
+                      "instruction": "<h4>📷 🏷️ Un logiciel ajoute automatiquement des mots clés à des photographies.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>la reconnaissance du son</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, ce n’est pas un son que l’IA doit savoir reconnaître.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>la reconnaissance d’image</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Les IA spécialisées dans la reconnaissance d’image sont notamment très utilisées dans le commerce en ligne pour taguer automatiquement des produits.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>la recommandation de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, pas de recommandation de contenu. L’ia doit savoir identifier quelque chose.</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>la génération de contenu</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ici, pas de génération de contenu. L’IA doit savoir identifier quelque chose.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "6589bd5c-b120-4f5f-a089-62922f54de59",
-      "type": "activity",
-      "title": "Transfert",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "7289c873-1f53-4e62-8ed0-5462618547dd",
-            "type": "qcu-declarative",
-            "instruction": "<p>Maintenant, vous en savez plus sur ce qu'est l'intelligence artificielle.<br>Dans votre quotidien, utilisez-vous des appareils avec de l’intelligence artificielle ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "diagnosis": "<p>Pas étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "diagnosis": "<p>Étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>J'hésite.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Vous n'êtes pas sûr, mais il y a de grandes chances que ce soit le cas. &nbsp;L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
-                }
+          "id": "6589bd5c-b120-4f5f-a089-62922f54de59",
+          "type": "activity",
+          "title": "Transfert",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7289c873-1f53-4e62-8ed0-5462618547dd",
+                "type": "qcu-declarative",
+                "instruction": "<p>Maintenant, vous en savez plus sur ce qu'est l'intelligence artificielle.<br>Dans votre quotidien, utilisez-vous des appareils avec de l’intelligence artificielle ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Pas étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Étonnant ! L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>J'hésite.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Vous n'êtes pas sûr, mais il y a de grandes chances que ce soit le cas. &nbsp;L'intelligence artificielle est présente&nbsp;dans de nombreux appareils et services de notre quotidien.</p>"
+                    }
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
@@ -15,896 +15,902 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "545e7548-7ab7-4cfa-924e-2c683ee69c2a",
-      "type": "discovery",
-      "title": "Accroche",
-      "components": [
+      "id": "4cfda631-617e-4c41-a338-0029aedada5d",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "3253ef34-0f94-4d65-aa02-a710b0969020",
-            "type": "text",
-            "content": "<p>Nathan a utilisé un logiciel d’IA générative pour préparer une sortie pour l'anniversaire de sa sœur. Il n’est pas content du résultat. Voici sa discussion avec son amie, Asma&nbsp;:</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "35c7d03b-8c62-40e6-a31d-5111e8dcc46a",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Nathan et Asma",
-              "messages": [
-                {
-                  "userName": "Nathan",
-                  "direction": "outgoing",
-                  "content": "Oh la la ! Je suis dégoûté… 😩"
-                },
-                {
-                  "userName": "Asma",
-                  "direction": "incoming",
-                  "content": "Bah pourquoi ? Qu’est-ce qui t’arrive ? 😟"
-                },
-                {
-                  "userName": "Nathan",
-                  "direction": "outgoing",
-                  "content": "Je me suis servi de ChatGPT pour préparer la soirée d'anniversaire de ma sœur, mais ça a été la catastrophe... Elle veut plus me parler !"
-                },
-                {
-                  "userName": "Asma",
-                  "direction": "incoming",
-                  "content": "À cause de ChatGPT ? 🙁"
-                },
-                {
-                  "userName": "Nathan",
-                  "direction": "outgoing",
-                  "content": " Oui ! J’ai demandé à ChatGPT de trouver une salle d'arcades pour se retrouver là-bas samedi soir... Mais une fois arrivés à l'adresse donnée par ChatGPT, c'était une agence immobilière. 😤"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "275886f3-8af7-48b1-bf0d-01a5dd8c1619",
-      "type": "transition",
-      "title": "Transition - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "659f8b1c-5e64-44f3-ae18-0fc89e093fa1",
-            "type": "text",
-            "content": "<p>Nathan n’est pas le premier à recevoir une information fausse de la part d’un logiciel d'IA générative…<br> Les IA génératives font-elles vraiment des erreurs ? 🤨</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1c338346-67e9-48b3-a9c1-f704ba38389b",
-      "type": "discovery",
-      "title": "Activité découverte - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3147aedb-8fc2-4510-aad8-fa7f35e77dd7",
-            "type": "text",
-            "content": "<p>Découvrez ci-dessous plusieurs exemples de réponses données par des logiciels d'IA générative. Ces exemples sont inspirés de réponses réelles.<br>Dans certains cas, le logiciel d'IA générative donne une réponse juste, dans d'autres, il donne une réponse contenant des erreurs.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "44ab1d9c-5cad-4bec-81ea-416dfd913635",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-hallu-carousel.html",
-            "instruction": "<p>Pour chacun des exemples, indiquez votre niveau de confiance en la réponse donnée par un logiciel d'IA générative en cliquant sur la jauge.<br>Il ne s'agit pas de deviner si la réponse donnée est juste ou non.</p>",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "be1e7402-03dc-41d4-b688-f14631793661",
-      "type": "lesson",
-      "title": "Leçon - 1 ",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "545e7548-7ab7-4cfa-924e-2c683ee69c2a",
+          "type": "discovery",
+          "title": "Accroche",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "0e9f94cd-7236-4f68-a50e-b079cc0f9c9d",
-                  "type": "text",
-                  "content": "<p>L'IA générative peut faire des erreurs. Elle peut <strong>générer des affirmations fausses ou erronées et les présenter comme des faits, de vraies informations</strong>.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "3253ef34-0f94-4d65-aa02-a710b0969020",
+                "type": "text",
+                "content": "<p>Nathan a utilisé un logiciel d’IA générative pour préparer une sortie pour l'anniversaire de sa sœur. Il n’est pas content du résultat. Voici sa discussion avec son amie, Asma&nbsp;:</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "f51cf525-1be0-4a0b-8a88-13e7d5af0f9d",
-                  "type": "text",
-                  "content": "<p>L’IA générative peut, par exemple, donner une mauvaise date, inventer des événements, faire une erreur mathématique ou indiquer une information scientifique fausse.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "03c80544-03eb-4d77-a592-f91c68ecb91a",
-                  "type": "text",
-                  "content": "<p><strong>Les réponses des IA génératives</strong> sont souvent bien écrites et vraisemblables, présentées avec assurance&nbsp;: elles<strong> inspirent confiance</strong>.&nbsp;C’est pourquoi il n'est<strong> pas facile de repérer les erreurs</strong> des IA génératives. 🔎</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "9533c53b-ac7a-41f5-819b-b36890024108",
-      "type": "transition",
-      "title": "Transition - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "dfbdf13e-7d02-464b-a8b7-29fa03a35c51",
-            "type": "text",
-            "content": "<p>Vous savez à présent que les IA génératives peuvent faire des erreurs. Mais pourquoi ces erreurs existent-elles ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "eaa1a776-2d39-460c-8642-5a43ab6093e1",
-      "type": "discovery",
-      "title": "Activité découverte - 2",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "8a46c2ba-91ac-4e36-9007-094a7ef6a871",
-                  "type": "text",
-                  "content": "<p>Irène sait que le joueur de tennis Carlos Alcaraz a gagné deux fois le tournoi de Roland-Garros. Mais elle a un doute sur ses années de victoire.<br>Voici sa conversation avec un logiciel d’IA générative&nbsp;:</p>"
-                },
-                {
-                  "id": "f4df02e1-bebf-4557-9226-18e38cfbb6b2",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/hallucinations/capturetennis.png",
-                  "alt": "Capture d'écran d'une conversation avec un logiciel d'IA générative décrit dans l'alternative textuelle",
-                  "alternativeText": "",
-                  "legend": "",
-                  "licence": ""
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "21e1f6a8-8ea2-4b0c-8a6c-e68a1f875920",
-                  "type": "text",
-                  "content": "<p>Ici le logiciel d’IA générative a fait une erreur. Carlos Alcaraz a bien remporté le tournoi de Roland-Garros deux fois&nbsp;: une fois en 2024 et une fois en 2025.</p>"
-                },
-                {
-                  "id": "ceed2a7c-76f9-44f1-be34-a2285cd1aa4d",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>À votre avis, qu’est ce qui peut expliquer l’erreur du logiciel d’IA générative ?</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "35c7d03b-8c62-40e6-a31d-5111e8dcc46a",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Nathan et Asma",
+                  "messages": [
                     {
-                      "id": "1",
-                      "content": "<p>L'ordinateur d’Irène n'est pas assez puissant, il a provoqué un bug.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, la réponse donnée par le logiciel d'IA générative ne dépend pas de la puissance de l'ordinateur d'Irène. <br>Par contre, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
-                      }
+                      "userName": "Nathan",
+                      "direction": "outgoing",
+                      "content": "Oh la la ! Je suis dégoûté… 😩"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Les données avec lesquelles le logiciel a été entraîné datent d’avant 2025.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Effectivement, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
-                      }
+                      "userName": "Asma",
+                      "direction": "incoming",
+                      "content": "Bah pourquoi ? Qu’est-ce qui t’arrive ? 😟"
                     },
                     {
-                      "id": "3",
-                      "content": "<p>Le logiciel ne compte pas la victoire de 2025 car il était pour l’autre finaliste, Jannik Sinner.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, le logiciel d'IA générative n'a pas de préférence pour un joueur plutôt qu'un autre. <br>Par contre, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
-                      }
+                      "userName": "Nathan",
+                      "direction": "outgoing",
+                      "content": "Je me suis servi de ChatGPT pour préparer la soirée d'anniversaire de ma sœur, mais ça a été la catastrophe... Elle veut plus me parler !"
+                    },
+                    {
+                      "userName": "Asma",
+                      "direction": "incoming",
+                      "content": "À cause de ChatGPT ? 🙁"
+                    },
+                    {
+                      "userName": "Nathan",
+                      "direction": "outgoing",
+                      "content": " Oui ! J’ai demandé à ChatGPT de trouver une salle d'arcades pour se retrouver là-bas samedi soir... Mais une fois arrivés à l'adresse donnée par ChatGPT, c'était une agence immobilière. 😤"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "275886f3-8af7-48b1-bf0d-01a5dd8c1619",
+          "type": "transition",
+          "title": "Transition - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "659f8b1c-5e64-44f3-ae18-0fc89e093fa1",
+                "type": "text",
+                "content": "<p>Nathan n’est pas le premier à recevoir une information fausse de la part d’un logiciel d'IA générative…<br> Les IA génératives font-elles vraiment des erreurs ? 🤨</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1c338346-67e9-48b3-a9c1-f704ba38389b",
+          "type": "discovery",
+          "title": "Activité découverte - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3147aedb-8fc2-4510-aad8-fa7f35e77dd7",
+                "type": "text",
+                "content": "<p>Découvrez ci-dessous plusieurs exemples de réponses données par des logiciels d'IA générative. Ces exemples sont inspirés de réponses réelles.<br>Dans certains cas, le logiciel d'IA générative donne une réponse juste, dans d'autres, il donne une réponse contenant des erreurs.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "44ab1d9c-5cad-4bec-81ea-416dfd913635",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/LSI/ia-hallu-carousel.html",
+                "instruction": "<p>Pour chacun des exemples, indiquez votre niveau de confiance en la réponse donnée par un logiciel d'IA générative en cliquant sur la jauge.<br>Il ne s'agit pas de deviner si la réponse donnée est juste ou non.</p>",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "be1e7402-03dc-41d4-b688-f14631793661",
+          "type": "lesson",
+          "title": "Leçon - 1 ",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "0e9f94cd-7236-4f68-a50e-b079cc0f9c9d",
+                      "type": "text",
+                      "content": "<p>L'IA générative peut faire des erreurs. Elle peut <strong>générer des affirmations fausses ou erronées et les présenter comme des faits, de vraies informations</strong>.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "f51cf525-1be0-4a0b-8a88-13e7d5af0f9d",
+                      "type": "text",
+                      "content": "<p>L’IA générative peut, par exemple, donner une mauvaise date, inventer des événements, faire une erreur mathématique ou indiquer une information scientifique fausse.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "03c80544-03eb-4d77-a592-f91c68ecb91a",
+                      "type": "text",
+                      "content": "<p><strong>Les réponses des IA génératives</strong> sont souvent bien écrites et vraisemblables, présentées avec assurance&nbsp;: elles<strong> inspirent confiance</strong>.&nbsp;C’est pourquoi il n'est<strong> pas facile de repérer les erreurs</strong> des IA génératives. 🔎</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "c3e770fb-f410-4b3a-9be6-465e0bba410a",
-      "type": "lesson",
-      "title": "Leçon - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f4ed67e2-662f-4f88-8730-d6e3669c6f0a",
-            "type": "text",
-            "content": "<p>Une IA générative a été conçue pour <strong>répondre aux demandes des utilisateurs</strong>, pas pour dire la vérité !</p>"
-          }
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "9533c53b-ac7a-41f5-819b-b36890024108",
+          "type": "transition",
+          "title": "Transition - 2",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "52714cef-23e1-49d0-99ed-19880ba569ca",
-                  "type": "text",
-                  "content": "<p>Certaines erreurs dans les réponses des IA génératives viennent des données qu’on leur a transmises pour s’entraîner. Les <strong>données d'entraînement </strong>peuvent contenir <strong>des erreurs ou ne&nbsp;</strong><strong>plus être d’actualité</strong>.</p>"
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "dfbdf13e-7d02-464b-a8b7-29fa03a35c51",
+                "type": "text",
+                "content": "<p>Vous savez à présent que les IA génératives peuvent faire des erreurs. Mais pourquoi ces erreurs existent-elles ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "eaa1a776-2d39-460c-8642-5a43ab6093e1",
+          "type": "discovery",
+          "title": "Activité découverte - 2",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "a2f3a3ca-b439-472e-86bb-69af0c01f178",
-                  "type": "text",
-                  "content": "<p>D’autres erreurs sont inventées par l’IA. L’IA générative répond souvent  «&nbsp;sans savoir&nbsp;» et <strong>par prédiction</strong>&nbsp;: elle génère la réponse qui lui paraît la plus probable. On appelle ces erreurs <strong>des hallucinations</strong>.<br>Par exemple, quand on demande à un logiciel d’IA générative de nous donner l’auteur d’une citation, il peut l’attribuer à quelqu’un d’autre. 🤷</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "7c22a815-14fb-4bba-aa7f-d292f9708aaf",
-                  "type": "text",
-                  "content": "<p>Certaines <strong>demandes d’utilisateurs</strong> peuvent <strong>contenir des erreurs ou être farfelues</strong>.<br>Par exemple, en 2024 ChatGPT a répondu à la question «&nbsp;Quel est le record du monde de traversée de la Manche à pied ?&nbsp;» en citant un nageur allemand et en inventant un temps de 14 heures et 51 minutes.</p>"
+                  "elements": [
+                    {
+                      "id": "8a46c2ba-91ac-4e36-9007-094a7ef6a871",
+                      "type": "text",
+                      "content": "<p>Irène sait que le joueur de tennis Carlos Alcaraz a gagné deux fois le tournoi de Roland-Garros. Mais elle a un doute sur ses années de victoire.<br>Voici sa conversation avec un logiciel d’IA générative&nbsp;:</p>"
+                    },
+                    {
+                      "id": "f4df02e1-bebf-4557-9226-18e38cfbb6b2",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/hallucinations/capturetennis.png",
+                      "alt": "Capture d'écran d'une conversation avec un logiciel d'IA générative décrit dans l'alternative textuelle",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
+                    }
+                  ]
                 },
                 {
-                  "id": "dfbbd712-d034-4c91-819a-4431aec8beb2",
-                  "type": "text",
-                  "content": "<p>🤔<strong> Bon à savoir</strong> <br>Les IA génératives sont aussi capables d’inventer des choses, à la demande des utilisateurs (écrire un poème, dessiner une vache rose). Dans ce cas, ce ne sont pas des erreurs !</p>"
+                  "elements": [
+                    {
+                      "id": "21e1f6a8-8ea2-4b0c-8a6c-e68a1f875920",
+                      "type": "text",
+                      "content": "<p>Ici le logiciel d’IA générative a fait une erreur. Carlos Alcaraz a bien remporté le tournoi de Roland-Garros deux fois&nbsp;: une fois en 2024 et une fois en 2025.</p>"
+                    },
+                    {
+                      "id": "ceed2a7c-76f9-44f1-be34-a2285cd1aa4d",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>À votre avis, qu’est ce qui peut expliquer l’erreur du logiciel d’IA générative ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>L'ordinateur d’Irène n'est pas assez puissant, il a provoqué un bug.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, la réponse donnée par le logiciel d'IA générative ne dépend pas de la puissance de l'ordinateur d'Irène. <br>Par contre, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Les données avec lesquelles le logiciel a été entraîné datent d’avant 2025.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Effectivement, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Le logiciel ne compte pas la victoire de 2025 car il était pour l’autre finaliste, Jannik Sinner.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, le logiciel d'IA générative n'a pas de préférence pour un joueur plutôt qu'un autre. <br>Par contre, l'erreur peut venir des données avec lesquelles le logiciel a été entraîné. Si ces données datent d'avant 2025, le logiciel ne connaît qu'une seule victoire de Carlos Alcaraz à Roland-Garros.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "7702cae5-8666-4e9c-800d-bba765aac882",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8456e440-7043-4a73-aac3-bd7de3f44dcc",
-            "type": "text",
-            "content": "<p>Les IA génératives peuvent faire des erreurs.<br>Mais que font les développeurs d’IA génératives pour empêcher ça ? 😱</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "586a05db-64a4-447b-861e-344d4fe87863",
-      "type": "discovery",
-      "title": "Activité découverte - 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "337317e2-a1cf-471b-8182-4914fa6b7360",
-            "type": "text",
-            "content": "<p>Au fil du temps, la réponse d'un logiciel d'IA générative à une même question peut évoluer.<br>Observez les deux discussions ci-dessous et répondez à la question.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "4a6674be-8c5a-4c01-852e-ccc1c9c80138",
-            "type": "custom",
-            "tagName": "llm-compare-messages",
-            "props": {
-              "conversation1": {
-                "title": "ChatGPT version 3 - Février 2023",
-                "llmName": "ChatGPT"
-              },
-              "conversation2": {
-                "title": "ChatGPT version 4o - Juillet 2025",
-                "llmName": "ChatGPT"
-              },
-              "userName": "Utilisateur",
-              "messages": [
+          "id": "c3e770fb-f410-4b3a-9be6-465e0bba410a",
+          "type": "lesson",
+          "title": "Leçon - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f4ed67e2-662f-4f88-8730-d6e3669c6f0a",
+                "type": "text",
+                "content": "<p>Une IA générative a été conçue pour <strong>répondre aux demandes des utilisateurs</strong>, pas pour dire la vérité !</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "direction": "outbound",
-                  "content": "Combien il y a de pays qui commencent par la lettre « V » ?"
+                  "elements": [
+                    {
+                      "id": "52714cef-23e1-49d0-99ed-19880ba569ca",
+                      "type": "text",
+                      "content": "<p>Certaines erreurs dans les réponses des IA génératives viennent des données qu’on leur a transmises pour s’entraîner. Les <strong>données d'entraînement </strong>peuvent contenir <strong>des erreurs ou ne&nbsp;</strong><strong>plus être d’actualité</strong>.</p>"
+                    }
+                  ]
                 },
-                [
+                {
+                  "elements": [
+                    {
+                      "id": "a2f3a3ca-b439-472e-86bb-69af0c01f178",
+                      "type": "text",
+                      "content": "<p>D’autres erreurs sont inventées par l’IA. L’IA générative répond souvent  «&nbsp;sans savoir&nbsp;» et <strong>par prédiction</strong>&nbsp;: elle génère la réponse qui lui paraît la plus probable. On appelle ces erreurs <strong>des hallucinations</strong>.<br>Par exemple, quand on demande à un logiciel d’IA générative de nous donner l’auteur d’une citation, il peut l’attribuer à quelqu’un d’autre. 🤷</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7c22a815-14fb-4bba-aa7f-d292f9708aaf",
+                      "type": "text",
+                      "content": "<p>Certaines <strong>demandes d’utilisateurs</strong> peuvent <strong>contenir des erreurs ou être farfelues</strong>.<br>Par exemple, en 2024 ChatGPT a répondu à la question «&nbsp;Quel est le record du monde de traversée de la Manche à pied ?&nbsp;» en citant un nageur allemand et en inventant un temps de 14 heures et 51 minutes.</p>"
+                    },
+                    {
+                      "id": "dfbbd712-d034-4c91-819a-4431aec8beb2",
+                      "type": "text",
+                      "content": "<p>🤔<strong> Bon à savoir</strong> <br>Les IA génératives sont aussi capables d’inventer des choses, à la demande des utilisateurs (écrire un poème, dessiner une vache rose). Dans ce cas, ce ne sont pas des erreurs !</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "7702cae5-8666-4e9c-800d-bba765aac882",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8456e440-7043-4a73-aac3-bd7de3f44dcc",
+                "type": "text",
+                "content": "<p>Les IA génératives peuvent faire des erreurs.<br>Mais que font les développeurs d’IA génératives pour empêcher ça ? 😱</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "586a05db-64a4-447b-861e-344d4fe87863",
+          "type": "discovery",
+          "title": "Activité découverte - 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "337317e2-a1cf-471b-8182-4914fa6b7360",
+                "type": "text",
+                "content": "<p>Au fil du temps, la réponse d'un logiciel d'IA générative à une même question peut évoluer.<br>Observez les deux discussions ci-dessous et répondez à la question.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4a6674be-8c5a-4c01-852e-ccc1c9c80138",
+                "type": "custom",
+                "tagName": "llm-compare-messages",
+                "props": {
+                  "conversation1": {
+                    "title": "ChatGPT version 3 - Février 2023",
+                    "llmName": "ChatGPT"
+                  },
+                  "conversation2": {
+                    "title": "ChatGPT version 4o - Juillet 2025",
+                    "llmName": "ChatGPT"
+                  },
+                  "userName": "Utilisateur",
+                  "messages": [
+                    {
+                      "direction": "outbound",
+                      "content": "Combien il y a de pays qui commencent par la lettre « V » ?"
+                    },
+                    [
+                      {
+                        "direction": "inbound",
+                        "content": "Il n'y a aucun pays qui commence par la lettre « V ». "
+                      },
+                      {
+                        "direction": "inbound",
+                        "content": "Il y a 4 pays dont le nom commence par la lettre « V » : <ul><li>Vanuatu</li><li>Vatican</li><li>Venezuela</li><li>Vietnam</li></ul> "
+                      }
+                    ]
+                  ]
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c28617dd-2134-4551-8157-b7beef89ab35",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, pourquoi y a-t-il une différence entre les réponses de ChatPT 3 et de ChatGPT 4o ?</p>",
+                "proposals": [
                   {
-                    "direction": "inbound",
-                    "content": "Il n'y a aucun pays qui commence par la lettre « V ». "
+                    "id": "1",
+                    "content": "<p>ChatGPT 3 n’était pas encore disponible dans ces 4 pays, il ne les a pas comptés.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
+                    }
                   },
                   {
-                    "direction": "inbound",
-                    "content": "Il y a 4 pays dont le nom commence par la lettre « V » : <ul><li>Vanuatu</li><li>Vatican</li><li>Venezuela</li><li>Vietnam</li></ul> "
+                    "id": "2",
+                    "content": "<p>En 2023, il n’y avait aucun pays commençant par la lettre V.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>L’erreur a été corrigée avec la mise à jour de ChatGPT 4.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Efefctivement, les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6ad583ab-11b2-4530-a663-75544292108a",
+          "type": "lesson",
+          "title": "Leçon - 3",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "36e95488-a2db-4463-9b0f-5d5252cb38b2",
+                      "type": "text",
+                      "content": "<p>Grâce à des mises à jour régulières, les ingénieurs essaient en continu de <strong>réduire les erreurs</strong> que les IA génératives produisent. Ainsi, les IA génératives <strong>s’améliorent d’années en années</strong> !</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "5360a6aa-999e-4d02-b3cb-20421fae3ab2",
+                      "type": "text",
+                      "content": "<p>Mais, c’est une <strong>tâche difficile</strong>&nbsp;:&nbsp;il n'y a pas de différence de forme entre une réponse contenant une erreur et une qui n'en contient pas. <br>Il n’existe donc <strong>pas de méthode technique pour détecter les erreurs </strong>et les éviter complètement.</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "99d91ba2-5d1e-4a2d-92ef-4e61219a903e",
+          "type": "transition",
+          "title": "Transition - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "af12a991-ef36-4557-bd5b-d9f668bdcf33",
+                "type": "text",
+                "content": "<p>Mais alors, si les IA génératives font des erreurs que les développeurs ne peuvent pas corriger, que peut faire un utilisateur ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "eff7343b-ae10-44d7-9113-710a43ece810",
+          "type": "discovery",
+          "title": "Activité découverte - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ecffdbbe-78c7-4da7-9b7d-2426eb9daf3c",
+                "type": "text",
+                "content": "<p>Depuis sa dernière utilisation de l'IA, Nathan n'utilise plus l'IA générative. Asma veut laisser encore une chance à l'IA, mais pour elle, pas question de se laisser avoir !&nbsp;<br>Pour la préparation d'un document important, elle interroge un logiciel d'IA générative.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0b9a3ac4-f723-45ea-bfcd-c31200474bee",
+                "type": "text",
+                "content": "<p><strong>Parmi les réactions suivantes, sélectionnez s’il s’agit d’un bon réflexe ou d’un mauvais réflexe pour Asma face à la réponse du logiciel d'IA générative.</strong></p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "81eb63dc-b909-461d-bea3-e32cf2637240",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Réflexe 1&nbsp;: Asma copie et colle la réponse du logiciel d'IA générative dans son document, sans la lire.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>bon réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, c'est un mauvais réflexe ! Il faut toujours lire l’ensemble des réponses données par un logiciel d’IA générative.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>mauvais réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et oui, c'est un mauvais réflexe ! Il faut toujours lire l’ensemble des réponses données par un logiciel d’IA générative.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "079936fa-826a-46da-903c-32dfd0089327",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Réflexe 2&nbsp;:&nbsp;Asma lit toute la réponse et s’interroge sur une partie de la réponse de l'IA. Elle demande au logiciel d'IA générative de préciser sa réponse en donnant sa source.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>bon réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et oui, c'est un bon réflexe ! Poursuivre la discussion avec l’IA permet parfois d’avoir une réponse plus claire ou même une correction.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>mauvais réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, c'est un bon réflexe ! Poursuivre la discussion avec l’IA permet parfois d’avoir une réponse plus claire ou même une correction.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "ff81face-e51c-4bf6-8b49-50c9abd5cfdd",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Réflexe 3&nbsp;: Asma cherche la source de l’information sur internet pour comparer avec l’information donnée par le logiciel d'IA générative.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>bon réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et oui, c'est un bon réflexe ! Dans tous les cas, vérifier et croiser les sources permet d’éviter de relayer une erreur ou une fausse information.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>mauvais réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, c'est bon réflexe ! Dans tous les cas, vérifier et croiser les sources permet d’éviter de relayer une erreur ou une fausse information.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "0aa2dee4-60a8-4ab7-8390-0ca87779414c",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Réflexe 4&nbsp;:&nbsp;Asma lit en entier la réponse donnée par le logiciel d'IA générative. Elle la trouve très bien écrite et l’utilise dans son document.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>bon réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non, c'est un mauvais réflexe ! Une réponse bien écrite n’est pas forcément correcte. Il faut garder un regard critique, même quand le ton est convaincant.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>mauvais réflexe</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et oui, c'est un mauvais réflexe ! Une réponse bien écrite n’est pas forcément correcte. Il faut garder un regard critique, même quand le ton est convaincant.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "25aa32f6-954f-4032-98db-6659ac47a66e",
+          "type": "lesson",
+          "title": "Leçon - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3a72064b-2d02-47ef-b524-18d51dcc6be8",
+                "type": "text",
+                "content": "<p>Il faut toujours garder en tête qu’une IA générative peut faire une erreur ou halluciner dans ses réponses. Mais vous pouvez apprendre à repérer ces erreurs… à condition d’adopter les bons réflexes&nbsp;:</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "491608fe-ec87-4e10-b98a-c1c6f67a500c",
+                      "type": "text",
+                      "content": "<p>🔍 Avoir un <strong>regard critique</strong> sur les réponses de l’IA générative et se poser des questions sur ce qu'on lit.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "910d0bec-69e4-4a7f-818c-eab90643959b",
+                      "type": "text",
+                      "content": "<p>📖 Prendre le temps de <strong>lire les réponses en entier</strong>. Parfois, l’erreur ne saute pas aux yeux. Elle peut se cacher dans un détail&nbsp;: une date, un chiffre, un exemple, etc.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "495a2819-756c-415c-993d-ad37eaa4fecf",
+                      "type": "text",
+                      "content": "<p>🧭&nbsp;<strong>Vérifier les informations </strong> en les comparant avec d’autres sources.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "eba1acf6-d04c-4d74-85a0-05b4a9dc488f",
+                      "type": "text",
+                      "content": "<p>💬 <strong>Poursuivre la discussion</strong>. Si vous détectez une erreur dans la réponse d’une IA générative, vous pouvez lui signaler et lui demander de se corriger.</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "987668e7-59a9-438d-ad54-4723abc701d8",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d889292f-a892-4ad8-b7e8-0ef529fe13cf",
+                "type": "text",
+                "content": "<ul><li>L'objectif d’une <strong>IA générative</strong> est de répondre aux demandes d’un utilisateur. <strong>Son objectif n’est pas de dire la vérité</strong>. 🤥</li><br><li>Une <strong>IA générative peut faire des erreurs</strong>, par exemple présenter des affirmations fausses comme vraies. ❌</li><br><li>Les développeurs d’IA génératives essaient de réduire les erreurs. Mais il n’existe <strong>pas de moyen technique pour empêcher complètement ces erreurs.</strong> 🔧</li><br><li>Face à ces erreurs, difficiles à détecter, c’est à l’utilisateur de <strong>faire preuve d’esprit critique</strong> et de <strong>croiser les sources</strong> d’informations pour les vérifier. 🔎</li><br></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a5db0e26-49fc-457c-943a-cc24d3aa1551",
+          "type": "activity",
+          "title": "Activité d'application - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1700c207-060a-416d-9f0d-033518299509",
+                "type": "qab",
+                "instruction": "<p>Pour chacune des affirmations suivantes, indiquez si elle est vraie ou fausse.</p>",
+                "cards": [
+                  {
+                    "id": "59dcf865-08c0-4110-90bf-99c3acff78b7",
+                    "text": "Un logiciel d’IA générative peut faire des erreurs.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "1e2967ec-943a-4687-b2c7-a6056004452c",
+                    "text": "Si un logiciel d’IA générative fait une erreur, il suffit de continuer la conversation pour qu’elle se corrige automatiquement.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "eeea3baf-f5fb-4ed1-8831-52a2f1f0323f",
+                    "text": "Quand un logiciel d’IA générative est sûr de sa réponse, il le précise dans sa réponse.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "72527d55-9757-4b17-b2b3-c47e27873893",
+                    "text": "Si un logiciel d’IA générative affirme quelque chose, il vaut mieux le vérifier avec d’autres sources.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "32646287-4172-4919-b6d5-c1813adb13e3",
+          "type": "activity",
+          "title": "Activité d'application - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ac09a36f-6446-4ced-9c4b-8ab544e113d9",
+                "type": "text",
+                "content": "<p>Voici ci-dessous des exemples d’erreurs dans des réponses données par des logiciels d’IA génératives. Pour chaque exemple, indiquez quelle est la source d'erreur correspondante.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "95d84a4d-2ee5-4e6a-96b6-de148a586781",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia5-Djoko.jpg",
+                      "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
+                      "alternativeText": "<p>Question utilisateur&nbsp;: Comment va le tennisman Djokovic ?</p><p>Réponse du logiciel d'IA générative&nbsp;: Novak Djokovic va bien, il continue de performer à un niveau très élevé sur le circuit ATP. Ses récents résultats montrent qu'il reste l'un des meilleurs joueurs du monde. Il a eu quelques problèmes de santé et des blessures par le passé, mais il semble s'être bien rétabli.</p>",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "4973d664-0caf-4e10-9ea9-7fae95bf0164",
+                      "type": "text",
+                      "content": "<p>Léonie a vérifié&nbsp;: le jour où elle a posé sa question au logiciel d'IA générative, le sportif s’était gravement blessé la veille.</p>"
+                    },
+                    {
+                      "id": "113b842e-f66b-43cf-a82a-d5484b37fe22",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>La réponse de l’IA ne comporte pas d'éléments inventés. La vérification de Léonie montre que le sportif s’était gravement blessé la veille de la question à l’IA.<br>N'hésitez pas à réessayer.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>La demande de Léonie comporte une erreur que l’IA n’a pas corrigée.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p></p><p>L’erreur faite par l’IA ne vient pas de la demande de l’utilisateur mais plutôt du logiciel d’IA générative.<br>N'hésitez pas à réessayer.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse !&nbsp;🎉</p>",
+                            "diagnosis": "<p>Ici la blessure du sportif est une donnée trop récente pour l'IA.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "29f0994f-8dfb-41c8-b4a4-45fa0e289814",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia6-emoji.jpg",
+                      "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
+                      "alternativeText": "<p>Question utilisateur&nbsp;:&nbsp;Peux-tu me montrer l'émoji hippocampe ?</p><p>Réponse de l'IA&nbsp;: 🦞</p><p>Deuxième question utilisateur&nbsp;:&nbsp;Tu es sûr ?</p><p>Réponse de l'IA&nbsp;:&nbsp;Oups c'est un homard. Voici l'émoji hippocampe 🦑</p>",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "9c2ddfdc-0dc9-435c-b3be-1ea4bf999895",
+                      "type": "text",
+                      "content": "<p>L'IA n'a pas donné de réponse satisfaisante à Darius.<br>Darius a donc vérifié par ailleurs et il a découvert que l'émoji hippocampe n'existe pas. et il a découvert que l'émoji hippocampe n'existe pas.</p>"
+                    },
+                    {
+                      "id": "9d16a295-07ca-493c-a8a3-c0265390b17a",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p></p><p>Les réponses de l’IA tentent de répondre correctement à la question de Darius. Ce ne sont pas des hallucinations.<br>N'hésitez pas à réessayer.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>La demande de Darius comporte une erreur que l’IA n’a pas corrigée.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>La demande est impossible, il n’existe pas d’émoji hippocampe.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse</p>",
+                            "diagnosis": "<p>Il est vrai que de nouveaux émojis sont régulièrement créés. Mais ce n’est pas la source de l’erreur de l’IA ici.<br>N'hésitez pas à réessayer.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "5944e2ca-cb95-4cdc-9d7c-74741421dd43",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia7-source.jpg",
+                      "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
+                      "alternativeText": "<p>Question utilisateur&nbsp;: Donne moi un article en français sur le traitement des eaux pluviales, d’une revue scientifique, rédigée au format APA 7e édition.</p><p>Réponse de l'IA&nbsp;:&nbsp;Voici un article traitant du traitement des eaux pluviales, formaté selon APA 7e.<br><strong>Barra, M., Houeix, K., Hemminki, J., &amp; Grandin, G. </strong>(2019).&nbsp;<em>Gestion des eaux pluviales et biodiversité urbaine&nbsp;: état de la contamination et préconisations</em>.&nbsp;<strong>Annales de la Floristique Régionale Île‑de‑France</strong>, 10–33.</p>",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "53332773-3d53-4d86-8ab3-7af01a291d1d",
+                      "type": "text",
+                      "content": "<p>Amalia a vérifié la réponse de l'IA&nbsp;: ces auteurs n’ont rien écrit ensemble et l'article est introuvable.</p>"
+                    },
+                    {
+                      "id": "a8a788a2-f80a-4a3e-bd05-88fc46a64469",
+                      "type": "qcu",
+                      "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>L’IA générative a rassemblé des auteurs, un titre et une revue scientifique pour créer une source d’apparence crédible. C’est une hallucination, l’article n’existe pas.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>La demande d'Amalia comporte une erreur que l’IA n’a pas corrigée.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p></p><p>La demande d’Amalia ne comprend pas d’erreur. La source de l’erreur se situe du côté du logiciel d’IA générative.<br>N'hésitez pas à réessayer.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>L’erreur relevée par Amalia est que cet article ne semble pas exister. La source de l’erreur n’est donc pas un problème de données d’entraînement. <br>N'hésitez pas à réessayer.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "76a59954-f4c5-49af-8236-2424e33b67ea",
+          "type": "activity",
+          "title": "Transfert",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ffd4ab68-15fb-497d-bf67-9820d17feee3",
+                "type": "qcu-declarative",
+                "instruction": "<p>Maintenant que vous avez joué ce module, que ferez-vous si un logiciel d'IA générative vous dit que la Statue de la Liberté se trouve à Tokyo ?&nbsp;🗽</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Vous vérifiez cette information dans une encyclopédie. 📖</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !&nbsp;</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Vous supposez que la Statue de la liberté a été déplacée. 🧳</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Si un monument aussi connu était déplacé, il y aurait de nombreuses informations à ce sujet. Vérifier l'information serait une bonne idée !&nbsp;</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Vous cherchez sur internet une confirmation. 🔎</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Vous réservez vos billets d’avion immédiatement. ✈️</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Attention ! Vous pourriez être déçu par votre voyage si vous partez pour voir la Statue de la Liberté à Tokyo.&nbsp;Vérifier l'information serait une bonne idée !</p>"
+                    }
                   }
                 ]
-              ]
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c28617dd-2134-4551-8157-b7beef89ab35",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, pourquoi y a-t-il une différence entre les réponses de ChatPT 3 et de ChatGPT 4o ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>ChatGPT 3 n’était pas encore disponible dans ces 4 pays, il ne les a pas comptés.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>En 2023, il n’y avait aucun pays commençant par la lettre V.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>L’erreur a été corrigée avec la mise à jour de ChatGPT 4.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Efefctivement, les logiciels d’IA générative sont fréquemment mis à jour par les développeurs. Ces mises à jour permettent de corriger des erreurs.</p>"
-                }
               }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6ad583ab-11b2-4530-a663-75544292108a",
-      "type": "lesson",
-      "title": "Leçon - 3",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "36e95488-a2db-4463-9b0f-5d5252cb38b2",
-                  "type": "text",
-                  "content": "<p>Grâce à des mises à jour régulières, les ingénieurs essaient en continu de <strong>réduire les erreurs</strong> que les IA génératives produisent. Ainsi, les IA génératives <strong>s’améliorent d’années en années</strong> !</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "5360a6aa-999e-4d02-b3cb-20421fae3ab2",
-                  "type": "text",
-                  "content": "<p>Mais, c’est une <strong>tâche difficile</strong>&nbsp;:&nbsp;il n'y a pas de différence de forme entre une réponse contenant une erreur et une qui n'en contient pas. <br>Il n’existe donc <strong>pas de méthode technique pour détecter les erreurs </strong>et les éviter complètement.</p>"
-                }
-              ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "99d91ba2-5d1e-4a2d-92ef-4e61219a903e",
-      "type": "transition",
-      "title": "Transition - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "af12a991-ef36-4557-bd5b-d9f668bdcf33",
-            "type": "text",
-            "content": "<p>Mais alors, si les IA génératives font des erreurs que les développeurs ne peuvent pas corriger, que peut faire un utilisateur ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "eff7343b-ae10-44d7-9113-710a43ece810",
-      "type": "discovery",
-      "title": "Activité découverte - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ecffdbbe-78c7-4da7-9b7d-2426eb9daf3c",
-            "type": "text",
-            "content": "<p>Depuis sa dernière utilisation de l'IA, Nathan n'utilise plus l'IA générative. Asma veut laisser encore une chance à l'IA, mais pour elle, pas question de se laisser avoir !&nbsp;<br>Pour la préparation d'un document important, elle interroge un logiciel d'IA générative.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0b9a3ac4-f723-45ea-bfcd-c31200474bee",
-            "type": "text",
-            "content": "<p><strong>Parmi les réactions suivantes, sélectionnez s’il s’agit d’un bon réflexe ou d’un mauvais réflexe pour Asma face à la réponse du logiciel d'IA générative.</strong></p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "81eb63dc-b909-461d-bea3-e32cf2637240",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Réflexe 1&nbsp;: Asma copie et colle la réponse du logiciel d'IA générative dans son document, sans la lire.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>bon réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, c'est un mauvais réflexe ! Il faut toujours lire l’ensemble des réponses données par un logiciel d’IA générative.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>mauvais réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et oui, c'est un mauvais réflexe ! Il faut toujours lire l’ensemble des réponses données par un logiciel d’IA générative.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "079936fa-826a-46da-903c-32dfd0089327",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Réflexe 2&nbsp;:&nbsp;Asma lit toute la réponse et s’interroge sur une partie de la réponse de l'IA. Elle demande au logiciel d'IA générative de préciser sa réponse en donnant sa source.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>bon réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et oui, c'est un bon réflexe ! Poursuivre la discussion avec l’IA permet parfois d’avoir une réponse plus claire ou même une correction.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>mauvais réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, c'est un bon réflexe ! Poursuivre la discussion avec l’IA permet parfois d’avoir une réponse plus claire ou même une correction.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "ff81face-e51c-4bf6-8b49-50c9abd5cfdd",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Réflexe 3&nbsp;: Asma cherche la source de l’information sur internet pour comparer avec l’information donnée par le logiciel d'IA générative.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>bon réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et oui, c'est un bon réflexe ! Dans tous les cas, vérifier et croiser les sources permet d’éviter de relayer une erreur ou une fausse information.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>mauvais réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, c'est bon réflexe ! Dans tous les cas, vérifier et croiser les sources permet d’éviter de relayer une erreur ou une fausse information.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "0aa2dee4-60a8-4ab7-8390-0ca87779414c",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Réflexe 4&nbsp;:&nbsp;Asma lit en entier la réponse donnée par le logiciel d'IA générative. Elle la trouve très bien écrite et l’utilise dans son document.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>bon réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non, c'est un mauvais réflexe ! Une réponse bien écrite n’est pas forcément correcte. Il faut garder un regard critique, même quand le ton est convaincant.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>mauvais réflexe</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et oui, c'est un mauvais réflexe ! Une réponse bien écrite n’est pas forcément correcte. Il faut garder un regard critique, même quand le ton est convaincant.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "25aa32f6-954f-4032-98db-6659ac47a66e",
-      "type": "lesson",
-      "title": "Leçon - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3a72064b-2d02-47ef-b524-18d51dcc6be8",
-            "type": "text",
-            "content": "<p>Il faut toujours garder en tête qu’une IA générative peut faire une erreur ou halluciner dans ses réponses. Mais vous pouvez apprendre à repérer ces erreurs… à condition d’adopter les bons réflexes&nbsp;:</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "491608fe-ec87-4e10-b98a-c1c6f67a500c",
-                  "type": "text",
-                  "content": "<p>🔍 Avoir un <strong>regard critique</strong> sur les réponses de l’IA générative et se poser des questions sur ce qu'on lit.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "910d0bec-69e4-4a7f-818c-eab90643959b",
-                  "type": "text",
-                  "content": "<p>📖 Prendre le temps de <strong>lire les réponses en entier</strong>. Parfois, l’erreur ne saute pas aux yeux. Elle peut se cacher dans un détail&nbsp;: une date, un chiffre, un exemple, etc.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "495a2819-756c-415c-993d-ad37eaa4fecf",
-                  "type": "text",
-                  "content": "<p>🧭&nbsp;<strong>Vérifier les informations </strong> en les comparant avec d’autres sources.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "eba1acf6-d04c-4d74-85a0-05b4a9dc488f",
-                  "type": "text",
-                  "content": "<p>💬 <strong>Poursuivre la discussion</strong>. Si vous détectez une erreur dans la réponse d’une IA générative, vous pouvez lui signaler et lui demander de se corriger.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "987668e7-59a9-438d-ad54-4723abc701d8",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d889292f-a892-4ad8-b7e8-0ef529fe13cf",
-            "type": "text",
-            "content": "<ul><li>L'objectif d’une <strong>IA générative</strong> est de répondre aux demandes d’un utilisateur. <strong>Son objectif n’est pas de dire la vérité</strong>. 🤥</li><br><li>Une <strong>IA générative peut faire des erreurs</strong>, par exemple présenter des affirmations fausses comme vraies. ❌</li><br><li>Les développeurs d’IA génératives essaient de réduire les erreurs. Mais il n’existe <strong>pas de moyen technique pour empêcher complètement ces erreurs.</strong> 🔧</li><br><li>Face à ces erreurs, difficiles à détecter, c’est à l’utilisateur de <strong>faire preuve d’esprit critique</strong> et de <strong>croiser les sources</strong> d’informations pour les vérifier. 🔎</li><br></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a5db0e26-49fc-457c-943a-cc24d3aa1551",
-      "type": "activity",
-      "title": "Activité d'application - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1700c207-060a-416d-9f0d-033518299509",
-            "type": "qab",
-            "instruction": "<p>Pour chacune des affirmations suivantes, indiquez si elle est vraie ou fausse.</p>",
-            "cards": [
-              {
-                "id": "59dcf865-08c0-4110-90bf-99c3acff78b7",
-                "text": "Un logiciel d’IA générative peut faire des erreurs.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "1e2967ec-943a-4687-b2c7-a6056004452c",
-                "text": "Si un logiciel d’IA générative fait une erreur, il suffit de continuer la conversation pour qu’elle se corrige automatiquement.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "eeea3baf-f5fb-4ed1-8831-52a2f1f0323f",
-                "text": "Quand un logiciel d’IA générative est sûr de sa réponse, il le précise dans sa réponse.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "72527d55-9757-4b17-b2b3-c47e27873893",
-                "text": "Si un logiciel d’IA générative affirme quelque chose, il vaut mieux le vérifier avec d’autres sources.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "32646287-4172-4919-b6d5-c1813adb13e3",
-      "type": "activity",
-      "title": "Activité d'application - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ac09a36f-6446-4ced-9c4b-8ab544e113d9",
-            "type": "text",
-            "content": "<p>Voici ci-dessous des exemples d’erreurs dans des réponses données par des logiciels d’IA génératives. Pour chaque exemple, indiquez quelle est la source d'erreur correspondante.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "95d84a4d-2ee5-4e6a-96b6-de148a586781",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia5-Djoko.jpg",
-                  "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
-                  "alternativeText": "<p>Question utilisateur&nbsp;: Comment va le tennisman Djokovic ?</p><p>Réponse du logiciel d'IA générative&nbsp;: Novak Djokovic va bien, il continue de performer à un niveau très élevé sur le circuit ATP. Ses récents résultats montrent qu'il reste l'un des meilleurs joueurs du monde. Il a eu quelques problèmes de santé et des blessures par le passé, mais il semble s'être bien rétabli.</p>",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "4973d664-0caf-4e10-9ea9-7fae95bf0164",
-                  "type": "text",
-                  "content": "<p>Léonie a vérifié&nbsp;: le jour où elle a posé sa question au logiciel d'IA générative, le sportif s’était gravement blessé la veille.</p>"
-                },
-                {
-                  "id": "113b842e-f66b-43cf-a82a-d5484b37fe22",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>La réponse de l’IA ne comporte pas d'éléments inventés. La vérification de Léonie montre que le sportif s’était gravement blessé la veille de la question à l’IA.<br>N'hésitez pas à réessayer.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>La demande de Léonie comporte une erreur que l’IA n’a pas corrigée.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p></p><p>L’erreur faite par l’IA ne vient pas de la demande de l’utilisateur mais plutôt du logiciel d’IA générative.<br>N'hésitez pas à réessayer.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse !&nbsp;🎉</p>",
-                        "diagnosis": "<p>Ici la blessure du sportif est une donnée trop récente pour l'IA.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "29f0994f-8dfb-41c8-b4a4-45fa0e289814",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia6-emoji.jpg",
-                  "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
-                  "alternativeText": "<p>Question utilisateur&nbsp;:&nbsp;Peux-tu me montrer l'émoji hippocampe ?</p><p>Réponse de l'IA&nbsp;: 🦞</p><p>Deuxième question utilisateur&nbsp;:&nbsp;Tu es sûr ?</p><p>Réponse de l'IA&nbsp;:&nbsp;Oups c'est un homard. Voici l'émoji hippocampe 🦑</p>",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "9c2ddfdc-0dc9-435c-b3be-1ea4bf999895",
-                  "type": "text",
-                  "content": "<p>L'IA n'a pas donné de réponse satisfaisante à Darius.<br>Darius a donc vérifié par ailleurs et il a découvert que l'émoji hippocampe n'existe pas. et il a découvert que l'émoji hippocampe n'existe pas.</p>"
-                },
-                {
-                  "id": "9d16a295-07ca-493c-a8a3-c0265390b17a",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p></p><p>Les réponses de l’IA tentent de répondre correctement à la question de Darius. Ce ne sont pas des hallucinations.<br>N'hésitez pas à réessayer.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>La demande de Darius comporte une erreur que l’IA n’a pas corrigée.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>La demande est impossible, il n’existe pas d’émoji hippocampe.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse</p>",
-                        "diagnosis": "<p>Il est vrai que de nouveaux émojis sont régulièrement créés. Mais ce n’est pas la source de l’erreur de l’IA ici.<br>N'hésitez pas à réessayer.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "5944e2ca-cb95-4cdc-9d7c-74741421dd43",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/hallucinations/erreursia7-source.jpg",
-                  "alt": "Extrait d'un échange sur un logiciel d'IA générative, contenu détaillé dans l'alternative textuelle.",
-                  "alternativeText": "<p>Question utilisateur&nbsp;: Donne moi un article en français sur le traitement des eaux pluviales, d’une revue scientifique, rédigée au format APA 7e édition.</p><p>Réponse de l'IA&nbsp;:&nbsp;Voici un article traitant du traitement des eaux pluviales, formaté selon APA 7e.<br><strong>Barra, M., Houeix, K., Hemminki, J., &amp; Grandin, G. </strong>(2019).&nbsp;<em>Gestion des eaux pluviales et biodiversité urbaine&nbsp;: état de la contamination et préconisations</em>.&nbsp;<strong>Annales de la Floristique Régionale Île‑de‑France</strong>, 10–33.</p>",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "53332773-3d53-4d86-8ab3-7af01a291d1d",
-                  "type": "text",
-                  "content": "<p>Amalia a vérifié la réponse de l'IA&nbsp;: ces auteurs n’ont rien écrit ensemble et l'article est introuvable.</p>"
-                },
-                {
-                  "id": "a8a788a2-f80a-4a3e-bd05-88fc46a64469",
-                  "type": "qcu",
-                  "instruction": "<p>Quelle est la source de l'erreur du logiciel d'IA générative ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>L’IA générative répond par prédiction et génère une hallucination.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>L’IA générative a rassemblé des auteurs, un titre et une revue scientifique pour créer une source d’apparence crédible. C’est une hallucination, l’article n’existe pas.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>La demande d'Amalia comporte une erreur que l’IA n’a pas corrigée.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p></p><p>La demande d’Amalia ne comprend pas d’erreur. La source de l’erreur se situe du côté du logiciel d’IA générative.<br>N'hésitez pas à réessayer.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Les données d’entraînement de l’IA sont fausses ou trop anciennes.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>L’erreur relevée par Amalia est que cet article ne semble pas exister. La source de l’erreur n’est donc pas un problème de données d’entraînement. <br>N'hésitez pas à réessayer.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "76a59954-f4c5-49af-8236-2424e33b67ea",
-      "type": "activity",
-      "title": "Transfert",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ffd4ab68-15fb-497d-bf67-9820d17feee3",
-            "type": "qcu-declarative",
-            "instruction": "<p>Maintenant que vous avez joué ce module, que ferez-vous si un logiciel d'IA générative vous dit que la Statue de la Liberté se trouve à Tokyo ?&nbsp;🗽</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Vous vérifiez cette information dans une encyclopédie. 📖</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !&nbsp;</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Vous supposez que la Statue de la liberté a été déplacée. 🧳</p>",
-                "feedback": {
-                  "diagnosis": "<p>Si un monument aussi connu était déplacé, il y aurait de nombreuses informations à ce sujet. Vérifier l'information serait une bonne idée !&nbsp;</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Vous cherchez sur internet une confirmation. 🔎</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, c'est un bon réflexe en cas de doute !</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Vous réservez vos billets d’avion immédiatement. ✈️</p>",
-                "feedback": {
-                  "diagnosis": "<p>Attention ! Vous pourriez être déçu par votre voyage si vous partez pour voir la Statue de la Liberté à Tokyo.&nbsp;Vérifier l'information serait une bonne idée !</p>"
-                }
-              }
-            ]
-          }
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
@@ -15,547 +15,553 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "1ab1964a-9967-4739-9004-c5e2c9de36f0",
-      "type": "discovery",
-      "title": "Accroche",
-      "components": [
+      "id": "e0bf2631-4a43-46a1-8bbc-b06f11574719",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "09245327-cd08-4874-b006-1018c3b6b419",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Asso Yoga à Roulette",
-              "messages": [
-                {
-                  "userName": "Gustave",
-                  "direction": "incoming",
-                  "content": "J'ai du mal à trouver un nom pour mon association de yoga à roulettes. J’aimerais quelque chose d’original mais je n’ai pas d’inspiration... 🤯"
-                },
-                {
-                  "userName": "Maëlle",
-                  "direction": "outgoing",
-                  "content": "🤖 Tu devrais essayer avec un logiciel d'IA générative, ça peut vraiment t’aider à trouver des idées sympas ! 💡"
-                },
-                {
-                  "userName": "Gustave",
-                  "direction": "incoming",
-                  "content": "Vraiment ? 😮 Mais… Je fais comment ?"
-                },
-                {
-                  "userName": "Maëlle",
-                  "direction": "outgoing",
-                  "content": "C’est super simple ! 😄 Tu lui écris ce que tu veux, mais fais bien attention à ton prompt. 😉"
+          "id": "1ab1964a-9967-4739-9004-c5e2c9de36f0",
+          "type": "discovery",
+          "title": "Accroche",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "09245327-cd08-4874-b006-1018c3b6b419",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Asso Yoga à Roulette",
+                  "messages": [
+                    {
+                      "userName": "Gustave",
+                      "direction": "incoming",
+                      "content": "J'ai du mal à trouver un nom pour mon association de yoga à roulettes. J’aimerais quelque chose d’original mais je n’ai pas d’inspiration... 🤯"
+                    },
+                    {
+                      "userName": "Maëlle",
+                      "direction": "outgoing",
+                      "content": "🤖 Tu devrais essayer avec un logiciel d'IA générative, ça peut vraiment t’aider à trouver des idées sympas ! 💡"
+                    },
+                    {
+                      "userName": "Gustave",
+                      "direction": "incoming",
+                      "content": "Vraiment ? 😮 Mais… Je fais comment ?"
+                    },
+                    {
+                      "userName": "Maëlle",
+                      "direction": "outgoing",
+                      "content": "C’est super simple ! 😄 Tu lui écris ce que tu veux, mais fais bien attention à ton prompt. 😉"
+                    }
+                  ]
                 }
-              ]
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "d94fdd26-ddf1-449e-b7ce-1aadc990b423",
-      "type": "transition",
-      "title": "texte de transition",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f30fee84-9b24-4f58-b216-375817170298",
-            "type": "text",
-            "content": "<p>Gustave a suivi le conseil de Maëlle. Il a demandé à un logiciel d'IA générative de lui donner des idées de noms pour son association. Voici sa discussion avec le logiciel.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "94156810-5197-4cd7-b58c-86cde94d6323",
-      "type": "discovery",
-      "title": "Activité découverte",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "88af557c-e8f8-4bce-bc72-4f3aa35262fa",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/NAI/decouverteinterfaceIA.html",
-            "instruction": "<p>Cliquez sur les différentes zones de la conversation pour en apprendre plus.</p>",
-            "height": 550
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "4cd2311c-6c89-4d04-9087-1b874a412882",
-            "type": "qcu",
-            "instruction": "<p>Parmi les messages de cette discussion, lequel est le prompt ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Des idées de noms pour une association de yoga à roulettes ?</p>",
-                "feedback": {
-                  "state": "<p>Bien vu !&nbsp;</p>",
-                  "diagnosis": "<p>En effet, le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Bien sûr, voici quelques idées de noms pour une association de yoga&nbsp;:</p><p>1. Yoga en mouvement</p><p>2. Roulez en Paix</p><p>3.&nbsp;Équilibre sur Roues</p><p>4. Yoga en Roue Libre</p>",
-                "feedback": {
-                  "state": "<p>Et non !&nbsp;</p>",
-                  "diagnosis": "<p>C'est la réponse donnée par un logiciel d'IA générative. Le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Écrivez votre message ici.</p>",
-                "feedback": {
-                  "state": "<p>Et non !</p>",
-                  "diagnosis": "<p>C'est le champ de saisie, la zone pour écrire les prompts ! Le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
-                }
+          "id": "d94fdd26-ddf1-449e-b7ce-1aadc990b423",
+          "type": "transition",
+          "title": "texte de transition",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f30fee84-9b24-4f58-b216-375817170298",
+                "type": "text",
+                "content": "<p>Gustave a suivi le conseil de Maëlle. Il a demandé à un logiciel d'IA générative de lui donner des idées de noms pour son association. Voici sa discussion avec le logiciel.</p>"
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "63c077cf-0a98-4526-b946-8ee3c28afeec",
-      "type": "lesson",
-      "title": "Leçon 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6080355f-69c8-4803-a7e2-b301556ac9e3",
-            "type": "text",
-            "content": "<ul><li>Le prompt est la question posée ou la consigne donnée à un logiciel d'IA générative.🤖</li><li>Les réponses d'un logiciel d'IA générative s'affichent comme dans une conversation de messagerie instantanée.&nbsp;</li><li>Il y a toujours une zone pour écrire le prompt suivant.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d50b83d9-4966-4480-be2b-18c5063b5457",
-      "type": "transition",
-      "title": "texte de transition 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7f1f3b24-7160-405c-8e88-fdd69b131ddf",
-            "type": "text",
-            "content": "<p>Maintenant que vous savez vous repérer dans une conversation avec un logiciel d'IA générative, nous allons voir comment rédiger un prompt&nbsp;!📝</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "29e32ca5-8ad5-49bf-a9bb-104d0172e662",
-      "type": "activity",
-      "title": "activité découverte 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4f730efe-b5ff-4d66-ba0d-b0105d347dc4",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/NAI/observationreponseia.html",
-            "instruction": "<p>Glissez et déposez chaque prompt dans la zone où l'on écrit les prompts.</p><p>Observez la réponse du logiciel d'IA générative.</p>",
-            "height": 500
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d7c97543-452a-4777-9f6e-7d33e3d0d077",
-            "type": "qcu",
-            "instruction": "<p>D’après ce que vous venez de voir, laquelle de ces affirmations est vraie ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>On parle à un logiciel d'IA générative en langage informatique.</p>",
-                "feedback": {
-                  "state": "<p>Et non ! </p>",
-                  "diagnosis": "<p>On parle à un logiciel d'IA générative comme on parle à une autre personne.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>On parle à un logiciel d'IA générative comme on parle avec une autre personne.</p>",
-                "feedback": {
-                  "state": "<p>Bravo !</p>",
-                  "diagnosis": "<p><br></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>On parle à un logiciel d'IA générative avec des mots-clés uniquement.</p>",
-                "feedback": {
-                  "state": "<p>Et non&nbsp; !</p>",
-                  "diagnosis": "<p>On parle à un logiciel d'IA générative comme on parle à une autre personne.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2f0b42f0-02a3-4133-8401-ec270f2ca315",
-      "type": "lesson",
-      "title": "Leçon 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "90cd34bf-4182-4c72-ab1a-22ea98ab9c46",
-            "type": "text",
-            "content": "<p>Comme vous avez pu le voir, on fait des demandes en <strong>langage courant</strong> à un logiciel d'IA générative, pas besoin de connaître des commandes spéciales ! 💬 <br>En revanche, pour que le logiciel d'IA générative comprenne bien la demande, il faut être <strong>précis</strong>.</p><p><br>📌 <strong>Bon à savoir</strong></p><p>Une bonne façon d’être précis est d’utiliser des <strong>verbes d’actions</strong> comme&nbsp;: «&nbsp;lister&nbsp;», «&nbsp;traduire&nbsp;», «&nbsp;résumer&nbsp;», etc.<br><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ba2c3789-f2bd-46e6-a1ca-38dd47088df8",
-      "type": "transition",
-      "title": "texte de transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1ad822c8-cf06-43b8-adf4-9acc12f22fff",
-            "type": "text",
-            "content": "<p>Dans certains cas, utiliser un verbe adapté ne suffit pas.😅 Il faut aussi donner des éléments qui décrivent le résultat que l’on veut obtenir. Voyons cela ensemble !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a39e914f-631d-491c-a4d8-14df1686de2c",
-      "type": "activity",
-      "title": "activité découverte 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0a0f1cf5-3f03-448c-b551-93d51482ab33",
-            "type": "text",
-            "content": "<p>Cette fois-ci, Gustave cherche une recette de gâteau pour 10 personnes.🍰Mais il est allergique au chocolat.🍫</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "19a2c102-618f-497d-b68f-48a9bb72d1d7",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/NAI/Promptgateaupistache.html",
-            "instruction": "<p>Glissez et déposez les prompts suivants dans le champ de saisie et observez les réponses du logiciel d'IA générative.</p>",
-            "height": 400
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ee3bd7af-b9d4-432d-a6a2-78bada14d03a",
-            "type": "qcu",
-            "instruction": "<p>D'après vous, parmi ces prompts, lequel exprime au mieux le besoin de Gustave ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>écris une recette de gâteau</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse !</p>",
-                  "diagnosis": "<p>Le logiciel d'IA générative ne peut pas deviner les détails d’une demande. Pour être sûr d’avoir la réponse recherchée, il faut préciser tous les éléments importants de la demande dans le prompt.<br><br></p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>écris une recette de gâteau pour 10 personnes</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse !</p>",
-                  "diagnosis": "<p>Le logiciel d'IA générative ne peut pas deviner les détails d’une demande. Pour être sûr d’avoir la réponse recherchée, il faut préciser tous les éléments importants de la demande dans le prompt.<br><br></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>écris une recette de gâteau pour 10 personnes sans chocolat</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse !</p>",
-                  "diagnosis": "<p>En effet, ce prompt contient des éléments précis&nbsp;:&nbsp;un verbe, le nombre de personnes et les ingrédients à supprimer.</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8d975832-e974-4253-bb75-3a3d3636f52c",
-      "type": "lesson",
-      "title": "Leçon 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "29fbfaf4-e1f9-4f19-9bbb-38f8a712e352",
-            "type": "text",
-            "content": "<p>📌Une autre façon d’être précis, c’est de donner au logiciel d'IA générative autant d’<strong>informations</strong> que possible. Cela donne du contexte.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d6d77cc3-71d7-4b18-a74d-d39424ca6b0a",
-      "type": "activity",
-      "title": "activité découverte 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1995ea30-4dc2-484a-8847-0cbf16d36902",
-            "type": "text",
-            "content": "<p>Regardez l'image puis répondez à la question ci-dessous&nbsp;: </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "b001a5e6-0916-4aa2-b4e7-0ad3d412ed2c",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/mon-premier-prompt/Crocodile.png",
-            "alt": "",
-            "alternativeText": "<p>Pix IA LLM</p><p>Bienvenue sur Pix IA LLM</p><p>Prompt&nbsp;: Je veux adopter un animal. J'habite en appartement. Quelles sont les 5 meilleures options ?</p><p>Réponse IA&nbsp;: Voici cinq options d'animaux adaptés à la vie en appartement&nbsp;:</p><p>1. Chat</p><p>2. Poisson</p><p>3. Lapin</p><p>4. Crocodile</p><p>5. Hamster</p><p>Zone de saisie du prompt&nbsp;: Écrivez votre message ici</p><p>Bouton \"Envoyer\"</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "85194ba2-923f-4907-9842-381361271bdc",
-            "type": "qcu",
-            "instruction": "<p>Selon vous, la liste d’animaux donnée par le logiciel d'IA générative ci-dessus répond-elle bien au prompt ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>La réponse du logiciel d'IA générative est adaptée à la demande.</p>",
-                "feedback": {
-                  "state": "<p>Et non !</p>",
-                  "diagnosis": "<p>La réponse du logiciel d'IA générative ne respecte pas ce qui est demandé dans le prompt ! Le crocodile n'est pas l'animal le plus adapté pour un appartement, c'est dangereux et même illégal !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>La réponse du logiciel d'IA générative n'est pas adaptée à la demande.</p>",
-                "feedback": {
-                  "state": "<p>Bien vu !</p>",
-                  "diagnosis": "<p>La réponse du logiciel d'IA générative n’est pas adaptée&nbsp;: adopter un crocodile n'est pas une bonne option pour quelqu’un qui habite en appartement, c'est dangereux et même illégal !<br><br></p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "<p>Petit coup de pouce !</p>",
-                  "diagnosis": "<p>Regardez bien, la réponse du logiciel d'IA générative ne respecte pas ce qui est demandé dans le prompt&nbsp;: le crocodile n'est pas l'animal le plus adapté pour un appartement !</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7f3868a0-f259-4394-9bbb-d04b34c55366",
-      "type": "lesson",
-      "title": "Leçon 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ebd5d937-c04e-47da-98b2-7ddde874cb50",
-            "type": "text",
-            "content": "<p>Même si le prompt est clair et précis, et que la réponse paraît bien rédigée, <strong>un logiciel d'IA générative peut se tromper</strong>.😓 Il faut TOUJOURS relire et vérifier la réponse.</p><p><br>💡<strong>Astuce</strong></p><p>On peut continuer la conversation en lui envoyant un nouveau message pour <strong>ajuster ou corriger</strong> la réponse.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1ec0a8c6-ed7a-4e91-b886-7dc192490bb7",
-      "type": "summary",
-      "title": "Recap",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "33210c11-0e87-4d93-9190-089654d57ee4",
-            "type": "text",
-            "content": "<p>📌 Résumons l’essentiel avant de passer à la suite&nbsp;: <br></p><ul><li>Un prompt («&nbsp;instruction&nbsp;» ou «&nbsp;requête&nbsp;» en français) est une <strong>question</strong> que l’on pose ou une <strong>consigne</strong> que l’on donne au logiciel d'IA générative pour qu’il produise une réponse.🧑‍💻</li><li>Un prompt s’écrit en <strong>langage courant</strong>, comme si on parlait à un autre être humain.🗣️</li><li>Plus la <strong>demande est claire et précise</strong>, plus la réponse du logiciel d'IA générative sera adaptée et pertinente.🤓<ul><li>On peut utiliser des <strong>verbes d’action</strong> comme «&nbsp;Traduis&nbsp;», «&nbsp;Liste&nbsp;», «&nbsp;Résume&nbsp;», etc.</li><li>On peut ajouter des <strong>informations supplémentaires</strong> pour donner du contexte.</li></ul></li><li>Il est important de <strong>toujours relire la réponse</strong> du logiciel d'IA générative pour vérifier qu'il répond bien à la demande.🕵️</li><li>Si la réponse du logiciel d'IA générative ne convient pas, il faut <strong>reformuler</strong> son prompt pour mieux guider le logiciel.📝</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "227201e2-d165-401d-a9b2-2fc6294205db",
-      "type": "transition",
-      "title": "texte de transition 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ae11054b-571a-4577-8554-c2731f729647",
-            "type": "text",
-            "content": "<p>Vous connaissez maintenant les règles de base pour formuler un prompt. À vous d’appliquer ces règles&nbsp;!🙌</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "bdbe0b99-02d8-48a9-951f-1e85e2ea25d8",
-      "type": "activity",
-      "title": "activité application",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "63c7f73f-b9b1-4c9b-a983-29b5dc8030b9",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/NAI/glisserdeposerlesbonsverbes.html",
-            "instruction": "<p>Glissez et déposez le verbe qui convient le plus pour compléter chaque prompt ci-dessous en fonction des réponses de l'IA générative.</p>",
-            "height": 500
-          }
-        }
-      ]
-    },
-    {
-      "id": "2078a0df-7a93-4dc1-97b8-33705eb70cac",
-      "type": "activity",
-      "title": "activité application 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "79e24dbc-b512-479b-913d-5df858490409",
-            "type": "qab",
-            "instruction": "<p>Classez chaque prompt ci-dessous selon sa précision dans une des catégories suivantes&nbsp;:&nbsp; «&nbsp;clair et précis&nbsp;» ou «&nbsp;flou et vague&nbsp;».</p>",
-            "cards": [
-              {
-                "id": "5ff6c7e9-b9c5-4b49-a6f9-b381075c2163",
-                "text": "Quels sont les meilleurs outils gratuits pour faire du montage vidéo niveau débutant sur smartphone ? 📹",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "A"
-              },
-              {
-                "id": "b4b01d06-618d-4195-b8a4-f564fc86d8b4",
-                "text": "Aide-moi dans mes projets. 💭",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "B"
-              },
-              {
-                "id": "b581e981-47db-4513-b05b-19cb219aac00",
-                "text": "Parle-moi d’histoire, j’ai envie d’apprendre. 📖",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "B"
-              },
-              {
-                "id": "ad6bccf7-ce67-47ff-a60a-dd9938d61715",
-                "text": "Donne-moi une recette rapide et végétarienne à base de carottes et pois chiches. 🍲",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "A"
-              },
-              {
-                "id": "1abb2292-e98c-4181-8d00-4e4f5e2f5f89",
-                "text": "Propose trois idées d’activités d'art plastique pour un atelier enfants (6–8 ans). 🧒",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "A"
-              },
-              {
-                "id": "03ab1311-5107-4ece-83b9-6146c92efad3",
-                "text": "Comment réussir dans la vie pour être heureux ? 🏆",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Clair et précis",
-                "proposalB": "Flou et vague",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "cea108c3-9bab-406c-be58-dd976b1680bc",
-      "type": "transition",
-      "title": "texte de transition 5",
-      "components": [
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "bd373d86-9859-4f63-a693-bec98c2e7300",
-            "type": "text",
-            "content": "<p>Vous avez appris à parler à un logiciel d'IA générative.👏 Maintenant, place à la pratique&nbsp;: voyons si vous pouvez obtenir la réponse voulue !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "140fd885-4562-4a9c-a19a-cae9cc0715b9",
-      "type": "challenge",
-      "title": "Activité défi",
-      "components": [
+          "id": "94156810-5197-4cd7-b58c-86cde94d6323",
+          "type": "discovery",
+          "title": "Activité découverte",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "88af557c-e8f8-4bce-bc72-4f3aa35262fa",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/NAI/decouverteinterfaceIA.html",
+                "instruction": "<p>Cliquez sur les différentes zones de la conversation pour en apprendre plus.</p>",
+                "height": 550
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4cd2311c-6c89-4d04-9087-1b874a412882",
+                "type": "qcu",
+                "instruction": "<p>Parmi les messages de cette discussion, lequel est le prompt ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Des idées de noms pour une association de yoga à roulettes ?</p>",
+                    "feedback": {
+                      "state": "<p>Bien vu !&nbsp;</p>",
+                      "diagnosis": "<p>En effet, le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Bien sûr, voici quelques idées de noms pour une association de yoga&nbsp;:</p><p>1. Yoga en mouvement</p><p>2. Roulez en Paix</p><p>3.&nbsp;Équilibre sur Roues</p><p>4. Yoga en Roue Libre</p>",
+                    "feedback": {
+                      "state": "<p>Et non !&nbsp;</p>",
+                      "diagnosis": "<p>C'est la réponse donnée par un logiciel d'IA générative. Le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Écrivez votre message ici.</p>",
+                    "feedback": {
+                      "state": "<p>Et non !</p>",
+                      "diagnosis": "<p>C'est le champ de saisie, la zone pour écrire les prompts ! Le prompt, c'est la question posée ou la consigne donnée au logiciel d'IA générative.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "2d39db49-0ab2-4222-8911-abb459b16fef",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Utilisation d'un véritable LLM",
-            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cma2ihhoa000bwg011i86qb30",
-            "instruction": "<p>Écrivez un prompt au logiciel d'IA générative ci-dessous pour qu’il crée un poème sur votre animal préféré.<br><br></p>",
-            "solution": "<p></p>",
-            "height": 500
-          }
+          "id": "63c077cf-0a98-4526-b946-8ee3c28afeec",
+          "type": "lesson",
+          "title": "Leçon 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6080355f-69c8-4803-a7e2-b301556ac9e3",
+                "type": "text",
+                "content": "<ul><li>Le prompt est la question posée ou la consigne donnée à un logiciel d'IA générative.🤖</li><li>Les réponses d'un logiciel d'IA générative s'affichent comme dans une conversation de messagerie instantanée.&nbsp;</li><li>Il y a toujours une zone pour écrire le prompt suivant.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d50b83d9-4966-4480-be2b-18c5063b5457",
+          "type": "transition",
+          "title": "texte de transition 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7f1f3b24-7160-405c-8e88-fdd69b131ddf",
+                "type": "text",
+                "content": "<p>Maintenant que vous savez vous repérer dans une conversation avec un logiciel d'IA générative, nous allons voir comment rédiger un prompt&nbsp;!📝</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "29e32ca5-8ad5-49bf-a9bb-104d0172e662",
+          "type": "activity",
+          "title": "activité découverte 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4f730efe-b5ff-4d66-ba0d-b0105d347dc4",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/NAI/observationreponseia.html",
+                "instruction": "<p>Glissez et déposez chaque prompt dans la zone où l'on écrit les prompts.</p><p>Observez la réponse du logiciel d'IA générative.</p>",
+                "height": 500
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d7c97543-452a-4777-9f6e-7d33e3d0d077",
+                "type": "qcu",
+                "instruction": "<p>D’après ce que vous venez de voir, laquelle de ces affirmations est vraie ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>On parle à un logiciel d'IA générative en langage informatique.</p>",
+                    "feedback": {
+                      "state": "<p>Et non ! </p>",
+                      "diagnosis": "<p>On parle à un logiciel d'IA générative comme on parle à une autre personne.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>On parle à un logiciel d'IA générative comme on parle avec une autre personne.</p>",
+                    "feedback": {
+                      "state": "<p>Bravo !</p>",
+                      "diagnosis": "<p><br></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>On parle à un logiciel d'IA générative avec des mots-clés uniquement.</p>",
+                    "feedback": {
+                      "state": "<p>Et non&nbsp; !</p>",
+                      "diagnosis": "<p>On parle à un logiciel d'IA générative comme on parle à une autre personne.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2f0b42f0-02a3-4133-8401-ec270f2ca315",
+          "type": "lesson",
+          "title": "Leçon 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "90cd34bf-4182-4c72-ab1a-22ea98ab9c46",
+                "type": "text",
+                "content": "<p>Comme vous avez pu le voir, on fait des demandes en <strong>langage courant</strong> à un logiciel d'IA générative, pas besoin de connaître des commandes spéciales ! 💬 <br>En revanche, pour que le logiciel d'IA générative comprenne bien la demande, il faut être <strong>précis</strong>.</p><p><br>📌 <strong>Bon à savoir</strong></p><p>Une bonne façon d’être précis est d’utiliser des <strong>verbes d’actions</strong> comme&nbsp;: «&nbsp;lister&nbsp;», «&nbsp;traduire&nbsp;», «&nbsp;résumer&nbsp;», etc.<br><br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ba2c3789-f2bd-46e6-a1ca-38dd47088df8",
+          "type": "transition",
+          "title": "texte de transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1ad822c8-cf06-43b8-adf4-9acc12f22fff",
+                "type": "text",
+                "content": "<p>Dans certains cas, utiliser un verbe adapté ne suffit pas.😅 Il faut aussi donner des éléments qui décrivent le résultat que l’on veut obtenir. Voyons cela ensemble !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a39e914f-631d-491c-a4d8-14df1686de2c",
+          "type": "activity",
+          "title": "activité découverte 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0a0f1cf5-3f03-448c-b551-93d51482ab33",
+                "type": "text",
+                "content": "<p>Cette fois-ci, Gustave cherche une recette de gâteau pour 10 personnes.🍰Mais il est allergique au chocolat.🍫</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "19a2c102-618f-497d-b68f-48a9bb72d1d7",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/NAI/Promptgateaupistache.html",
+                "instruction": "<p>Glissez et déposez les prompts suivants dans le champ de saisie et observez les réponses du logiciel d'IA générative.</p>",
+                "height": 400
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ee3bd7af-b9d4-432d-a6a2-78bada14d03a",
+                "type": "qcu",
+                "instruction": "<p>D'après vous, parmi ces prompts, lequel exprime au mieux le besoin de Gustave ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>écris une recette de gâteau</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse !</p>",
+                      "diagnosis": "<p>Le logiciel d'IA générative ne peut pas deviner les détails d’une demande. Pour être sûr d’avoir la réponse recherchée, il faut préciser tous les éléments importants de la demande dans le prompt.<br><br></p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>écris une recette de gâteau pour 10 personnes</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse !</p>",
+                      "diagnosis": "<p>Le logiciel d'IA générative ne peut pas deviner les détails d’une demande. Pour être sûr d’avoir la réponse recherchée, il faut préciser tous les éléments importants de la demande dans le prompt.<br><br></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>écris une recette de gâteau pour 10 personnes sans chocolat</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse !</p>",
+                      "diagnosis": "<p>En effet, ce prompt contient des éléments précis&nbsp;:&nbsp;un verbe, le nombre de personnes et les ingrédients à supprimer.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8d975832-e974-4253-bb75-3a3d3636f52c",
+          "type": "lesson",
+          "title": "Leçon 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "29fbfaf4-e1f9-4f19-9bbb-38f8a712e352",
+                "type": "text",
+                "content": "<p>📌Une autre façon d’être précis, c’est de donner au logiciel d'IA générative autant d’<strong>informations</strong> que possible. Cela donne du contexte.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d6d77cc3-71d7-4b18-a74d-d39424ca6b0a",
+          "type": "activity",
+          "title": "activité découverte 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1995ea30-4dc2-484a-8847-0cbf16d36902",
+                "type": "text",
+                "content": "<p>Regardez l'image puis répondez à la question ci-dessous&nbsp;: </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "b001a5e6-0916-4aa2-b4e7-0ad3d412ed2c",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/mon-premier-prompt/Crocodile.png",
+                "alt": "",
+                "alternativeText": "<p>Pix IA LLM</p><p>Bienvenue sur Pix IA LLM</p><p>Prompt&nbsp;: Je veux adopter un animal. J'habite en appartement. Quelles sont les 5 meilleures options ?</p><p>Réponse IA&nbsp;: Voici cinq options d'animaux adaptés à la vie en appartement&nbsp;:</p><p>1. Chat</p><p>2. Poisson</p><p>3. Lapin</p><p>4. Crocodile</p><p>5. Hamster</p><p>Zone de saisie du prompt&nbsp;: Écrivez votre message ici</p><p>Bouton \"Envoyer\"</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "85194ba2-923f-4907-9842-381361271bdc",
+                "type": "qcu",
+                "instruction": "<p>Selon vous, la liste d’animaux donnée par le logiciel d'IA générative ci-dessus répond-elle bien au prompt ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>La réponse du logiciel d'IA générative est adaptée à la demande.</p>",
+                    "feedback": {
+                      "state": "<p>Et non !</p>",
+                      "diagnosis": "<p>La réponse du logiciel d'IA générative ne respecte pas ce qui est demandé dans le prompt ! Le crocodile n'est pas l'animal le plus adapté pour un appartement, c'est dangereux et même illégal !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>La réponse du logiciel d'IA générative n'est pas adaptée à la demande.</p>",
+                    "feedback": {
+                      "state": "<p>Bien vu !</p>",
+                      "diagnosis": "<p>La réponse du logiciel d'IA générative n’est pas adaptée&nbsp;: adopter un crocodile n'est pas une bonne option pour quelqu’un qui habite en appartement, c'est dangereux et même illégal !<br><br></p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "<p>Petit coup de pouce !</p>",
+                      "diagnosis": "<p>Regardez bien, la réponse du logiciel d'IA générative ne respecte pas ce qui est demandé dans le prompt&nbsp;: le crocodile n'est pas l'animal le plus adapté pour un appartement !</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7f3868a0-f259-4394-9bbb-d04b34c55366",
+          "type": "lesson",
+          "title": "Leçon 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ebd5d937-c04e-47da-98b2-7ddde874cb50",
+                "type": "text",
+                "content": "<p>Même si le prompt est clair et précis, et que la réponse paraît bien rédigée, <strong>un logiciel d'IA générative peut se tromper</strong>.😓 Il faut TOUJOURS relire et vérifier la réponse.</p><p><br>💡<strong>Astuce</strong></p><p>On peut continuer la conversation en lui envoyant un nouveau message pour <strong>ajuster ou corriger</strong> la réponse.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1ec0a8c6-ed7a-4e91-b886-7dc192490bb7",
+          "type": "summary",
+          "title": "Recap",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "33210c11-0e87-4d93-9190-089654d57ee4",
+                "type": "text",
+                "content": "<p>📌 Résumons l’essentiel avant de passer à la suite&nbsp;: <br></p><ul><li>Un prompt («&nbsp;instruction&nbsp;» ou «&nbsp;requête&nbsp;» en français) est une <strong>question</strong> que l’on pose ou une <strong>consigne</strong> que l’on donne au logiciel d'IA générative pour qu’il produise une réponse.🧑‍💻</li><li>Un prompt s’écrit en <strong>langage courant</strong>, comme si on parlait à un autre être humain.🗣️</li><li>Plus la <strong>demande est claire et précise</strong>, plus la réponse du logiciel d'IA générative sera adaptée et pertinente.🤓<ul><li>On peut utiliser des <strong>verbes d’action</strong> comme «&nbsp;Traduis&nbsp;», «&nbsp;Liste&nbsp;», «&nbsp;Résume&nbsp;», etc.</li><li>On peut ajouter des <strong>informations supplémentaires</strong> pour donner du contexte.</li></ul></li><li>Il est important de <strong>toujours relire la réponse</strong> du logiciel d'IA générative pour vérifier qu'il répond bien à la demande.🕵️</li><li>Si la réponse du logiciel d'IA générative ne convient pas, il faut <strong>reformuler</strong> son prompt pour mieux guider le logiciel.📝</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "227201e2-d165-401d-a9b2-2fc6294205db",
+          "type": "transition",
+          "title": "texte de transition 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ae11054b-571a-4577-8554-c2731f729647",
+                "type": "text",
+                "content": "<p>Vous connaissez maintenant les règles de base pour formuler un prompt. À vous d’appliquer ces règles&nbsp;!🙌</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "bdbe0b99-02d8-48a9-951f-1e85e2ea25d8",
+          "type": "activity",
+          "title": "activité application",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "63c7f73f-b9b1-4c9b-a983-29b5dc8030b9",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/NAI/glisserdeposerlesbonsverbes.html",
+                "instruction": "<p>Glissez et déposez le verbe qui convient le plus pour compléter chaque prompt ci-dessous en fonction des réponses de l'IA générative.</p>",
+                "height": 500
+              }
+            }
+          ]
+        },
+        {
+          "id": "2078a0df-7a93-4dc1-97b8-33705eb70cac",
+          "type": "activity",
+          "title": "activité application 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "79e24dbc-b512-479b-913d-5df858490409",
+                "type": "qab",
+                "instruction": "<p>Classez chaque prompt ci-dessous selon sa précision dans une des catégories suivantes&nbsp;:&nbsp; «&nbsp;clair et précis&nbsp;» ou «&nbsp;flou et vague&nbsp;».</p>",
+                "cards": [
+                  {
+                    "id": "5ff6c7e9-b9c5-4b49-a6f9-b381075c2163",
+                    "text": "Quels sont les meilleurs outils gratuits pour faire du montage vidéo niveau débutant sur smartphone ? 📹",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "b4b01d06-618d-4195-b8a4-f564fc86d8b4",
+                    "text": "Aide-moi dans mes projets. 💭",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "b581e981-47db-4513-b05b-19cb219aac00",
+                    "text": "Parle-moi d’histoire, j’ai envie d’apprendre. 📖",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "ad6bccf7-ce67-47ff-a60a-dd9938d61715",
+                    "text": "Donne-moi une recette rapide et végétarienne à base de carottes et pois chiches. 🍲",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "1abb2292-e98c-4181-8d00-4e4f5e2f5f89",
+                    "text": "Propose trois idées d’activités d'art plastique pour un atelier enfants (6–8 ans). 🧒",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "03ab1311-5107-4ece-83b9-6146c92efad3",
+                    "text": "Comment réussir dans la vie pour être heureux ? 🏆",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Clair et précis",
+                    "proposalB": "Flou et vague",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "cea108c3-9bab-406c-be58-dd976b1680bc",
+          "type": "transition",
+          "title": "texte de transition 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bd373d86-9859-4f63-a693-bec98c2e7300",
+                "type": "text",
+                "content": "<p>Vous avez appris à parler à un logiciel d'IA générative.👏 Maintenant, place à la pratique&nbsp;: voyons si vous pouvez obtenir la réponse voulue !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "140fd885-4562-4a9c-a19a-cae9cc0715b9",
+          "type": "challenge",
+          "title": "Activité défi",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2d39db49-0ab2-4222-8911-abb459b16fef",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Utilisation d'un véritable LLM",
+                "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cma2ihhoa000bwg011i86qb30",
+                "instruction": "<p>Écrivez un prompt au logiciel d'IA générative ci-dessous pour qu’il crée un poème sur votre animal préféré.<br><br></p>",
+                "solution": "<p></p>",
+                "height": 500
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -15,797 +15,803 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "d46bad0c-2cf2-4f48-81d6-b97be61cfe32",
-      "type": "transition",
-      "title": "Transition - 1 ",
-      "components": [
+      "id": "5d2a1259-f8eb-4bbf-b95d-3ebf7a592ee3",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "12937b3b-7031-45e3-9aeb-6d3a6ea6533a",
-            "type": "text",
-            "content": "<p>Franck a une fille de 8 ans, Marilou. Pour son anniversaire, elle voudrait un jeu vidéo dont elle a entendu parler à l’école&nbsp;: Dragon’s Kingdom. 🎮</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4812058e-6ccf-4d4b-889d-c5a18882292a",
-      "type": "discovery",
-      "title": "Accroche",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "442fa2ba-d532-423b-ba89-c4ff38ff270c",
-            "type": "text",
-            "content": "<p>Avant d’acheter et de télécharger le jeu réclamé par sa fille de 8 ans, Franck se rend sur la fiche du jeu en ligne pour regarder les informations concernant le jeu. 👀</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3fd2025c-f39b-4f28-9243-ac390b7106c2",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_dragonkingdom.png",
-            "alt": "capture d’écran de la page d’installation du jeu vidéo Dragon’s kingdom détaillée dans l’alternative textuelle",
-            "alternativeText": "<p>Jeu Craft Dragon’s kingdom</p><ul><li>Epix</li><li>Étiquette «&nbsp;Consoles&nbsp;»</li><li>18,99€<br></li><li>Bouton «&nbsp;Obtenir&nbsp;»</li><li>Pictogramme «&nbsp;PEGI 12&nbsp;», «&nbsp;peur&nbsp;»</li><li>Abonnement requis pour le jeu en ligne</li><li>Achats intra jeux facultatifs</li><li>Interaction entre les utilisateurs</li><li>Jeu en ligne facultatif</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3aeba304-6774-4d57-a19a-3309f2181368",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, ce jeu est-il adapté à l’âge de Marilou ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Sur la boîte ou la fiche d’un jeu, plusieurs informations permettent de savoir si un jeu est adapté pour un enfant, en fonction de son âge notamment. </p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien joué ! Sur la boîte ou la fiche d’un jeu, plusieurs informations permettent de savoir si un jeu est adapté pour un enfant, en fonction de son âge notamment. </p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d6e7ddf5-e76d-4e4b-b9d9-17a7d039c340",
-      "type": "transition",
-      "title": "Transition - 2 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5d5e7130-c5d2-4aa0-bb7f-20e89b27cbd8",
-            "type": "text",
-            "content": "<p>Avant de choisir un jeu vidéo pour sa fille, Franck peut vérifier plusieurs informations au sujet du jeu.<br>Découvrons ensemble la première information&nbsp;: la signalétique européenne PEGI.<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9a521207-4957-4512-8d24-b6e0f3d21226",
-      "type": "discovery",
-      "title": "Activité découverte - 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "958e2877-83ba-42a4-9622-3ce3a078127d",
-            "type": "text",
-            "content": "<p>Sur les jeux vidéo vendus en France, on peut voir des pictogrammes. Ces pictogrammes donnent des indications importantes.<br>Observez les images suivantes et répondez aux questions.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "d46bad0c-2cf2-4f48-81d6-b97be61cfe32",
+          "type": "transition",
+          "title": "Transition - 1 ",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "c9c01da7-3d63-45a6-a0d2-5d7f80dab582",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boitier_alva.png",
-                  "alt": "Boîte du jeu vidéo Les chroniques d’Alva détaillée dans l’alternative textuelle",
-                  "alternativeText": "<p>Boîte du jeu vidéo «&nbsp;Les chroniques d’Alva&nbsp;»&nbsp;:&nbsp;<br></p><ul><li>Illustration d’une elfe, de dos, avec une lance à la main qui regarde un chateau au loin.</li><li>Titre «&nbsp;Les chroniques d’Alva&nbsp;»</li><li>Pictogramme «&nbsp;PEGI 12 &nbsp;»</li></ul>"
-                },
-                {
-                  "id": "1255d0bf-0434-4add-9873-051c841af667",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Que signifie l’indication «&nbsp;12 &nbsp;» sur ce jeu ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Le jeu est trop difficile pour les enfants de moins de 12 ans.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le pictogramme âge PEGI n’indique pas la difficulté d’un jeu. Par exemple un jeu avec le pictogramme PEGI 3 peut être trop compliqué pour un enfant de 4 ans. Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Le jeu est inadapté aux enfants de moins de 12 ans.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Tout à fait ! Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué. Il n’indique pas la difficulté du jeu.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Le jeu ne peut pas être vendu à un enfant de moins de 12 ans.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le pictogramme âge PEGI est indicatif, il n’empêche pas la vente en fonction de l’âge. Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "12937b3b-7031-45e3-9aeb-6d3a6ea6533a",
+                "type": "text",
+                "content": "<p>Franck a une fille de 8 ans, Marilou. Pour son anniversaire, elle voudrait un jeu vidéo dont elle a entendu parler à l’école&nbsp;: Dragon’s Kingdom. 🎮</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4812058e-6ccf-4d4b-889d-c5a18882292a",
+          "type": "discovery",
+          "title": "Accroche",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "442fa2ba-d532-423b-ba89-c4ff38ff270c",
+                "type": "text",
+                "content": "<p>Avant d’acheter et de télécharger le jeu réclamé par sa fille de 8 ans, Franck se rend sur la fiche du jeu en ligne pour regarder les informations concernant le jeu. 👀</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "3fd2025c-f39b-4f28-9243-ac390b7106c2",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_dragonkingdom.png",
+                "alt": "capture d’écran de la page d’installation du jeu vidéo Dragon’s kingdom détaillée dans l’alternative textuelle",
+                "alternativeText": "<p>Jeu Craft Dragon’s kingdom</p><ul><li>Epix</li><li>Étiquette «&nbsp;Consoles&nbsp;»</li><li>18,99€<br></li><li>Bouton «&nbsp;Obtenir&nbsp;»</li><li>Pictogramme «&nbsp;PEGI 12&nbsp;», «&nbsp;peur&nbsp;»</li><li>Abonnement requis pour le jeu en ligne</li><li>Achats intra jeux facultatifs</li><li>Interaction entre les utilisateurs</li><li>Jeu en ligne facultatif</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3aeba304-6774-4d57-a19a-3309f2181368",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, ce jeu est-il adapté à l’âge de Marilou ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Sur la boîte ou la fiche d’un jeu, plusieurs informations permettent de savoir si un jeu est adapté pour un enfant, en fonction de son âge notamment. </p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien joué ! Sur la boîte ou la fiche d’un jeu, plusieurs informations permettent de savoir si un jeu est adapté pour un enfant, en fonction de son âge notamment. </p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d6e7ddf5-e76d-4e4b-b9d9-17a7d039c340",
+          "type": "transition",
+          "title": "Transition - 2 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5d5e7130-c5d2-4aa0-bb7f-20e89b27cbd8",
+                "type": "text",
+                "content": "<p>Avant de choisir un jeu vidéo pour sa fille, Franck peut vérifier plusieurs informations au sujet du jeu.<br>Découvrons ensemble la première information&nbsp;: la signalétique européenne PEGI.<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9a521207-4957-4512-8d24-b6e0f3d21226",
+          "type": "discovery",
+          "title": "Activité découverte - 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "958e2877-83ba-42a4-9622-3ce3a078127d",
+                "type": "text",
+                "content": "<p>Sur les jeux vidéo vendus en France, on peut voir des pictogrammes. Ces pictogrammes donnent des indications importantes.<br>Observez les images suivantes et répondez aux questions.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "1360e72b-5248-41b0-9dfc-1d85264cb97c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_pixelworld.png",
-                  "alt": "capture d’écran de la page d’installation du Pixel World détaillée dans l’alternative textuelle",
-                  "alternativeText": "<p>Fiche du jeu vidéo «Pixel world&nbsp;»&nbsp;:</p><ul><li>Titre «&nbsp;Pixel world&nbsp;»</li><li>Pixel industry</li><li>Action et aventure, Famille et enfants</li><li>4,2 étoiles, 23,5k avis</li><li>Bouton «&nbsp;Obtenir&nbsp;»</li><li>Pictogramme «&nbsp;Pegi !&nbsp;»</li></ul>"
+                  "elements": [
+                    {
+                      "id": "c9c01da7-3d63-45a6-a0d2-5d7f80dab582",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boitier_alva.png",
+                      "alt": "Boîte du jeu vidéo Les chroniques d’Alva détaillée dans l’alternative textuelle",
+                      "alternativeText": "<p>Boîte du jeu vidéo «&nbsp;Les chroniques d’Alva&nbsp;»&nbsp;:&nbsp;<br></p><ul><li>Illustration d’une elfe, de dos, avec une lance à la main qui regarde un chateau au loin.</li><li>Titre «&nbsp;Les chroniques d’Alva&nbsp;»</li><li>Pictogramme «&nbsp;PEGI 12 &nbsp;»</li></ul>"
+                    },
+                    {
+                      "id": "1255d0bf-0434-4add-9873-051c841af667",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Que signifie l’indication «&nbsp;12 &nbsp;» sur ce jeu ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Le jeu est trop difficile pour les enfants de moins de 12 ans.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le pictogramme âge PEGI n’indique pas la difficulté d’un jeu. Par exemple un jeu avec le pictogramme PEGI 3 peut être trop compliqué pour un enfant de 4 ans. Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Le jeu est inadapté aux enfants de moins de 12 ans.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Tout à fait ! Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué. Il n’indique pas la difficulté du jeu.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Le jeu ne peut pas être vendu à un enfant de moins de 12 ans.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le pictogramme âge PEGI est indicatif, il n’empêche pas la vente en fonction de l’âge. Le pictogramme âge PEGI indique la présence de contenus inadaptés aux enfants en dessous de l’âge indiqué.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 },
                 {
-                  "id": "10dfb9e3-02de-4f3f-b7d1-aae0d1991f9e",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Que signifie le pictogramme «&nbsp;!&nbsp;» sur ce jeu ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Le jeu doit être utilisé avec l’accompagnement des parents.</p>",
-                      "feedback": {
-                        "diagnosis": "<p> Effectivement, ce pictogramme «&nbsp;!&nbsp;» signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs. Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient donc d’accompagner les enfants dans leur utilisation.</p>"
-                      }
+                      "id": "1360e72b-5248-41b0-9dfc-1d85264cb97c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_pixelworld.png",
+                      "alt": "capture d’écran de la page d’installation du Pixel World détaillée dans l’alternative textuelle",
+                      "alternativeText": "<p>Fiche du jeu vidéo «Pixel world&nbsp;»&nbsp;:</p><ul><li>Titre «&nbsp;Pixel world&nbsp;»</li><li>Pixel industry</li><li>Action et aventure, Famille et enfants</li><li>4,2 étoiles, 23,5k avis</li><li>Bouton «&nbsp;Obtenir&nbsp;»</li><li>Pictogramme «&nbsp;Pegi !&nbsp;»</li></ul>"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Le jeu n’a aucune recommandation PEGI.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Le pictogramme «&nbsp;!&nbsp;» fait partie de la signalétique PEGI. Il signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs. Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient  d’accompagner les enfants dans leur utilisation.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Le jeu est déconseillé aux enfants de moins de 7 ans.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Pas tout à fait. Le pictogramme «&nbsp;!&nbsp;» signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs.&nbsp;Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient d’accompagner les enfants dans leur utilisation.</p>"
-                      }
+                      "id": "10dfb9e3-02de-4f3f-b7d1-aae0d1991f9e",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Que signifie le pictogramme «&nbsp;!&nbsp;» sur ce jeu ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Le jeu doit être utilisé avec l’accompagnement des parents.</p>",
+                          "feedback": {
+                            "diagnosis": "<p> Effectivement, ce pictogramme «&nbsp;!&nbsp;» signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs. Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient donc d’accompagner les enfants dans leur utilisation.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Le jeu n’a aucune recommandation PEGI.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Le pictogramme «&nbsp;!&nbsp;» fait partie de la signalétique PEGI. Il signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs. Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient  d’accompagner les enfants dans leur utilisation.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Le jeu est déconseillé aux enfants de moins de 7 ans.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Pas tout à fait. Le pictogramme «&nbsp;!&nbsp;» signale des jeux ou applications qui contiennent une grande variété de contenus créés par les utilisateurs.&nbsp;Il peut donc y avoir des contenus non adaptés aux enfants ! Il convient d’accompagner les enfants dans leur utilisation.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "935c4c4c-4705-4e2e-8c8f-a8db2a285bde",
-      "type": "lesson",
-      "title": "Leçon - 1 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7c0ff98b-7522-4c04-af69-aa8eaf516d32",
-            "type": "text",
-            "content": "<p>Découvrez les informations clés à retenir concernant la signalétique PEGI&nbsp;:&nbsp;</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "682ce2e6-b587-49f8-9860-ad0e32c62664",
-            "type": "video",
-            "title": "La signalétique PEGI",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.mp4",
-            "poster": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.jpg",
-            "subtitles": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.vtt",
-            "transcription": "<p>La signalétique PEGI<br><br> Franck regarde la fiche du jeu vidéo que sa fille aimerait avoir. <br>Ce jeu est-il adapté à son âge ?&nbsp; <br>Pour le savoir, Franck peut s’appuyer sur la signalétique PEGI. La signalétique PEGI est un ensemble de pictogrammes qui sont présents sur tous les jeux vendus en France et dans de nombreux pays, que ce soit sur les boîtes vendues en magasins ou sur les boutiques en ligne.&nbsp; <br>Ces pictogrammes donnent une indication aux parents mais ils n’interdisent pas la vente des jeux.&nbsp;La première série de pictogrammes marque le fait que le jeu n’est pas adapté aux enfants en dessous de l’âge indiqué. Ainsi, un jeu avec le pictogramme PEGI 7 sera déconseillé aux enfants de moins de 7 ans.&nbsp;Attention, ces pictogrammes n’indiquent pas la difficulté du jeu par rapport à l’âge de l’enfant. <br>Par exemple, un jeu avec le pictogramme PEGI 3 ne contient pas de contenus choquants pour un enfant de 3 ans, mais il peut être trop compliqué pour lui ! À côté du pictogramme d’âge, il peut y avoir, en plus, des marqueurs thématiques qui donnent une information sur le contenu du jeu. Sur certains jeux ou applications, il n’y a pas de pictogramme d’âge, mais un pictogramme «&nbsp;Accompagnement des parents recommandé&nbsp;».&nbsp; <br>Ce pictogramme est présent sur des jeux et applications qui contiennent des contenus créés par les utilisateurs. Il peut donc y avoir des contenus adaptés pour les plus jeunes mais d’autres moins, il vaut donc mieux utiliser le jeu en étant accompagné par les parents. <br>Et si, comme Franck, vous voulez en savoir plus sur la signalétique PEGI, rendez-vous sur pédagojeux.fr. PédaGoJeux est un collectif qui informe et accompagne les familles autour des jeux vidéo.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f55cd373-221b-499b-9186-5d3ec7d383da",
-      "type": "transition",
-      "title": "Transition - 3 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "89b50860-22ca-4d9d-b0fa-f4e759acf654",
-            "type": "text",
-            "content": "<p>Franck sait à présent vérifier l’âge recommandé pour un jeu.<br>Il veut maintenant éviter que Marilou dépense de l’argent en achetant des bonus pendant qu'elle joue. 💸</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8e67cf94-6397-406d-915a-336b8527a729",
-      "type": "discovery",
-      "title": "Activité découverte - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "db51f147-b80d-4ca1-af7c-b4e052b8f6c8",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, quels jeux vidéo peuvent proposer d'acheter des bonus pendant le jeu ? </p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>les jeux payants<br></p>",
-                "feedback": {
-                  "diagnosis": "<p>Pas tout à fait ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>les jeux gratuits</p>",
-                "feedback": {
-                  "diagnosis": "<p>Pas tout à fait ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>les deux</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et oui ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b30b20c6-ba19-4992-8efb-20a6bf932c01",
-      "type": "lesson",
-      "title": "Leçon - 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b7989927-5257-4f02-82d7-23d92e666c4c",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_jeu_achats.png",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8d643cd3-6b97-4817-a495-0cf23e06e375",
-            "type": "text",
-            "content": "<p>👛 Dans un jeu vidéo (gratuit ou payant), des achats de quelques centimes ou euros peuvent être proposés tout au long de la partie pour obtenir, par exemple&nbsp;: </p><ul>    <li>de la <strong>monnaie virtuelle</strong>&nbsp;</li>    <li>des <strong>bonus </strong>ou des <strong>vies </strong>supplémentaires</li>    <li>des améliorations pour les personnages&nbsp;</li></ul><p>Ces achats en jeu sont appelés des <strong>achats intégrés</strong>.</p><p>⚠️ <strong>Attention</strong><br> Même si ce sont de petites sommes d’argent, la facture peut vite grimper ! Et si une carte bancaire est enregistrée sur l’appareil (smartphone, console, etc.), l’achat sera débité automatiquement sans que vous soyez averti.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fe9fa67b-ddfc-4932-8f5d-eba163a206b9",
-      "type": "discovery",
-      "title": "Activité découverte - 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0121f934-4457-4d3c-8647-9fa18f880973",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boitier_cake.png",
-            "alt": "Dos de la boîte d’un jeu vidéo détaillée dans l’alternative textuelle",
-            "alternativeText": "<p>Dos de la boîte d’un jeu vidéo&nbsp;:&nbsp;</p><ul>    <li>Présentation du jeu&nbsp;: <ul>            <li>Courez ! Sautez ! Explorez les mondes des gâteaux et aidez Flora la pâtissière à traverser plus de 80 niveaux !</li>            <li>Nouveau&nbsp;:&nbsp;Saupoudrage scintillant</li>            <li>Nouveau&nbsp;:&nbsp;Dragée explosive</li>            <li>Nouveau&nbsp;:&nbsp;Cœur  chocolat coulant</li>        </ul>    </li>    <li>Caractéristiques&nbsp;:<ul>            <li>Multijoueur local&nbsp;:&nbsp;jusqu’à 8 joueurs</li>            <li>Jeu en ligne&nbsp;:&nbsp;jusqu’à 12 joueurs</li>            <li>Online&nbsp;:&nbsp;Le jeu en ligne nécessite un abonnement payant au service Online.</li>            <li>Pictogramme «&nbsp;Pegi 3&nbsp;»</li>            <li>Pictogramme «&nbsp;Achats intégrés&nbsp;»</li>            <li>Compatible manette pro</li>            <li>Compatible volant</li>        </ul>    </li>    <li>Avertissements&nbsp;:&nbsp; <ul>            <li>Attention, chez certaines personnes, l’utilisation de ce jeu nécessite des précautions d’emploi particulières qui sont détaillées dans la notice jointe.</li>            <li>Ce logiciel peut comporter du placement de produit et de la publicité.</li>            <li>Ne jetez pas cette carte de jeu à la poubelle.</li>        </ul>    </li></ul>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "05677303-3d47-40e0-ae61-f915014bcc07",
-            "type": "qcu-discovery",
-            "instruction": "<p>Observez la boîte du jeu ci-dessus, puis sélectionnez la bonne réponse.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Il n’y a pas d’achats intégrés dans ce jeu.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non ! Avez-vous vérifié la présence de mots tels que «&nbsp;achats intra-jeu&nbsp;» ou «&nbsp;achats intégrés&nbsp;» sur cette boîte ?</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Il y a des achats intégrés dans ce jeu.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et oui ! Un pictogramme «&nbsp;Achats intégrés&nbsp;» à côté du pictogramme «&nbsp;PEGI 3&nbsp;» indique que ce jeu contient des achats intégrés.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "75794098-82f6-4f6e-b768-5315ea55ae6b",
-      "type": "lesson",
-      "title": "Leçon - 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4b68478d-45e1-411c-bf18-f384d0503cfa",
-            "type": "text",
-            "content": "<p>Si un jeu contient des achats intégrés, le joueur doit obligatoirement être prévenu.</p><p>🔎 Pour le savoir, regardez la boîte ou la fiche du jeu en ligne et cherchez le <strong>pictogramme PEGI </strong>ci-dessous ou les mentions «&nbsp;<strong>achats intégrés</strong>&nbsp;» ou «&nbsp;<strong>achats intra-jeu facultatifs</strong>&nbsp;».</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cb04fd65-c770-4cd3-bc76-7967f4dbb3fd",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_achats_integres_mentions.png",
-            "alt": "Image du pictogramme PEGI décrite dans l’alternative textuelle",
-            "alternativeText": "<p>Images du Pictogramme PEGI «&nbsp;Achats intégrés&nbsp;» et des différentes mentions&nbsp;: «&nbsp;achats intra-jeu&nbsp;», «&nbsp;achats intra-jeu facultatifs&nbsp;», «&nbsp;inclut des achats intégrés&nbsp;», «&nbsp;achats intra-jeu (y compris divers articles&nbsp;», «&nbsp;achats numériques&nbsp;».</p>",
-            "legend": "",
-            "licence": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "05e28282-c8aa-4664-8b33-234988efe390",
-      "type": "discovery",
-      "title": "Activité découverte - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "213f2140-9378-4bdb-9b7f-91837f4a5c9b",
-            "type": "text",
-            "content": "<p>Certains jeux proposent des achats intégrés particulièrement attirants&nbsp;:<strong> les loot boxes</strong> (ou boîtes à butins en français).</p>\n<p>Répondez à la question ci-dessous.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "141f008d-5024-4aed-ba4c-eeb967a37814",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_lornitteclan.png",
-            "alt": "capture d’écran de la page d’installation du jeu vidéo Lorttnite Clan détaillée dans l’alternative textuelle",
-            "alternativeText": "<p>Jeu Lorttnite Clan&nbsp;:</p><ul><li>   4,1 étoiles   </li><li>Communauté compétitive   </li><li>Commandes rapides à maîtriser   </li><li>Lien «&nbsp;vue d’ensemble&nbsp;»   </li><li>Contenus additionnels   </li><li>FAQ </li><li>Pictogramme «&nbsp;PEGI 12&nbsp;»,   Violence, achats dans le jeu (inclut des éléments aléatoires)    </li><li>Jeu de base   </li><li>Gratuit   </li><li>Boutons&nbsp;: «&nbsp;obtenir&nbsp;», «&nbsp;ajouter au panier&nbsp;», «&nbsp;ajouter à la liste de souhaits&nbsp;»</li></ul>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "79eb2b10-ddc5-4921-9f2e-f85066c2858f",
-            "type": "qcu-discovery",
-            "instruction": "<p>Observez la fiche du jeu ci-dessus, puis sélectionnez la bonne réponse.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Il n’y a pas d’achats intégrés dans ce jeu.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» indique bien la présence d'achats intégrés.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Il y a des achats intégrés dans ce jeu, mais pas de loot boxes.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» est complétée par la mention obligatoire «&nbsp;Inclut des contenus aléatoires&nbsp;».</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Il y a des achats intégrés et des loot boxes dans ce jeu.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» est complétée par la mention obligatoire «&nbsp;Inclut des contenus aléatoires&nbsp;».</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d09b483b-c182-44be-9c55-8c570e7b70d2",
-      "type": "lesson",
-      "title": "Leçon - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7e196da5-2ea2-4d9e-b368-3ef5b71143cd",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boite_mystere.png",
-            "alt": "",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "051ce5cd-3dcc-45a2-a1cd-a9ab74763588",
-            "type": "text",
-            "content": "<p>📦 Une loot box (boîte à butins) est un <strong>objet virtuel </strong> (un coffre, une boîte, etc) qu’un joueur peut acheter dans le jeu.<br>Chaque loot box contient des objets, communs ou très rares, à utiliser dans le jeu.<br><strong>Ce contenu est aléatoire, comme pour une pochette-surprise ou des cartes à collectionner.</strong><br>Le joueur est souvent incité à acheter des loot boxes lors des parties, pour obtenir l’objet qu’il souhaite ou pour avancer plus efficacement dans le jeu.</p><p><br>🤔 <strong>Bon à savoir</strong>&nbsp;<br>Depuis mai 2020, un jeu qui propose des loot boxes doit obligatoirement indiquer «&nbsp;<strong>Inclut des contenus aléatoires</strong>&nbsp;» sur la boîte ou la fiche du jeu.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "71521687-4fb1-4d45-a2d8-f33221dec895",
-      "type": "transition",
-      "title": "Transition - 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d841ddce-baf4-48c7-95b8-c03bb38fa232",
-            "type": "text",
-            "content": "<p>Après avoir vérifié le pictogramme d’âge PEGI et la présence d’achats intégrés, Franck peut vérifier une troisième information clé&nbsp;: la possibilité d’interagir avec d’autres joueurs dans le jeu. 💬</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "64eb0f7d-40d3-4dee-aa36-78fc19141a6c",
-      "type": "discovery",
-      "title": "Activité découverte - 5",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "139b7a65-92b9-4d4c-ba16-1badbbe24bd1",
-            "type": "text",
-            "content": "<p>De nombreux jeux vidéo en ligne se jouent en équipe. Les joueurs doivent donc discuter ensemble, par écrit ou en vocal, afin de collaborer et progresser dans le jeu.</p><p><strong>Ces discussions en ligne comportent des risques</strong>. 🎧&nbsp;<br>Un enfant peut être exposé à des personnes avec de mauvaises intentions ou à du contenu choquant. 😱</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "59cff0b1-f82f-4f5a-a91f-fccf43d7b366",
-            "type": "qcu-discovery",
-            "instruction": "<p>À votre avis, quelle affirmation est vraie ? </p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Tous les jeux vidéo sur ordinateur permettent de discuter en ligne avec d'autres joueurs.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Seuls les jeux vidéo sur console permettent de discuter en ligne avec d'autres joueurs</p>",
-                "feedback": {
-                  "diagnosis": "<p>Et non, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Certains jeux vidéo permettent de discuter en ligne avec d'autres joueurs quel que soit l'équipement utilisé.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Effectivement, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "779de80b-ba18-4e95-ab6d-bbc5ce8edd5a",
-      "type": "lesson",
-      "title": "Leçon - 5 : Les interactions entre joueurs",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "935c4c4c-4705-4e2e-8c8f-a8db2a285bde",
+          "type": "lesson",
+          "title": "Leçon - 1 ",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "d85a05a1-0c9d-4ce7-ad25-9333eb3a75c3",
-                  "type": "text",
-                  "content": "<h3>Quels sont les risques des discussions en ligne ?</h3><p>Il est impossible de savoir qui se trouve réellement de l’autre côté de l’écran. Les personnes avec de mauvaises intentions cherchent souvent à&nbsp;: </p><ul><li>manipuler les autres joueurs</li><li>proposer des rencontres dans la vraie vie</li><li>pousser à partager des photos ou des informations personnelles</li></ul><p>⚠️ <strong>Attention</strong><br>Même avec un jeu qui ne permet pas de discuter avec d’autres joueurs, ce risque n’est pas écarté. En effet, certaines consoles permettent de discuter en ligne, tout comme les ordinateurs et les smartphones.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "7c0ff98b-7522-4c04-af69-aa8eaf516d32",
+                "type": "text",
+                "content": "<p>Découvrez les informations clés à retenir concernant la signalétique PEGI&nbsp;:&nbsp;</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "682ce2e6-b587-49f8-9860-ad0e32c62664",
+                "type": "video",
+                "title": "La signalétique PEGI",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.mp4",
+                "poster": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.jpg",
+                "subtitles": "https://assets.pix.org/modules/jeux-video-enfant/signaletique_pegi_ppn3.vtt",
+                "transcription": "<p>La signalétique PEGI<br><br> Franck regarde la fiche du jeu vidéo que sa fille aimerait avoir. <br>Ce jeu est-il adapté à son âge ?&nbsp; <br>Pour le savoir, Franck peut s’appuyer sur la signalétique PEGI. La signalétique PEGI est un ensemble de pictogrammes qui sont présents sur tous les jeux vendus en France et dans de nombreux pays, que ce soit sur les boîtes vendues en magasins ou sur les boutiques en ligne.&nbsp; <br>Ces pictogrammes donnent une indication aux parents mais ils n’interdisent pas la vente des jeux.&nbsp;La première série de pictogrammes marque le fait que le jeu n’est pas adapté aux enfants en dessous de l’âge indiqué. Ainsi, un jeu avec le pictogramme PEGI 7 sera déconseillé aux enfants de moins de 7 ans.&nbsp;Attention, ces pictogrammes n’indiquent pas la difficulté du jeu par rapport à l’âge de l’enfant. <br>Par exemple, un jeu avec le pictogramme PEGI 3 ne contient pas de contenus choquants pour un enfant de 3 ans, mais il peut être trop compliqué pour lui ! À côté du pictogramme d’âge, il peut y avoir, en plus, des marqueurs thématiques qui donnent une information sur le contenu du jeu. Sur certains jeux ou applications, il n’y a pas de pictogramme d’âge, mais un pictogramme «&nbsp;Accompagnement des parents recommandé&nbsp;».&nbsp; <br>Ce pictogramme est présent sur des jeux et applications qui contiennent des contenus créés par les utilisateurs. Il peut donc y avoir des contenus adaptés pour les plus jeunes mais d’autres moins, il vaut donc mieux utiliser le jeu en étant accompagné par les parents. <br>Et si, comme Franck, vous voulez en savoir plus sur la signalétique PEGI, rendez-vous sur pédagojeux.fr. PédaGoJeux est un collectif qui informe et accompagne les familles autour des jeux vidéo.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f55cd373-221b-499b-9186-5d3ec7d383da",
+          "type": "transition",
+          "title": "Transition - 3 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "89b50860-22ca-4d9d-b0fa-f4e759acf654",
+                "type": "text",
+                "content": "<p>Franck sait à présent vérifier l’âge recommandé pour un jeu.<br>Il veut maintenant éviter que Marilou dépense de l’argent en achetant des bonus pendant qu'elle joue. 💸</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8e67cf94-6397-406d-915a-336b8527a729",
+          "type": "discovery",
+          "title": "Activité découverte - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "db51f147-b80d-4ca1-af7c-b4e052b8f6c8",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, quels jeux vidéo peuvent proposer d'acheter des bonus pendant le jeu ? </p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>les jeux payants<br></p>",
+                    "feedback": {
+                      "diagnosis": "<p>Pas tout à fait ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>les jeux gratuits</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Pas tout à fait ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>les deux</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et oui ! En&nbsp;fait, tous les jeux, qu'ils soient gratuits ou payants, peuvent proposer des achats en cours de jeu.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b30b20c6-ba19-4992-8efb-20a6bf932c01",
+          "type": "lesson",
+          "title": "Leçon - 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b7989927-5257-4f02-82d7-23d92e666c4c",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_jeu_achats.png",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8d643cd3-6b97-4817-a495-0cf23e06e375",
+                "type": "text",
+                "content": "<p>👛 Dans un jeu vidéo (gratuit ou payant), des achats de quelques centimes ou euros peuvent être proposés tout au long de la partie pour obtenir, par exemple&nbsp;: </p><ul>    <li>de la <strong>monnaie virtuelle</strong>&nbsp;</li>    <li>des <strong>bonus </strong>ou des <strong>vies </strong>supplémentaires</li>    <li>des améliorations pour les personnages&nbsp;</li></ul><p>Ces achats en jeu sont appelés des <strong>achats intégrés</strong>.</p><p>⚠️ <strong>Attention</strong><br> Même si ce sont de petites sommes d’argent, la facture peut vite grimper ! Et si une carte bancaire est enregistrée sur l’appareil (smartphone, console, etc.), l’achat sera débité automatiquement sans que vous soyez averti.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "fe9fa67b-ddfc-4932-8f5d-eba163a206b9",
+          "type": "discovery",
+          "title": "Activité découverte - 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0121f934-4457-4d3c-8647-9fa18f880973",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boitier_cake.png",
+                "alt": "Dos de la boîte d’un jeu vidéo détaillée dans l’alternative textuelle",
+                "alternativeText": "<p>Dos de la boîte d’un jeu vidéo&nbsp;:&nbsp;</p><ul>    <li>Présentation du jeu&nbsp;: <ul>            <li>Courez ! Sautez ! Explorez les mondes des gâteaux et aidez Flora la pâtissière à traverser plus de 80 niveaux !</li>            <li>Nouveau&nbsp;:&nbsp;Saupoudrage scintillant</li>            <li>Nouveau&nbsp;:&nbsp;Dragée explosive</li>            <li>Nouveau&nbsp;:&nbsp;Cœur  chocolat coulant</li>        </ul>    </li>    <li>Caractéristiques&nbsp;:<ul>            <li>Multijoueur local&nbsp;:&nbsp;jusqu’à 8 joueurs</li>            <li>Jeu en ligne&nbsp;:&nbsp;jusqu’à 12 joueurs</li>            <li>Online&nbsp;:&nbsp;Le jeu en ligne nécessite un abonnement payant au service Online.</li>            <li>Pictogramme «&nbsp;Pegi 3&nbsp;»</li>            <li>Pictogramme «&nbsp;Achats intégrés&nbsp;»</li>            <li>Compatible manette pro</li>            <li>Compatible volant</li>        </ul>    </li>    <li>Avertissements&nbsp;:&nbsp; <ul>            <li>Attention, chez certaines personnes, l’utilisation de ce jeu nécessite des précautions d’emploi particulières qui sont détaillées dans la notice jointe.</li>            <li>Ce logiciel peut comporter du placement de produit et de la publicité.</li>            <li>Ne jetez pas cette carte de jeu à la poubelle.</li>        </ul>    </li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "05677303-3d47-40e0-ae61-f915014bcc07",
+                "type": "qcu-discovery",
+                "instruction": "<p>Observez la boîte du jeu ci-dessus, puis sélectionnez la bonne réponse.</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Il n’y a pas d’achats intégrés dans ce jeu.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non ! Avez-vous vérifié la présence de mots tels que «&nbsp;achats intra-jeu&nbsp;» ou «&nbsp;achats intégrés&nbsp;» sur cette boîte ?</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Il y a des achats intégrés dans ce jeu.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et oui ! Un pictogramme «&nbsp;Achats intégrés&nbsp;» à côté du pictogramme «&nbsp;PEGI 3&nbsp;» indique que ce jeu contient des achats intégrés.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "75794098-82f6-4f6e-b768-5315ea55ae6b",
+          "type": "lesson",
+          "title": "Leçon - 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4b68478d-45e1-411c-bf18-f384d0503cfa",
+                "type": "text",
+                "content": "<p>Si un jeu contient des achats intégrés, le joueur doit obligatoirement être prévenu.</p><p>🔎 Pour le savoir, regardez la boîte ou la fiche du jeu en ligne et cherchez le <strong>pictogramme PEGI </strong>ci-dessous ou les mentions «&nbsp;<strong>achats intégrés</strong>&nbsp;» ou «&nbsp;<strong>achats intra-jeu facultatifs</strong>&nbsp;».</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cb04fd65-c770-4cd3-bc76-7967f4dbb3fd",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_achats_integres_mentions.png",
+                "alt": "Image du pictogramme PEGI décrite dans l’alternative textuelle",
+                "alternativeText": "<p>Images du Pictogramme PEGI «&nbsp;Achats intégrés&nbsp;» et des différentes mentions&nbsp;: «&nbsp;achats intra-jeu&nbsp;», «&nbsp;achats intra-jeu facultatifs&nbsp;», «&nbsp;inclut des achats intégrés&nbsp;», «&nbsp;achats intra-jeu (y compris divers articles&nbsp;», «&nbsp;achats numériques&nbsp;».</p>",
+                "legend": "",
+                "licence": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "05e28282-c8aa-4664-8b33-234988efe390",
+          "type": "discovery",
+          "title": "Activité découverte - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "213f2140-9378-4bdb-9b7f-91837f4a5c9b",
+                "type": "text",
+                "content": "<p>Certains jeux proposent des achats intégrés particulièrement attirants&nbsp;:<strong> les loot boxes</strong> (ou boîtes à butins en français).</p>\n<p>Répondez à la question ci-dessous.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "141f008d-5024-4aed-ba4c-eeb967a37814",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_lornitteclan.png",
+                "alt": "capture d’écran de la page d’installation du jeu vidéo Lorttnite Clan détaillée dans l’alternative textuelle",
+                "alternativeText": "<p>Jeu Lorttnite Clan&nbsp;:</p><ul><li>   4,1 étoiles   </li><li>Communauté compétitive   </li><li>Commandes rapides à maîtriser   </li><li>Lien «&nbsp;vue d’ensemble&nbsp;»   </li><li>Contenus additionnels   </li><li>FAQ </li><li>Pictogramme «&nbsp;PEGI 12&nbsp;»,   Violence, achats dans le jeu (inclut des éléments aléatoires)    </li><li>Jeu de base   </li><li>Gratuit   </li><li>Boutons&nbsp;: «&nbsp;obtenir&nbsp;», «&nbsp;ajouter au panier&nbsp;», «&nbsp;ajouter à la liste de souhaits&nbsp;»</li></ul>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "79eb2b10-ddc5-4921-9f2e-f85066c2858f",
+                "type": "qcu-discovery",
+                "instruction": "<p>Observez la fiche du jeu ci-dessus, puis sélectionnez la bonne réponse.</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Il n’y a pas d’achats intégrés dans ce jeu.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» indique bien la présence d'achats intégrés.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Il y a des achats intégrés dans ce jeu, mais pas de loot boxes.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» est complétée par la mention obligatoire «&nbsp;Inclut des contenus aléatoires&nbsp;».</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Il y a des achats intégrés et des loot boxes dans ce jeu.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, la mention&nbsp; «&nbsp;Achats dans le jeu&nbsp;» est complétée par la mention obligatoire «&nbsp;Inclut des contenus aléatoires&nbsp;».</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d09b483b-c182-44be-9c55-8c570e7b70d2",
+          "type": "lesson",
+          "title": "Leçon - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7e196da5-2ea2-4d9e-b368-3ef5b71143cd",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_boite_mystere.png",
+                "alt": "",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "051ce5cd-3dcc-45a2-a1cd-a9ab74763588",
+                "type": "text",
+                "content": "<p>📦 Une loot box (boîte à butins) est un <strong>objet virtuel </strong> (un coffre, une boîte, etc) qu’un joueur peut acheter dans le jeu.<br>Chaque loot box contient des objets, communs ou très rares, à utiliser dans le jeu.<br><strong>Ce contenu est aléatoire, comme pour une pochette-surprise ou des cartes à collectionner.</strong><br>Le joueur est souvent incité à acheter des loot boxes lors des parties, pour obtenir l’objet qu’il souhaite ou pour avancer plus efficacement dans le jeu.</p><p><br>🤔 <strong>Bon à savoir</strong>&nbsp;<br>Depuis mai 2020, un jeu qui propose des loot boxes doit obligatoirement indiquer «&nbsp;<strong>Inclut des contenus aléatoires</strong>&nbsp;» sur la boîte ou la fiche du jeu.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "71521687-4fb1-4d45-a2d8-f33221dec895",
+          "type": "transition",
+          "title": "Transition - 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d841ddce-baf4-48c7-95b8-c03bb38fa232",
+                "type": "text",
+                "content": "<p>Après avoir vérifié le pictogramme d’âge PEGI et la présence d’achats intégrés, Franck peut vérifier une troisième information clé&nbsp;: la possibilité d’interagir avec d’autres joueurs dans le jeu. 💬</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "64eb0f7d-40d3-4dee-aa36-78fc19141a6c",
+          "type": "discovery",
+          "title": "Activité découverte - 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "139b7a65-92b9-4d4c-ba16-1badbbe24bd1",
+                "type": "text",
+                "content": "<p>De nombreux jeux vidéo en ligne se jouent en équipe. Les joueurs doivent donc discuter ensemble, par écrit ou en vocal, afin de collaborer et progresser dans le jeu.</p><p><strong>Ces discussions en ligne comportent des risques</strong>. 🎧&nbsp;<br>Un enfant peut être exposé à des personnes avec de mauvaises intentions ou à du contenu choquant. 😱</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "59cff0b1-f82f-4f5a-a91f-fccf43d7b366",
+                "type": "qcu-discovery",
+                "instruction": "<p>À votre avis, quelle affirmation est vraie ? </p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Tous les jeux vidéo sur ordinateur permettent de discuter en ligne avec d'autres joueurs.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Seuls les jeux vidéo sur console permettent de discuter en ligne avec d'autres joueurs</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Et non, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Certains jeux vidéo permettent de discuter en ligne avec d'autres joueurs quel que soit l'équipement utilisé.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Effectivement, quel que soit l'équipement (smartphone, tablette, console, ordinateur) de nombreux jeux vidéo permettent de discuter entre joueurs.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "779de80b-ba18-4e95-ab6d-bbc5ce8edd5a",
+          "type": "lesson",
+          "title": "Leçon - 5 : Les interactions entre joueurs",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "6b8112ec-45ab-4665-b690-9adf0b6e93ac",
-                  "type": "text",
-                  "content": "<h3>Comment se protéger ?</h3><p>🔎 D’abord, il faut être attentif lors du choix d’un jeu vidéo. Sur les boîtes ou les pages en ligne des jeux, la mention d’interaction entre joueurs peut prendre différentes formes&nbsp;: «&nbsp;<strong>les utilisateurs interagissent</strong>&nbsp;», «&nbsp;<strong>interaction entre les joueurs</strong>&nbsp;», «&nbsp;<strong>interactivité des utilisateurs</strong>&nbsp;»...</p>"
+                  "elements": [
+                    {
+                      "id": "d85a05a1-0c9d-4ce7-ad25-9333eb3a75c3",
+                      "type": "text",
+                      "content": "<h3>Quels sont les risques des discussions en ligne ?</h3><p>Il est impossible de savoir qui se trouve réellement de l’autre côté de l’écran. Les personnes avec de mauvaises intentions cherchent souvent à&nbsp;: </p><ul><li>manipuler les autres joueurs</li><li>proposer des rencontres dans la vraie vie</li><li>pousser à partager des photos ou des informations personnelles</li></ul><p>⚠️ <strong>Attention</strong><br>Même avec un jeu qui ne permet pas de discuter avec d’autres joueurs, ce risque n’est pas écarté. En effet, certaines consoles permettent de discuter en ligne, tout comme les ordinateurs et les smartphones.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "9e9b11ab-0ffb-4dc9-917a-f5e336300ce5",
-                  "type": "image",
-                  "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_capture_pegi.png",
-                  "alt": "Capture d’écran de la page d’installation d’un jeu vidéo avec la mention « interactivité des utilisateurs » encadrée",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "61751690-1ee8-41ee-86c4-f9903230c9f6",
-                  "type": "text",
-                  "content": "<p>⚙️ Pour limiter les discussions qui passent par les consoles, smartphones ou ordinateurs, il est possible de paramétrer le contrôle parental de chacun des appareils.</p><p>🗣️ Enfin, il est important de discuter fréquemment avec les enfants des risques et des usages à autoriser ou non.</p>"
+                  "elements": [
+                    {
+                      "id": "6b8112ec-45ab-4665-b690-9adf0b6e93ac",
+                      "type": "text",
+                      "content": "<h3>Comment se protéger ?</h3><p>🔎 D’abord, il faut être attentif lors du choix d’un jeu vidéo. Sur les boîtes ou les pages en ligne des jeux, la mention d’interaction entre joueurs peut prendre différentes formes&nbsp;: «&nbsp;<strong>les utilisateurs interagissent</strong>&nbsp;», «&nbsp;<strong>interaction entre les joueurs</strong>&nbsp;», «&nbsp;<strong>interactivité des utilisateurs</strong>&nbsp;»...</p>"
+                    },
+                    {
+                      "id": "9e9b11ab-0ffb-4dc9-917a-f5e336300ce5",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_capture_pegi.png",
+                      "alt": "Capture d’écran de la page d’installation d’un jeu vidéo avec la mention « interactivité des utilisateurs » encadrée",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "61751690-1ee8-41ee-86c4-f9903230c9f6",
+                      "type": "text",
+                      "content": "<p>⚙️ Pour limiter les discussions qui passent par les consoles, smartphones ou ordinateurs, il est possible de paramétrer le contrôle parental de chacun des appareils.</p><p>🗣️ Enfin, il est important de discuter fréquemment avec les enfants des risques et des usages à autoriser ou non.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "4a349720-15b7-4c86-a431-344410332fd5",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7346e1eb-4591-4913-9c39-9d23dfcf7db8",
-            "type": "text",
-            "content": "<p><strong>Avant de choisir un jeu vidéo pour votre enfant, il y a trois informations clés à vérifier&nbsp;:</strong></p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "7779f759-5490-45c0-863f-18d37805a6b9",
-            "type": "image",
-            "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_resume.png",
-            "alt": "Infographie détaillée dans l’alternative textuelle",
-            "alternativeText": "<p>Les 3 informations à vérifier&nbsp;:&nbsp;</p><ol>    <li>la recommandation de la signalétique PEGI</li>    <li>la présence d’achats intégrés</li>    <li>la possibilité de discuter avec d’autres joueurs</li></ol>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f75135d6-68f6-40b5-a8d7-59a33a23ac39",
-            "type": "text",
-            "content": "<p>👉 Et vous, aviez-vous déjà remarqué ces 3 informations sur les jeux ? 👀</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "aaa9d376-b55d-437f-91ca-bb6ba7505b06",
-      "type": "activity",
-      "title": "Activité d'application - 1 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "99f21e69-cdb4-4428-9153-ae857a148ee7",
-            "type": "text",
-            "content": "<p>Voyons si vous avez retenu l'essentiel.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2480d448-edb5-4039-9887-e35c9bbfaa21",
-            "type": "qab",
-            "instruction": "<p>Pour chacune des affirmations, indiquez si elle est vraie ou fausse.</p>",
-            "cards": [
-              {
-                "id": "d60d243f-cb78-42c3-b20a-54e8944015b3",
-                "text": "Tous les jeux vidéo vendus en France comportent un pictogramme de la signalétique PEGI.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "3a1a3899-b92c-4f55-a7f5-f33fd5ddacf1",
-                "text": "Les achats intégrés ne concernent que les jeux vidéo gratuits.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "2e15a3c4-1f71-4314-9f39-49a13bacc387",
-                "text": "Une loot box est un peu comme une pochette-surprise : son contenu est aléatoire.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "8b345f46-4c3a-493a-aa3b-a24c727aa19c",
-                "text": "Certains jeux vidéo permettent de discuter avec des joueurs de tous âges à travers le monde.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
+          "id": "4a349720-15b7-4c86-a431-344410332fd5",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7346e1eb-4591-4913-9c39-9d23dfcf7db8",
+                "type": "text",
+                "content": "<p><strong>Avant de choisir un jeu vidéo pour votre enfant, il y a trois informations clés à vérifier&nbsp;:</strong></p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7779f759-5490-45c0-863f-18d37805a6b9",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/jeux-video-enfant/ppn3_resume.png",
+                "alt": "Infographie détaillée dans l’alternative textuelle",
+                "alternativeText": "<p>Les 3 informations à vérifier&nbsp;:&nbsp;</p><ol>    <li>la recommandation de la signalétique PEGI</li>    <li>la présence d’achats intégrés</li>    <li>la possibilité de discuter avec d’autres joueurs</li></ol>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f75135d6-68f6-40b5-a8d7-59a33a23ac39",
+                "type": "text",
+                "content": "<p>👉 Et vous, aviez-vous déjà remarqué ces 3 informations sur les jeux ? 👀</p>"
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "5e318a39-c2ef-4b2a-8a86-acf86092490b",
-      "type": "transition",
-      "title": "Transition - 5",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "45a1378d-e5bc-43a1-a5c8-b190d5aad710",
-            "type": "text",
-            "content": "<p>Franck sait maintenant que Dragon’s Kingdom, le jeu demandé par Marilou n’est pas adapté à son âge.<br>Après discussion avec sa fille de 8 ans, Franck souhaite lui acheter un autre jeu sur les dragons. 🐲</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6e7dad63-ee7e-428b-a25f-08d760b00503",
-      "type": "challenge",
-      "title": "Choix final",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5403d509-05f4-4473-ab7c-18e244aa234c",
-            "type": "text",
-            "content": "<p>Il veut lui offrir un jeu&nbsp;: </p><ul><li> sans contenus inadaptés pour son âge selon la signalétique PEGI</li><li>sans achats intégrés</li><li>sans possibilité de discuter avec d’autres joueurs dans le jeu</li></ul><p>👇 Voici, ci-dessous, les fiches des trois jeux vidéo sur le thème des dragons que Franck a sélectionnés.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "c7e69b60-f1ae-41b8-9cbc-80f22c6f634a",
-            "type": "custom",
-            "tagName": "pix-carousel",
-            "props": {
-              "type": "image",
-              "slides": [
-                {
-                  "title": "Mon petit dragon",
-                  "description": "",
-                  "displayWidth": 750,
-                  "image": {
-                    "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_mignon.png",
-                    "alt": "Jeu Mon petit dragon : cake éditeur, consoles, bouton ajouter au panier, pictogramme Pegi 3, achats intra-jeu facultatifs."
+          "id": "aaa9d376-b55d-437f-91ca-bb6ba7505b06",
+          "type": "activity",
+          "title": "Activité d'application - 1 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "99f21e69-cdb4-4428-9153-ae857a148ee7",
+                "type": "text",
+                "content": "<p>Voyons si vous avez retenu l'essentiel.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2480d448-edb5-4039-9887-e35c9bbfaa21",
+                "type": "qab",
+                "instruction": "<p>Pour chacune des affirmations, indiquez si elle est vraie ou fausse.</p>",
+                "cards": [
+                  {
+                    "id": "d60d243f-cb78-42c3-b20a-54e8944015b3",
+                    "text": "Tous les jeux vidéo vendus en France comportent un pictogramme de la signalétique PEGI.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
                   },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La quête de l'eau",
-                  "description": "",
-                  "displayWidth": 750,
-                  "image": {
-                    "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_eau.png",
-                    "alt": "Jeu La quête de l'eau : Niamtoc, aventure, 4,8 étoiles, 21,5k avis, bouton obtenir, pictogramme Pegi 7, pictogramme peur."
+                  {
+                    "id": "3a1a3899-b92c-4f55-a7f5-f33fd5ddacf1",
+                    "text": "Les achats intégrés ne concernent que les jeux vidéo gratuits.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
                   },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Le tournoi des cieux",
-                  "description": "",
-                  "displayWidth": 750,
-                  "image": {
-                    "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_ciel.png",
-                    "alt": "Jeu Le tournoi des cieux : 4,3 étoiles, communauté compétitive, commandes rapides à maîtriser, pictogramme Pegi 7, violence, interaction entre joueurs, bouton obtenir, bouton ajouter au panier."
+                  {
+                    "id": "2e15a3c4-1f71-4314-9f39-49a13bacc387",
+                    "text": "Une loot box est un peu comme une pochette-surprise : son contenu est aléatoire.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
                   },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
+                  {
+                    "id": "8b345f46-4c3a-493a-aa3b-a24c727aa19c",
+                    "text": "Certains jeux vidéo permettent de discuter avec des joueurs de tous âges à travers le monde.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
                   }
-                }
-              ],
-              "aspectRatio": 0,
-              "randomSlides": false,
-              "titleLevel": 0,
-              "disableAnimation": false
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9ac76a42-e7ba-477c-a865-e0dd8617b850",
-            "type": "qcu",
-            "instruction": "<p>Parmi ces trois jeux, lequel correspond aux critères de Franck ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Mon petit dragon</p>",
+                ],
                 "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Ce jeu contient des achats intégrés. Avez-vous vérifié la présence d’achats intégrés ou d’interactions entre les utilisateurs dans les autres jeux ?</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>La quête de l’eau</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse ! 🎉</p>",
-                  "diagnosis": "<p>Ce jeu est adapté à partir de 7 ans et ne contient ni achats intégrés ni interactions entre les joueurs dans le jeu. <br>Le pictogramme «&nbsp;peur&nbsp;» à côté du pictogramme «&nbsp;7&nbsp;» indique que le jeu contient des images ou des sons qui peuvent effrayer mais qu’il est évalué par la signalétique PEGI comme adapté pour des enfants à partir de 7 ans.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Le tournoi des cieux</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Ce jeu propose des interactions entre les utilisateurs. Avez-vous vérifié la présence d’achats intégrés ou d’interactions entre les utilisateurs dans les autres jeux ?</p>"
+                  "diagnosis": ""
                 }
               }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e48264b9-a0b5-4783-a78a-9844b9a6e77f",
-      "type": "transition",
-      "title": "",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "bb51dffa-ef4f-4124-80e4-e7024e2280dc",
-            "type": "text",
-            "content": "<p>Grâce à vous, Franck a choisi un jeu vidéo pour Marilou ! 👏<br>Il peut à présent jouer avec elle, pour l’accompagner dans sa découverte du jeu.</p>"
-          }
+          "id": "5e318a39-c2ef-4b2a-8a86-acf86092490b",
+          "type": "transition",
+          "title": "Transition - 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "45a1378d-e5bc-43a1-a5c8-b190d5aad710",
+                "type": "text",
+                "content": "<p>Franck sait maintenant que Dragon’s Kingdom, le jeu demandé par Marilou n’est pas adapté à son âge.<br>Après discussion avec sa fille de 8 ans, Franck souhaite lui acheter un autre jeu sur les dragons. 🐲</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6e7dad63-ee7e-428b-a25f-08d760b00503",
+          "type": "challenge",
+          "title": "Choix final",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5403d509-05f4-4473-ab7c-18e244aa234c",
+                "type": "text",
+                "content": "<p>Il veut lui offrir un jeu&nbsp;: </p><ul><li> sans contenus inadaptés pour son âge selon la signalétique PEGI</li><li>sans achats intégrés</li><li>sans possibilité de discuter avec d’autres joueurs dans le jeu</li></ul><p>👇 Voici, ci-dessous, les fiches des trois jeux vidéo sur le thème des dragons que Franck a sélectionnés.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c7e69b60-f1ae-41b8-9cbc-80f22c6f634a",
+                "type": "custom",
+                "tagName": "pix-carousel",
+                "props": {
+                  "type": "image",
+                  "slides": [
+                    {
+                      "title": "Mon petit dragon",
+                      "description": "",
+                      "displayWidth": 750,
+                      "image": {
+                        "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_mignon.png",
+                        "alt": "Jeu Mon petit dragon : cake éditeur, consoles, bouton ajouter au panier, pictogramme Pegi 3, achats intra-jeu facultatifs."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La quête de l'eau",
+                      "description": "",
+                      "displayWidth": 750,
+                      "image": {
+                        "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_eau.png",
+                        "alt": "Jeu La quête de l'eau : Niamtoc, aventure, 4,8 étoiles, 21,5k avis, bouton obtenir, pictogramme Pegi 7, pictogramme peur."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Le tournoi des cieux",
+                      "description": "",
+                      "displayWidth": 750,
+                      "image": {
+                        "src": "https://assets.pix.org/modules/jeux-video-enfant/jeu_dragon_ciel.png",
+                        "alt": "Jeu Le tournoi des cieux : 4,3 étoiles, communauté compétitive, commandes rapides à maîtriser, pictogramme Pegi 7, violence, interaction entre joueurs, bouton obtenir, bouton ajouter au panier."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "aspectRatio": 0,
+                  "randomSlides": false,
+                  "titleLevel": 0,
+                  "disableAnimation": false
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9ac76a42-e7ba-477c-a865-e0dd8617b850",
+                "type": "qcu",
+                "instruction": "<p>Parmi ces trois jeux, lequel correspond aux critères de Franck ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Mon petit dragon</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Ce jeu contient des achats intégrés. Avez-vous vérifié la présence d’achats intégrés ou d’interactions entre les utilisateurs dans les autres jeux ?</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>La quête de l’eau</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse ! 🎉</p>",
+                      "diagnosis": "<p>Ce jeu est adapté à partir de 7 ans et ne contient ni achats intégrés ni interactions entre les joueurs dans le jeu. <br>Le pictogramme «&nbsp;peur&nbsp;» à côté du pictogramme «&nbsp;7&nbsp;» indique que le jeu contient des images ou des sons qui peuvent effrayer mais qu’il est évalué par la signalétique PEGI comme adapté pour des enfants à partir de 7 ans.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Le tournoi des cieux</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Ce jeu propose des interactions entre les utilisateurs. Avez-vous vérifié la présence d’achats intégrés ou d’interactions entre les utilisateurs dans les autres jeux ?</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e48264b9-a0b5-4783-a78a-9844b9a6e77f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bb51dffa-ef4f-4124-80e4-e7024e2280dc",
+                "type": "text",
+                "content": "<p>Grâce à vous, Franck a choisi un jeu vidéo pour Marilou ! 👏<br>Il peut à présent jouer avec elle, pour l’accompagner dans sa découverte du jeu.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
@@ -14,1065 +14,1071 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "3bcfed7b-a553-492d-aa88-db8242addf5b",
-      "type": "transition",
-      "title": "Introduction",
-      "components": [
+      "id": "49b5ee70-4cfc-4785-a45c-5da517bebbd0",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "35a9be34-9b63-4cf5-b984-432010aff74e",
-            "type": "text",
-            "content": "<p>Enzo a produit sur son ordinateur un texte à l’aide d’un logiciel d'intelligence artificielle générative. </p><p>Il ne pensait pas que son ordinateur était si puissant.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4f996ce8-939b-436d-b372-f4aec1955d5b",
-      "type": "discovery",
-      "title": "Discussion intro",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d6a611ae-9e90-402b-8b35-03dcdc5e3faf",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Discussion intro",
-              "messages": [
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "C’est impressionnant comme l’IA a boosté mon ordinateur ! 🤯"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Tu parles de ton vieil ordinateur ?"
-                },
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "Oui mais grâce à l'IA, maintenant, il arrive à répondre à toutes mes demandes !"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "C'est incroyable ! "
-                }
-              ]
+          "id": "3bcfed7b-a553-492d-aa88-db8242addf5b",
+          "type": "transition",
+          "title": "Introduction",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35a9be34-9b63-4cf5-b984-432010aff74e",
+                "type": "text",
+                "content": "<p>Enzo a produit sur son ordinateur un texte à l’aide d’un logiciel d'intelligence artificielle générative. </p><p>Il ne pensait pas que son ordinateur était si puissant.</p>"
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "bcfc5017-0b98-4603-9ed3-31506ec52d15",
-      "type": "transition",
-      "title": "L'IA ne booste pas",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fdf4e875-c31c-4637-b9e1-62a9b77046e7",
-            "type": "text",
-            "content": "<p>Même avec un ordinateur peu puissant, ou un smartphone basique, on peut obtenir des réponses à toutes nos demandes grâce à l’IA. </p><p><strong>Mais comment est-ce possible ?</strong></p><p>Voyons où sont produites les réponses à nos demandes.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "45117f02-c379-4ed0-9691-52c7fc31555b",
-      "type": "discovery",
-      "title": "Trajet requête & réponse",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "926790dc-f2f3-43bf-a6d4-d20f3b39c5cb",
-            "type": "text",
-            "content": "<p>Que se passe-t-il quand on fait une demande à un logiciel d’IA générative ? </p><p> Découvrez <strong>le trajet d'une demande</strong> à un logiciel d'IA générative.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "f2081d5f-2054-477d-86d8-942e2b72c511",
-            "type": "custom",
-            "tagName": "pix-carousel",
-            "props": {
-              "type": "image",
-              "slides": [
-                {
-                  "title": "Enzo rédige et envoie sa demande au logiciel d'IA générative",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete02.jpeg",
-                    "alt": "Enzo envoie sa demande au logiciel d'IA générative"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La demande est envoyée sur le réseau WIFi jusqu'à sa box",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete03.jpeg",
-                    "alt": "Enzo rédige et envoie sa demande au logiciel d'IA générative"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La demande d'Enzo voyage sur le réseau internet mondial",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete04.jpeg",
-                    "alt": "La demande d'Enzo voyage sur le réseau internet mondial"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La demande d'Enzo parvient à un supercalculateur",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete05.jpeg",
-                    "alt": "La demande d'Enzo parvient à un supercalculateur"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Le supercalculateur calcule la réponse à apporter",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete06.jpeg",
-                    "alt": "Le supercalculateur calcule la réponse à apporter"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse est prête à être envoyée",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete07.jpeg",
-                    "alt": "La réponse est prête à être envoyée"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse fait le trajet retour sur internet",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete08.jpeg",
-                    "alt": "La réponse fait le trajet retour sur internet"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse est envoyée par WiFi à l'ordinateur",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete09.jpeg",
-                    "alt": "La réponse est envoyée par WiFi à l'ordinateur"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse est affichée sur l'écran d'Enzo",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete10.jpeg",
-                    "alt": "La réponse est affichée sur l'écran d'Enzo"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                }
-              ],
-              "aspectRatio": 0,
-              "randomSlides": false,
-              "titleLevel": 0,
-              "disableAnimation": true
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6a585a2a-9d17-4307-befd-906559ec80b1",
-            "type": "qcu",
-            "instruction": "<p>Lorsqu’on fait une demande à un logiciel d’IA générative, la réponse est calculée&nbsp;:</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Dans notre appareil personnel</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Votre demande voyage depuis votre ordinateur via internet jusqu’à un supercalculateur, peut-être situé à l’autre bout du monde. C’est là-bas que la réponse est calculée.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Dans un supercalculateur</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse !&nbsp;🎉</p>",
-                  "diagnosis": "<p>Ce supercalculateur est peut-être situé à l’autre bout du monde !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Sur internet</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Votre demande voyage depuis votre ordinateur via internet jusqu’à un supercalculateur, peut-être situé à l’autre bout du monde. C’est là-bas que la réponse est calculée.</p>"
+          "id": "4f996ce8-939b-436d-b372-f4aec1955d5b",
+          "type": "discovery",
+          "title": "Discussion intro",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d6a611ae-9e90-402b-8b35-03dcdc5e3faf",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Discussion intro",
+                  "messages": [
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "C’est impressionnant comme l’IA a boosté mon ordinateur ! 🤯"
+                    },
+                    {
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Tu parles de ton vieil ordinateur ?"
+                    },
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "Oui mais grâce à l'IA, maintenant, il arrive à répondre à toutes mes demandes !"
+                    },
+                    {
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "C'est incroyable ! "
+                    }
+                  ]
                 }
               }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "24f08127-eeea-44a5-a5b3-21c7f333b760",
-      "type": "lesson",
-      "title": "Un long voyage",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "140817f0-531a-44a6-83bb-2a7b094848c8",
-            "type": "text",
-            "content": "<p>🚀<strong> Un long voyage</strong></p><p>Quand on interroge un logiciel d’IA générative, la requête (prompt) est <strong>envoyée par le réseau internet dans un immense centre informatique, un supercalculateur</strong>, quelque part dans le monde.&nbsp; </p><p>La réponse nous est ensuite renvoyée.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fff6aed9-7c64-4f1a-933f-0640c9ff6c1b",
-      "type": "transition",
-      "title": "Discussion fonctionnement supercalculateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "92f6e0bb-fa86-4734-be11-d8f3d016e005",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Discussion ressources",
-              "messages": [
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "Alors c’est pas mon ordinateur qui est devenu puissant 😞"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Bah tant qu’il te permet d’utiliser l’IA, ça suffit."
-                },
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "C’est vrai ! Mais j’aimerais bien savoir comment fait le supercalculateur."
-                }
-              ]
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "c568c13b-5f8e-40a2-a934-bcf5e30e73ae",
-      "type": "discovery",
-      "title": "Découverte traitement supercalculateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8ceec6c1-0391-4644-8bee-edf0be8c7038",
-            "type": "text",
-            "content": "<p>Découvrez <strong>comment le supercalculateur répond </strong>à la demande d’Enzo</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "d281c4c1-9718-4e6d-a6b0-508f4489fcae",
-            "type": "custom",
-            "tagName": "pix-carousel",
-            "props": {
-              "type": "image",
-              "slides": [
-                {
-                  "title": "Une requête est reçue par le supercalculateur",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete01.jpeg",
-                    "alt": "Une requête est reçue par le supercalculateur"
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Elle est transmise à des serveurs (gros ordinateurs) spécialisés pour l'IA.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete02.jpeg",
-                    "alt": "Elle est transmise à des serveurs (gros ordinateurs) spécialisés pour l'IA."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Les serveurs calculent la réponse. Ils consomment de l'énergie.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete03.jpeg",
-                    "alt": "Les serveurs calculent la réponse. Ils consomment de l'énergie."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Les serveurs dégagent de la chaleur.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete04.jpeg",
-                    "alt": "Les serveurs dégagent de la chaleur."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Un système de refroidissement est nécessaire. Il consomme de l'énergie supplémentaire et de l'eau.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete05.jpeg",
-                    "alt": "Un système de refroidissement est nécessaire. Il consomme de l'énergie supplémentaire et de l'eau."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "Les serveurs poursuivent les calculs et préparent la réponse.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete06.jpeg",
-                    "alt": "Les serveurs poursuivent les calculs et préparent la réponse."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse est prête et sort des serveurs.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete07.jpeg",
-                    "alt": "La réponse est prête et sort des serveurs."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                },
-                {
-                  "title": "La réponse sort du supercalculateur et est envoyée sur internet.",
-                  "description": "",
-                  "displayWidth": 600,
-                  "image": {
-                    "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete08.jpeg",
-                    "alt": "La réponse sort du supercalculateur et est envoyée sur internet."
-                  },
-                  "license": {
-                    "name": "",
-                    "attribution": "",
-                    "url": ""
-                  }
-                }
-              ],
-              "aspectRatio": 0,
-              "randomSlides": false,
-              "titleLevel": 0,
-              "disableAnimation": true
+          "id": "bcfc5017-0b98-4603-9ed3-31506ec52d15",
+          "type": "transition",
+          "title": "L'IA ne booste pas",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fdf4e875-c31c-4637-b9e1-62a9b77046e7",
+                "type": "text",
+                "content": "<p>Même avec un ordinateur peu puissant, ou un smartphone basique, on peut obtenir des réponses à toutes nos demandes grâce à l’IA. </p><p><strong>Mais comment est-ce possible ?</strong></p><p>Voyons où sont produites les réponses à nos demandes.</p>"
+              }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "67ffb9ff-0a27-4ef4-aefe-ea406e053988",
-      "type": "lesson",
-      "title": "L’IA, ça calcule, ça chauffe, ça consomme",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "40de84e9-fc48-40c3-9d3f-499f6454d46a",
-            "type": "text",
-            "content": "<p><strong>⚡L’IA, ça calcule, ça chauffe, ça consomme</strong></p><p>Le traitement d’une requête nécessite de <strong>nombreux calculs</strong>. Pour effectuer ces calculs, il faut du <strong>matériel très complexe</strong>, qui <strong>consomme de l’électricité</strong> et qui a <strong>besoin d’être refroidi</strong> en permanence avec <strong>de l'eau</strong>.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "01360a56-4628-41bf-9d07-0052f0383413",
-      "type": "transition",
-      "title": "Discussion je consomme",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9fc41408-a61d-4e6c-aee4-7f0ede9102a4",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Discussion supercalculateurs",
-              "messages": [
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "Alors quand j’utilise un logiciel d’IA générative, je consomme de l’énergie à l’autre bout du monde !"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Oui et moi aussi !"
-                },
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "Et les milliers d’autres utilisateurs avec nous ! "
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "e3806d90-2517-49c0-9514-047a21915ea8",
-      "type": "discovery",
-      "title": "découverte conso prompts multiples",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8286afa8-20b5-4e86-99bc-7daf29f91363",
-            "type": "text",
-            "content": "<p>Imaginons que <strong>plusieurs personnes demandent la même chose en même temps</strong> à un logiciel d’IA générative. </p>\n<p>En <strong>choisissant la demande</strong> envoyée <strong>et le</strong> <strong>nombre d'utilisateurs</strong>, testez la <strong>capacité de calcul</strong> d’un supercalculateur pour répondre aux questions suivantes.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "a44b87c8-ecf4-45dd-9cf7-1dc90492ef91",
-            "type": "custom-draft",
-            "title": "Test de la capacité de calcul d'un superclculateur",
-            "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementInferenceSpinner02.html",
-            "instruction": "",
-            "height": 450
-          }
+          "id": "45117f02-c379-4ed0-9691-52c7fc31555b",
+          "type": "discovery",
+          "title": "Trajet requête & réponse",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "926790dc-f2f3-43bf-a6d4-d20f3b39c5cb",
+                "type": "text",
+                "content": "<p>Que se passe-t-il quand on fait une demande à un logiciel d’IA générative ? </p><p> Découvrez <strong>le trajet d'une demande</strong> à un logiciel d'IA générative.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f2081d5f-2054-477d-86d8-942e2b72c511",
+                "type": "custom",
+                "tagName": "pix-carousel",
+                "props": {
+                  "type": "image",
+                  "slides": [
+                    {
+                      "title": "Enzo rédige et envoie sa demande au logiciel d'IA générative",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete02.jpeg",
+                        "alt": "Enzo envoie sa demande au logiciel d'IA générative"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La demande est envoyée sur le réseau WIFi jusqu'à sa box",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete03.jpeg",
+                        "alt": "Enzo rédige et envoie sa demande au logiciel d'IA générative"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La demande d'Enzo voyage sur le réseau internet mondial",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete04.jpeg",
+                        "alt": "La demande d'Enzo voyage sur le réseau internet mondial"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La demande d'Enzo parvient à un supercalculateur",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete05.jpeg",
+                        "alt": "La demande d'Enzo parvient à un supercalculateur"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Le supercalculateur calcule la réponse à apporter",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete06.jpeg",
+                        "alt": "Le supercalculateur calcule la réponse à apporter"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse est prête à être envoyée",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete07.jpeg",
+                        "alt": "La réponse est prête à être envoyée"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse fait le trajet retour sur internet",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete08.jpeg",
+                        "alt": "La réponse fait le trajet retour sur internet"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse est envoyée par WiFi à l'ordinateur",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete09.jpeg",
+                        "alt": "La réponse est envoyée par WiFi à l'ordinateur"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse est affichée sur l'écran d'Enzo",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/voyageRequete10.jpeg",
+                        "alt": "La réponse est affichée sur l'écran d'Enzo"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "aspectRatio": 0,
+                  "randomSlides": false,
+                  "titleLevel": 0,
+                  "disableAnimation": true
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6a585a2a-9d17-4307-befd-906559ec80b1",
+                "type": "qcu",
+                "instruction": "<p>Lorsqu’on fait une demande à un logiciel d’IA générative, la réponse est calculée&nbsp;:</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Dans notre appareil personnel</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Votre demande voyage depuis votre ordinateur via internet jusqu’à un supercalculateur, peut-être situé à l’autre bout du monde. C’est là-bas que la réponse est calculée.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Dans un supercalculateur</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse !&nbsp;🎉</p>",
+                      "diagnosis": "<p>Ce supercalculateur est peut-être situé à l’autre bout du monde !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Sur internet</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Votre demande voyage depuis votre ordinateur via internet jusqu’à un supercalculateur, peut-être situé à l’autre bout du monde. C’est là-bas que la réponse est calculée.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "24f08127-eeea-44a5-a5b3-21c7f333b760",
+          "type": "lesson",
+          "title": "Un long voyage",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "43d66e84-554c-4750-8658-7329c4a4f759",
-                  "type": "qcu",
-                  "instruction": "<p>Si on envoie <strong>environ</strong>&nbsp;<strong>800 demandes</strong> de <strong>création de vidéo</strong>, le supercalculateur peut-il les traiter ?</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "140817f0-531a-44a6-83bb-2a7b094848c8",
+                "type": "text",
+                "content": "<p>🚀<strong> Un long voyage</strong></p><p>Quand on interroge un logiciel d’IA générative, la requête (prompt) est <strong>envoyée par le réseau internet dans un immense centre informatique, un supercalculateur</strong>, quelque part dans le monde.&nbsp; </p><p>La réponse nous est ensuite renvoyée.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "fff6aed9-7c64-4f1a-933f-0640c9ff6c1b",
+          "type": "transition",
+          "title": "Discussion fonctionnement supercalculateur",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "92f6e0bb-fa86-4734-be11-d8f3d016e005",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Discussion ressources",
+                  "messages": [
                     {
-                      "id": "1",
-                      "content": "<p>Oui</p>",
-                      "feedback": {
-                        "state": "<p>En effet.&nbsp;</p>",
-                        "diagnosis": ""
-                      }
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "Alors c’est pas mon ordinateur qui est devenu puissant 😞"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Non</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Sélectionner la demande de création d'une vidéo et ajuster la quantité à environ 800 pour visualiser le résultat.</p>"
-                      }
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Bah tant qu’il te permet d’utiliser l’IA, ça suffit."
+                    },
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "C’est vrai ! Mais j’aimerais bien savoir comment fait le supercalculateur."
                     }
-                  ],
-                  "solution": "1"
+                  ]
                 }
-              ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "c568c13b-5f8e-40a2-a934-bcf5e30e73ae",
+          "type": "discovery",
+          "title": "Découverte traitement supercalculateur",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8ceec6c1-0391-4644-8bee-edf0be8c7038",
+                "type": "text",
+                "content": "<p>Découvrez <strong>comment le supercalculateur répond </strong>à la demande d’Enzo</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "541dc2cc-dd98-43cd-ba10-a81adb041750",
-                  "type": "qcu",
-                  "instruction": "<p>Si on envoie <strong>environ 25 000 demandes</strong> de <strong>création de dessin</strong>, le supercalculateur peut-il les traiter ?</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "d281c4c1-9718-4e6d-a6b0-508f4489fcae",
+                "type": "custom",
+                "tagName": "pix-carousel",
+                "props": {
+                  "type": "image",
+                  "slides": [
                     {
-                      "id": "1",
-                      "content": "<p>Oui</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse</p>",
-                        "diagnosis": "<p>Sélectionner la demande de création d'un dessin et ajuster la quantité à environ 25 000 pour visualiser le résultat.</p>"
+                      "title": "Une requête est reçue par le supercalculateur",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete01.jpeg",
+                        "alt": "Une requête est reçue par le supercalculateur"
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
                       }
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Non</p>",
-                      "feedback": {
-                        "state": "<p>En effet</p>",
-                        "diagnosis": ""
+                      "title": "Elle est transmise à des serveurs (gros ordinateurs) spécialisés pour l'IA.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete02.jpeg",
+                        "alt": "Elle est transmise à des serveurs (gros ordinateurs) spécialisés pour l'IA."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Les serveurs calculent la réponse. Ils consomment de l'énergie.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete03.jpeg",
+                        "alt": "Les serveurs calculent la réponse. Ils consomment de l'énergie."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Les serveurs dégagent de la chaleur.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete04.jpeg",
+                        "alt": "Les serveurs dégagent de la chaleur."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Un système de refroidissement est nécessaire. Il consomme de l'énergie supplémentaire et de l'eau.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete05.jpeg",
+                        "alt": "Un système de refroidissement est nécessaire. Il consomme de l'énergie supplémentaire et de l'eau."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "Les serveurs poursuivent les calculs et préparent la réponse.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete06.jpeg",
+                        "alt": "Les serveurs poursuivent les calculs et préparent la réponse."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse est prête et sort des serveurs.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete07.jpeg",
+                        "alt": "La réponse est prête et sort des serveurs."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "title": "La réponse sort du supercalculateur et est envoyée sur internet.",
+                      "description": "",
+                      "displayWidth": 600,
+                      "image": {
+                        "src": "https://assets.pix.org/draft/modules/les-IA-consomment/traitementRequete08.jpeg",
+                        "alt": "La réponse sort du supercalculateur et est envoyée sur internet."
+                      },
+                      "license": {
+                        "name": "",
+                        "attribution": "",
+                        "url": ""
                       }
                     }
                   ],
-                  "solution": "2"
+                  "aspectRatio": 0,
+                  "randomSlides": false,
+                  "titleLevel": 0,
+                  "disableAnimation": true
                 }
-              ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "67ffb9ff-0a27-4ef4-aefe-ea406e053988",
+          "type": "lesson",
+          "title": "L’IA, ça calcule, ça chauffe, ça consomme",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "40de84e9-fc48-40c3-9d3f-499f6454d46a",
+                "type": "text",
+                "content": "<p><strong>⚡L’IA, ça calcule, ça chauffe, ça consomme</strong></p><p>Le traitement d’une requête nécessite de <strong>nombreux calculs</strong>. Pour effectuer ces calculs, il faut du <strong>matériel très complexe</strong>, qui <strong>consomme de l’électricité</strong> et qui a <strong>besoin d’être refroidi</strong> en permanence avec <strong>de l'eau</strong>.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "01360a56-4628-41bf-9d07-0052f0383413",
+          "type": "transition",
+          "title": "Discussion je consomme",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9fc41408-a61d-4e6c-aee4-7f0ede9102a4",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Discussion supercalculateurs",
+                  "messages": [
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "Alors quand j’utilise un logiciel d’IA générative, je consomme de l’énergie à l’autre bout du monde !"
+                    },
+                    {
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Oui et moi aussi !"
+                    },
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "Et les milliers d’autres utilisateurs avec nous ! "
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "e3806d90-2517-49c0-9514-047a21915ea8",
+          "type": "discovery",
+          "title": "découverte conso prompts multiples",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8286afa8-20b5-4e86-99bc-7daf29f91363",
+                "type": "text",
+                "content": "<p>Imaginons que <strong>plusieurs personnes demandent la même chose en même temps</strong> à un logiciel d’IA générative. </p>\n<p>En <strong>choisissant la demande</strong> envoyée <strong>et le</strong> <strong>nombre d'utilisateurs</strong>, testez la <strong>capacité de calcul</strong> d’un supercalculateur pour répondre aux questions suivantes.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "83a69884-2d96-4bd9-99b3-a28cdf11c90c",
-                  "type": "qcu",
-                  "instruction": "<p>Si on envoie <strong>environ 90 000 demandes</strong> de <strong>création de texte</strong>, le supercalculateur peut-il les traiter ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Oui</p>",
-                      "feedback": {
-                        "state": "<p>En effet</p>",
-                        "diagnosis": ""
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Non</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse</p>",
-                        "diagnosis": "<p>Sélectionner la demande de création d'un poème et ajuster la quantité à environ 90 000 pour visualiser le résultat.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "a44b87c8-ecf4-45dd-9cf7-1dc90492ef91",
+                "type": "custom-draft",
+                "title": "Test de la capacité de calcul d'un superclculateur",
+                "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementInferenceSpinner02.html",
+                "instruction": "",
+                "height": 450
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "4dc8f82c-9470-4b3f-8a62-2379fb66bcab",
-                  "type": "qcu",
-                  "instruction": "<p>Quel type de requête demande le plus de puissance de calcul ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>génération de texte</p>",
-                      "feedback": {
-                        "state": "<p>Pas vraiment</p>",
-                        "diagnosis": "<p>Testez les trois requêtes avec un nombre d'environ 15 000 utilisateurs.</p>"
-                      }
-                    },
-                    {
-                      "id": "1",
-                      "content": "<p>génération d'image</p>",
-                      "feedback": {
-                        "state": "<p>Pas vraiment</p>",
-                        "diagnosis": "<p>Testez les trois requêtes avec un nombre d'environ 15 000 utilisateurs.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>génération de vidéo</p>",
-                      "feedback": {
-                        "state": "<p>Exactement</p>",
-                        "diagnosis": "<p>Ce sont bien <strong>les vidéos qui demandent la plus grande puissance de calculs</strong>.</p>"
-                      }
+                      "id": "43d66e84-554c-4750-8658-7329c4a4f759",
+                      "type": "qcu",
+                      "instruction": "<p>Si on envoie <strong>environ</strong>&nbsp;<strong>800 demandes</strong> de <strong>création de vidéo</strong>, le supercalculateur peut-il les traiter ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Oui</p>",
+                          "feedback": {
+                            "state": "<p>En effet.&nbsp;</p>",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Non</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Sélectionner la demande de création d'une vidéo et ajuster la quantité à environ 800 pour visualiser le résultat.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "3"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "541dc2cc-dd98-43cd-ba10-a81adb041750",
+                      "type": "qcu",
+                      "instruction": "<p>Si on envoie <strong>environ 25 000 demandes</strong> de <strong>création de dessin</strong>, le supercalculateur peut-il les traiter ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Oui</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse</p>",
+                            "diagnosis": "<p>Sélectionner la demande de création d'un dessin et ajuster la quantité à environ 25 000 pour visualiser le résultat.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Non</p>",
+                          "feedback": {
+                            "state": "<p>En effet</p>",
+                            "diagnosis": ""
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "83a69884-2d96-4bd9-99b3-a28cdf11c90c",
+                      "type": "qcu",
+                      "instruction": "<p>Si on envoie <strong>environ 90 000 demandes</strong> de <strong>création de texte</strong>, le supercalculateur peut-il les traiter ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Oui</p>",
+                          "feedback": {
+                            "state": "<p>En effet</p>",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Non</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse</p>",
+                            "diagnosis": "<p>Sélectionner la demande de création d'un poème et ajuster la quantité à environ 90 000 pour visualiser le résultat.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "4dc8f82c-9470-4b3f-8a62-2379fb66bcab",
+                      "type": "qcu",
+                      "instruction": "<p>Quel type de requête demande le plus de puissance de calcul ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>génération de texte</p>",
+                          "feedback": {
+                            "state": "<p>Pas vraiment</p>",
+                            "diagnosis": "<p>Testez les trois requêtes avec un nombre d'environ 15 000 utilisateurs.</p>"
+                          }
+                        },
+                        {
+                          "id": "1",
+                          "content": "<p>génération d'image</p>",
+                          "feedback": {
+                            "state": "<p>Pas vraiment</p>",
+                            "diagnosis": "<p>Testez les trois requêtes avec un nombre d'environ 15 000 utilisateurs.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>génération de vidéo</p>",
+                          "feedback": {
+                            "state": "<p>Exactement</p>",
+                            "diagnosis": "<p>Ce sont bien <strong>les vidéos qui demandent la plus grande puissance de calculs</strong>.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "c388aeb1-74d6-49cf-924c-87fa8a015bb7",
-      "type": "lesson",
-      "title": "Leçon conso énergie supercalculateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "74be751a-51ef-4ed3-a8d4-a2e7e7b464a8",
-            "type": "text",
-            "content": "<p>💻 <strong>⚡ Beaucoup d’utilisateurs, beaucoup d’énergie !</strong> </p><p>Un supercalculateur reçoit <strong>des milliers de requêtes en même temps</strong>.&nbsp;Pour la fabrication d’images haute définition ou de vidéos, les calculs sont beaucoup plus importants que pour produire du texte.&nbsp; </p><p>Le supercalculateur effectue en parallèle l’ensemble des calculs pour répondre aux demandes qu’il reçoit. Cela consomme <strong>une énorme quantité d’énergie. </strong></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c3504f09-f774-4145-9b8b-2d9d0f114c85",
-      "type": "transition",
-      "title": "Discussion épuiser la planète",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9cddd982-33fa-4b0f-8283-16daf5666a7b",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "transition bons usages",
-              "messages": [
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "L’IA c’est génial, mais j’ai pas envie d'épuiser la planète"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Moi non plus, je vais arrêter de l’utiliser."
-                },
-                {
-                  "userName": "Enzo",
-                  "direction": "incoming",
-                  "content": "L'IA, c’est quand même utile parfois."
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Peut-être…"
-                },
-                {
-                  "userName": "Alice",
-                  "direction": "outgoing",
-                  "content": "Tu penses à quoi par exemple ?"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "e09da5c3-ca5a-45a0-b15e-7dc8b98572af",
-      "type": "discovery",
-      "title": "Découverte QCU bons usages stepper",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "65f0620b-6632-480d-ad77-f4a2e7e59289",
-            "type": "text",
-            "content": "<p>Pour limiter la consommation des logiciels d’IA générative, on peut agir à notre niveau en adaptant nos usages. </p><p> À votre avis, <strong>l'IA est-elle utile</strong> pour répondre aux demandes suivantes  ?</p>"
-          }
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "c388aeb1-74d6-49cf-924c-87fa8a015bb7",
+          "type": "lesson",
+          "title": "Leçon conso énergie supercalculateur",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "3e3e04f1-89a3-418a-b91b-2a773e018c5d",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Dessine-moi la terre vue depuis l’espace.</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "74be751a-51ef-4ed3-a8d4-a2e7e7b464a8",
+                "type": "text",
+                "content": "<p>💻 <strong>⚡ Beaucoup d’utilisateurs, beaucoup d’énergie !</strong> </p><p>Un supercalculateur reçoit <strong>des milliers de requêtes en même temps</strong>.&nbsp;Pour la fabrication d’images haute définition ou de vidéos, les calculs sont beaucoup plus importants que pour produire du texte.&nbsp; </p><p>Le supercalculateur effectue en parallèle l’ensemble des calculs pour répondre aux demandes qu’il reçoit. Cela consomme <strong>une énorme quantité d’énergie. </strong></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c3504f09-f774-4145-9b8b-2d9d0f114c85",
+          "type": "transition",
+          "title": "Discussion épuiser la planète",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9cddd982-33fa-4b0f-8283-16daf5666a7b",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "transition bons usages",
+                  "messages": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>💡Mauvais choix !</p><p>Cette image <strong>peut facilement être trouvée sur internet</strong>.</p>"
-                      }
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "L’IA c’est génial, mais j’ai pas envie d'épuiser la planète"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En effet !</p><p>Cette image peut facilement être trouvée sur internet.</p>"
-                      }
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Moi non plus, je vais arrêter de l’utiliser."
+                    },
+                    {
+                      "userName": "Enzo",
+                      "direction": "incoming",
+                      "content": "L'IA, c’est quand même utile parfois."
+                    },
+                    {
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Peut-être…"
+                    },
+                    {
+                      "userName": "Alice",
+                      "direction": "outgoing",
+                      "content": "Tu penses à quoi par exemple ?"
                     }
-                  ],
-                  "solution": "2"
+                  ]
                 }
-              ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "e09da5c3-ca5a-45a0-b15e-7dc8b98572af",
+          "type": "discovery",
+          "title": "Découverte QCU bons usages stepper",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "65f0620b-6632-480d-ad77-f4a2e7e59289",
+                "type": "text",
+                "content": "<p>Pour limiter la consommation des logiciels d’IA générative, on peut agir à notre niveau en adaptant nos usages. </p><p> À votre avis, <strong>l'IA est-elle utile</strong> pour répondre aux demandes suivantes  ?</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "8e89075a-83e7-4c13-8673-8573438c65c3",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Résume en français un document en finlandais de 25 pages.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En effet !</p><p>L’IA peut vous faire <strong>gagner du temps</strong>, et vous permettre d’évaluer si l’article est intéressant pour vous.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Pourquoi pas ?</p><p>L’IA peut vous faire <strong>gagner du temps</strong>, et vous permettre d’évaluer si l’article est intéressant pour vous.</p>"
-                      }
+                      "id": "3e3e04f1-89a3-418a-b91b-2a773e018c5d",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Dessine-moi la terre vue depuis l’espace.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>💡Mauvais choix !</p><p>Cette image <strong>peut facilement être trouvée sur internet</strong>.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En effet !</p><p>Cette image peut facilement être trouvée sur internet.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "4793a2cc-0044-4a58-a1b7-eb186ecc4243",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Écris une courte scène de théâtre pour 5 acteurs sur le thème de la révolution française.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Ça se défend.</p><p>L'IA peut être une bonne <strong>source d’inspiration</strong> pour commencer ce projet, mais vous pouvez aussi faire marcher votre imagination.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Ça se discute.</p><p>L'IA peut être une bonne <strong>source d’inspiration</strong> pour commencer ce projet, mais vous pouvez aussi faire marcher votre imagination.</p>"
-                      }
+                      "id": "8e89075a-83e7-4c13-8673-8573438c65c3",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Résume en français un document en finlandais de 25 pages.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En effet !</p><p>L’IA peut vous faire <strong>gagner du temps</strong>, et vous permettre d’évaluer si l’article est intéressant pour vous.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Pourquoi pas ?</p><p>L’IA peut vous faire <strong>gagner du temps</strong>, et vous permettre d’évaluer si l’article est intéressant pour vous.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "366e03b8-b1d7-4e99-a0b2-2e8c8da3e64c",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Quelle est la météo à Paris aujourd’hui ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Mauvais choix.</p><p>Il existe <strong>des</strong> <strong>solutions bien plus efficaces</strong> pour obtenir cette information.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En effet !</p><p>Il existe <strong>des solutions bien plus efficaces</strong> pour obtenir cette information.</p>"
-                      }
+                      "id": "4793a2cc-0044-4a58-a1b7-eb186ecc4243",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Écris une courte scène de théâtre pour 5 acteurs sur le thème de la révolution française.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Ça se défend.</p><p>L'IA peut être une bonne <strong>source d’inspiration</strong> pour commencer ce projet, mais vous pouvez aussi faire marcher votre imagination.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Ça se discute.</p><p>L'IA peut être une bonne <strong>source d’inspiration</strong> pour commencer ce projet, mais vous pouvez aussi faire marcher votre imagination.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "366e03b8-b1d7-4e99-a0b2-2e8c8da3e64c",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Quelle est la météo à Paris aujourd’hui ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Mauvais choix.</p><p>Il existe <strong>des</strong> <strong>solutions bien plus efficaces</strong> pour obtenir cette information.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En effet !</p><p>Il existe <strong>des solutions bien plus efficaces</strong> pour obtenir cette information.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "a17d541a-c8dd-427a-a685-4842f7e8f164",
-      "type": "lesson",
-      "title": "Leçon - Agir pour réduire l'impact",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "65f0620b-6632-480d-ad77-f4a2e7e59288",
-            "type": "text",
-            "content": "<p><strong>🌱Agir pour réduire la consommation d’énergie</strong></p><p> Pour réduire les coûts énergétiques des supercalculateurs, on peut essayer collectivement d’utiliser les IA génératives à un juste besoin.&nbsp;</p><ul><li>Éviter les requêtes inutiles ou répétées</li><li>Privilégier des solutions plus efficaces quand elles existent</li><li>Éviter les demandes d'images ou de vidéos</li></ul><p><strong>🤔Bon à savoir</strong>&nbsp; </p><p>Les concepteurs des IA génératives peuvent aussi faire des efforts  comme améliorer les logiciels, améliorer les machines ou choisir des énergies renouvelables.&nbsp;</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b25e5fb3-86bd-48c4-91a4-974a292583cf",
-      "type": "summary",
-      "title": "Récap",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d705c485-ea6d-4109-a7c7-b236684b8330",
-            "type": "text",
-            "content": "<p><strong>&nbsp;💡Résumons avant de passer à la suite&nbsp;:</strong></p><ul>    <li>Pour répondre à nos <strong>millions de demandes</strong>, les logiciels d’IA génératives doivent faire de <strong>nombreux calculs</strong>.</li>    <li>C’est le rôle des <strong>supercalculateurs</strong>, parfois situés à l’autre bout du monde.</li>    <li>Pour <strong>faire ces calculs</strong>, et <strong>refroidir</strong> les supercalculateurs, il faut <strong>beaucoup d’énergie et beaucoup d'eau</strong>.</li>    <li><strong>Certaines requêtes</strong>, comme la fabrication d’images HD ou de vidéos, demandent plus de calculs, et <strong>nécessitent plus d’énergie.</strong></li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "71592ce9-8d26-4195-99e6-83d851451514",
-      "type": "transition",
-      "title": "Transition activités",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d7cbb4d1-4b0b-4802-8421-2e842b364655",
-            "type": "text",
-            "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9b4eca67-e1d7-4a2e-a1c2-9318b2f97130",
-      "type": "activity",
-      "title": "QAB évaluation",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "1854f199-bd3e-4b9a-a329-d402b2f0ada8",
-            "type": "qab",
-            "instruction": "<p>Pour chaque affirmation ci-dessous, dites si elle est vraie ou fausse&nbsp;:</p>",
-            "cards": [
-              {
-                "id": "ab9a5aac-3d1b-4a9e-a827-12c0bd978b61",
-                "text": "Quand je fais une requête à l’IA sur mon smartphone, c’est mon smartphone qui calcule la réponse.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "0bbd5412-c042-497c-b4f9-885053f6752b",
-                "text": "Les requêtes sont envoyées à l’IA via le réseau internet.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "e30055c9-16ef-4c03-a78e-d531edb9062b",
-                "text": "Pour répondre à une demande, l’IA effectue un grand nombre de calculs.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "5b09edb2-4fd1-4153-8dd9-0cd3caf7becf",
-                "text": "Un supercalculateur traite une seule requête à la fois.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
+          "id": "a17d541a-c8dd-427a-a685-4842f7e8f164",
+          "type": "lesson",
+          "title": "Leçon - Agir pour réduire l'impact",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "65f0620b-6632-480d-ad77-f4a2e7e59288",
+                "type": "text",
+                "content": "<p><strong>🌱Agir pour réduire la consommation d’énergie</strong></p><p> Pour réduire les coûts énergétiques des supercalculateurs, on peut essayer collectivement d’utiliser les IA génératives à un juste besoin.&nbsp;</p><ul><li>Éviter les requêtes inutiles ou répétées</li><li>Privilégier des solutions plus efficaces quand elles existent</li><li>Éviter les demandes d'images ou de vidéos</li></ul><p><strong>🤔Bon à savoir</strong>&nbsp; </p><p>Les concepteurs des IA génératives peuvent aussi faire des efforts  comme améliorer les logiciels, améliorer les machines ou choisir des énergies renouvelables.&nbsp;</p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "82b4ad43-6e5a-45f7-9b31-c2c0e4004f04",
-      "type": "activity",
-      "title": "QCU évaluation 1",
-      "components": [
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "542558c9-7795-4928-b45a-02aa19d7993e",
-            "type": "qcu",
-            "instruction": "<p>Qu’est-ce qui consomme de grandes quantités d’énergie dans un supercalculateur ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>La connexion internet et le chauffage du bâtiment.</p>",
+          "id": "b25e5fb3-86bd-48c4-91a4-974a292583cf",
+          "type": "summary",
+          "title": "Récap",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d705c485-ea6d-4109-a7c7-b236684b8330",
+                "type": "text",
+                "content": "<p><strong>&nbsp;💡Résumons avant de passer à la suite&nbsp;:</strong></p><ul>    <li>Pour répondre à nos <strong>millions de demandes</strong>, les logiciels d’IA génératives doivent faire de <strong>nombreux calculs</strong>.</li>    <li>C’est le rôle des <strong>supercalculateurs</strong>, parfois situés à l’autre bout du monde.</li>    <li>Pour <strong>faire ces calculs</strong>, et <strong>refroidir</strong> les supercalculateurs, il faut <strong>beaucoup d’énergie et beaucoup d'eau</strong>.</li>    <li><strong>Certaines requêtes</strong>, comme la fabrication d’images HD ou de vidéos, demandent plus de calculs, et <strong>nécessitent plus d’énergie.</strong></li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "71592ce9-8d26-4195-99e6-83d851451514",
+          "type": "transition",
+          "title": "Transition activités",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d7cbb4d1-4b0b-4802-8421-2e842b364655",
+                "type": "text",
+                "content": "<p>Voyons si vous avez retenu l’essentiel.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9b4eca67-e1d7-4a2e-a1c2-9318b2f97130",
+          "type": "activity",
+          "title": "QAB évaluation",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1854f199-bd3e-4b9a-a329-d402b2f0ada8",
+                "type": "qab",
+                "instruction": "<p>Pour chaque affirmation ci-dessous, dites si elle est vraie ou fausse&nbsp;:</p>",
+                "cards": [
+                  {
+                    "id": "ab9a5aac-3d1b-4a9e-a827-12c0bd978b61",
+                    "text": "Quand je fais une requête à l’IA sur mon smartphone, c’est mon smartphone qui calcule la réponse.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "0bbd5412-c042-497c-b4f9-885053f6752b",
+                    "text": "Les requêtes sont envoyées à l’IA via le réseau internet.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "e30055c9-16ef-4c03-a78e-d531edb9062b",
+                    "text": "Pour répondre à une demande, l’IA effectue un grand nombre de calculs.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "5b09edb2-4fd1-4153-8dd9-0cd3caf7becf",
+                    "text": "Un supercalculateur traite une seule requête à la fois.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  }
+                ],
                 "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>N'hésitez pas à consulter le récapitulatif ou les parties précédentes du module pour vous aider☝️</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Les calculs et le refroidissement des machines.</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse !&nbsp; 🎉</p>",
-                  "diagnosis": "<p>Ce sont bien les calculs effectués par le supercalculateur et le refroidissement des machines qui consomment beaucoup d’énergie.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>L’éclairage et la vidéo-surveillance.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>N'hésitez pas à consulter le récapitulatif ou les parties précédentes du module pour vous aider☝️</p>"
+                  "diagnosis": ""
                 }
               }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "afc05027-935b-4624-9212-b653781b1795",
-      "type": "activity",
-      "title": "QCU évaluation 2",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "b7b1b0e7-ae82-415b-9241-11cdff8bbdfd",
-            "type": "qcu",
-            "instruction": "<p>Quelle requête à un logiciel d'IA générative consomme le plus d’énergie ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Rédiger un rapport de stage de <strong>70 pages</strong>.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Même si ce rapport de stage fait 70 pages, ce n’est pas ce qui consommera le plus d'énergie.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Créer&nbsp;<strong>une</strong> <strong>vidéo de 15 secondes</strong>.</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse !&nbsp; 🎉</p>",
-                  "diagnosis": "<p>Tout à fait, c’est bien la création vidéo qui demande le plus de <strong>puissance de calcul</strong>,&nbsp;et donc qui consommera le <strong>plus d’énergie</strong>.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Créer&nbsp;<strong>un</strong> <strong>poster</strong> publicitaire.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Les images demandent souvent plus de calcul aux logiciels d'IA générative. Mais ce n’est pas la requête qui consomme le plus d'énergie dans la liste ci-dessus.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Écrire <strong>un mail</strong> de réclamation.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Un texte court ne demande pas beaucoup d'énegie par rapport aux autres exemples ci-dessus.</p>"
-                }
+          "id": "82b4ad43-6e5a-45f7-9b31-c2c0e4004f04",
+          "type": "activity",
+          "title": "QCU évaluation 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "542558c9-7795-4928-b45a-02aa19d7993e",
+                "type": "qcu",
+                "instruction": "<p>Qu’est-ce qui consomme de grandes quantités d’énergie dans un supercalculateur ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>La connexion internet et le chauffage du bâtiment.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>N'hésitez pas à consulter le récapitulatif ou les parties précédentes du module pour vous aider☝️</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Les calculs et le refroidissement des machines.</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse !&nbsp; 🎉</p>",
+                      "diagnosis": "<p>Ce sont bien les calculs effectués par le supercalculateur et le refroidissement des machines qui consomment beaucoup d’énergie.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>L’éclairage et la vidéo-surveillance.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>N'hésitez pas à consulter le récapitulatif ou les parties précédentes du module pour vous aider☝️</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
               }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0e50ec33-1ce6-4bf6-a3f4-a79d5be756c7",
-      "type": "challenge",
-      "title": "Transfert",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "98bf1662-2985-452d-ba51-1d625f43bebb",
-            "type": "custom-draft",
-            "title": "Calculatrice d'impact environnemental des usages de l'IA générative",
-            "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementTransfert04.html",
-            "instruction": "<p>Maintenant, essayons de voir à quoi correspond la consommation d’énergie de <strong>votre utilisation de l’IA.</strong></p>",
-            "height": 550
-          }
+          "id": "afc05027-935b-4624-9212-b653781b1795",
+          "type": "activity",
+          "title": "QCU évaluation 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b7b1b0e7-ae82-415b-9241-11cdff8bbdfd",
+                "type": "qcu",
+                "instruction": "<p>Quelle requête à un logiciel d'IA générative consomme le plus d’énergie ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Rédiger un rapport de stage de <strong>70 pages</strong>.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Même si ce rapport de stage fait 70 pages, ce n’est pas ce qui consommera le plus d'énergie.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Créer&nbsp;<strong>une</strong> <strong>vidéo de 15 secondes</strong>.</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse !&nbsp; 🎉</p>",
+                      "diagnosis": "<p>Tout à fait, c’est bien la création vidéo qui demande le plus de <strong>puissance de calcul</strong>,&nbsp;et donc qui consommera le <strong>plus d’énergie</strong>.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Créer&nbsp;<strong>un</strong> <strong>poster</strong> publicitaire.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Les images demandent souvent plus de calcul aux logiciels d'IA générative. Mais ce n’est pas la requête qui consomme le plus d'énergie dans la liste ci-dessus.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Écrire <strong>un mail</strong> de réclamation.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Un texte court ne demande pas beaucoup d'énegie par rapport aux autres exemples ci-dessus.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0e50ec33-1ce6-4bf6-a3f4-a79d5be756c7",
+          "type": "challenge",
+          "title": "Transfert",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "98bf1662-2985-452d-ba51-1d625f43bebb",
+                "type": "custom-draft",
+                "title": "Calculatrice d'impact environnemental des usages de l'IA générative",
+                "url": "https://1024pix.github.io/atelier-contenus/FRI/IAEnvironnementTransfert04.html",
+                "instruction": "<p>Maintenant, essayons de voir à quoi correspond la consommation d’énergie de <strong>votre utilisation de l’IA.</strong></p>",
+                "height": 550
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -15,572 +15,578 @@
       "Savoir créer un mot de passe solide"
     ]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "b742184b-085d-44e8-978e-533fe7e7d07e",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "8e3a38da-ed26-40bd-a382-8e44b4c0d64a",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "1c3814f8-60f5-4024-86a8-6d0c270eceb1",
-            "type": "text",
-            "content": "<p>Un mot de passe sert à protéger vos informations et vos données. Il faut qu’il soit <strong>solide</strong>, c'est-à-dire difficile à trouver.&nbsp;🔐<br>Sinon, on peut le deviner facilement et lire vos mails, voir vos photos ou envoyer des messages à votre place.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "00962dcd-9636-44b1-b1c8-d4a5ab2d90c8",
-      "type": "activity",
-      "title": "Les mots de passe les plus courants",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d8d3f524-10c7-4190-986b-f1e309efb124",
-            "type": "qrocm",
-            "instruction": "<p>Certains mots de passe sont très utilisés et donc faciles à deviner. <br>À votre avis, quel est le mot de passe le plus utilisé en France&#8239;?</p>",
-            "proposals": [
-              {
-                "input": "mot-de-passe",
-                "type": "input",
-                "inputType": "text",
-                "size": 15,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Mot de passe",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": [
-                  "123456",
-                  "123456789",
-                  "azerty",
-                  "admin",
-                  "1234561",
-                  "azertyuiop",
-                  "loulou",
-                  "000000",
-                  "doudou",
-                  "password",
-                  "marseille",
-                  "motdepasse",
-                  "12345678",
-                  "chouchou",
-                  "soleil",
-                  "cheval",
-                  "12345",
-                  "Password",
-                  "bonjour",
-                  "1234567891",
-                  "1234",
-                  "0000",
-                  "toto",
-                  "azerty123"
-                ]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bien vu&#8239;!",
-                "diagnosis": "<p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
-              },
-              "invalid": {
-                "state": "Dommage&#8239;!",
-                "diagnosis": "<p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+          "id": "b742184b-085d-44e8-978e-533fe7e7d07e",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1c3814f8-60f5-4024-86a8-6d0c270eceb1",
+                "type": "text",
+                "content": "<p>Un mot de passe sert à protéger vos informations et vos données. Il faut qu’il soit <strong>solide</strong>, c'est-à-dire difficile à trouver.&nbsp;🔐<br>Sinon, on peut le deviner facilement et lire vos mails, voir vos photos ou envoyer des messages à votre place.</p>"
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "87c93058-1f81-4b08-8575-6095aac1b91a",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "598a96f0-4628-4879-9cfd-5ff8982c1da3",
-            "type": "text",
-            "content": "<p>Choisir un mot de passe très utilisé est risqué. Regardons ensemble les risques dont il faut se protéger.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "831fd61c-54ae-4b21-bd3f-61f40887a869",
-      "type": "lesson",
-      "title": "Les risques liés aux mots de passe",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "826281e7-865f-462d-abc0-77537c42a2b4",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">🧑‍💻&nbsp;🔮&nbsp;</span>Une personne peut deviner votre mot de passe.</h3><p>Si vous utilisez des informations privées dans votre mot de passe, il est possible qu’une personne de votre entourage le devine facilement.</p><p><span aria-hidden=\"true\">⚠️</span> Elle pourra alors accéder à vos données personnelles et privées. Et ce n’est peut-être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "aae5ea61-68b7-4089-90a1-6ecc707664c9",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">🤖&nbsp;🏴‍☠️&nbsp;</span>Un logiciel informatique peut pirater votre mot de passe.</h3><p>Les ordinateurs sont capables de trouver des mots de passe en testant très rapidement différentes combinaisons possibles.<br>En 2023, un mot de passe court comme <code>$0Leil@?</code> peut être piraté en 5 minutes seulement. Mais avec un mot de passe plus long, comme <code>$0Leil@1504</code>, cette durée passe à 226 ans.</p> <p><span aria-hidden=\"true\">⚠️</span> En général, le pirate ne vous connaît pas. Il cherche certainement à revendre vos informations ou à vous voler de l’argent.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "de7d19e0-e74c-4431-b832-93773ea601ed",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f300766c-5fa3-4dbe-8922-00dc73304c7b",
-            "type": "text",
-            "content": "<p>Un exemple&nbsp;: Austin a utilisé des informations personnelles pour créer son mot de passe. Vous allez pouvoir le deviner facilement. À vous de jouer.&nbsp;🕵🏻‍♂️&nbsp;🕵🏿‍♀️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1cda400f-008c-49db-b46b-6f783ccbc273",
-      "type": "activity",
-      "title": "Deviner le mot de passe d'Austin",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7ef31e68-e798-4a92-86a0-ad61ebd9b915",
-            "type": "text",
-            "content": "<p>Austin est producteur de miel dans les Vosges.<br>Il a utilisé les deux informations suivantes pour créer son mot de passe&nbsp;:</p><ul><li>Il est né le <strong>15 novembre 1984</strong>.</li><li>Il a un enfant qui s’appelle <strong>Bill</strong>.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2695bb89-112c-49d1-80b2-469d824af58f",
-            "type": "qrocm",
-            "instruction": "<p>À votre avis, quel peut être le mot de passe d'Austin&#8239;?</p>",
-            "proposals": [
-              {
-                "input": "mot-de-passe",
-                "type": "input",
-                "inputType": "text",
-                "size": 15,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Mot de passe d'Austin",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": [
-                  "Bill15111984",
-                  "15111984Bill",
-                  "Bill151184",
-                  "151184Bill",
-                  "bill15111984",
-                  "15111984bill",
-                  "bill151184",
-                  "151184bill",
-                  "Bill15novembre1984",
-                  "15novembre1984Bill",
-                  "Bill15novembre84",
-                  "15novembre84Bill",
-                  "bill15novembre1984",
-                  "15novembre1984bill",
-                  "bill15novembre84",
-                  "15novembre84bill",
-                  "Bill15/11/1984",
-                  "15/11/1984Bill",
-                  "Bill15/11/84",
-                  "15/11/84Bill",
-                  "bill15/11/1984",
-                  "15/11/1984bill",
-                  "bill15/11/84",
-                  "15/11/84bill",
-                  "Bill151119",
-                  "151119Bill",
-                  "Bill1511",
-                  "1511Bill",
-                  "bill1511",
-                  "1511bill",
-                  "bill1511",
-                  "1511bill",
-                  "Bill15novembre",
-                  "15novembreBill",
-                  "Bill15novembre",
-                  "15novembreBill",
-                  "bill15novembre",
-                  "15novembrebill",
-                  "bill15novembre",
-                  "15novembrebill",
-                  "Bill15/11",
-                  "15/11Bill",
-                  "Bill15/11",
-                  "15/11Bill",
-                  "bill15/11",
-                  "15/11bill",
-                  "bill15/11",
-                  "15/11bill"
-                ]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct.",
-                "diagnosis": "<p> C’est un <strong>mot de passe faible</strong>, c’est-à-dire facile à trouver.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p> Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184&#8239;? Et utilisé le prénom de son fils Bill&#8239;?</p>"
+          "id": "00962dcd-9636-44b1-b1c8-d4a5ab2d90c8",
+          "type": "activity",
+          "title": "Les mots de passe les plus courants",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d8d3f524-10c7-4190-986b-f1e309efb124",
+                "type": "qrocm",
+                "instruction": "<p>Certains mots de passe sont très utilisés et donc faciles à deviner. <br>À votre avis, quel est le mot de passe le plus utilisé en France&#8239;?</p>",
+                "proposals": [
+                  {
+                    "input": "mot-de-passe",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 15,
+                    "display": "block",
+                    "placeholder": "",
+                    "ariaLabel": "Mot de passe",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": [
+                      "123456",
+                      "123456789",
+                      "azerty",
+                      "admin",
+                      "1234561",
+                      "azertyuiop",
+                      "loulou",
+                      "000000",
+                      "doudou",
+                      "password",
+                      "marseille",
+                      "motdepasse",
+                      "12345678",
+                      "chouchou",
+                      "soleil",
+                      "cheval",
+                      "12345",
+                      "Password",
+                      "bonjour",
+                      "1234567891",
+                      "1234",
+                      "0000",
+                      "toto",
+                      "azerty123"
+                    ]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bien vu&#8239;!",
+                    "diagnosis": "<p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+                  },
+                  "invalid": {
+                    "state": "Dommage&#8239;!",
+                    "diagnosis": "<p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+                  }
+                }
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "17d853ee-fc15-4d26-8896-dd3bc0692161",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b975bec3-4fef-42ca-8b40-ce9b59836b4c",
-            "type": "text",
-            "content": "<p>Pour créer un mot de passe solide, il y a certaines règles à suivre. Regardons de plus près&#8239;!</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1564f763-5ba5-48ef-b752-dac463319899",
-      "type": "lesson",
-      "title": "Bonnes pratiques de création de mot de passe",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "02bb0017-a74d-4c78-8502-3c57d9f12209",
-            "type": "text",
-            "content": "<h3>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h3><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "7f89a519-a5ce-4484-9952-eb6869b94291",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
-            "type": "text",
-            "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2895432c-72a3-44be-ae0e-52041f5b847e",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c4505a09-864c-48f8-8077-013fae2db291",
-            "type": "text",
-            "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "46374bab-fea7-4693-b97b-aadf2083e6f3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f3d1330a-31f0-4252-8a89-db95905b6f09",
-            "type": "text",
-            "content": "<p>Vérifions que vous avez compris l'essentiel avec quelques exemples.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "65e80d85-4590-4662-8765-f1b3d995f21a",
-      "type": "activity",
-      "title": "Quizz mots de passe solides",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a3730b39-ff34-4744-a5dc-5d4687def82d",
-            "type": "text",
-            "content": "<p>Pour chaque affimation, choisissez si elle est vraie ou fausse.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "87c93058-1f81-4b08-8575-6095aac1b91a",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "669c89e1-167e-40a3-a198-2ee226494b2e",
-                  "type": "qcu",
-                  "instruction": "<p>Un mot de passe long est plus dur à pirater qu'un mot de passe court.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Correct&#8239;!&nbsp;🎉",
-                        "diagnosis": ""
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse&#8239;!",
-                        "diagnosis": ""
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "598a96f0-4628-4879-9cfd-5ff8982c1da3",
+                "type": "text",
+                "content": "<p>Choisir un mot de passe très utilisé est risqué. Regardons ensemble les risques dont il faut se protéger.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "831fd61c-54ae-4b21-bd3f-61f40887a869",
+          "type": "lesson",
+          "title": "Les risques liés aux mots de passe",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "826281e7-865f-462d-abc0-77537c42a2b4",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">🧑‍💻&nbsp;🔮&nbsp;</span>Une personne peut deviner votre mot de passe.</h3><p>Si vous utilisez des informations privées dans votre mot de passe, il est possible qu’une personne de votre entourage le devine facilement.</p><p><span aria-hidden=\"true\">⚠️</span> Elle pourra alors accéder à vos données personnelles et privées. Et ce n’est peut-être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "006acae6-1bca-420f-ba74-29e7e0369069",
-                  "type": "qcu",
-                  "instruction": "<p>Utiliser des caractères spéciaux rend les mots de passe moins solides.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse&#8239;!",
-                        "diagnosis": ""
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Correct&#8239;!&nbsp;🎉",
-                        "diagnosis": ""
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "aae5ea61-68b7-4089-90a1-6ecc707664c9",
+                "type": "text",
+                "content": "<hr>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">🤖&nbsp;🏴‍☠️&nbsp;</span>Un logiciel informatique peut pirater votre mot de passe.</h3><p>Les ordinateurs sont capables de trouver des mots de passe en testant très rapidement différentes combinaisons possibles.<br>En 2023, un mot de passe court comme <code>$0Leil@?</code> peut être piraté en 5 minutes seulement. Mais avec un mot de passe plus long, comme <code>$0Leil@1504</code>, cette durée passe à 226 ans.</p> <p><span aria-hidden=\"true\">⚠️</span> En général, le pirate ne vous connaît pas. Il cherche certainement à revendre vos informations ou à vous voler de l’argent.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "de7d19e0-e74c-4431-b832-93773ea601ed",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f300766c-5fa3-4dbe-8922-00dc73304c7b",
+                "type": "text",
+                "content": "<p>Un exemple&nbsp;: Austin a utilisé des informations personnelles pour créer son mot de passe. Vous allez pouvoir le deviner facilement. À vous de jouer.&nbsp;🕵🏻‍♂️&nbsp;🕵🏿‍♀️</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1cda400f-008c-49db-b46b-6f783ccbc273",
+          "type": "activity",
+          "title": "Deviner le mot de passe d'Austin",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7ef31e68-e798-4a92-86a0-ad61ebd9b915",
+                "type": "text",
+                "content": "<p>Austin est producteur de miel dans les Vosges.<br>Il a utilisé les deux informations suivantes pour créer son mot de passe&nbsp;:</p><ul><li>Il est né le <strong>15 novembre 1984</strong>.</li><li>Il a un enfant qui s’appelle <strong>Bill</strong>.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2695bb89-112c-49d1-80b2-469d824af58f",
+                "type": "qrocm",
+                "instruction": "<p>À votre avis, quel peut être le mot de passe d'Austin&#8239;?</p>",
+                "proposals": [
+                  {
+                    "input": "mot-de-passe",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 15,
+                    "display": "block",
+                    "placeholder": "",
+                    "ariaLabel": "Mot de passe d'Austin",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": [
+                      "Bill15111984",
+                      "15111984Bill",
+                      "Bill151184",
+                      "151184Bill",
+                      "bill15111984",
+                      "15111984bill",
+                      "bill151184",
+                      "151184bill",
+                      "Bill15novembre1984",
+                      "15novembre1984Bill",
+                      "Bill15novembre84",
+                      "15novembre84Bill",
+                      "bill15novembre1984",
+                      "15novembre1984bill",
+                      "bill15novembre84",
+                      "15novembre84bill",
+                      "Bill15/11/1984",
+                      "15/11/1984Bill",
+                      "Bill15/11/84",
+                      "15/11/84Bill",
+                      "bill15/11/1984",
+                      "15/11/1984bill",
+                      "bill15/11/84",
+                      "15/11/84bill",
+                      "Bill151119",
+                      "151119Bill",
+                      "Bill1511",
+                      "1511Bill",
+                      "bill1511",
+                      "1511bill",
+                      "bill1511",
+                      "1511bill",
+                      "Bill15novembre",
+                      "15novembreBill",
+                      "Bill15novembre",
+                      "15novembreBill",
+                      "bill15novembre",
+                      "15novembrebill",
+                      "bill15novembre",
+                      "15novembrebill",
+                      "Bill15/11",
+                      "15/11Bill",
+                      "Bill15/11",
+                      "15/11Bill",
+                      "bill15/11",
+                      "15/11bill",
+                      "bill15/11",
+                      "15/11bill"
+                    ]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct.",
+                    "diagnosis": "<p> C’est un <strong>mot de passe faible</strong>, c’est-à-dire facile à trouver.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p> Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184&#8239;? Et utilisé le prénom de son fils Bill&#8239;?</p>"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "17d853ee-fc15-4d26-8896-dd3bc0692161",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b975bec3-4fef-42ca-8b40-ce9b59836b4c",
+                "type": "text",
+                "content": "<p>Pour créer un mot de passe solide, il y a certaines règles à suivre. Regardons de plus près&#8239;!</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1564f763-5ba5-48ef-b752-dac463319899",
+          "type": "lesson",
+          "title": "Bonnes pratiques de création de mot de passe",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "02bb0017-a74d-4c78-8502-3c57d9f12209",
+                "type": "text",
+                "content": "<h3>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h3><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7f89a519-a5ce-4484-9952-eb6869b94291",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
+                "type": "text",
+                "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2895432c-72a3-44be-ae0e-52041f5b847e",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c4505a09-864c-48f8-8077-013fae2db291",
+                "type": "text",
+                "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "46374bab-fea7-4693-b97b-aadf2083e6f3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f3d1330a-31f0-4252-8a89-db95905b6f09",
+                "type": "text",
+                "content": "<p>Vérifions que vous avez compris l'essentiel avec quelques exemples.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "65e80d85-4590-4662-8765-f1b3d995f21a",
+          "type": "activity",
+          "title": "Quizz mots de passe solides",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a3730b39-ff34-4744-a5dc-5d4687def82d",
+                "type": "text",
+                "content": "<p>Pour chaque affimation, choisissez si elle est vraie ou fausse.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "68f45335-8aab-40f5-baff-9719ce8b582a",
-                  "type": "qcu",
-                  "instruction": "<p>Utiliser sa date de naissance comme mot de passe le rend facile à trouver.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Vrai",
-                      "feedback": {
-                        "state": "Correct&#8239;!&nbsp;🎉",
-                        "diagnosis": ""
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "Faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse&#8239;!",
-                        "diagnosis": ""
-                      }
+                      "id": "669c89e1-167e-40a3-a198-2ee226494b2e",
+                      "type": "qcu",
+                      "instruction": "<p>Un mot de passe long est plus dur à pirater qu'un mot de passe court.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!&nbsp;🎉",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse&#8239;!",
+                            "diagnosis": ""
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "006acae6-1bca-420f-ba74-29e7e0369069",
+                      "type": "qcu",
+                      "instruction": "<p>Utiliser des caractères spéciaux rend les mots de passe moins solides.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse&#8239;!",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Correct&#8239;!&nbsp;🎉",
+                            "diagnosis": ""
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "68f45335-8aab-40f5-baff-9719ce8b582a",
+                      "type": "qcu",
+                      "instruction": "<p>Utiliser sa date de naissance comme mot de passe le rend facile à trouver.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!&nbsp;🎉",
+                            "diagnosis": ""
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse&#8239;!",
+                            "diagnosis": ""
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "4de2a620-e73f-4e33-934a-495d8a7c0a1a",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ec48b813-4f04-45ac-9515-eb6e559e354c",
-            "type": "text",
-            "content": "<p>En plus des règles que vous venez de voir, voici aussi quelques astuces pour vous aider à créer vos mots de passe.&nbsp;💡</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f14510d6-ee18-48be-8bb6-39a9427e3102",
-      "type": "lesson",
-      "title": "Astuces de gestion de mots de passe",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
-            "type": "text",
-            "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "b8bc3e1e-bf21-4b3b-8dce-0a0213aefb1b",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f6edeae6-fbfb-4dce-b556-1bb7928d5ff5",
-            "type": "text",
-            "content": "<h3>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h3><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "95098e06-e113-46ba-afa0-b7890d5cf467",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "dadd152e-350c-4710-8609-af5f92e69b2c",
-            "type": "text",
-            "content": "<h3>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h3><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "77b65d81-a20a-4a45-b8c5-cfe23d5ba671",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3d582ec1-c82d-488e-9e2d-0208cfd29871",
-            "type": "text",
-            "content": "<p>Maintenant que vous en savez plus, vous allez pouvoir aider Austin.&nbsp;🧑🏻‍💼<br> Austin veut créer un mot de passe qui est solide.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6336bac0-c272-40cc-a002-ee724a5ec4c8",
-      "type": "activity",
-      "title": "Les conseils à donner à un ami",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5db8677e-2c9e-4f36-b932-4989459af149",
-            "type": "qcm",
-            "instruction": "<p>Quels conseils pouvez-vous donner à Austin pour créer un mot de passe solide&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Créer un mot de passe qui est long."
-              },
-              {
-                "id": "2",
-                "content": "Choisir un mot de passe qu'il utilise déjà."
-              },
-              {
-                "id": "3",
-                "content": "Décider de son mot de passe avec un ami."
-              },
-              {
-                "id": "4",
-                "content": "Se servir d'une phrase et garder certains caractères."
+          "id": "4de2a620-e73f-4e33-934a-495d8a7c0a1a",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ec48b813-4f04-45ac-9515-eb6e559e354c",
+                "type": "text",
+                "content": "<p>En plus des règles que vous venez de voir, voici aussi quelques astuces pour vous aider à créer vos mots de passe.&nbsp;💡</p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct.",
-                "diagnosis": "<p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
+            }
+          ]
+        },
+        {
+          "id": "f14510d6-ee18-48be-8bb6-39a9427e3102",
+          "type": "lesson",
+          "title": "Astuces de gestion de mots de passe",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
+                "type": "text",
+                "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
               }
             },
-            "solutions": ["1", "4"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "faafaf63-05b8-49e1-85c5-cd7865c48f9f",
-      "type": "transition",
-      "title": "",
-      "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b8bc3e1e-bf21-4b3b-8dce-0a0213aefb1b",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f6edeae6-fbfb-4dce-b556-1bb7928d5ff5",
+                "type": "text",
+                "content": "<h3>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h3><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "95098e06-e113-46ba-afa0-b7890d5cf467",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "dadd152e-350c-4710-8609-af5f92e69b2c",
+                "type": "text",
+                "content": "<h3>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h3><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "b1ae2c3c-e383-4f82-b6d0-deda5b24eaa4",
-            "type": "text",
-            "content": "<p>Créer des mots de passe solides n'est pas simple. Mais cette étape est nécessaire pour se protéger.</p><p>Voici ci-dessous une synthèse des informations à retenir de ce module.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1ed4223a-2b8f-4c2c-8dcb-3d0567b562b0",
-      "type": "lesson",
-      "title": "Sécuriser ses mots de passe : synthèse",
-      "components": [
+          "id": "77b65d81-a20a-4a45-b8c5-cfe23d5ba671",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3d582ec1-c82d-488e-9e2d-0208cfd29871",
+                "type": "text",
+                "content": "<p>Maintenant que vous en savez plus, vous allez pouvoir aider Austin.&nbsp;🧑🏻‍💼<br> Austin veut créer un mot de passe qui est solide.</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "2e695244-52c5-4277-8414-d18777d0d242",
-            "type": "text",
-            "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
-          }
+          "id": "6336bac0-c272-40cc-a002-ee724a5ec4c8",
+          "type": "activity",
+          "title": "Les conseils à donner à un ami",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5db8677e-2c9e-4f36-b932-4989459af149",
+                "type": "qcm",
+                "instruction": "<p>Quels conseils pouvez-vous donner à Austin pour créer un mot de passe solide&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Créer un mot de passe qui est long."
+                  },
+                  {
+                    "id": "2",
+                    "content": "Choisir un mot de passe qu'il utilise déjà."
+                  },
+                  {
+                    "id": "3",
+                    "content": "Décider de son mot de passe avec un ami."
+                  },
+                  {
+                    "id": "4",
+                    "content": "Se servir d'une phrase et garder certains caractères."
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct.",
+                    "diagnosis": "<p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
+                  }
+                },
+                "solutions": ["1", "4"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "faafaf63-05b8-49e1-85c5-cd7865c48f9f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b1ae2c3c-e383-4f82-b6d0-deda5b24eaa4",
+                "type": "text",
+                "content": "<p>Créer des mots de passe solides n'est pas simple. Mais cette étape est nécessaire pour se protéger.</p><p>Voici ci-dessous une synthèse des informations à retenir de ce module.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1ed4223a-2b8f-4c2c-8dcb-3d0567b562b0",
+          "type": "lesson",
+          "title": "Sécuriser ses mots de passe : synthèse",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2e695244-52c5-4277-8414-d18777d0d242",
+                "type": "text",
+                "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -14,716 +14,722 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "f8e5630c-2680-4308-86a9-c17071e8c367",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "56b7fbd4-e58b-4ac2-8830-dc2e50a43510",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "f7038b18-cf54-4db5-aba1-462ddbbbbda6",
-            "type": "text",
-            "content": "<p>Sur votre ordinateur, vous pouvez brancher plusieurs appareils, comme une souris ou un clavier.&nbsp;🖱️&nbsp;⌨️</p><p>Pour les brancher, il y a des prises de différentes formes : ce sont les ports de connexion. Commençons avec un exemple.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8bb146db-104c-41e2-aa79-14f7a06e0930",
-      "type": "discovery",
-      "title": "Charger un ordinateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f76ed857-626c-4980-8635-89d5a66f3f3b",
-            "type": "text",
-            "content": "<p>Maxime a reçu un ordinateur portable pour son anniversaire. </p><p>Pour le démarrer, il doit d’abord le mettre à charger.<span aria-hidden=\"true\">🔌</span> </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "df8684e9-e844-4a83-a556-b0a6fc955b7b",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/PE8szHW.jpeg",
-            "alt": "Photo du côté d'un ordinateur portable, où se trouvent les ports de connexion. ",
-            "alternativeText": "<p>Sur cette photographie d'un côté de l'ordinateur portable, il y a 6 ports de connexion.<br><strong>Les 3 premiers ports de connexion sont entourés.</strong><br></p><ul><li>Le port n°1 est rond, à côté dun symbole de prise et d'un voyant<br></li><li>Le port n°2 a une forme en T, à côté d'un symbole de réseau.<br></li><li>Le port n°3 a une forme rectangle avec les deux coins du bas aplatis, il est écrit HDMI.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fda3b31f-4f97-44fb-80b7-3698df48c79a",
-            "type": "qcu",
-            "instruction": "<p>Sur quel port Maxime doit-il brancher le chargeur ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>port n°1</p>",
-                "feedback": {
-                  "state": "Bonne réponse.&nbsp;🎉&nbsp;",
-                  "diagnosis": "<p>C'est bien sur ce port que se branche le chargeur.<br> Selon la marque et le modèle de votre ordinateur, ce port peut changer de taille ou de forme.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>port n°2</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Il ne permet pas de charger l'ordinateur.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>port n°3</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Ce port s'appelle le port HDMI, il ne permet pas de charger l'ordinateur.</p>"
-                }
+          "id": "f8e5630c-2680-4308-86a9-c17071e8c367",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f7038b18-cf54-4db5-aba1-462ddbbbbda6",
+                "type": "text",
+                "content": "<p>Sur votre ordinateur, vous pouvez brancher plusieurs appareils, comme une souris ou un clavier.&nbsp;🖱️&nbsp;⌨️</p><p>Pour les brancher, il y a des prises de différentes formes : ce sont les ports de connexion. Commençons avec un exemple.</p>"
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "58cf284e-53d4-43be-ae7d-c26bd600defb",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c0642e02-74b1-4b42-a09d-3a6f7b714775",
-            "type": "text",
-            "content": "<p>Maintenant que vous avez aidé Maxime à charger son ordinateur, découvrez les autres ports de connexion.&nbsp;💻<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3b26ddd0-8d3b-4f84-bee3-58cbe4073798",
-      "type": "lesson",
-      "title": "Les ports de connexion d'un ordinateur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e6730d81-c115-4821-a415-4f719a252746",
-            "type": "text",
-            "content": "<p>Découvrez les 6 ports de connexions principaux de l'ordinateur ci-dessous.</p>"
-          }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "83a85de9-4a5e-41a4-b8e6-f583a817121e",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/WQgsiuV.jpeg",
-            "alt": "Schéma de l'ensemble des ports qui vont être présentés",
-            "alternativeText": ""
-          }
+          "id": "8bb146db-104c-41e2-aa79-14f7a06e0930",
+          "type": "discovery",
+          "title": "Charger un ordinateur",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f76ed857-626c-4980-8635-89d5a66f3f3b",
+                "type": "text",
+                "content": "<p>Maxime a reçu un ordinateur portable pour son anniversaire. </p><p>Pour le démarrer, il doit d’abord le mettre à charger.<span aria-hidden=\"true\">🔌</span> </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "df8684e9-e844-4a83-a556-b0a6fc955b7b",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/PE8szHW.jpeg",
+                "alt": "Photo du côté d'un ordinateur portable, où se trouvent les ports de connexion. ",
+                "alternativeText": "<p>Sur cette photographie d'un côté de l'ordinateur portable, il y a 6 ports de connexion.<br><strong>Les 3 premiers ports de connexion sont entourés.</strong><br></p><ul><li>Le port n°1 est rond, à côté dun symbole de prise et d'un voyant<br></li><li>Le port n°2 a une forme en T, à côté d'un symbole de réseau.<br></li><li>Le port n°3 a une forme rectangle avec les deux coins du bas aplatis, il est écrit HDMI.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fda3b31f-4f97-44fb-80b7-3698df48c79a",
+                "type": "qcu",
+                "instruction": "<p>Sur quel port Maxime doit-il brancher le chargeur ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>port n°1</p>",
+                    "feedback": {
+                      "state": "Bonne réponse.&nbsp;🎉&nbsp;",
+                      "diagnosis": "<p>C'est bien sur ce port que se branche le chargeur.<br> Selon la marque et le modèle de votre ordinateur, ce port peut changer de taille ou de forme.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>port n°2</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Il ne permet pas de charger l'ordinateur.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>port n°3</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Ce port s'appelle le port HDMI, il ne permet pas de charger l'ordinateur.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "623628e4-2ea8-4753-911b-c946725280c4",
-            "type": "text",
-            "content": "<p>À la suite de ces explications, vous devrez retrouver certains de ces ports dans des exemples concrets.</p>"
-          }
+          "id": "58cf284e-53d4-43be-ae7d-c26bd600defb",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c0642e02-74b1-4b42-a09d-3a6f7b714775",
+                "type": "text",
+                "content": "<p>Maintenant que vous avez aidé Maxime à charger son ordinateur, découvrez les autres ports de connexion.&nbsp;💻<br></p>"
+              }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "3b26ddd0-8d3b-4f84-bee3-58cbe4073798",
+          "type": "lesson",
+          "title": "Les ports de connexion d'un ordinateur",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "c4bd304a-e9a9-4f6c-a661-2174a172a8c1",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/eE3t59S.jpeg",
-                  "alt": "Schéma d'un port d'alimentation",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "df4b59c7-b4d8-450c-985a-dc9bc9735f26",
-                  "type": "text",
-                  "content": "<p>Ce port est un <strong>port d’alimentation électrique</strong>.</p><p> Il sert à recharger un ordinateur et à le connecter au réseau électrique.&nbsp;<span aria-hidden=\"true\">🔌</span> </p><p>Sur les ordinateurs portables, il existe de nombreuses variantes. Sur un ordinateur fixe, ce port est plus gros.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "e6730d81-c115-4821-a415-4f719a252746",
+                "type": "text",
+                "content": "<p>Découvrez les 6 ports de connexions principaux de l'ordinateur ci-dessous.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "a66efa37-9da8-4e18-a483-43c59271e3d5",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/x4JWIrP.jpeg",
-                  "alt": "Schéma d'un port USB",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "706f1c55-3009-4cff-affe-6548076d65ac",
-                  "type": "text",
-                  "content": "<p>Ce port est un <strong>port USB</strong>. </p><p>Il sert à connecter différents appareils externes à l’ordinateur.</p><p> Par exemple : une souris, un clavier, une clé USB, etc.&nbsp;&nbsp;<span aria-hidden=\"true\">🖱️</span>&nbsp;<span aria-hidden=\"true\">🎮</span></p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "83a85de9-4a5e-41a4-b8e6-f583a817121e",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/WQgsiuV.jpeg",
+                "alt": "Schéma de l'ensemble des ports qui vont être présentés",
+                "alternativeText": ""
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "3d8eedf5-f4d1-4f58-b2a4-b5c814d79fab",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/Aep47Hv.jpeg",
-                  "alt": "Schéma d'un port USB-C",
-                  "alternativeText": "<p><br></p>"
-                },
-                {
-                  "id": "c75612ca-f9c2-4453-88db-725bb817151b",
-                  "type": "text",
-                  "content": "<p>Ce port est un port <strong>USB Type C</strong> ou <strong>USB-C</strong>. </p><p>Ce port est souvent présent sur les téléphones portables. Sur un ordinateur, il&nbsp;sert à connecter différents appareils externes : téléphone portable, chargeur, écran, etc.  </p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "623628e4-2ea8-4753-911b-c946725280c4",
+                "type": "text",
+                "content": "<p>À la suite de ces explications, vous devrez retrouver certains de ces ports dans des exemples concrets.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "ddb6295c-6549-4698-805b-d18154a0fcf9",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/C7p4TbW.jpeg",
-                  "alt": "Schéma d'un port HDMI",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "c4bd304a-e9a9-4f6c-a661-2174a172a8c1",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/eE3t59S.jpeg",
+                      "alt": "Schéma d'un port d'alimentation",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "df4b59c7-b4d8-450c-985a-dc9bc9735f26",
+                      "type": "text",
+                      "content": "<p>Ce port est un <strong>port d’alimentation électrique</strong>.</p><p> Il sert à recharger un ordinateur et à le connecter au réseau électrique.&nbsp;<span aria-hidden=\"true\">🔌</span> </p><p>Sur les ordinateurs portables, il existe de nombreuses variantes. Sur un ordinateur fixe, ce port est plus gros.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "86851d7d-0ce8-48a3-b8ac-433da8134dec",
-                  "type": "text",
-                  "content": "<p>Ce port est un <strong>port HDMI</strong>. </p><p>On peut le reconnaître grâce à sa forme. Il porte souvent l'inscription \"HDMI\" juste à côté.</p><p>Ce port sert principalement à connecter un écran ou un vidéoprojecteur à l’ordinateur, comme le port VGA.&nbsp;<span aria-hidden=\"true\">📽️</span></p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "7e24dbe8-7d09-4bc6-bb94-b01f16c4cd0b",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/0xGKMk6.jpeg",
-                  "alt": "Schéma d'un port ethernet",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "a66efa37-9da8-4e18-a483-43c59271e3d5",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/x4JWIrP.jpeg",
+                      "alt": "Schéma d'un port USB",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "706f1c55-3009-4cff-affe-6548076d65ac",
+                      "type": "text",
+                      "content": "<p>Ce port est un <strong>port USB</strong>. </p><p>Il sert à connecter différents appareils externes à l’ordinateur.</p><p> Par exemple : une souris, un clavier, une clé USB, etc.&nbsp;&nbsp;<span aria-hidden=\"true\">🖱️</span>&nbsp;<span aria-hidden=\"true\">🎮</span></p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "be359a9d-19d2-49a7-8699-8921156e554c",
-                  "type": "text",
-                  "content": "<p>Ce port est un <strong>port Ethernet</strong>. On l'appelle aussi RJ45.  </p><p>Il est utilisé pour connecter l’ordinateur à la box internet grâce à un câble Ethernet.&nbsp;<span aria-hidden=\"true\">🌐</span></p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "9ea49b3f-a39f-4d0f-9879-611ffe218f3c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/kzql8CG.jpeg",
-                  "alt": "Schéma d'un port jack",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "3d8eedf5-f4d1-4f58-b2a4-b5c814d79fab",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/Aep47Hv.jpeg",
+                      "alt": "Schéma d'un port USB-C",
+                      "alternativeText": "<p><br></p>"
+                    },
+                    {
+                      "id": "c75612ca-f9c2-4453-88db-725bb817151b",
+                      "type": "text",
+                      "content": "<p>Ce port est un port <strong>USB Type C</strong> ou <strong>USB-C</strong>. </p><p>Ce port est souvent présent sur les téléphones portables. Sur un ordinateur, il&nbsp;sert à connecter différents appareils externes : téléphone portable, chargeur, écran, etc.  </p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
-                  "type": "text",
-                  "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>. </p><p>Il est petit et rond. Il est souvent accompagné d’une image de casque.&nbsp;<span aria-hidden=\"true\">🎧</span> </p><p>Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
+                  "elements": [
+                    {
+                      "id": "ddb6295c-6549-4698-805b-d18154a0fcf9",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/C7p4TbW.jpeg",
+                      "alt": "Schéma d'un port HDMI",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "86851d7d-0ce8-48a3-b8ac-433da8134dec",
+                      "type": "text",
+                      "content": "<p>Ce port est un <strong>port HDMI</strong>. </p><p>On peut le reconnaître grâce à sa forme. Il porte souvent l'inscription \"HDMI\" juste à côté.</p><p>Ce port sert principalement à connecter un écran ou un vidéoprojecteur à l’ordinateur, comme le port VGA.&nbsp;<span aria-hidden=\"true\">📽️</span></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7e24dbe8-7d09-4bc6-bb94-b01f16c4cd0b",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/0xGKMk6.jpeg",
+                      "alt": "Schéma d'un port ethernet",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "be359a9d-19d2-49a7-8699-8921156e554c",
+                      "type": "text",
+                      "content": "<p>Ce port est un <strong>port Ethernet</strong>. On l'appelle aussi RJ45.  </p><p>Il est utilisé pour connecter l’ordinateur à la box internet grâce à un câble Ethernet.&nbsp;<span aria-hidden=\"true\">🌐</span></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9ea49b3f-a39f-4d0f-9879-611ffe218f3c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/kzql8CG.jpeg",
+                      "alt": "Schéma d'un port jack",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
+                      "type": "text",
+                      "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>. </p><p>Il est petit et rond. Il est souvent accompagné d’une image de casque.&nbsp;<span aria-hidden=\"true\">🎧</span> </p><p>Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "efb9a8ad-2bef-4741-977f-d216b8ecc64d",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "23617f5e-3001-4562-937a-dac1adf32c07",
-            "type": "text",
-            "content": "<p>Maintenant que vous en savez plus sur les ports de connexion, vous allez  pouvoir aider Maxime.&nbsp;🙋‍♂️<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "259bb2d0-8815-4bab-885a-a54f7d6d9606",
-      "type": "activity",
-      "title": "Vos ports de connexion",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "efda82dc-1a96-488c-9d8d-a1bd5a8f1241",
-            "type": "text",
-            "content": "<p>Maxime veut brancher son clavier USB ⌨️ à son ordinateur.&nbsp;<br>Voici ci-dessous l'ordinateur de Maxime&nbsp;:</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "0f6485ad-1db7-4154-8c9c-b4432f51234f",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/eH6ZR5W.jpeg",
-            "alt": "Photographie de côté d'un ordinateur portable avec 5 ports de connexion différents.",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9548df1b-3bb4-4d7f-93ce-965de364797e",
-            "type": "qcu",
-            "instruction": "<p>Sur quel port Maxime peut-il brancher son <strong>clavier USB</strong> ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>port n°1</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>C'est le port d’alimentation électrique qui permet de charger l'ordinateur.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>port n°2</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>C'est le port Ethernet qui permet de se connecter à la box internet.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>port n°3</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>C'est le port HDMI qui sert souvent à connecter un autre écran ou un vidéoprojecteur. </p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>port n°4</p>",
-                "feedback": {
-                  "state": "Bonne réponse !&nbsp;🎉",
-                  "diagnosis": "<p>Maxime a deux ports USB sur son ordinateur. Il peut brancher son clavier sur l'un ou sur l'autre.</p>"
-                }
-              },
-              {
-                "id": "5",
-                "content": "<p>port n°5</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>C'est le port jack, qui permet à Maxime de brancher son casque audio.</p>"
-                }
-              },
-              {
-                "id": "6",
-                "content": "<p>port n°6</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>C'est le port USB de Type C, ou USB-C. Il permet à Maxime de brancher des appareils audio, vidéo, ou son téléphone portable. </p>"
-                }
+          "id": "efb9a8ad-2bef-4741-977f-d216b8ecc64d",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "23617f5e-3001-4562-937a-dac1adf32c07",
+                "type": "text",
+                "content": "<p>Maintenant que vous en savez plus sur les ports de connexion, vous allez  pouvoir aider Maxime.&nbsp;🙋‍♂️<br></p>"
               }
-            ],
-            "solution": "4"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ba5e1aa3-c271-4635-88a7-3a7d8aa75f8f",
-      "type": "transition",
-      "title": "",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "2a99722d-7860-4835-bc96-5625f645c673",
-            "type": "text",
-            "content": "<p>Le clavier de Maxime se branche en USB. <br>D'autres objets se branchent aussi sur le port USB.&nbsp;Découvrez-les.&nbsp;</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "75091cc6-61ca-4b9e-a6a0-89701ed721a8",
-      "type": "lesson",
-      "title": "Les appareils qui se branchent via USB",
-      "components": [
+          "id": "259bb2d0-8815-4bab-885a-a54f7d6d9606",
+          "type": "activity",
+          "title": "Vos ports de connexion",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "efda82dc-1a96-488c-9d8d-a1bd5a8f1241",
+                "type": "text",
+                "content": "<p>Maxime veut brancher son clavier USB ⌨️ à son ordinateur.&nbsp;<br>Voici ci-dessous l'ordinateur de Maxime&nbsp;:</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0f6485ad-1db7-4154-8c9c-b4432f51234f",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/eH6ZR5W.jpeg",
+                "alt": "Photographie de côté d'un ordinateur portable avec 5 ports de connexion différents.",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9548df1b-3bb4-4d7f-93ce-965de364797e",
+                "type": "qcu",
+                "instruction": "<p>Sur quel port Maxime peut-il brancher son <strong>clavier USB</strong> ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>port n°1</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>C'est le port d’alimentation électrique qui permet de charger l'ordinateur.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>port n°2</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>C'est le port Ethernet qui permet de se connecter à la box internet.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>port n°3</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>C'est le port HDMI qui sert souvent à connecter un autre écran ou un vidéoprojecteur. </p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>port n°4</p>",
+                    "feedback": {
+                      "state": "Bonne réponse !&nbsp;🎉",
+                      "diagnosis": "<p>Maxime a deux ports USB sur son ordinateur. Il peut brancher son clavier sur l'un ou sur l'autre.</p>"
+                    }
+                  },
+                  {
+                    "id": "5",
+                    "content": "<p>port n°5</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>C'est le port jack, qui permet à Maxime de brancher son casque audio.</p>"
+                    }
+                  },
+                  {
+                    "id": "6",
+                    "content": "<p>port n°6</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>C'est le port USB de Type C, ou USB-C. Il permet à Maxime de brancher des appareils audio, vidéo, ou son téléphone portable. </p>"
+                    }
+                  }
+                ],
+                "solution": "4"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "ba5e1aa3-c271-4635-88a7-3a7d8aa75f8f",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "7930251f-b89b-48f2-a67e-dfecfef8e446",
-                  "type": "text",
-                  "content": "<p>Le port USB est très utilisé. Il permet de brancher à son ordinateur des appareils avec des fonctionnalités très différentes.<br>On le reconnait de deux façons :</p><ul><li>le port est rectangulaire, avec une barre à l'intérieur,</li><li>il a un symbole : une flèche avec des ronds et des carrés.<br></li></ul>"
-                },
-                {
-                  "id": "1d80f9ef-7fb9-4f01-b8e0-849814fc1883",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/tlq08tk.jpeg",
-                  "alt": "Le port USB et le symbole de l'USB",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "597e5a9a-e924-45d6-9b37-806d0e5c1578",
-                  "type": "text",
-                  "content": "<p>Découvrez quelques exemples d'appareils qui se branchant en USB. <br>Vous devrez ensuite identifier en image quels appareils se branchent au port USB.</p>"
-                }
-              ]
-            },
+              "type": "element",
+              "element": {
+                "id": "2a99722d-7860-4835-bc96-5625f645c673",
+                "type": "text",
+                "content": "<p>Le clavier de Maxime se branche en USB. <br>D'autres objets se branchent aussi sur le port USB.&nbsp;Découvrez-les.&nbsp;</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "75091cc6-61ca-4b9e-a6a0-89701ed721a8",
+          "type": "lesson",
+          "title": "Les appareils qui se branchent via USB",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "fdbfa739-e38f-41d6-ba98-6660fe729e16",
-                  "type": "text",
-                  "content": "<h3>Une clé USB ou un clavier sans-fil (avec récepteur USB)</h3>"
+                  "elements": [
+                    {
+                      "id": "7930251f-b89b-48f2-a67e-dfecfef8e446",
+                      "type": "text",
+                      "content": "<p>Le port USB est très utilisé. Il permet de brancher à son ordinateur des appareils avec des fonctionnalités très différentes.<br>On le reconnait de deux façons :</p><ul><li>le port est rectangulaire, avec une barre à l'intérieur,</li><li>il a un symbole : une flèche avec des ronds et des carrés.<br></li></ul>"
+                    },
+                    {
+                      "id": "1d80f9ef-7fb9-4f01-b8e0-849814fc1883",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/tlq08tk.jpeg",
+                      "alt": "Le port USB et le symbole de l'USB",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "597e5a9a-e924-45d6-9b37-806d0e5c1578",
+                      "type": "text",
+                      "content": "<p>Découvrez quelques exemples d'appareils qui se branchant en USB. <br>Vous devrez ensuite identifier en image quels appareils se branchent au port USB.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "34aee94d-4bdb-4923-8111-69a46ce158dd",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/JUTKL4Q.jpeg",
-                  "alt": "Photographie d'une clé USB et d'un clavier sans-fil et son récepteur USB",
-                  "alternativeText": "<h3>Une clé USB</h3><p>La clé USB comporte une prise USB. Elle se branche toute entière à l'ordinateur, sans besoin de cable.</p><h3>Un clavier sans-fil (avec récepteur USB)&nbsp;</h3>\n<p>Le clavier se branche à l'ordinateur grâce au récepteur USB. C'est une petite prise USB qui n'est pas reliée par un fil au clavier.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "b91728f4-a8f2-403b-81bc-520db8b8cbf0",
-                  "type": "text",
-                  "content": "\n<h3>Une souris filaire ou une manette de jeux vidéos</h3>"
+                  "elements": [
+                    {
+                      "id": "fdbfa739-e38f-41d6-ba98-6660fe729e16",
+                      "type": "text",
+                      "content": "<h3>Une clé USB ou un clavier sans-fil (avec récepteur USB)</h3>"
+                    },
+                    {
+                      "id": "34aee94d-4bdb-4923-8111-69a46ce158dd",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/JUTKL4Q.jpeg",
+                      "alt": "Photographie d'une clé USB et d'un clavier sans-fil et son récepteur USB",
+                      "alternativeText": "<h3>Une clé USB</h3><p>La clé USB comporte une prise USB. Elle se branche toute entière à l'ordinateur, sans besoin de cable.</p><h3>Un clavier sans-fil (avec récepteur USB)&nbsp;</h3>\n<p>Le clavier se branche à l'ordinateur grâce au récepteur USB. C'est une petite prise USB qui n'est pas reliée par un fil au clavier.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "b7f8feb2-b355-4fbd-99ec-48511303536f",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/SAWzPl8.jpeg",
-                  "alt": "Photo d'une souris filaire et d'une manette de jeu vidéo à connexion USB",
-                  "alternativeText": "<h3>Une souris filaire </h3><p>La souris est reliée à un cable, au bout de celui-ci on voit une prise USB.</p><h3>Une manette de jeux vidéos </h3><p>La manette est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "07bc0dd7-c121-4f6d-8e3a-ba45faffc93c",
-                  "type": "text",
-                  "content": "<h3>Un cable de chargeur de téléphone portable ou une webcam</h3>"
+                  "elements": [
+                    {
+                      "id": "b91728f4-a8f2-403b-81bc-520db8b8cbf0",
+                      "type": "text",
+                      "content": "\n<h3>Une souris filaire ou une manette de jeux vidéos</h3>"
+                    },
+                    {
+                      "id": "b7f8feb2-b355-4fbd-99ec-48511303536f",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/SAWzPl8.jpeg",
+                      "alt": "Photo d'une souris filaire et d'une manette de jeu vidéo à connexion USB",
+                      "alternativeText": "<h3>Une souris filaire </h3><p>La souris est reliée à un cable, au bout de celui-ci on voit une prise USB.</p><h3>Une manette de jeux vidéos </h3><p>La manette est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "06160ea0-d7dd-41ba-b455-c3078de15be6",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/EJKVD5d.jpeg",
-                  "alt": "Photo d'un câble de chargeur de téléphone portable à connexion USB, et d'une webcam à connexion USB",
-                  "alternativeText": "<h3>Un câble de téléphone portable </h3>\n<p>Le cable de chargeur de téléphone portable est muni d'une prise USB (pour le port de l'ordinateur), et d'une prise USB-C (pour le port du téléphone).</p><h3>Une webcam</h3><p>La webcam est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
+                  "elements": [
+                    {
+                      "id": "07bc0dd7-c121-4f6d-8e3a-ba45faffc93c",
+                      "type": "text",
+                      "content": "<h3>Un cable de chargeur de téléphone portable ou une webcam</h3>"
+                    },
+                    {
+                      "id": "06160ea0-d7dd-41ba-b455-c3078de15be6",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/EJKVD5d.jpeg",
+                      "alt": "Photo d'un câble de chargeur de téléphone portable à connexion USB, et d'une webcam à connexion USB",
+                      "alternativeText": "<h3>Un câble de téléphone portable </h3>\n<p>Le cable de chargeur de téléphone portable est muni d'une prise USB (pour le port de l'ordinateur), et d'une prise USB-C (pour le port du téléphone).</p><h3>Une webcam</h3><p>La webcam est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "b174e6d7-b450-43e7-81df-2103b9ed177d",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "124501e8-1100-44a2-a210-a3da56a6d11e",
-            "type": "text",
-            "content": "<p>Passons à la pratique avec quelques exemples.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e7aa8e1d-c88a-42ff-bf58-fe4371a1ce6a",
-      "type": "activity",
-      "title": "USB ou pas ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "270b0408-be92-484a-b9b2-5d302f01eecf",
-            "type": "text",
-            "content": "<p>Pour chaque affirmation ci-dessous, choisissez si elle est vraie ou fausse.</p>"
-          }
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "b174e6d7-b450-43e7-81df-2103b9ed177d",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "6f276b50-a00c-49f7-b22c-23dbef0c2bf2",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/xXHePcU.png",
-                  "alt": "Une souris d'ordinateur",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "54a04560-ab1b-410b-a2f7-771f6483d951",
-                  "type": "qcu",
-                  "instruction": "<p>Cette souris se connecte à un port USB pour fonctionner.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "vrai",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p> Cette souris filaire (qui se branche avec un fil) se branche à un port USB.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>C'était vrai. Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "124501e8-1100-44a2-a210-a3da56a6d11e",
+                "type": "text",
+                "content": "<p>Passons à la pratique avec quelques exemples.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e7aa8e1d-c88a-42ff-bf58-fe4371a1ce6a",
+          "type": "activity",
+          "title": "USB ou pas ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "270b0408-be92-484a-b9b2-5d302f01eecf",
+                "type": "text",
+                "content": "<p>Pour chaque affirmation ci-dessous, choisissez si elle est vraie ou fausse.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "49bb95aa-1074-45e9-8c85-c061efd07348",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/eJvzfPp.png",
-                  "alt": "Un casque audio",
-                  "alternativeText": ""
-                },
-                {
-                  "id": "690bfa69-b8fe-4036-8d3e-4c5e49261534",
-                  "type": "qcu",
-                  "instruction": "<p>Ce casque se connecte à un port USB pour fonctionner.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "vrai",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>C'était faux. Regardez bien l’extrémité du fil de ce casque audio : il est rond. Il ne se branche pas à un port USB, mais à un port jack.</p>"
-                      }
+                      "id": "6f276b50-a00c-49f7-b22c-23dbef0c2bf2",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/xXHePcU.png",
+                      "alt": "Une souris d'ordinateur",
+                      "alternativeText": ""
                     },
                     {
-                      "id": "2",
-                      "content": "faux",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p> Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>"
-                      }
+                      "id": "54a04560-ab1b-410b-a2f7-771f6483d951",
+                      "type": "qcu",
+                      "instruction": "<p>Cette souris se connecte à un port USB pour fonctionner.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "vrai",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p> Cette souris filaire (qui se branche avec un fil) se branche à un port USB.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>C'était vrai. Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "36b959d4-add7-403d-9e7f-aa4f0bf777b8",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/APVIHeB.png",
-                  "alt": "Photo d'un connecteur avec un symbole représentant une flèche avec des ronds et des carrés",
-                  "alternativeText": ""
+                  ]
                 },
                 {
-                  "id": "06af3ce9-50ee-469e-a649-d5d4476e60f5",
-                  "type": "qcu",
-                  "instruction": "<p>Le symbole de l’USB est représenté sur cette image.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "vrai",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p> Ce symbole peut changer un peu sur des ports USB plus récents.</p>"
-                      }
+                      "id": "49bb95aa-1074-45e9-8c85-c061efd07348",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/eJvzfPp.png",
+                      "alt": "Un casque audio",
+                      "alternativeText": ""
                     },
                     {
-                      "id": "2",
-                      "content": "faux",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>C'était vrai. Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
-                      }
+                      "id": "690bfa69-b8fe-4036-8d3e-4c5e49261534",
+                      "type": "qcu",
+                      "instruction": "<p>Ce casque se connecte à un port USB pour fonctionner.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "vrai",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>C'était faux. Regardez bien l’extrémité du fil de ce casque audio : il est rond. Il ne se branche pas à un port USB, mais à un port jack.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "faux",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p> Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "36b959d4-add7-403d-9e7f-aa4f0bf777b8",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/APVIHeB.png",
+                      "alt": "Photo d'un connecteur avec un symbole représentant une flèche avec des ronds et des carrés",
+                      "alternativeText": ""
+                    },
+                    {
+                      "id": "06af3ce9-50ee-469e-a649-d5d4476e60f5",
+                      "type": "qcu",
+                      "instruction": "<p>Le symbole de l’USB est représenté sur cette image.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "vrai",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p> Ce symbole peut changer un peu sur des ports USB plus récents.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "faux",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>C'était vrai. Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "0894fa96-0c3d-489c-a432-8c288b3e06cd",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f357712f-ff2f-4a72-ba76-f31bcc7faa50",
-            "type": "text",
-            "content": "<p>Testez vos connaissances sur tous les ports de connexion.&nbsp;🕹️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "daa8a389-28c3-4a42-870f-062375f53394",
-      "type": "summary",
-      "title": "Flashcard ports de connexion",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "612f9310-26cd-4923-8150-7192069cdea6",
-            "type": "flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
-            "title": "Les ports de connexion essentiels d'un ordinateur",
-            "introImage": {
-              "url": "https://assets.pix.org/draft/modules/LJa2WXI.png"
-            },
-            "cards": [
-              {
-                "id": "63f8e751-bc73-46a2-8a22-e00be116e23a",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/lPE5Iob.jpeg"
-                  },
-                  "text": "Quel port permet de brancher ce casque audio ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/kzql8CG.jpeg"
-                  },
-                  "text": "<p>Le port jack !&nbsp;<br>Il est souvent signalé par un dessin de casque.<br>On y branche tous les appareils audios : casques, écouteurs, chaîne hifi, micros.</p>"
-                }
-              },
-              {
-                "id": "f9399a97-3bf1-44ad-92c0-391a9f19c0bc",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/APVIHeB.png"
-                  },
-                  "text": "Quel est le nom du port auquel brancher ce câble ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/x4JWIrP.jpeg"
-                  },
-                  "text": "<p>Le port USB !&nbsp;</p>"
-                }
-              },
-              {
-                "id": "7d8b6e4a-7301-4eb4-89ac-f5c4d97f6003",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/tw392vB.jpeg"
-                  },
-                  "text": "Que permet de connecter ce port de connexion ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/BsjYWhh.jpeg"
-                  },
-                  "text": "<p>Ce port permet de connecter votre ordinateur à internet grâce au câble Ethernet.<br>Il s'appelle le port Ethernet.</p>"
-                }
-              },
-              {
-                "id": "47a351f1-151e-4e06-8f12-72ec24fdbcad",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/vXhuoz0.jpeg"
-                  },
-                  "text": "À quel port se branche ce câble ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/draft/modules/A5zShWC.jpeg"
-                  },
-                  "text": "<p>Au port HDMI.<br>Il permet notamment de brancher un second écran, ou de se raccorder à une télévision.</p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "5ebb51ab-d76e-4661-a114-dcf6ae2adc4f",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "22047103-8c88-42ae-8c51-e168e7b3f035",
-            "type": "text",
-            "content": "<p>Pour finir ce module, vous allez devoir explorer les ports de connexion de votre propre ordinateur.&nbsp;💻<br>À vous de jouer !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "57cea880-a324-4a1b-8cfe-a7c8d1b0f5b1",
-      "type": "challenge",
-      "title": "Vos ports de connexion",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "029cdc04-5fc3-4d1a-8127-6d5ad9084002",
-            "type": "text",
-            "content": "<p>Cherchez et nommez tous les ports de connexion de votre ordinateur.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e6c1fdff-e2a3-4108-a1f8-245dc7e3668f",
-            "type": "qcu",
-            "instruction": "<p>Pensez-vous avoir réussi à les trouver ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "oui",
-                "feedback": {
-                  "state": "Bravo !",
-                  "diagnosis": "<p>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "non",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Vous pouvez remonter la page et vous&nbsp;aider des schémas présentés, ou demander de l'aide à quelqu'un si c'est possible.<br>Selon l'âge et la marque de votre ordinateur, les ports de connexion de votre ordinateur peuvent varier.</p>"
-                }
+          "id": "0894fa96-0c3d-489c-a432-8c288b3e06cd",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f357712f-ff2f-4a72-ba76-f31bcc7faa50",
+                "type": "text",
+                "content": "<p>Testez vos connaissances sur tous les ports de connexion.&nbsp;🕹️</p>"
               }
-            ],
-            "solution": "1"
-          }
+            }
+          ]
+        },
+        {
+          "id": "daa8a389-28c3-4a42-870f-062375f53394",
+          "type": "summary",
+          "title": "Flashcard ports de connexion",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "612f9310-26cd-4923-8150-7192069cdea6",
+                "type": "flashcards",
+                "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
+                "title": "Les ports de connexion essentiels d'un ordinateur",
+                "introImage": {
+                  "url": "https://assets.pix.org/draft/modules/LJa2WXI.png"
+                },
+                "cards": [
+                  {
+                    "id": "63f8e751-bc73-46a2-8a22-e00be116e23a",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/lPE5Iob.jpeg"
+                      },
+                      "text": "Quel port permet de brancher ce casque audio ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/kzql8CG.jpeg"
+                      },
+                      "text": "<p>Le port jack !&nbsp;<br>Il est souvent signalé par un dessin de casque.<br>On y branche tous les appareils audios : casques, écouteurs, chaîne hifi, micros.</p>"
+                    }
+                  },
+                  {
+                    "id": "f9399a97-3bf1-44ad-92c0-391a9f19c0bc",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/APVIHeB.png"
+                      },
+                      "text": "Quel est le nom du port auquel brancher ce câble ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/x4JWIrP.jpeg"
+                      },
+                      "text": "<p>Le port USB !&nbsp;</p>"
+                    }
+                  },
+                  {
+                    "id": "7d8b6e4a-7301-4eb4-89ac-f5c4d97f6003",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/tw392vB.jpeg"
+                      },
+                      "text": "Que permet de connecter ce port de connexion ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/BsjYWhh.jpeg"
+                      },
+                      "text": "<p>Ce port permet de connecter votre ordinateur à internet grâce au câble Ethernet.<br>Il s'appelle le port Ethernet.</p>"
+                    }
+                  },
+                  {
+                    "id": "47a351f1-151e-4e06-8f12-72ec24fdbcad",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/vXhuoz0.jpeg"
+                      },
+                      "text": "À quel port se branche ce câble ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/draft/modules/A5zShWC.jpeg"
+                      },
+                      "text": "<p>Au port HDMI.<br>Il permet notamment de brancher un second écran, ou de se raccorder à une télévision.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "5ebb51ab-d76e-4661-a114-dcf6ae2adc4f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "22047103-8c88-42ae-8c51-e168e7b3f035",
+                "type": "text",
+                "content": "<p>Pour finir ce module, vous allez devoir explorer les ports de connexion de votre propre ordinateur.&nbsp;💻<br>À vous de jouer !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "57cea880-a324-4a1b-8cfe-a7c8d1b0f5b1",
+          "type": "challenge",
+          "title": "Vos ports de connexion",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "029cdc04-5fc3-4d1a-8127-6d5ad9084002",
+                "type": "text",
+                "content": "<p>Cherchez et nommez tous les ports de connexion de votre ordinateur.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e6c1fdff-e2a3-4108-a1f8-245dc7e3668f",
+                "type": "qcu",
+                "instruction": "<p>Pensez-vous avoir réussi à les trouver ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "oui",
+                    "feedback": {
+                      "state": "Bravo !",
+                      "diagnosis": "<p>Vous pouvez vérifier votre réponse avec les schémas présentés et demander une vérification par quelqu'un si c'est possible.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "non",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Vous pouvez remonter la page et vous&nbsp;aider des schémas présentés, ou demander de l'aide à quelqu'un si c'est possible.<br>Selon l'âge et la marque de votre ordinateur, les ports de connexion de votre ordinateur peuvent varier.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -15,560 +15,566 @@
       "Trouver des informations dans un article Wikipédia"
     ]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "7b561ece-4747-4770-b500-d1804393ea2f",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "f76bc32d-26ba-40d9-a0e5-c43ab0162128",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "383aad97-ff24-4cbb-844e-1d2346fe75b6",
-            "type": "text",
-            "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo ?&nbsp;🌎&nbsp;🧩</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "da95d2bc-e597-4366-a095-21f7ab0f4845",
-      "type": "activity",
-      "title": "Wikipédia : un site de référence !",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "30b9ada4-a87a-4dfb-baa2-d97925b0bba5",
-            "type": "text",
-            "content": "<p>Depuis sa création en 2001, Wikipédia a fait évoluer son logo à trois reprises.<br> Aujourd'hui, le logo représente un globe composé de pièces de puzzle avec différents symboles.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a4a95061-c1c4-475a-9cb8-c64928d40b8c",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/q1pokb5.png",
-            "alt": "Logos de Wikipédia de 2001 à 2010 décrits en alternative textuelle.",
-            "alternativeText": "Chronologie des logos de Wikipédia depuis sa création :<ul><li>2001 : image représentant un globe sur lequel est inscrit un article d'encyclopédie en langue anglaise. Deux segments noirs verticaux découpent le globe en trois morceaux.</li><li>2001 à 2003 : image représentant un globe sur lequel est inscrit un article d'encyclopédie en langue anglaise. Le nom \"Wikipédia\" est centré sous le globe, en lettres capitales. En dessous, le sous-titre \"The Free Encyclopedia\" est également centré et en caractères de taille plus petite.</li><li>2003 à 2010 : image représentant un globe incomplet constitué de pièces de puzzle. Sur chacune des pièces de puzzle figure un caractère de différents systèmes d'écriture, dont une lettre W en majuscule de l'alphabet latin. Le nom \"Wikipédia\" est centré sous le globe, en lettres capitales. En dessous, le sous-titre \"The Free Encyclopedia\" est également centré et en caractères de taille plus petite et en italiques.</li><li>depuis 2010 : les éléments sont quasiment identiques au logo de 2003 à 2010. La seule différence est le sous-titre qui n'est plus en italiques.</li></ul><p>Source : <a href=\"https://fr.wikipedia.org/wiki/Logo_de_Wikip%C3%A9dia\" target=\"_blank\">https://fr.wikipedia.org/wiki/Logo_de_Wikip%C3%A9dia</a></p><p>Licence : CC BY-SA 3.0 DEED</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d5acb701-fd9c-40d4-b59d-fb2fd8f6b3fe",
-            "type": "qcm",
-            "instruction": "<p>Une devinette&nbsp;: selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Le globe est incomplet car Wikipédia est constamment en construction."
-              },
-              {
-                "id": "2",
-                "content": "Le globe est incomplet car Wikipédia sera toujours ouvert."
-              },
-              {
-                "id": "3",
-                "content": "Les symboles représentent la diversité des savoirs rassemblés sur Wikipédia."
-              },
-              {
-                "id": "4",
-                "content": "Les symboles représentent les différentes langues qui existent sur Wikipédia."
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse&nbsp;! 🎉",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
-              }
-            },
-            "solutions": ["1", "4"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "348d488a-f837-4a5b-9f19-28644ee1e6d6",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "80813968-7b81-4859-8ed0-71c158c80e63",
-            "type": "text",
-            "content": "<p>Wikipédia repose sur 5 principes fondateurs qui font son identité et sa particularité en tant que site internet.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b7f1f203-cf5d-4da8-bfa2-46e01a625f61",
-      "type": "lesson",
-      "title": "Les principes fondateurs de Wikipédia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "afc8b60f-c2c1-405b-a6a4-a0e08e23ccc3",
-            "type": "text",
-            "content": "<h3>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h3><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "3bbf40bb-acd0-466f-a1ce-5c4bf9ccee8e",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "81710de7-1311-4980-81f5-87944e56de28",
-            "type": "text",
-            "content": "<h3>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h3><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "20ed0b8b-a858-440e-a587-4856f96ef5be",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "78385472-07b0-4229-bfb8-a10636690300",
-            "type": "text",
-            "content": "<h3>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h3><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "929661f0-ca4c-40fb-9df2-7832e97192e3",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
-            "type": "text",
-            "content": "<h3>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h3><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "1edb38ba-7542-4198-a5de-c260ef6b95ea",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ca62ac2d-950d-4c00-b14d-2ac9e7d509f2",
-            "type": "text",
-            "content": "<h3>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h3><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e9268398-fa62-4e1a-8dd2-3d7101b1457c",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d3825882-f259-454f-ace8-8b983a25357f",
-            "type": "text",
-            "content": "<p>On l'a vu, Wikipédia a une philosophie unique. Répondez à cette question pour vérifier que vous avez compris l'essentiel.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9a3926dd-750c-4b89-b1d0-9a286fe2d9e4",
-      "type": "activity",
-      "title": "Les principes fondateurs de Wikipédia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b15e1ab7-9f62-458b-8bfe-f039028a808b",
-            "type": "qcm",
-            "instruction": "<p>Parmi les mots suivants, quels sont ceux qui correspondent aux principes fondateurs de Wikipédia&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "collaboratif"
-              },
-              {
-                "id": "2",
-                "content": "académique"
-              },
-              {
-                "id": "3",
-                "content": "neutre"
-              },
-              {
-                "id": "4",
-                "content": "libre"
-              },
-              {
-                "id": "5",
-                "content": "exhaustif"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse&nbsp;! 🎉",
-                "diagnosis": "<p> Vous avez bien identifié les principes de Wikipédia. </p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span></p>"
-              }
-            },
-            "solutions": ["1", "3", "4"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "222d8ac2-f60c-4a90-b9f9-70902cad4f12",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d2327666-368c-4735-94e0-ba7b7b8325a7",
-            "type": "text",
-            "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues&#8239;?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "5f048ad8-d008-4956-840b-37e84138b433",
-      "type": "activity",
-      "title": "Le nombre de langues dans Wikipedia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c99efced-e183-4f4f-aec7-07a5da13294a",
-            "type": "qcu",
-            "instruction": "<p>Dans le monde, il existe environ 7000 langues.<br>Selon vous, dans combien de langues environ Wikipédia existe-t-il&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "100",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "250",
-                "feedback": {
-                  "state": "Bonne réponse&nbsp;! 🎉",
-                  "diagnosis": "<p> Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "400",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "700",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "974f2cf4-cbfc-4d82-ade1-93a47ff0d730",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "06c2a27a-ce5c-4242-b053-3b5dd1ab891c",
-            "type": "text",
-            "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;💰</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "09b21f5f-b7e7-4c7a-9059-bdb2a2be246d",
-      "type": "activity",
-      "title": "Le financement de Wikipédia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "46dec681-51e7-44f8-9422-9ccd77125f8b",
-            "type": "qcu",
-            "instruction": "<p>Selon vous, par quel moyen Wikipédia est-il financé&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "les publicités",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "les abonnements payants",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "les dons",
-                "feedback": {
-                  "state": "Oui, c'est correct.",
-                  "diagnosis": "<p> Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "68f812c0-8ac7-4df0-bdaa-5d3fd6e36bde",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "87823339-0045-4db4-88a5-ec1154f73330",
-            "type": "text",
-            "content": "<p>Dans la vidéo suivante, vous allez découvrir différentes méthodes pour trouver des informations sur Wikipédia et évaluer leur qualité.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d8ed222f-2a22-44a6-affe-fe6047689b2e",
-      "type": "lesson",
-      "title": "Trouver efficacement des informations dans un article Wikipédia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "10e352a0-0c46-4348-b392-dedc22a32960",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, vous passerez à la pratique. Vous devrez naviguer dans le sommaire d'un article Wikipédia et en identifier la qualité.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5d6862bf-899f-4f2e-ac63-185b9a209e1c",
-            "type": "video",
-            "title": "Une vidéo",
-            "url": "https://assets.pix.org/modules/principes-fondateurs-wikipedia/screencast-article.mp4",
-            "subtitles": "https://assets.pix.org/modules/placeholder-video.vtt",
-            "transcription": "<p>Bonjour à tous !<br> Aujourd’hui, je vais vous parler des articles sur Wikipédia. On va voir ensemble les vérifications à faire avant de lire un article Wikipédia comment bien se repérer et trouver efficacement des informations comment évaluer la qualité des informations dans ces articles.<br> C’est parti !<br>Sous nos yeux, un article Wikipédia.<br> C’est un article sur le romancier célèbre Jules Verne. On peut vérifier que c’est bien lui avec les pages d’homonymes : il y a plusieurs Jules Verne, mais on a bien celui que l’on voulait, c’est-à-dire le romancier.<br>L’article est écrit en français. Il existe en plusieurs langues, ici on voit qu’il y en a 120 ! Ce qu’il faut retenir, c’est que les articles dans d’autres langues sont écrits par d’autres personnes. Ce n’est pas une traduction directe de l’article français.<br>On a donc le bon article, je vous le présente plus en détails.<br>Pour commencer, ce que je trouve vraiment utile sur les articles Wikipédia, c’est le premier paragraphe. C’est une synthèse des informations de l’article.<br>Ici on trouve les principaux épisodes de la vie de Jules Verne : sa naissance, sa mort, ses romans, ses œuvres et sa notoriété.<br>Comme on le voit, l’article est très long donc pour chercher efficacement des informations, je vous conseille d’utiliser le sommaire, à gauche de l’écran.<br>Il permet de rejoindre rapidement une section de l’article. Par exemple, si je m’intéresse aux œuvres de Jules Verne, je peux y aller directement.<br>Une fois que je suis là, je peux commencer à lire et à chercher, ou utiliser une nouvelle fois le sommaire pour être plus précis. Par exemple, si je cherche des informations sur ses pièces de théâtre. On y va.<br>Si je veux des informations sur une pièce en particulier, par exemple Les Pailles rompues, je peux aller voir facilement l’article Wikipédia sur cette pièce en cliquant simplement sur le lien.<br>Au passage, c’est ce qui fait aussi de Wikipédia une encyclopédie : les connaissances sont rassemblées dans un même endroit et se font écho les unes les autres. Les sources des informations, qui sont externes à Wikipédia, sont indiquées en bas de la page.<br>Ce qu’il faut savoir également, c’est que les articles sont rédigés par plusieurs contributeurs bénévoles. Ils sont le plus souvent relus et analysés par la communauté.<br>Ici, on trouve la mention de “bon article”, ce qui signifie qu’il remplit des critères de qualité établis par Wikipédia.<br>Les mentions de qualité et d’alertes relatifs au contenu sont toujours en haut de la page.<br>Par exemple, sur un autre article. Il est indiqué que l’article ne cite pas assez ses sources. Donc je vais être très vigilant sur les informations que je vais y trouver.<br>Sur cet autre article, il est indiqué que c’est une ébauche : il peut être compléter et améliorer. Dans ce cas également, je vais être vigilant sur les informations et par exemple aller les re-vérifier avec d’autres sites.<br>Vous l’avez compris, avant de lire un article Wikipédia, regardez-donc bien ces indications pour savoir à quel point on peut faire confiance aux informations de l’article.<br>Voilà, merci d’avoir visionné cette vidéo, j’espère qu’elle vous a été utile et à très vite !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "cbf15e50-8f82-47a6-affd-8494c688b606",
-      "type": "activity",
-      "title": "Trouver efficacement des informations dans un article Wikipédia",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "01eb319e-8219-425a-b66f-00f8f73a4842",
-            "type": "text",
-            "content": "<h3>Répondez aux questions ci-dessous en naviguant dans  <a href=\"https://fr.wikipedia.org/wiki/Inca_(Majorque)\" target=\"blank\">l'article Wikipédia de la commune d'Inca.</a></h3>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cfcd33f1-3544-491d-95b4-0d028084ff32",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ea12a08f-fa0b-4693-a1fd-8a5baf27f494",
-            "type": "qrocm",
-            "instruction": "<p>Dans le sommaire de cet article, trouvez la section <strong>Début</strong>. Quel est le nom de la cinquième section&#8239;?</p>",
-            "proposals": [
-              {
+          "id": "7b561ece-4747-4770-b500-d1804393ea2f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "383aad97-ff24-4cbb-844e-1d2346fe75b6",
                 "type": "text",
-                "content": "<span>Nom de la cinquième section&nbsp;:</span>"
-              },
-              {
-                "input": "cinquieme-section",
-                "type": "input",
-                "inputType": "text",
-                "size": 20,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Remplir le nom de la cinquième section du sommaire de l'article Wikipédia proposé",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["Honneur"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse&nbsp;! 🎉",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": ""
+                "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo ?&nbsp;🌎&nbsp;🧩</p>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "c6526e70-ac27-47d3-9794-3e1e2d243334",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "649c29ee-0b22-4da3-ba2a-036bb3016425",
-            "type": "qrocm",
-            "instruction": "<p>Dans cet article, combien y a-t-il de Notes et références&#8239;? </p>",
-            "proposals": [
-              {
+          "id": "da95d2bc-e597-4366-a095-21f7ab0f4845",
+          "type": "activity",
+          "title": "Wikipédia : un site de référence !",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "30b9ada4-a87a-4dfb-baa2-d97925b0bba5",
                 "type": "text",
-                "content": "<span>Nombre&nbsp;:</span>"
-              },
-              {
-                "input": "nombre-ref",
-                "type": "input",
-                "inputType": "text",
-                "size": 1,
-                "display": "block",
-                "placeholder": "",
-                "ariaLabel": "Remplir avec le nombre de notes et références",
-                "defaultValue": "",
-                "tolerances": ["t1"],
-                "solutions": ["1"]
+                "content": "<p>Depuis sa création en 2001, Wikipédia a fait évoluer son logo à trois reprises.<br> Aujourd'hui, le logo représente un globe composé de pièces de puzzle avec différents symboles.</p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse&nbsp;! 🎉",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": ""
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a4a95061-c1c4-475a-9cb8-c64928d40b8c",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/q1pokb5.png",
+                "alt": "Logos de Wikipédia de 2001 à 2010 décrits en alternative textuelle.",
+                "alternativeText": "Chronologie des logos de Wikipédia depuis sa création :<ul><li>2001 : image représentant un globe sur lequel est inscrit un article d'encyclopédie en langue anglaise. Deux segments noirs verticaux découpent le globe en trois morceaux.</li><li>2001 à 2003 : image représentant un globe sur lequel est inscrit un article d'encyclopédie en langue anglaise. Le nom \"Wikipédia\" est centré sous le globe, en lettres capitales. En dessous, le sous-titre \"The Free Encyclopedia\" est également centré et en caractères de taille plus petite.</li><li>2003 à 2010 : image représentant un globe incomplet constitué de pièces de puzzle. Sur chacune des pièces de puzzle figure un caractère de différents systèmes d'écriture, dont une lettre W en majuscule de l'alphabet latin. Le nom \"Wikipédia\" est centré sous le globe, en lettres capitales. En dessous, le sous-titre \"The Free Encyclopedia\" est également centré et en caractères de taille plus petite et en italiques.</li><li>depuis 2010 : les éléments sont quasiment identiques au logo de 2003 à 2010. La seule différence est le sous-titre qui n'est plus en italiques.</li></ul><p>Source : <a href=\"https://fr.wikipedia.org/wiki/Logo_de_Wikip%C3%A9dia\" target=\"_blank\">https://fr.wikipedia.org/wiki/Logo_de_Wikip%C3%A9dia</a></p><p>Licence : CC BY-SA 3.0 DEED</p>"
               }
-            }
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "7c1830cb-1f48-4050-98c1-6ae34d14ee51",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "be1ba37e-0588-42ed-8fab-f47bf118953a",
-            "type": "qrocm",
-            "instruction": "<p>Quel est le niveau de qualité estimé de cet article&#8239;?</p>",
-            "proposals": [
-              {
-                "type": "text",
-                "content": "<span>Niveau de qualité estimé&nbsp;:</span>"
-              },
-              {
-                "input": "quality-wiki",
-                "type": "select",
-                "display": "block",
-                "placeholder": "- Sélectionner -",
-                "ariaLabel": "Choisir le niveau de qualité estimé",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d5acb701-fd9c-40d4-b59d-fb2fd8f6b3fe",
+                "type": "qcm",
+                "instruction": "<p>Une devinette&nbsp;: selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia&#8239;?</p>",
+                "proposals": [
                   {
                     "id": "1",
-                    "content": "Bon article"
+                    "content": "Le globe est incomplet car Wikipédia est constamment en construction."
                   },
                   {
                     "id": "2",
-                    "content": "Ébauche"
+                    "content": "Le globe est incomplet car Wikipédia sera toujours ouvert."
                   },
                   {
                     "id": "3",
-                    "content": "Non renseigné"
+                    "content": "Les symboles représentent la diversité des savoirs rassemblés sur Wikipédia."
+                  },
+                  {
+                    "id": "4",
+                    "content": "Les symboles représentent les différentes langues qui existent sur Wikipédia."
                   }
                 ],
-                "solutions": ["2"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse&nbsp;! 🎉",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": ""
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse&nbsp;! 🎉",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
+                  }
+                },
+                "solutions": ["1", "4"]
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "348d488a-f837-4a5b-9f19-28644ee1e6d6",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "80813968-7b81-4859-8ed0-71c158c80e63",
+                "type": "text",
+                "content": "<p>Wikipédia repose sur 5 principes fondateurs qui font son identité et sa particularité en tant que site internet.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b7f1f203-cf5d-4da8-bfa2-46e01a625f61",
+          "type": "lesson",
+          "title": "Les principes fondateurs de Wikipédia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "afc8b60f-c2c1-405b-a6a4-a0e08e23ccc3",
+                "type": "text",
+                "content": "<h3>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h3><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3bbf40bb-acd0-466f-a1ce-5c4bf9ccee8e",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "81710de7-1311-4980-81f5-87944e56de28",
+                "type": "text",
+                "content": "<h3>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h3><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "20ed0b8b-a858-440e-a587-4856f96ef5be",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "78385472-07b0-4229-bfb8-a10636690300",
+                "type": "text",
+                "content": "<h3>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h3><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "929661f0-ca4c-40fb-9df2-7832e97192e3",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
+                "type": "text",
+                "content": "<h3>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h3><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1edb38ba-7542-4198-a5de-c260ef6b95ea",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ca62ac2d-950d-4c00-b14d-2ac9e7d509f2",
+                "type": "text",
+                "content": "<h3>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h3><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e9268398-fa62-4e1a-8dd2-3d7101b1457c",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d3825882-f259-454f-ace8-8b983a25357f",
+                "type": "text",
+                "content": "<p>On l'a vu, Wikipédia a une philosophie unique. Répondez à cette question pour vérifier que vous avez compris l'essentiel.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9a3926dd-750c-4b89-b1d0-9a286fe2d9e4",
+          "type": "activity",
+          "title": "Les principes fondateurs de Wikipédia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b15e1ab7-9f62-458b-8bfe-f039028a808b",
+                "type": "qcm",
+                "instruction": "<p>Parmi les mots suivants, quels sont ceux qui correspondent aux principes fondateurs de Wikipédia&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "collaboratif"
+                  },
+                  {
+                    "id": "2",
+                    "content": "académique"
+                  },
+                  {
+                    "id": "3",
+                    "content": "neutre"
+                  },
+                  {
+                    "id": "4",
+                    "content": "libre"
+                  },
+                  {
+                    "id": "5",
+                    "content": "exhaustif"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse&nbsp;! 🎉",
+                    "diagnosis": "<p> Vous avez bien identifié les principes de Wikipédia. </p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span></p>"
+                  }
+                },
+                "solutions": ["1", "3", "4"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "222d8ac2-f60c-4a90-b9f9-70902cad4f12",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d2327666-368c-4735-94e0-ba7b7b8325a7",
+                "type": "text",
+                "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues&#8239;?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "5f048ad8-d008-4956-840b-37e84138b433",
+          "type": "activity",
+          "title": "Le nombre de langues dans Wikipedia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c99efced-e183-4f4f-aec7-07a5da13294a",
+                "type": "qcu",
+                "instruction": "<p>Dans le monde, il existe environ 7000 langues.<br>Selon vous, dans combien de langues environ Wikipédia existe-t-il&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "100",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "250",
+                    "feedback": {
+                      "state": "Bonne réponse&nbsp;! 🎉",
+                      "diagnosis": "<p> Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "400",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "700",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "974f2cf4-cbfc-4d82-ade1-93a47ff0d730",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "06c2a27a-ce5c-4242-b053-3b5dd1ab891c",
+                "type": "text",
+                "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;💰</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "09b21f5f-b7e7-4c7a-9059-bdb2a2be246d",
+          "type": "activity",
+          "title": "Le financement de Wikipédia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "46dec681-51e7-44f8-9422-9ccd77125f8b",
+                "type": "qcu",
+                "instruction": "<p>Selon vous, par quel moyen Wikipédia est-il financé&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "les publicités",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "les abonnements payants",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "les dons",
+                    "feedback": {
+                      "state": "Oui, c'est correct.",
+                      "diagnosis": "<p> Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "68f812c0-8ac7-4df0-bdaa-5d3fd6e36bde",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "87823339-0045-4db4-88a5-ec1154f73330",
+                "type": "text",
+                "content": "<p>Dans la vidéo suivante, vous allez découvrir différentes méthodes pour trouver des informations sur Wikipédia et évaluer leur qualité.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d8ed222f-2a22-44a6-affe-fe6047689b2e",
+          "type": "lesson",
+          "title": "Trouver efficacement des informations dans un article Wikipédia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "10e352a0-0c46-4348-b392-dedc22a32960",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, vous passerez à la pratique. Vous devrez naviguer dans le sommaire d'un article Wikipédia et en identifier la qualité.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "5d6862bf-899f-4f2e-ac63-185b9a209e1c",
+                "type": "video",
+                "title": "Une vidéo",
+                "url": "https://assets.pix.org/modules/principes-fondateurs-wikipedia/screencast-article.mp4",
+                "subtitles": "https://assets.pix.org/modules/placeholder-video.vtt",
+                "transcription": "<p>Bonjour à tous !<br> Aujourd’hui, je vais vous parler des articles sur Wikipédia. On va voir ensemble les vérifications à faire avant de lire un article Wikipédia comment bien se repérer et trouver efficacement des informations comment évaluer la qualité des informations dans ces articles.<br> C’est parti !<br>Sous nos yeux, un article Wikipédia.<br> C’est un article sur le romancier célèbre Jules Verne. On peut vérifier que c’est bien lui avec les pages d’homonymes : il y a plusieurs Jules Verne, mais on a bien celui que l’on voulait, c’est-à-dire le romancier.<br>L’article est écrit en français. Il existe en plusieurs langues, ici on voit qu’il y en a 120 ! Ce qu’il faut retenir, c’est que les articles dans d’autres langues sont écrits par d’autres personnes. Ce n’est pas une traduction directe de l’article français.<br>On a donc le bon article, je vous le présente plus en détails.<br>Pour commencer, ce que je trouve vraiment utile sur les articles Wikipédia, c’est le premier paragraphe. C’est une synthèse des informations de l’article.<br>Ici on trouve les principaux épisodes de la vie de Jules Verne : sa naissance, sa mort, ses romans, ses œuvres et sa notoriété.<br>Comme on le voit, l’article est très long donc pour chercher efficacement des informations, je vous conseille d’utiliser le sommaire, à gauche de l’écran.<br>Il permet de rejoindre rapidement une section de l’article. Par exemple, si je m’intéresse aux œuvres de Jules Verne, je peux y aller directement.<br>Une fois que je suis là, je peux commencer à lire et à chercher, ou utiliser une nouvelle fois le sommaire pour être plus précis. Par exemple, si je cherche des informations sur ses pièces de théâtre. On y va.<br>Si je veux des informations sur une pièce en particulier, par exemple Les Pailles rompues, je peux aller voir facilement l’article Wikipédia sur cette pièce en cliquant simplement sur le lien.<br>Au passage, c’est ce qui fait aussi de Wikipédia une encyclopédie : les connaissances sont rassemblées dans un même endroit et se font écho les unes les autres. Les sources des informations, qui sont externes à Wikipédia, sont indiquées en bas de la page.<br>Ce qu’il faut savoir également, c’est que les articles sont rédigés par plusieurs contributeurs bénévoles. Ils sont le plus souvent relus et analysés par la communauté.<br>Ici, on trouve la mention de “bon article”, ce qui signifie qu’il remplit des critères de qualité établis par Wikipédia.<br>Les mentions de qualité et d’alertes relatifs au contenu sont toujours en haut de la page.<br>Par exemple, sur un autre article. Il est indiqué que l’article ne cite pas assez ses sources. Donc je vais être très vigilant sur les informations que je vais y trouver.<br>Sur cet autre article, il est indiqué que c’est une ébauche : il peut être compléter et améliorer. Dans ce cas également, je vais être vigilant sur les informations et par exemple aller les re-vérifier avec d’autres sites.<br>Vous l’avez compris, avant de lire un article Wikipédia, regardez-donc bien ces indications pour savoir à quel point on peut faire confiance aux informations de l’article.<br>Voilà, merci d’avoir visionné cette vidéo, j’espère qu’elle vous a été utile et à très vite !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "cbf15e50-8f82-47a6-affd-8494c688b606",
+          "type": "activity",
+          "title": "Trouver efficacement des informations dans un article Wikipédia",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "01eb319e-8219-425a-b66f-00f8f73a4842",
+                "type": "text",
+                "content": "<h3>Répondez aux questions ci-dessous en naviguant dans  <a href=\"https://fr.wikipedia.org/wiki/Inca_(Majorque)\" target=\"blank\">l'article Wikipédia de la commune d'Inca.</a></h3>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cfcd33f1-3544-491d-95b4-0d028084ff32",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ea12a08f-fa0b-4693-a1fd-8a5baf27f494",
+                "type": "qrocm",
+                "instruction": "<p>Dans le sommaire de cet article, trouvez la section <strong>Début</strong>. Quel est le nom de la cinquième section&#8239;?</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Nom de la cinquième section&nbsp;:</span>"
+                  },
+                  {
+                    "input": "cinquieme-section",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 20,
+                    "display": "block",
+                    "placeholder": "",
+                    "ariaLabel": "Remplir le nom de la cinquième section du sommaire de l'article Wikipédia proposé",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["Honneur"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse&nbsp;! 🎉",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": ""
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c6526e70-ac27-47d3-9794-3e1e2d243334",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "649c29ee-0b22-4da3-ba2a-036bb3016425",
+                "type": "qrocm",
+                "instruction": "<p>Dans cet article, combien y a-t-il de Notes et références&#8239;? </p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Nombre&nbsp;:</span>"
+                  },
+                  {
+                    "input": "nombre-ref",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 1,
+                    "display": "block",
+                    "placeholder": "",
+                    "ariaLabel": "Remplir avec le nombre de notes et références",
+                    "defaultValue": "",
+                    "tolerances": ["t1"],
+                    "solutions": ["1"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse&nbsp;! 🎉",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": ""
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7c1830cb-1f48-4050-98c1-6ae34d14ee51",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "be1ba37e-0588-42ed-8fab-f47bf118953a",
+                "type": "qrocm",
+                "instruction": "<p>Quel est le niveau de qualité estimé de cet article&#8239;?</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Niveau de qualité estimé&nbsp;:</span>"
+                  },
+                  {
+                    "input": "quality-wiki",
+                    "type": "select",
+                    "display": "block",
+                    "placeholder": "- Sélectionner -",
+                    "ariaLabel": "Choisir le niveau de qualité estimé",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "1",
+                        "content": "Bon article"
+                      },
+                      {
+                        "id": "2",
+                        "content": "Ébauche"
+                      },
+                      {
+                        "id": "3",
+                        "content": "Non renseigné"
+                      }
+                    ],
+                    "solutions": ["2"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse&nbsp;! 🎉",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": ""
+                  }
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
@@ -15,655 +15,661 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "005b3848-5cad-49fb-876b-1cc430854d71",
-      "type": "transition",
-      "title": "Introduction",
-      "components": [
+      "id": "ca41f652-7dcc-468b-81a2-347086cd2bf7",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "339e443a-9eb7-476c-8689-9a7714c31607",
-            "type": "text",
-            "content": "<p>Gustave organise un tournoi de volley. 🏐</p><p>Il veut gagner du temps et demande à une IA générative d’écrire à sa place l’invitation aux participants. </p><p>Mais il est déçu du résultat… <br><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "92f571ad-1a64-4b64-ba8f-782337e61713",
-      "type": "discovery",
-      "title": "Conversation d'introduction",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f49a0fed-c65d-467e-a30d-73445381c61c",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Conversation d'introduction",
-              "messages": [
-                {
-                  "userName": "Gustave",
-                  "direction": "incoming",
-                  "content": "Je ne comprends pas... Tu arrives à faire plein de choses avec l'IA. Mais avec moi, ça ne marche pas !😒"
-                },
-                {
-                  "userName": "Emma",
-                  "direction": "outgoing",
-                  "content": "Ah bon ? Quel prompt as-tu utilisé ? 🤖"
-                },
-                {
-                  "userName": "Gustave",
-                  "direction": "incoming",
-                  "content": "Je voulais inviter les joueurs du tournoi. Mon prompt, c’était : « Écris une invitation au tournoi. »"
-                },
-                {
-                  "userName": "Emma",
-                  "direction": "outgoing",
-                  "content": "C’est normal, ton prompt est trop flou ! L’IA ne peut pas deviner ce que tu veux. 😉 Il y a des techniques pour améliorer les résultats. 💡"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "61cd268c-d7d3-4387-abf7-9312a2d8ea6f",
-      "type": "transition",
-      "title": "Transition : La qualité de la réponse de l’IA dépend de la qualité du prompt !",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "052ed96d-d123-49a0-b7aa-fb8c2d220ca8",
-            "type": "text",
-            "content": "<p>La réponse de l’IA dépend de la qualité du prompt. Voyons comment faire un prompt efficace.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0f187da9-1bbc-407f-bb5d-c29b09f2c950",
-      "type": "discovery",
-      "title": "Améliore le prompt de Gustave",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3f36edd3-42cd-4cf3-9063-1ad75166871c",
-            "type": "text",
-            "content": "<p>Le prompt de Gustave était&nbsp;: «&nbsp;Écris une invitation au tournoi.&nbsp;»</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e0c90c2f-086e-42b7-855e-a66a0a4773c6",
-            "type": "qcm",
-            "instruction": "<p>Selon vous, que faut-il ajouter au prompt de Gustave ?<br></p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>l’objet&nbsp;: «&nbsp;le tournoi de volley&nbsp;»</p>"
-              },
-              {
-                "id": "2",
-                "content": "<p>la date&nbsp;: «&nbsp;samedi prochain&nbsp;»</p>"
-              },
-              {
-                "id": "3",
-                "content": "<p>le lieu&nbsp;: «&nbsp;le gymnase des 3 sapins&nbsp;»</p>"
-              },
-              {
-                "id": "4",
-                "content": "<p>les destinataires&nbsp;: «&nbsp;les membres du club&nbsp;»</p>"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "<p>Bien vu !<br></p>",
-                "diagnosis": "<p>Le contexte donne du sens au prompt. Plus l'IA a des informations sur la situation, meilleure sera sa réponse.</p>"
-              },
-              "invalid": {
-                "state": "<p>Pas tout à fait !</p>",
-                "diagnosis": "<p>Il faut donner plus de précisions&nbsp;: le contexte donne du sens au prompt. Plus l'IA a des informations sur la situation, meilleure sera sa réponse.<br></p>"
-              }
-            },
-            "solutions": ["1", "2", "3", "4"]
-          }
-        }
-      ]
-    },
-    {
-      "id": "417ba69e-c96c-445a-b4dc-1107fd18c4cd",
-      "type": "lesson",
-      "title": "Le contexte du prompt",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "504fb0c6-f40a-403c-9471-e4fb0512e9cd",
-            "type": "text",
-            "content": "<p>➡️Un prompt bien formulé donne toujours à l’IA un contexte, c’est-à-dire des précisions sur la situation&nbsp;: le lieu, le moment, l’objectif, etc.&nbsp; <br>Sans contexte, l'IA risque de répondre de façon vague ou hors sujet.<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a0f82875-61f3-4a6a-ad1a-dc30f40cf405",
-      "type": "discovery",
-      "title": "Tester différents tons",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "77fa2e62-b572-40ed-ad92-2b6433efaf45",
-            "type": "text",
-            "content": "<p>Gustave a envoyé les invitations pour le tournoi. Il a hâte !&nbsp; </p><p>Mais certaines personnes ne lui ont pas encore répondu…&nbsp; <br>Il veut écrire un message de relance mais il hésite sur la manière de le formuler.🤔 <br></p>\n"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4f35bf9d-e319-4a6d-b1f5-dc0a84f2139d",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/JTE/testerleton.html",
-            "instruction": "<p>Testez différents tons de messages avec l’IA.</p>",
-            "height": 450
-          }
-        }
-      ]
-    },
-    {
-      "id": "9fb0fcf7-6cd7-4524-af0c-b6aba8da9994",
-      "type": "activity",
-      "title": "Quel est ton ton préféré ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "267f28d2-4540-427a-a775-c15c380c3d4b",
-            "type": "qcu-declarative",
-            "instruction": "<p>Quel message de relance créé avec l’IA est votre préféré ?&nbsp;<br></p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>celui avec un ton festif</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Un choix sympa !</strong>&nbsp; Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>celui avec un ton sérieux</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Un choix formel ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>celui avec un ton drôle</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Un choix original ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi. <br></p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>aucun ne me plait\t<br></p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Pas de souci !</strong> Il existe beaucoup d’autres tons : enfantin, ironique, poétique… Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi ! </p>"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "ac059738-54bc-4682-bc96-af014c8f6705",
-      "type": "lesson",
-      "title": "Le ton dans un prompt",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ae043fb4-a580-4c82-b6ef-041739c01870",
-            "type": "text",
-            "content": "<p>➡️ On peut modifier le ton d’un prompt en précisant&nbsp;:&nbsp; </p><ul><li>à qui on veut s’adresser,&nbsp;</li><li>de quelle manière (avec humour, de manière brève, pédagogue, professionnelle, etc.),</li><li>un rôle à jouer («&nbsp;tu es un poète&nbsp;», «&nbsp;en tant que coach sportif&nbsp;», «&nbsp;comme un professeur&nbsp;», etc.).</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0f81e6a6-c697-4c48-85bf-7b3e8c53f7bb",
-      "type": "activity",
-      "title": "Aide Gustave avec son prompt - identifie le format",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "16c152b9-5a18-48b5-a0f7-b1bfa1f8c41c",
-            "type": "text",
-            "content": "<p>Gustave veut entraîner les joueurs en vue du tournoi.<br>D’habitude, il prépare un document d'entraînement sous ce format.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4fd08276-0da3-4726-aa83-8ac498dcd561",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/tableaumanchette/travailmanchette.png",
-            "alt": "Un tableau d'exercice pour travailler la manchette",
-            "alternativeText": "<p>Un tableau avec 3 exercices pour travailler la manchette selon son niveau (débutant, intermédiaire, avancé)</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "29b0a00a-fb1e-4737-a84f-c154e3faff48",
-            "type": "qrocm",
-            "instruction": "<p>Quel est le format utilisé habituellement par Gustave ?</p><br>",
-            "proposals": [
-              {
-                "input": "CV1pzGeay4eJi1g7",
-                "type": "input",
-                "inputType": "text",
-                "size": 8,
-                "display": "inline",
-                "placeholder": "un seul mot",
-                "ariaLabel": "champs à remplir",
-                "defaultValue": "",
-                "tolerances": ["t1", "t2", "t3"],
-                "solutions": ["tableau"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "<p>Bien vu !&nbsp;<br></p>",
-                "diagnosis": "<p>Si vous voulez avoir un résultat similaire en demandant à l’IA, il faudra préciser le format.</p>"
-              },
-              "invalid": {
-                "state": "<p>Et non…&nbsp;<br></p>",
-                "diagnosis": "<p>Si vous voulez avoir un résultat similaire en demandant à l’IA, il faudra préciser le format, ici, un tableau.&nbsp;<br></p>"
+          "id": "005b3848-5cad-49fb-876b-1cc430854d71",
+          "type": "transition",
+          "title": "Introduction",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "339e443a-9eb7-476c-8689-9a7714c31607",
+                "type": "text",
+                "content": "<p>Gustave organise un tournoi de volley. 🏐</p><p>Il veut gagner du temps et demande à une IA générative d’écrire à sa place l’invitation aux participants. </p><p>Mais il est déçu du résultat… <br><br></p>"
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "154ad788-50ff-4a8c-abf1-a22307d4d2f8",
-      "type": "activity",
-      "title": "Aide Gustave avec son prompt - utilise le LLM",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "07920aa5-5dd7-46e4-9d81-8c85b887e5f2",
-            "type": "text",
-            "content": "<p>Gustave souhaite faire un <strong>tableau </strong>similaire, mais pour travailler les <strong>smashs</strong>.</p><p>Utilisez l'<strong>IA de Pix</strong> pour répondre à sa demande.&nbsp;N'hésitez pas à préciser au fur et à mesure.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "8bffec8d-b6c7-48ed-8d3d-5af8d094247e",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur LLM",
-            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbyvhypt0007wa01s7k2wl8k",
-            "instruction": "<p>À vous de jouer !</p>",
-            "solution": "<p></p>",
-            "height": 800
-          }
+          "id": "92f571ad-1a64-4b64-ba8f-782337e61713",
+          "type": "discovery",
+          "title": "Conversation d'introduction",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f49a0fed-c65d-467e-a30d-73445381c61c",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Conversation d'introduction",
+                  "messages": [
+                    {
+                      "userName": "Gustave",
+                      "direction": "incoming",
+                      "content": "Je ne comprends pas... Tu arrives à faire plein de choses avec l'IA. Mais avec moi, ça ne marche pas !😒"
+                    },
+                    {
+                      "userName": "Emma",
+                      "direction": "outgoing",
+                      "content": "Ah bon ? Quel prompt as-tu utilisé ? 🤖"
+                    },
+                    {
+                      "userName": "Gustave",
+                      "direction": "incoming",
+                      "content": "Je voulais inviter les joueurs du tournoi. Mon prompt, c’était : « Écris une invitation au tournoi. »"
+                    },
+                    {
+                      "userName": "Emma",
+                      "direction": "outgoing",
+                      "content": "C’est normal, ton prompt est trop flou ! L’IA ne peut pas deviner ce que tu veux. 😉 Il y a des techniques pour améliorer les résultats. 💡"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6ff09171-639a-4e55-a4d5-9beb8e4afea4",
-            "type": "text",
-            "content": "<p>\n    <br>\n</p>\n<p>\n</p><p></p><p></p><details>\n    <summary><span aria-hidden=\"true\">💡</span> L’astuce pratique</summary>\n    <p><span aria-hidden=\"true\">❌</span>Il vous arrive d'envoyer votre prompt alors que vous vouliez juste aller à la ligne ? <br> <span aria-hidden=\"true\">✅</span> Quand vous voulez aller à la ligne, appuyez à la fois sur les touches Maj (ou Shift⬆️)et Entrée </p>\n</details>\n<p></p><p></p><p></p>\n<p><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a280f603-3c78-4b98-a858-c2e0119a19af",
-      "type": "lesson",
-      "title": "L'importance du format et de l'itération dans les prompts",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c4a6a0a4-bbc8-4462-9098-af1e9d453cf3",
-            "type": "text",
-            "content": "<p>➡️Sans indication, l'IA choisira elle-même un format, qui risque ne pas correspondre vos attentes.&nbsp;🤔​</p><p>Préciser le <strong>format</strong> attendu dans le prompt permet de gagner du temps&nbsp;:&nbsp; </p><p>il peut s’agir d’un <strong>texte</strong>, d’un <strong>tableau</strong>, d’une <strong>liste</strong>, d’un <strong>plan détaillé</strong>… </p><p>On peut aussi préciser des <strong>contraintes </strong>dans ce format, par exemple&nbsp;:&nbsp; </p><ul><li>un texte d’une <strong>longueur maximale</strong> de 10 lignes, </li><li>un plan détaillé <strong>en précisant la structure</strong>, le nombre de parties et le titre.</li></ul><p>Mais vous n’avez pas besoin de préciser tous les détails et les contraintes dès le départ, vous pouvez le faire <strong>au fur et à mesure,</strong> en demandant des modifications.<br><br></p><p>💡Bon à savoir&nbsp;: Vous pouvez aussi demander à l’IA de partir d’un <strong>exemple </strong>et de le reproduire.<br><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "97606a38-68e2-427e-b8e5-65411cd7d5d5",
-      "type": "summary",
-      "title": "Récap' : l'essentiel pour faire des bons prompts",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "17178f53-901f-4547-9f8a-bfc40990214d",
-            "type": "text",
-            "content": "<p>📌 Résumons l’essentiel avant de passer à la suite&nbsp;: </p><ul><li>Utiliser un verbe d’<strong>action</strong> dans son prompt aide à décrire la tâche à l’IA.<ul><li>Par exemple : résume, décris, traduis, analyse…</li></ul></li><li>Un prompt efficace donne du <strong>contexte.</strong>&nbsp;Il donne à l'IA des précisions sur la situation.<ul><li>Par exemple : le lieu, le moment, l’objectif... 🎯</li></ul></li><li>Préciser le <strong>format attendu</strong> aide l'IA à structurer sa réponse selon vos besoins. <ul><li>Par exemple : une liste, un paragraphe, un tableau, un plan détaillé...&nbsp;📋</li></ul></li><li>Le <strong>ton </strong>d’un prompt guide le style de la réponse.<ul><li>Par exemple : sérieux, amical, professionnel, humoristique… 💬</li></ul></li><li>Attribuer un <strong>rôle </strong>ou une identité à l'IA peut aider à obtenir des réponses plus ciblées &nbsp;🤠</li></ul><p>Travailler avec une IA se fait le plus souvent par étape, vous pouvez préciser votre demande au fur et à mesure, et demander des corrections. 🔄</p><p><br><strong>⚠️</strong>Une réponse peut paraître claire et bien formulée mais contenir des <strong>erreurs</strong>.&nbsp;</p><ul><li><strong>Relire </strong>la réponse de l’IA est essentiel avant de la diffuser ou de la présenter à quelqu’un.🔍</li></ul><p></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b6a9f4ed-057a-490f-9d81-a0687b5ee269",
-      "type": "activity",
-      "title": "Analyse les prompts",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bfd964cd-dcb6-4bf6-8bde-182a05b75795",
-            "type": "text",
-            "content": "<p>Grâce à ces conseils, Gustave a amélioré ses techniques pour parler à l’IA.&nbsp;</p><p><br>Pour chaque prompt, sélectionnez tous les éléments qui rendent le prompt clair.</p>"
-          }
+          "id": "61cd268c-d7d3-4387-abf7-9312a2d8ea6f",
+          "type": "transition",
+          "title": "Transition : La qualité de la réponse de l’IA dépend de la qualité du prompt !",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "052ed96d-d123-49a0-b7aa-fb8c2d220ca8",
+                "type": "text",
+                "content": "<p>La réponse de l’IA dépend de la qualité du prompt. Voyons comment faire un prompt efficace.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "0f187da9-1bbc-407f-bb5d-c29b09f2c950",
+          "type": "discovery",
+          "title": "Améliore le prompt de Gustave",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "ae9cf536-d7b2-423f-872d-b20fc1217716",
-                  "type": "text",
-                  "content": "<p>«&nbsp;En tant que coach de volley, propose un plan détaillé avec des exercices pour un entraînement d’une heure pour des enfants de 6 à 8 ans qui sont débutants.&nbsp;»<br></p>"
-                },
-                {
-                  "id": "90b420d2-029d-4718-b865-8636cbb2daab",
-                  "type": "qcm",
-                  "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>le contexte</p>"
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le format<br></p>"
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le ton à adopter</p>"
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>le rôle à jouer</p>"
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "<p>Bien joué ! 🎉<br></p>",
-                      "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
-                    },
-                    "invalid": {
-                      "state": "<p>Mauvaise réponse.<br></p>",
-                      "diagnosis": "<p>Ici, le format est le plan détaillé, le rôle est le coach de volley et le contexte correspond à l’heure d'entraînement pour des enfants de 6 à 8 ans débutant.<br></p>"
-                    }
-                  },
-                  "solutions": ["1", "2", "4"]
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "3f36edd3-42cd-4cf3-9063-1ad75166871c",
+                "type": "text",
+                "content": "<p>Le prompt de Gustave était&nbsp;: «&nbsp;Écris une invitation au tournoi.&nbsp;»</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "f64e341e-4e3b-4088-827d-9f353b869749",
-                  "type": "text",
-                  "content": "<p>« Rédige un formulaire d’inscription formel pour une association de volley-ball qui fait des cours tous les jeudi de 18h à 20h à destination des joueurs adultes loisirs. »</p>"
-                },
-                {
-                  "id": "63e08249-f5bf-4ba0-93c1-9c864caab99b",
-                  "type": "qcm",
-                  "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>le contexte</p>"
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le format</p>"
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le ton à adopter<br></p>"
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>le rôle à jouer</p>"
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "<p>Bravo ! 🎉<br></p>",
-                      "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
-                    },
-                    "invalid": {
-                      "state": "<p>Mauvaise réponse.<br></p>",
-                      "diagnosis": "<p>Ici, le format est le formulaire d’inscription, le ton est formel et le contexte correspond à toutes les informations sur l’association, son public et la fréquence des cours.<br></p>"
-                    }
+              "type": "element",
+              "element": {
+                "id": "e0c90c2f-086e-42b7-855e-a66a0a4773c6",
+                "type": "qcm",
+                "instruction": "<p>Selon vous, que faut-il ajouter au prompt de Gustave ?<br></p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>l’objet&nbsp;: «&nbsp;le tournoi de volley&nbsp;»</p>"
                   },
-                  "solutions": ["1", "2", "3"]
-                }
-              ]
+                  {
+                    "id": "2",
+                    "content": "<p>la date&nbsp;: «&nbsp;samedi prochain&nbsp;»</p>"
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>le lieu&nbsp;: «&nbsp;le gymnase des 3 sapins&nbsp;»</p>"
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>les destinataires&nbsp;: «&nbsp;les membres du club&nbsp;»</p>"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "<p>Bien vu !<br></p>",
+                    "diagnosis": "<p>Le contexte donne du sens au prompt. Plus l'IA a des informations sur la situation, meilleure sera sa réponse.</p>"
+                  },
+                  "invalid": {
+                    "state": "<p>Pas tout à fait !</p>",
+                    "diagnosis": "<p>Il faut donner plus de précisions&nbsp;: le contexte donne du sens au prompt. Plus l'IA a des informations sur la situation, meilleure sera sa réponse.<br></p>"
+                  }
+                },
+                "solutions": ["1", "2", "3", "4"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "417ba69e-c96c-445a-b4dc-1107fd18c4cd",
+          "type": "lesson",
+          "title": "Le contexte du prompt",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "504fb0c6-f40a-403c-9471-e4fb0512e9cd",
+                "type": "text",
+                "content": "<p>➡️Un prompt bien formulé donne toujours à l’IA un contexte, c’est-à-dire des précisions sur la situation&nbsp;: le lieu, le moment, l’objectif, etc.&nbsp; <br>Sans contexte, l'IA risque de répondre de façon vague ou hors sujet.<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a0f82875-61f3-4a6a-ad1a-dc30f40cf405",
+          "type": "discovery",
+          "title": "Tester différents tons",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "77fa2e62-b572-40ed-ad92-2b6433efaf45",
+                "type": "text",
+                "content": "<p>Gustave a envoyé les invitations pour le tournoi. Il a hâte !&nbsp; </p><p>Mais certaines personnes ne lui ont pas encore répondu…&nbsp; <br>Il veut écrire un message de relance mais il hésite sur la manière de le formuler.🤔 <br></p>\n"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "40644c94-0cfe-407d-98d3-bf6b10a605dc",
-                  "type": "text",
-                  "content": "<p>«&nbsp;Décris un match de volley à la plage, comme si tu étais le célèbre écrivain Molière.&nbsp;»<br></p>"
-                },
-                {
-                  "id": "c11fd7b8-645a-43b7-80cd-a1953fe4180b",
-                  "type": "qcm",
-                  "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>le contexte</p>"
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>le format<br></p>"
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le ton à adopter<br></p>"
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>le rôle à jouer<br></p>"
-                    }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "<p>Bonne réponse ! 🎉<br></p>",
-                      "diagnosis": "<p>Ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
-                    },
-                    "invalid": {
-                      "state": "<p>Mauvaise réponse.<br></p>",
-                      "diagnosis": "<p>Ici, le rôle est Molière et le contexte, celui du match de volley à la plage.<br></p>"
+              "type": "element",
+              "element": {
+                "id": "4f35bf9d-e319-4a6d-b1f5-dc0a84f2139d",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/JTE/testerleton.html",
+                "instruction": "<p>Testez différents tons de messages avec l’IA.</p>",
+                "height": 450
+              }
+            }
+          ]
+        },
+        {
+          "id": "9fb0fcf7-6cd7-4524-af0c-b6aba8da9994",
+          "type": "activity",
+          "title": "Quel est ton ton préféré ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "267f28d2-4540-427a-a775-c15c380c3d4b",
+                "type": "qcu-declarative",
+                "instruction": "<p>Quel message de relance créé avec l’IA est votre préféré ?&nbsp;<br></p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>celui avec un ton festif</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Un choix sympa !</strong>&nbsp; Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
                     }
                   },
-                  "solutions": ["1", "4"]
-                }
-              ]
+                  {
+                    "id": "2",
+                    "content": "<p>celui avec un ton sérieux</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Un choix formel ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>celui avec un ton drôle</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Un choix original ! </strong>Au final, Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi. <br></p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>aucun ne me plait\t<br></p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Pas de souci !</strong> Il existe beaucoup d’autres tons : enfantin, ironique, poétique… Gustave choisira le ton approprié car c’est lui qui connaît le mieux les participants du tournoi ! </p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "ac059738-54bc-4682-bc96-af014c8f6705",
+          "type": "lesson",
+          "title": "Le ton dans un prompt",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ae043fb4-a580-4c82-b6ef-041739c01870",
+                "type": "text",
+                "content": "<p>➡️ On peut modifier le ton d’un prompt en précisant&nbsp;:&nbsp; </p><ul><li>à qui on veut s’adresser,&nbsp;</li><li>de quelle manière (avec humour, de manière brève, pédagogue, professionnelle, etc.),</li><li>un rôle à jouer («&nbsp;tu es un poète&nbsp;», «&nbsp;en tant que coach sportif&nbsp;», «&nbsp;comme un professeur&nbsp;», etc.).</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0f81e6a6-c697-4c48-85bf-7b3e8c53f7bb",
+          "type": "activity",
+          "title": "Aide Gustave avec son prompt - identifie le format",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "16c152b9-5a18-48b5-a0f7-b1bfa1f8c41c",
+                "type": "text",
+                "content": "<p>Gustave veut entraîner les joueurs en vue du tournoi.<br>D’habitude, il prépare un document d'entraînement sous ce format.<br></p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "4fd08276-0da3-4726-aa83-8ac498dcd561",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/tableaumanchette/travailmanchette.png",
+                "alt": "Un tableau d'exercice pour travailler la manchette",
+                "alternativeText": "<p>Un tableau avec 3 exercices pour travailler la manchette selon son niveau (débutant, intermédiaire, avancé)</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "29b0a00a-fb1e-4737-a84f-c154e3faff48",
+                "type": "qrocm",
+                "instruction": "<p>Quel est le format utilisé habituellement par Gustave ?</p><br>",
+                "proposals": [
+                  {
+                    "input": "CV1pzGeay4eJi1g7",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 8,
+                    "display": "inline",
+                    "placeholder": "un seul mot",
+                    "ariaLabel": "champs à remplir",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t2", "t3"],
+                    "solutions": ["tableau"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "<p>Bien vu !&nbsp;<br></p>",
+                    "diagnosis": "<p>Si vous voulez avoir un résultat similaire en demandant à l’IA, il faudra préciser le format.</p>"
+                  },
+                  "invalid": {
+                    "state": "<p>Et non…&nbsp;<br></p>",
+                    "diagnosis": "<p>Si vous voulez avoir un résultat similaire en demandant à l’IA, il faudra préciser le format, ici, un tableau.&nbsp;<br></p>"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "154ad788-50ff-4a8c-abf1-a22307d4d2f8",
+          "type": "activity",
+          "title": "Aide Gustave avec son prompt - utilise le LLM",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "07920aa5-5dd7-46e4-9d81-8c85b887e5f2",
+                "type": "text",
+                "content": "<p>Gustave souhaite faire un <strong>tableau </strong>similaire, mais pour travailler les <strong>smashs</strong>.</p><p>Utilisez l'<strong>IA de Pix</strong> pour répondre à sa demande.&nbsp;N'hésitez pas à préciser au fur et à mesure.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8bffec8d-b6c7-48ed-8d3d-5af8d094247e",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur LLM",
+                "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbyvhypt0007wa01s7k2wl8k",
+                "instruction": "<p>À vous de jouer !</p>",
+                "solution": "<p></p>",
+                "height": 800
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6ff09171-639a-4e55-a4d5-9beb8e4afea4",
+                "type": "text",
+                "content": "<p>\n    <br>\n</p>\n<p>\n</p><p></p><p></p><details>\n    <summary><span aria-hidden=\"true\">💡</span> L’astuce pratique</summary>\n    <p><span aria-hidden=\"true\">❌</span>Il vous arrive d'envoyer votre prompt alors que vous vouliez juste aller à la ligne ? <br> <span aria-hidden=\"true\">✅</span> Quand vous voulez aller à la ligne, appuyez à la fois sur les touches Maj (ou Shift⬆️)et Entrée </p>\n</details>\n<p></p><p></p><p></p>\n<p><br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a280f603-3c78-4b98-a858-c2e0119a19af",
+          "type": "lesson",
+          "title": "L'importance du format et de l'itération dans les prompts",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c4a6a0a4-bbc8-4462-9098-af1e9d453cf3",
+                "type": "text",
+                "content": "<p>➡️Sans indication, l'IA choisira elle-même un format, qui risque ne pas correspondre vos attentes.&nbsp;🤔​</p><p>Préciser le <strong>format</strong> attendu dans le prompt permet de gagner du temps&nbsp;:&nbsp; </p><p>il peut s’agir d’un <strong>texte</strong>, d’un <strong>tableau</strong>, d’une <strong>liste</strong>, d’un <strong>plan détaillé</strong>… </p><p>On peut aussi préciser des <strong>contraintes </strong>dans ce format, par exemple&nbsp;:&nbsp; </p><ul><li>un texte d’une <strong>longueur maximale</strong> de 10 lignes, </li><li>un plan détaillé <strong>en précisant la structure</strong>, le nombre de parties et le titre.</li></ul><p>Mais vous n’avez pas besoin de préciser tous les détails et les contraintes dès le départ, vous pouvez le faire <strong>au fur et à mesure,</strong> en demandant des modifications.<br><br></p><p>💡Bon à savoir&nbsp;: Vous pouvez aussi demander à l’IA de partir d’un <strong>exemple </strong>et de le reproduire.<br><br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "97606a38-68e2-427e-b8e5-65411cd7d5d5",
+          "type": "summary",
+          "title": "Récap' : l'essentiel pour faire des bons prompts",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "17178f53-901f-4547-9f8a-bfc40990214d",
+                "type": "text",
+                "content": "<p>📌 Résumons l’essentiel avant de passer à la suite&nbsp;: </p><ul><li>Utiliser un verbe d’<strong>action</strong> dans son prompt aide à décrire la tâche à l’IA.<ul><li>Par exemple : résume, décris, traduis, analyse…</li></ul></li><li>Un prompt efficace donne du <strong>contexte.</strong>&nbsp;Il donne à l'IA des précisions sur la situation.<ul><li>Par exemple : le lieu, le moment, l’objectif... 🎯</li></ul></li><li>Préciser le <strong>format attendu</strong> aide l'IA à structurer sa réponse selon vos besoins. <ul><li>Par exemple : une liste, un paragraphe, un tableau, un plan détaillé...&nbsp;📋</li></ul></li><li>Le <strong>ton </strong>d’un prompt guide le style de la réponse.<ul><li>Par exemple : sérieux, amical, professionnel, humoristique… 💬</li></ul></li><li>Attribuer un <strong>rôle </strong>ou une identité à l'IA peut aider à obtenir des réponses plus ciblées &nbsp;🤠</li></ul><p>Travailler avec une IA se fait le plus souvent par étape, vous pouvez préciser votre demande au fur et à mesure, et demander des corrections. 🔄</p><p><br><strong>⚠️</strong>Une réponse peut paraître claire et bien formulée mais contenir des <strong>erreurs</strong>.&nbsp;</p><ul><li><strong>Relire </strong>la réponse de l’IA est essentiel avant de la diffuser ou de la présenter à quelqu’un.🔍</li></ul><p></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b6a9f4ed-057a-490f-9d81-a0687b5ee269",
+          "type": "activity",
+          "title": "Analyse les prompts",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bfd964cd-dcb6-4bf6-8bde-182a05b75795",
+                "type": "text",
+                "content": "<p>Grâce à ces conseils, Gustave a amélioré ses techniques pour parler à l’IA.&nbsp;</p><p><br>Pour chaque prompt, sélectionnez tous les éléments qui rendent le prompt clair.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "5176e4d0-394a-4e27-a754-f675ee325595",
-                  "type": "text",
-                  "content": "<p>«&nbsp;En tant qu’humoriste, propose un court discours amusant (2 à 3 minutes) pour le pot de départ d’un joueur de volley de ton équipe qui déménage dans une autre ville. Inclus ses grandes qualités (humour, adresse, leadership) et ses petits défauts (impatient et bavard).&nbsp;»</p>"
+                  "elements": [
+                    {
+                      "id": "ae9cf536-d7b2-423f-872d-b20fc1217716",
+                      "type": "text",
+                      "content": "<p>«&nbsp;En tant que coach de volley, propose un plan détaillé avec des exercices pour un entraînement d’une heure pour des enfants de 6 à 8 ans qui sont débutants.&nbsp;»<br></p>"
+                    },
+                    {
+                      "id": "90b420d2-029d-4718-b865-8636cbb2daab",
+                      "type": "qcm",
+                      "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>le contexte</p>"
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le format<br></p>"
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le ton à adopter</p>"
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>le rôle à jouer</p>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "<p>Bien joué ! 🎉<br></p>",
+                          "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
+                        },
+                        "invalid": {
+                          "state": "<p>Mauvaise réponse.<br></p>",
+                          "diagnosis": "<p>Ici, le format est le plan détaillé, le rôle est le coach de volley et le contexte correspond à l’heure d'entraînement pour des enfants de 6 à 8 ans débutant.<br></p>"
+                        }
+                      },
+                      "solutions": ["1", "2", "4"]
+                    }
+                  ]
                 },
                 {
-                  "id": "bf5ec9f6-31ce-44ad-b880-5694072cd0e4",
-                  "type": "qcm",
-                  "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>le contexte<br></p>"
+                      "id": "f64e341e-4e3b-4088-827d-9f353b869749",
+                      "type": "text",
+                      "content": "<p>« Rédige un formulaire d’inscription formel pour une association de volley-ball qui fait des cours tous les jeudi de 18h à 20h à destination des joueurs adultes loisirs. »</p>"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>le format</p>"
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>le ton à adopter<br></p>"
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>le rôle à jouer<br></p>"
+                      "id": "63e08249-f5bf-4ba0-93c1-9c864caab99b",
+                      "type": "qcm",
+                      "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>le contexte</p>"
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le format</p>"
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le ton à adopter<br></p>"
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>le rôle à jouer</p>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "<p>Bravo ! 🎉<br></p>",
+                          "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
+                        },
+                        "invalid": {
+                          "state": "<p>Mauvaise réponse.<br></p>",
+                          "diagnosis": "<p>Ici, le format est le formulaire d’inscription, le ton est formel et le contexte correspond à toutes les informations sur l’association, son public et la fréquence des cours.<br></p>"
+                        }
+                      },
+                      "solutions": ["1", "2", "3"]
                     }
-                  ],
-                  "feedbacks": {
-                    "valid": {
-                      "state": "<p>Bien joué !</p>",
-                      "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.<br></p>"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "40644c94-0cfe-407d-98d3-bf6b10a605dc",
+                      "type": "text",
+                      "content": "<p>«&nbsp;Décris un match de volley à la plage, comme si tu étais le célèbre écrivain Molière.&nbsp;»<br></p>"
                     },
-                    "invalid": {
-                      "state": "<p>Mauvaise réponse.<br></p>",
-                      "diagnosis": "<p>Ici, l’humoriste est le rôle, le format est un court discours, le ton est amusant. Le contexte est le pot de départ d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
+                    {
+                      "id": "c11fd7b8-645a-43b7-80cd-a1953fe4180b",
+                      "type": "qcm",
+                      "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>le contexte</p>"
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le format<br></p>"
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le ton à adopter<br></p>"
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>le rôle à jouer<br></p>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "<p>Bonne réponse ! 🎉<br></p>",
+                          "diagnosis": "<p>Ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.</p>"
+                        },
+                        "invalid": {
+                          "state": "<p>Mauvaise réponse.<br></p>",
+                          "diagnosis": "<p>Ici, le rôle est Molière et le contexte, celui du match de volley à la plage.<br></p>"
+                        }
+                      },
+                      "solutions": ["1", "4"]
                     }
-                  },
-                  "solutions": ["1", "2", "3", "4"]
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "5176e4d0-394a-4e27-a754-f675ee325595",
+                      "type": "text",
+                      "content": "<p>«&nbsp;En tant qu’humoriste, propose un court discours amusant (2 à 3 minutes) pour le pot de départ d’un joueur de volley de ton équipe qui déménage dans une autre ville. Inclus ses grandes qualités (humour, adresse, leadership) et ses petits défauts (impatient et bavard).&nbsp;»</p>"
+                    },
+                    {
+                      "id": "bf5ec9f6-31ce-44ad-b880-5694072cd0e4",
+                      "type": "qcm",
+                      "instruction": "<p>Quels éléments rendent ce prompt clair ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>le contexte<br></p>"
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>le format</p>"
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>le ton à adopter<br></p>"
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>le rôle à jouer<br></p>"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "<p>Bien joué !</p>",
+                          "diagnosis": "<p>Tous ces éléments rendent ce prompt clair. Mais il n’est pas toujours nécessaire de les mettre tous.<br></p>"
+                        },
+                        "invalid": {
+                          "state": "<p>Mauvaise réponse.<br></p>",
+                          "diagnosis": "<p>Ici, l’humoriste est le rôle, le format est un court discours, le ton est amusant. Le contexte est le pot de départ d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
+                        }
+                      },
+                      "solutions": ["1", "2", "3", "4"]
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "bde3a9c6-8c31-465d-94ac-20276ea7a445",
-      "type": "lesson",
-      "title": "Gustave organise les notes ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e90e7470-54a6-444d-bc77-39cfc9b0fad1",
-            "type": "text",
-            "content": "<p>Gustave a pris des notes lors de la réunion d’organisation du tournoi :&nbsp;</p><p><br><em>- max 12 équipes. 5v5, équipes mixtes → tout le monde ok</em></p><p><em>- arbitres → bénévoles, relancer ceux du dernier tournoi-</em></p><p><em>- 2 sponsors ( eau+ salle de sport) ok, pizzeria en négos</em></p><p><em>- playlist en cours un peu d’ambiance, c’est gérésono ? </em></p><p><em>-&nbsp;pas clair → voir avec mairie pr matos</em></p><p><em>- si pluie → gymnase dispo ? ok ! :-)</em></p><p><em>- buvette : jus, sandwichs, fruits → pas de chaudrécompenses ? médailles → à chiffrer</em></p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e0f68d47-e46e-4ec7-b368-a95b1972151c",
-            "type": "text",
-            "content": "<p>Gustave veut envoyer un <strong>compte-rendu </strong>aux personnes qui n’ont pas pû présentes.</p>"
-          }
+          "id": "bde3a9c6-8c31-465d-94ac-20276ea7a445",
+          "type": "lesson",
+          "title": "Gustave organise les notes ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e90e7470-54a6-444d-bc77-39cfc9b0fad1",
+                "type": "text",
+                "content": "<p>Gustave a pris des notes lors de la réunion d’organisation du tournoi :&nbsp;</p><p><br><em>- max 12 équipes. 5v5, équipes mixtes → tout le monde ok</em></p><p><em>- arbitres → bénévoles, relancer ceux du dernier tournoi-</em></p><p><em>- 2 sponsors ( eau+ salle de sport) ok, pizzeria en négos</em></p><p><em>- playlist en cours un peu d’ambiance, c’est gérésono ? </em></p><p><em>-&nbsp;pas clair → voir avec mairie pr matos</em></p><p><em>- si pluie → gymnase dispo ? ok ! :-)</em></p><p><em>- buvette : jus, sandwichs, fruits → pas de chaudrécompenses ? médailles → à chiffrer</em></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e0f68d47-e46e-4ec7-b368-a95b1972151c",
+                "type": "text",
+                "content": "<p>Gustave veut envoyer un <strong>compte-rendu </strong>aux personnes qui n’ont pas pû présentes.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "db74d65f-dcbf-493d-aeb9-818e0f5f13a8",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur de LLM",
+                "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbux83260005wa011nxx2c6n",
+                "instruction": "<p>Discute avec l’IA de Pix jusqu'à obtenir un compte-rendu fidèle.<br></p>",
+                "solution": "Pix",
+                "height": 800
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6df04b1d-5b20-4d74-ade1-bebfe4384c5c",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><details><summary>Indice 1</summary><p>Avez-vous vérifié le résultat proposé par l’IA  ?</p></details><details><summary>Indice 2</summary><p> Avez-vous vérifié les récompenses dans le compte-rendu ? </p></details><details><summary>Indice 3</summary><p>Avez-vous demandé à l’IA de corriger sa réponse ?</p></details><p></p><p></p><p></p><p></p><p></p><p></p><p></p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "db74d65f-dcbf-493d-aeb9-818e0f5f13a8",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur de LLM",
-            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbux83260005wa011nxx2c6n",
-            "instruction": "<p>Discute avec l’IA de Pix jusqu'à obtenir un compte-rendu fidèle.<br></p>",
-            "solution": "Pix",
-            "height": 800
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "6df04b1d-5b20-4d74-ade1-bebfe4384c5c",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><details><summary>Indice 1</summary><p>Avez-vous vérifié le résultat proposé par l’IA  ?</p></details><details><summary>Indice 2</summary><p> Avez-vous vérifié les récompenses dans le compte-rendu ? </p></details><details><summary>Indice 3</summary><p>Avez-vous demandé à l’IA de corriger sa réponse ?</p></details><p></p><p></p><p></p><p></p><p></p><p></p><p></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "d2f8112e-2fcf-4ccd-a1e5-1879c6987de9",
-      "type": "challenge",
-      "title": "Défi : l'actualité du tournoi",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "dd2cf906-b77f-4c4d-8f11-9aa53a606d03",
-            "type": "text",
-            "content": "<p>Gustave est content ; le tournoi de l’été a été un succès !&nbsp;🌞</p><p>Pour chaque édition du tournoi, il crée une publication sur le site du gymnase, à sa manière…</p><p>Ses précédentes publications sont disponibles ci-dessous&nbsp;:<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c992a84d-933f-4a33-8485-5b64cacd6aea",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/JTE/actualitestournoi.html",
-            "instruction": "",
-            "height": 550
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "52c9f208-8f95-4926-a64e-214041a834d2",
-            "type": "text",
-            "content": "<p>À votre tour d’écrire l’<strong>actualité du tournoi de l’été</strong> à la façon des précédentes actualités de Gustave et en vous basant sur la photo illustrant le tournoi.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9fb1cf79-a154-4b71-a1e5-cea6803b950b",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/volleyraptor.png",
-            "alt": "Une affiche concernant le tournoi de volley - lire l'alternative textuelle",
-            "alternativeText": "<p>Une affiche concernant le tournoi de Volley. </p><p>Elle annonce l'équipe des volley-raptors vainqueur !&nbsp;</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fbe1b91f-a423-45f5-8329-1cd50f436944",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur LLM",
-            "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbuxyoa30006wa01agdl8qu1",
-            "instruction": "<p>Utilisez&nbsp;<strong>l'IA de Pix</strong> pour le faire, à vous de jouer !</p>",
-            "solution": "<p></p>",
-            "height": 800
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e553af3a-34e3-4238-be9c-d40466cf43dd",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><p></p><p></p><p></p><p></p><p></p><details><summary>Indice 1</summary><p>Avez-vous pensé à décrire le format voulu ?</p></details><details><summary>Indice 2</summary><p> Avez-vous vérifié que le résultat comportait bien l'équipe vainqueur ?</p></details><p></p><p></p><p></p><p></p><p></p>"
-          }
+          "id": "d2f8112e-2fcf-4ccd-a1e5-1879c6987de9",
+          "type": "challenge",
+          "title": "Défi : l'actualité du tournoi",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "dd2cf906-b77f-4c4d-8f11-9aa53a606d03",
+                "type": "text",
+                "content": "<p>Gustave est content ; le tournoi de l’été a été un succès !&nbsp;🌞</p><p>Pour chaque édition du tournoi, il crée une publication sur le site du gymnase, à sa manière…</p><p>Ses précédentes publications sont disponibles ci-dessous&nbsp;:<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c992a84d-933f-4a33-8485-5b64cacd6aea",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/JTE/actualitestournoi.html",
+                "instruction": "",
+                "height": 550
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "52c9f208-8f95-4926-a64e-214041a834d2",
+                "type": "text",
+                "content": "<p>À votre tour d’écrire l’<strong>actualité du tournoi de l’été</strong> à la façon des précédentes actualités de Gustave et en vous basant sur la photo illustrant le tournoi.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9fb1cf79-a154-4b71-a1e5-cea6803b950b",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/volleyraptor.png",
+                "alt": "Une affiche concernant le tournoi de volley - lire l'alternative textuelle",
+                "alternativeText": "<p>Une affiche concernant le tournoi de Volley. </p><p>Elle annonce l'équipe des volley-raptors vainqueur !&nbsp;</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fbe1b91f-a423-45f5-8329-1cd50f436944",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur LLM",
+                "url": "https://epreuves.pix.fr/pix-llm/pix-llm.html?mode=cmbuxyoa30006wa01agdl8qu1",
+                "instruction": "<p>Utilisez&nbsp;<strong>l'IA de Pix</strong> pour le faire, à vous de jouer !</p>",
+                "solution": "<p></p>",
+                "height": 800
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e553af3a-34e3-4238-be9c-d40466cf43dd",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><p></p><p></p><p></p><p></p><p></p><details><summary>Indice 1</summary><p>Avez-vous pensé à décrire le format voulu ?</p></details><details><summary>Indice 2</summary><p> Avez-vous vérifié que le résultat comportait bien l'équipe vainqueur ?</p></details><p></p><p></p><p></p><p></p><p></p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -15,530 +15,536 @@
       "Repérer si une source d’information est fiable"
     ]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "6e73eee3-c7d8-4194-b08c-5085553aaf0d",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "c36f022f-cc4b-46d8-830d-6001140c4863",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "40401525-ac7b-401d-ace7-0afa3cdeb2fc",
-            "type": "text",
-            "content": "<p>Léna et Elias discutent par SMS des Jeux asiatiques de 2029. 🏅 Léna cherche à savoir si l’information donnée par Elias est vraie ou fausse.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "652a469a-36b8-41ae-8cc5-1853b35d08ef",
-      "type": "activity",
-      "title": "Les JO d’hiver 2029 dans le désert : info ou rumeur ?",
-      "components": [
+          "id": "6e73eee3-c7d8-4194-b08c-5085553aaf0d",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "40401525-ac7b-401d-ace7-0afa3cdeb2fc",
+                "type": "text",
+                "content": "<p>Léna et Elias discutent par SMS des Jeux asiatiques de 2029. 🏅 Léna cherche à savoir si l’information donnée par Elias est vraie ou fausse.</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "652a469a-36b8-41ae-8cc5-1853b35d08ef",
+          "type": "activity",
+          "title": "Les JO d’hiver 2029 dans le désert : info ou rumeur ?",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "70598c0e-6292-48a2-8729-401978cc7003",
-                  "type": "text",
-                  "content": "<p>Lancez la vidéo pour voir le début de leur discussion.<br>En regardant cette vidéo, posez-vous la question suivante&nbsp;: <strong>est-ce que l'information donnée par Elias est plutôt vraie ou plutôt fausse&nbsp;?</strong></p>"
-                },
-                {
-                  "id": "646da25e-81c2-44ef-a5da-ae0a43666389",
-                  "type": "video",
-                  "title": "Discussion entre Elias et Léna (1 sur 2)",
-                  "url": "https://assets.pix.org/modules/sources-informations/chat-1.mp4",
-                  "subtitles": "",
-                  "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert&#8239;!</li><li>Léna&nbsp;: T’es sûr&#8239;? Comment tu le sais&#8239;?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">👉</span> C'est assez dur de savoir si cette information est plutôt vraie ou fausse. On ne sait pas encore comment Sandy a obtenu cette information.</p><p>Voici la suite de la discussion entre Elias et Léna. Après la vidéo, vous devrez choisir si l’information d’Elias est plutôt vraie ou plutôt fausse.</p>"
-                },
-                {
-                  "id": "b78ca338-28c5-4a95-9513-3824997aa841",
-                  "type": "video",
-                  "title": "Discussion entre Elias et Léna (2 sur 2)",
-                  "url": "https://assets.pix.org/modules/sources-informations/chat-2.mp4",
-                  "subtitles": "",
-                  "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup&#8239;?</li><li>Elias&nbsp;: Sandy l’a vu sur internet&#8239;!</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp&#8239;?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
-                },
-                {
-                  "id": "8aca8852-a771-4ee2-b686-a2fb6b4f57c5",
-                  "type": "qcu",
-                  "instruction": "<p>Maintenant, est-ce que l'information donnée par Elias semble vraie&#8239;?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "plutôt oui",
-                      "feedback": {
-                        "state": "",
-                        "diagnosis": "<p>Oui. Cette information a été vérifiée par des journalistes. Elle a de grandes chances d'être vraie.</p>"
-                      }
+                      "id": "70598c0e-6292-48a2-8729-401978cc7003",
+                      "type": "text",
+                      "content": "<p>Lancez la vidéo pour voir le début de leur discussion.<br>En regardant cette vidéo, posez-vous la question suivante&nbsp;: <strong>est-ce que l'information donnée par Elias est plutôt vraie ou plutôt fausse&nbsp;?</strong></p>"
                     },
                     {
-                      "id": "2",
-                      "content": "plutôt non",
-                      "feedback": {
-                        "state": "",
-                        "diagnosis": "<p>Cette information a de grandes chances d'être vraie.<br> Elle provient d'un article du journal « FranceInfo ». Cette information a été vérifiée par des journalistes.</p>"
-                      }
+                      "id": "646da25e-81c2-44ef-a5da-ae0a43666389",
+                      "type": "video",
+                      "title": "Discussion entre Elias et Léna (1 sur 2)",
+                      "url": "https://assets.pix.org/modules/sources-informations/chat-1.mp4",
+                      "subtitles": "",
+                      "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert&#8239;!</li><li>Léna&nbsp;: T’es sûr&#8239;? Comment tu le sais&#8239;?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
                     }
-                  ],
-                  "solution": "1"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">👉</span> C'est assez dur de savoir si cette information est plutôt vraie ou fausse. On ne sait pas encore comment Sandy a obtenu cette information.</p><p>Voici la suite de la discussion entre Elias et Léna. Après la vidéo, vous devrez choisir si l’information d’Elias est plutôt vraie ou plutôt fausse.</p>"
+                    },
+                    {
+                      "id": "b78ca338-28c5-4a95-9513-3824997aa841",
+                      "type": "video",
+                      "title": "Discussion entre Elias et Léna (2 sur 2)",
+                      "url": "https://assets.pix.org/modules/sources-informations/chat-2.mp4",
+                      "subtitles": "",
+                      "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup&#8239;?</li><li>Elias&nbsp;: Sandy l’a vu sur internet&#8239;!</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp&#8239;?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
+                    },
+                    {
+                      "id": "8aca8852-a771-4ee2-b686-a2fb6b4f57c5",
+                      "type": "qcu",
+                      "instruction": "<p>Maintenant, est-ce que l'information donnée par Elias semble vraie&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "plutôt oui",
+                          "feedback": {
+                            "state": "",
+                            "diagnosis": "<p>Oui. Cette information a été vérifiée par des journalistes. Elle a de grandes chances d'être vraie.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "plutôt non",
+                          "feedback": {
+                            "state": "",
+                            "diagnosis": "<p>Cette information a de grandes chances d'être vraie.<br> Elle provient d'un article du journal « FranceInfo ». Cette information a été vérifiée par des journalistes.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "7087774d-21ac-4a7a-86a5-4f2c7e067d23",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6616dc41-0667-45f3-9326-841f29b72b62",
-            "type": "text",
-            "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;ℹ️<br>On vous explique tout dans la leçon suivante.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "54cc6a3f-9603-4863-9ba4-052210425be2",
-      "type": "lesson",
-      "title": "C’est quoi une source d’information ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "35d79e83-1d3c-4da1-aaed-37dd8e5eae03",
-            "type": "text",
-            "content": "<p>À la suite de cette leçon, une question sera posée sur la définition d'une source d'information.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "e9d8230a-f3bf-49d1-a533-6c74d22e4de6",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
-            "type": "text",
-            "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a91f12e7-a297-4dc0-9f81-2a0ccbaba3f8",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e3ebd36a-c8b9-4990-af63-061329824708",
-            "type": "text",
-            "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "425df763-0803-4b55-ad53-9ed0a04f8242",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5fc304fc-5fc6-49f3-8170-a921b3fd8f67",
-            "type": "text",
-            "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;🎯</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "42e4007c-9123-4aff-806a-6d7a8de3fd0a",
-      "type": "activity",
-      "title": "Définition d’une source d’information",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6ffc239b-2d88-4bed-bdd9-f1ecf215ad11",
-            "type": "qcu",
-            "instruction": "<p>Quelle définition peut-on donner d'une source d'information&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "C'est le jour de l'événement qui a mené à cette information.",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "C'est le réseau social où est publiée cette information.",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "C'est la personne à l'origine de cette information.",
-                "feedback": {
-                  "state": "Bonne réponse&nbsp;! 🎉",
-                  "diagnosis": "<p> La source d'une information est la personne <strong>témoin</strong> de l'information.</p>"
-                }
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e42841d4-c66c-4eae-ba0d-e35ea0aff090",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6fd96c29-72a2-4b26-aecd-5cb16115e6a0",
-            "type": "text",
-            "content": "<p>Maintenant que vous connaissez la définition d'une source d'information, voyons un exemple.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4617af32-54f4-47ac-8d0f-d4fe26925895",
-      "type": "activity",
-      "title": "Y a-t-il une source à cette information ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "96cf39cd-88df-4104-a155-0fff0b40ac31",
-            "type": "text",
-            "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>&nbsp;<span aria-hidden=\"true\">🛸</span><br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "edbeb7c0-52cc-45b8-b3b9-d8cdac00536f",
-            "type": "video",
-            "title": "Une vidéo",
-            "url": "https://assets.pix.org/modules/sources-informations/itw-saturne.mp4",
-            "subtitles": "https://assets.pix.org/modules/sources-informations/itw-saturne.vtt",
-            "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour&#8239;! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité&#8239;? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
-            "type": "text",
-            "content": "<hr>Dans l'interview, on entend que Madame Sarah a sûrement vu une aurore boréale et non une soucoupe volante."
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "921f42c0-b47b-44b7-8bde-328c40e03e44",
-            "type": "qcu",
-            "instruction": "<p>Qui est la source de cette information&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "le journaliste Dupont",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "la professeure Saturne",
-                "feedback": {
-                  "state": "Oui,c'est correct.",
-                  "diagnosis": "<p> la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Madame Sarah",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "cac941ed-91f8-4ed0-8fdc-3fa5c154a5cf",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bcfc36a3-15e1-4097-8ca5-e8c62b08d2d5",
-            "type": "text",
-            "content": "<p>À la radio ou sur internet, une information peut être partagée pour plusieurs raisons, par différentes sources. <br>Regardons ça de plus près.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c7d94063-57ee-4e9d-b6d3-effb3e67792a",
-      "type": "lesson",
-      "title": "Différents types de source d'informations",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d0a2bb58-be8e-4f75-a626-8ac387771dfe",
-            "type": "text",
-            "content": "<p>Après cette leçon, des publications vous seront présentées. Vous devrez choisir pour chaque publication le type de source correspondant.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "bb24db79-0624-4d43-b1bb-a5510ba12c40",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
-            "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2fe6bf3f-c77c-4e21-a57e-8be804171e00",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
-            "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "783421ea-d3eb-437d-9eac-7b51bade7fdb",
-            "type": "text",
-            "content": "<hr>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
-            "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "17a074c4-b1b5-46fb-a9b8-b46b0015c5a1",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bd9bf91d-bb84-4529-a212-06c2db761b15",
-            "type": "text",
-            "content": "<p>À vous de jouer sur des exemples concrets.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "305ec524-f9c4-4745-86cf-29afb1c95e50",
-      "type": "activity",
-      "title": "Différents types de source d'informations",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "714fd0bb-9252-4c53-a1a2-ce4168e76a1b",
-            "type": "text",
-            "content": "<p>Pour chaque publication, choisissez si elle est fiable, humoristique ou contestable.</p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "7087774d-21ac-4a7a-86a5-4f2c7e067d23",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "276594e5-b95b-4fa3-8b93-ba8138669d70",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/6RtSHW0.png",
-                  "alt": "Publication de JournalDeBlagues (@journalblague) sur X (Twitter) décrite dans l'alternative textuelle",
-                  "alternativeText": "Publication de JournalDeBlagues (@journalblague) sur X (Twitter) à 15h57 le 6 octobre 2023&nbsp;: &laquo;&nbsp;Reportage&nbsp;: cet élève avait fait ses devoirs mais son chien les a vraiment mangé. La maîtresse le met au coin pendant 72 heures sans nourriture.&nbsp;&raquo;"
-                },
-                {
-                  "id": "ff187918-225d-49de-99dd-2a316ccd09bf",
-                  "type": "qcu",
-                  "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "fiable",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "humoristique",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "contestable",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "6616dc41-0667-45f3-9326-841f29b72b62",
+                "type": "text",
+                "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;ℹ️<br>On vous explique tout dans la leçon suivante.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "54cc6a3f-9603-4863-9ba4-052210425be2",
+          "type": "lesson",
+          "title": "C’est quoi une source d’information ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35d79e83-1d3c-4da1-aaed-37dd8e5eae03",
+                "type": "text",
+                "content": "<p>À la suite de cette leçon, une question sera posée sur la définition d'une source d'information.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "966d5373-3bb5-434c-ae3f-04dfa16a7e4c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/R4Duhiy.png",
-                  "alt": "Publication de franceinfo (@franceinfo) sur X (Twitter) décrite dans l'alternative textuelle",
-                  "alternativeText": "Publication de franceinfo (@franceinfo) sur X (Twitter) à 15h57 le 6 février 2023&nbsp;: &laquo;&nbsp;Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site.&nbsp;&raquo;"
-                },
-                {
-                  "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
-                  "type": "qcu",
-                  "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "fiable",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "humoristique",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "contestable",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "e9d8230a-f3bf-49d1-a533-6c74d22e4de6",
+                "type": "text",
+                "content": "<hr>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
+                "type": "text",
+                "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a91f12e7-a297-4dc0-9f81-2a0ccbaba3f8",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e3ebd36a-c8b9-4990-af63-061329824708",
+                "type": "text",
+                "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "425df763-0803-4b55-ad53-9ed0a04f8242",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5fc304fc-5fc6-49f3-8170-a921b3fd8f67",
+                "type": "text",
+                "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;🎯</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "42e4007c-9123-4aff-806a-6d7a8de3fd0a",
+          "type": "activity",
+          "title": "Définition d’une source d’information",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6ffc239b-2d88-4bed-bdd9-f1ecf215ad11",
+                "type": "qcu",
+                "instruction": "<p>Quelle définition peut-on donner d'une source d'information&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "C'est le jour de l'événement qui a mené à cette information.",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "C'est le réseau social où est publiée cette information.",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "C'est la personne à l'origine de cette information.",
+                    "feedback": {
+                      "state": "Bonne réponse&nbsp;! 🎉",
+                      "diagnosis": "<p> La source d'une information est la personne <strong>témoin</strong> de l'information.</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e42841d4-c66c-4eae-ba0d-e35ea0aff090",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6fd96c29-72a2-4b26-aecd-5cb16115e6a0",
+                "type": "text",
+                "content": "<p>Maintenant que vous connaissez la définition d'une source d'information, voyons un exemple.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4617af32-54f4-47ac-8d0f-d4fe26925895",
+          "type": "activity",
+          "title": "Y a-t-il une source à cette information ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "96cf39cd-88df-4104-a155-0fff0b40ac31",
+                "type": "text",
+                "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>&nbsp;<span aria-hidden=\"true\">🛸</span><br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "edbeb7c0-52cc-45b8-b3b9-d8cdac00536f",
+                "type": "video",
+                "title": "Une vidéo",
+                "url": "https://assets.pix.org/modules/sources-informations/itw-saturne.mp4",
+                "subtitles": "https://assets.pix.org/modules/sources-informations/itw-saturne.vtt",
+                "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour&#8239;! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité&#8239;? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
+                "type": "text",
+                "content": "<hr>Dans l'interview, on entend que Madame Sarah a sûrement vu une aurore boréale et non une soucoupe volante."
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "921f42c0-b47b-44b7-8bde-328c40e03e44",
+                "type": "qcu",
+                "instruction": "<p>Qui est la source de cette information&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "le journaliste Dupont",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "la professeure Saturne",
+                    "feedback": {
+                      "state": "Oui,c'est correct.",
+                      "diagnosis": "<p> la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Madame Sarah",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "cac941ed-91f8-4ed0-8fdc-3fa5c154a5cf",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bcfc36a3-15e1-4097-8ca5-e8c62b08d2d5",
+                "type": "text",
+                "content": "<p>À la radio ou sur internet, une information peut être partagée pour plusieurs raisons, par différentes sources. <br>Regardons ça de plus près.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c7d94063-57ee-4e9d-b6d3-effb3e67792a",
+          "type": "lesson",
+          "title": "Différents types de source d'informations",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "d0a2bb58-be8e-4f75-a626-8ac387771dfe",
+                "type": "text",
+                "content": "<p>Après cette leçon, des publications vous seront présentées. Vous devrez choisir pour chaque publication le type de source correspondant.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bb24db79-0624-4d43-b1bb-a5510ba12c40",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
+                "type": "text",
+                "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2fe6bf3f-c77c-4e21-a57e-8be804171e00",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
+                "type": "text",
+                "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "783421ea-d3eb-437d-9eac-7b51bade7fdb",
+                "type": "text",
+                "content": "<hr>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
+                "type": "text",
+                "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "17a074c4-b1b5-46fb-a9b8-b46b0015c5a1",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bd9bf91d-bb84-4529-a212-06c2db761b15",
+                "type": "text",
+                "content": "<p>À vous de jouer sur des exemples concrets.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "305ec524-f9c4-4745-86cf-29afb1c95e50",
+          "type": "activity",
+          "title": "Différents types de source d'informations",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "714fd0bb-9252-4c53-a1a2-ce4168e76a1b",
+                "type": "text",
+                "content": "<p>Pour chaque publication, choisissez si elle est fiable, humoristique ou contestable.</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "7fc108bf-49a4-43e0-a0bc-ae09750e5cd9",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/9nQlmC6.png",
-                  "alt": "Publication de Association des vendeurs de poissons rouges (@ilovefish) sur X (Twitter) décrite dans l'alternative textuelle",
-                  "alternativeText": "Publication de Association des vendeurs de poissons rouges (@ilovefish) sur X (Twitter) à 17h32 le 8 juin 2023&nbsp;: &laquo;&nbsp;Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin&#8239;!&nbsp;&raquo;"
+                  "elements": [
+                    {
+                      "id": "276594e5-b95b-4fa3-8b93-ba8138669d70",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/6RtSHW0.png",
+                      "alt": "Publication de JournalDeBlagues (@journalblague) sur X (Twitter) décrite dans l'alternative textuelle",
+                      "alternativeText": "Publication de JournalDeBlagues (@journalblague) sur X (Twitter) à 15h57 le 6 octobre 2023&nbsp;: &laquo;&nbsp;Reportage&nbsp;: cet élève avait fait ses devoirs mais son chien les a vraiment mangé. La maîtresse le met au coin pendant 72 heures sans nourriture.&nbsp;&raquo;"
+                    },
+                    {
+                      "id": "ff187918-225d-49de-99dd-2a316ccd09bf",
+                      "type": "qcu",
+                      "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "fiable",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "humoristique",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "contestable",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 },
                 {
-                  "id": "9e252501-ecb0-46dc-ae3e-f5646e7cc252",
-                  "type": "qcu",
-                  "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "fiable",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
-                      }
+                      "id": "966d5373-3bb5-434c-ae3f-04dfa16a7e4c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/R4Duhiy.png",
+                      "alt": "Publication de franceinfo (@franceinfo) sur X (Twitter) décrite dans l'alternative textuelle",
+                      "alternativeText": "Publication de franceinfo (@franceinfo) sur X (Twitter) à 15h57 le 6 février 2023&nbsp;: &laquo;&nbsp;Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site.&nbsp;&raquo;"
                     },
                     {
-                      "id": "2",
-                      "content": "humoristique",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "contestable",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
-                      }
+                      "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
+                      "type": "qcu",
+                      "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "fiable",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "humoristique",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "contestable",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "3"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7fc108bf-49a4-43e0-a0bc-ae09750e5cd9",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/9nQlmC6.png",
+                      "alt": "Publication de Association des vendeurs de poissons rouges (@ilovefish) sur X (Twitter) décrite dans l'alternative textuelle",
+                      "alternativeText": "Publication de Association des vendeurs de poissons rouges (@ilovefish) sur X (Twitter) à 17h32 le 8 juin 2023&nbsp;: &laquo;&nbsp;Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin&#8239;!&nbsp;&raquo;"
+                    },
+                    {
+                      "id": "9e252501-ecb0-46dc-ae3e-f5646e7cc252",
+                      "type": "qcu",
+                      "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "fiable",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "humoristique",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "contestable",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
                 }
               ]
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-def-ia-supervise.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-def-ia-supervise.json
@@ -14,665 +14,659 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "61f7db09-722e-442f-9aca-8fe39c425b41",
-      "type": "discovery",
-      "title": "Accroche - conversation ",
-      "components": [
+      "id": "5d715660-2778-4800-b1cb-f76bc62a46d8",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "6e186654-fd70-4d4c-af3e-530b7664b193",
-            "type": "text",
-            "content": "<p>Arthur a entendu parler de l’ail des ours, une plante qui se mange, et il voudrait goûter. 😋 </p><p>Mais il a peur de se tromper pendant sa cueillette, alors il demande à Lila. 🧺<br><br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "dad28e9d-425d-4637-b848-052231cb225f",
-            "type": "custom",
-            "tagName": "message-conversation",
-            "props": {
-              "title": "Arthur demande à Lila comment reconnaître l'ail des ours",
-              "messages": [
-                {
-                  "userName": "Arthur",
-                  "direction": "incoming",
-                  "content": "Dis, tu sais où comment reconnaître de  l’ail des ours, toi ? 🌿"
-                },
-                {
-                  "userName": "Lila",
-                  "direction": "outgoing",
-                  "content": "Pas vraiment… Ce n’est pas si facile, ça ressemble à la colchique et au muguet, des plantes toxiques ! 🥴"
-                },
-                {
-                  "userName": "Lila",
-                  "direction": "outgoing",
-                  "content": "Mais tu tombes bien, justement, je viens de créer un logiciel d’IA qui reconnait les plantes !"
-                },
-                {
-                  "userName": "Arthur",
-                  "direction": "incoming",
-                  "content": "Un logiciel ? Comment ça marche ? Comment pourrait-il faire mieux que nous ?"
-                },
-                {
-                  "userName": "Lila",
-                  "direction": "outgoing",
-                  "content": "Il reconnaît en un clin d’œil les moindres détails des feuilles. Tu veux l’essayer ?"
-                },
-                {
-                  "userName": "Arthur",
-                  "direction": "incoming",
-                  "content": "J’hésite… Tu crois vraiment qu’on peut lui faire confiance ? "
-                },
-                {
-                  "userName": "Lila",
-                  "direction": "outgoing",
-                  "content": "Écoute, je t’explique comment ça marche, tu verras s’il est fiable."
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "0b6be806-422b-4281-a5c6-7b0bf89262ca",
-      "type": "discovery",
-      "title": "Découverte n°1 - Données étiquetées",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "365d0e92-7b9e-406a-920b-4d12e08c7a28",
-            "type": "text",
-            "content": "<p>Mettez-vous un instant à la place du logiciel de Lila. 🤖 </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "21c10c6e-591b-43f5-8894-6818ffdf5581",
-            "type": "custom-draft",
-            "title": "Elément interactif où il faut apprendre à reconnaître l’ail des ours du muguet",
-            "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-ailours-ou-muguet.html",
-            "instruction": "<p>Observez ces photographies d’ail des ours et de muguet. Vous devrez ensuite les reconnaître.👀 Vous êtes prêt ?</p>",
-            "height": 550
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5f687ff0-e980-4b61-bbdb-33b89e5beffe",
-            "type": "text",
-            "content": "<p>Vous vous êtes entraîné à reconnaître des photos, voyons maintenant comment fait un logiciel d'IA. 🔍</p><p></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3fd6303e-499d-4ace-a5a6-8882a118726d",
-      "type": "lesson",
-      "title": "Lesson n°1  : données étiquetées",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "61f7db09-722e-442f-9aca-8fe39c425b41",
+          "type": "discovery",
+          "title": "Accroche - conversation ",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "e2964222-34ba-41d5-a8f4-d52b30c22bd2",
-                  "type": "text",
-                  "content": "<p>Pour apprendre à reconnaître des images, un logiciel d’IA fait un peu ce que vous avez fait&nbsp;:</p><ul><li>D'abord, on vous a donné <strong>plusieurs exemples</strong> de photographies de plantes.🌼</li><li>Chaque photographie était <strong>accompagnée de son nom</strong>.</li><li>Ensuite, on vous a demandé de <strong>reconnaître</strong> le nom de la plante sur chaque photographie. Pour cela, vous avez repéré les caractéristiques de chaque plante pour pouvoir les identifier par la suite. 🧐</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "e089a941-4bfb-473f-879a-892f1be410ce",
-                  "type": "text",
-                  "content": "<p>C’est un peu pareil pour un logiciel d’IA&nbsp;: </p><ul><li>On lui donne <strong>beaucoup d’exemples </strong>de ce qu’il doit reconnaître. C’est ce que l’on appelle <strong>un jeu de données.</strong> </li><li>Chaque<strong> photographie </strong>est associé à une <strong>étiquette</strong>. Ce sont <strong>des données étiquetées</strong>.🏷️</li><li>Le logiciel d’IA<strong> analyse les caractéristiques</strong> de tous les exemples (forme, couleur, texture...) pour ensuite associer lui-même chaque exemple à son étiquette.🔍</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "a7118db8-ea1e-4b7d-b2e9-12903eaa12b3",
-                  "type": "text",
-                  "content": "<p>On parle alors d’<strong>apprentissage supervisé</strong>. </p><p>Pourquoi ? Parce qu’au départ, ce sont des humains qui attribuent les étiquettes aux données : ils “<strong>supervisent</strong>” ainsi l’apprentissage du logiciel.👨🏽‍💻 </p><br><p>L’apprentissage supervisé est <strong>l’une des méthodes de l’apprentissage automatique</strong>.</p><p>L’apprentissage automatique est une des techniques de l’intelligence artificielle.🤖</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "db006d48-ab80-407b-92c3-65094b635c9e",
-      "type": "discovery",
-      "title": "Découverte 2a - décomposition en valeurs numérique",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0021ca26-1ddb-4a0f-a3de-2c9a5ad6b9f0",
-            "type": "custom-draft",
-            "title": "Décomposition de l'image en valeur numérique",
-            "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-decomposition-image.html",
-            "instruction": "",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "b0076163-02ae-4805-af3e-dd82781347ba",
-      "type": "lesson",
-      "title": "Lesson 2a : décomposition en valeurs numériques",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8e0084cb-c38a-49db-8126-4d3bb0b3077f",
-            "type": "text",
-            "content": "<p>En <strong>apprentissage automatique</strong>, on n'a pas besoin d'expliquer au logiciel comment associer une image à son étiquette&nbsp;: il <strong>analyse</strong> les pixels, détecte les caractéristiques visuelles et les convertit en <strong>valeurs numériques</strong>.🔢</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3b2f5ec0-e70b-422a-9d55-84b741885c40",
-      "type": "transition",
-      "title": "transition n°1 ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bde3a389-1875-4e42-9c06-1cab0c51be96",
-            "type": "text",
-            "content": "<p>Maintenant, regardons de plus près&nbsp;: comment le logiciel fait le lien entre la donnée d’entrée (la photo) et la donnée de sortie (son nom) ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ee2eb6fe-6740-45f4-886a-994545855110",
-      "type": "discovery",
-      "title": "Découverte 2b : Ajustement des paramètres",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9e2e1178-89e5-4c87-beb1-b7548e6d3937",
-            "type": "text",
-            "content": "<p>Mettons-nous de nouveau à la place du logiciel qui est en train d’apprendre.🤖 </p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e5badfae-bca4-421a-ae72-299891ef31da",
-            "type": "text",
-            "content": "<p>Cette photo montre un ail des ours.🌱 </p><p>Ajustez les paramètres de calculs, jusqu’à ce que la prédiction soit correct.</p><p><u><a href=\"https://chatgpt.com/canvas/shared/68938299db4c81918a29a187e641d506\" target=\"_blank\">[Pour tester le POI, non fonctionnel pour l'instant... cliquer ici]</a></u></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "bfd4c766-52aa-449d-876e-8970972999c9",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/ia-def-ind/futur-poi-ajustement-parametres.png",
-            "alt": "futur POI",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "bdc51924-26ee-4f22-b302-fe4dec080387",
-      "type": "lesson",
-      "title": "Lesson 2b : Ajustement des paramètres",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "58f708f8-ad08-4c04-9876-c616e6d9a490",
-                  "type": "text",
-                  "content": "<p>Le logiciel dispose de plusieurs<strong> paramètres </strong>pour faire des<strong> calculs </strong>sur ces valeurs.</p><p>Au départ, les paramétres sont ajustés au hasard, produisant un<strong> résultat de calcul</strong>.</p><p>Le logiciel compare à chaque fois ces résultats, que l'on appelle<strong> des prédictions</strong>, aux réponses attendues🎲</p><p>Ainsi, par essai erreur,<strong> il ajuste progressivement les paramètres </strong>jusqu'à obtenir la bonne prédiction.🧮</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "b3d22c1d-d09e-4f92-8691-5cf7bcddcb96",
-                  "type": "text",
-                  "content": "<p>🤔 Le saviez-vous ?</p><p><br> Ce type de modèle de calcul s’appelle un “<strong>réseau de neurone</strong>” car les chercheurs se sont inspirés du cerveau humain.🧠<br></p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "d11b5bf5-bd63-40d2-92dd-d03b5d5b7bf2",
-      "type": "discovery",
-      "title": "Découverte 3 : Généralisation",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "7f771c91-272f-42e9-875c-97640fcb7809",
-                  "type": "text",
-                  "content": "<p>Lila a donné à son logiciel des centaines de photographies ressemblant à celles ci-dessous.</p><p>Elle se demande si cet entrainement suffit pour qu'il reconnaisse l’ail des ours. 🥕</p>"
-                },
-                {
-                  "id": "1b67fab0-9ad4-45a6-aded-160b77b24993",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-def-ind/jeudedonne-sanslegende.png",
-                  "alt": "Une illustration du jeu de données avec des exemples",
-                  "alternativeText": "<p>On voit des photos d'ail des ours (avec des fleurs, avec des feuilles) et de muguet (avec des feuilles, avec des fleurs)</p>",
-                  "legend": "Une photo de bulbes d'ail des ours",
-                  "licence": ""
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "9d1e71cd-8787-439d-9dc7-d9b395435fad",
-                  "type": "text",
-                  "content": "<p>Elle veut maintenant tester son programme sur une nouvelle photographie d'ail des ours.<br></p>"
-                },
-                {
-                  "id": "4fc2b7dc-0cc9-4e29-bb93-9c7ab25bcc60",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-def-ind/ailoursbulbe.jpg",
-                  "alt": "Une photo de bulbes d'ail des ours",
-                  "alternativeText": "<p>Une photo de bulbes d'ail des ours</p>",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "9f0116d7-03e8-4657-ac04-9b310c4562f1",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>A votre avis, cette IA va-t-elle reconnaître que cette image est de l'ail des ours ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Probablement oui.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Bien vu ! Mais savez-vous pourquoi ?</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Probablement non<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et non ! Et savez-vous pourquoi ?</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "a990944f-d268-4eac-99cc-8f4e88123baa",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>A votre avis, pourquoi ce logiciel n'est pas capable de dire que cette photographie est de l'ail des ours ?  <br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Les images d'entraînement ne comportent pas de photos de bulbes.<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>Et oui ! Ces données ne sont pas suffisamment variées, elles manquent de diversité.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Les images ne sont pas d’assez bonne qualité&nbsp;: elles sont souvent flous.<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>Si les images étaient flous, ça serait un problème ! </p><p> Mais ce n’est pas le cas ici, le problème principal est que les photos d'entraînement ne comportent pas de bulbes !</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Plusieurs photos d’ail des ours ont été étiquetées comme étant du muguet.<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>Bien sûr, si les images étaient mal étiquetées, ça serait un problème !<br>Mais ce n’est pas le cas ici, le problème principal est que les photos d'entraînement ne contiennent pas de bulbes !<br></p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "08c2f199-5026-487b-9c27-9f16d4ab481f",
-      "type": "lesson",
-      "title": "Lesson 3 : Généralisation",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "4f15ba33-8b56-49de-a277-be097b576d94",
-                  "type": "text",
-                  "content": "<p>Le but du logiciel est de prédire la bonne étiquette sur des exemples qu'on ne lui a pas donné lors de son entraînement. C’est la <strong>généralisation.</strong> 🚀</p><p>Pour atteindre une<strong> bonne généralisation</strong>, il faut lui donner des<strong> exemples variés</strong>, différents entre eux et représentant tous les cas typiques. Ceci réduit le risque d'erreur. </p><p>📌<strong>Important&nbsp;:</strong></p><p>Une prédiction est<strong> statistique,</strong> il y a donc toujours un risque d’erreur.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "f31ca24b-f958-4c77-bc38-6024c832b4c3",
-                  "type": "text",
-                  "content": "<p>On appelle<strong> phase de test</strong> l'étape de vérification de&nbsp;la performance du logiciel confronté à des <strong>nouveaux exemples non étiquetés</strong>.  <br>Parfois, on constate qu'on a encore besoin de l'entraîner&nbsp;pour pouvoir l’utiliser de façon fiable.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "06144dc9-610d-483a-a79c-62d17de1749e",
-                  "type": "text",
-                  "content": "<p>💡<strong>Bon à savoir&nbsp;:</strong><br> <strong>le logiciel ne peut trouver que les étiquettes qu’il a appris à prédire.</strong></p>"
-                },
-                {
-                  "id": "fdc063a3-de25-43e4-ab22-007339ad8d68",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-def-ind/schema-nouvelle-etiquette.png",
-                  "alt": "Un schéma ",
-                  "alternativeText": "<p>Un schéma représentant le fait que le logiciel ne peut pas prédire \"Tournesol\" s'il n'a été entrainé qu'avec des étiquettes \"ail des ours\" ou \"muguet\".</p>",
-                  "legend": "Si le logiciel ne connaît que les étiquettes “ail des ours” et “muguet” et qu’on lui présente une image de “tournesol”, il ne peut pas prédire que c’est un tournesol. Il va seulement donner une prédiction qui s’approche des étiquettes qu’il connaît.",
-                  "licence": ""
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "e41f6414-5ef6-44ee-8501-31077ec9d258",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f071912a-b067-4d03-8217-cc087d3cdbff",
-            "type": "text",
-            "content": "<p>Avec beaucoup de nouvelles données, et quelques corrections, le logiciel est prêt ! 🎉<br>Lila, curieuse, se demande&nbsp;: que pourrait-on faire d’autre avec l’apprentissage supervisé ? 🤔<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f62d3175-8837-4713-996f-34c1e9846c98",
-      "type": "discovery",
-      "title": "Découverte 4 - D’autres cas d’usages, dont le texte",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5ec6e39a-0852-4ee9-b892-5a4b66b890e3",
-            "type": "text",
-            "content": "<p>Lila se dit qu’elle pourrait générer le texte de description de ces plantes.<br>Mais l’apprentissage sur du texte ne nécessite pas les mêmes données.<br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "191e100f-8a78-4ad9-b6d0-65533eba3ad8",
-            "type": "custom-draft",
-            "title": "Un tableau interactif pour associez les bonnes données à la bonne IA",
-            "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-generalisation-texte.html",
-            "instruction": "<p>A vous de jouer, complétez le schéma avec les bonnes données pour le bon objectif !<br></p>",
-            "height": 550
-          }
-        }
-      ]
-    },
-    {
-      "id": "4b313eb6-b343-47ea-983d-dd82fe7ac03c",
-      "type": "transition",
-      "title": "Transition 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "136e86b1-cc7d-4e9c-a5f4-a3f1e5808757",
-            "type": "text",
-            "content": "<p>Lila est contente, son logiciel est terminé.🚀  Elle va pouvoir le faire tester à Arthur !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3f86b7a5-8df1-48a0-94ef-2a28c8c0c010",
-      "type": "lesson",
-      "title": "Leçon #4 : D’autres cas d’usages, dont le texte",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "a041b7dc-9566-4bee-aaf4-106de9a98662",
-                  "type": "text",
-                  "content": "<p>L’apprentissage supervisé n'est pas utilisé que pour la reconnaissance d’image.</p><p>Les logiciels d’IA génératives conversationnels sont entraînés à <strong>générer du texte </strong>selon un <strong>principe proche</strong>&nbsp;: <br></p><ul><li>On leur donne des <strong>textes</strong>, dans lesquels il y a des <strong>trous </strong>(<strong>exemples</strong>),🕳️</li><li> et chaque trous est associé au <strong>mot manquant</strong> (<strong>étiquette</strong>). 🏷️ </li></ul><p>Ces logiciels analysent les caractéristiques des textes et s'entraînent à prédire le mot manquant. 📃<br></p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "6c7d45cc-dc13-40d7-abc3-ef396c31f54c",
-                  "type": "text",
-                  "content": "<p>La technique d’<strong>apprentissage supervisé</strong> peut être utilisée dans <strong>beaucoup d’autres cas</strong>&nbsp;:</p><ul><li>la prédiction de la météo 🌦️, </li><li>la reconnaissance vocale 💬, </li><li>l’identification de tumeurs dans des images médicales 🩻…</li></ul><p>Des <strong>données différentes</strong> sont nécessaires pour chacun de ces cas.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "4d0abb22-6ba4-4905-9f94-0a5ce818789e",
-      "type": "summary",
-      "title": "Récapitulatif",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c68dc04d-69b2-4ca6-9635-e38fea109723",
-            "type": "text",
-            "content": "<ul><li>L’<strong>apprentissage automatique</strong> est l’une des <strong>branches de l’intelligence </strong><strong>artificielle</strong>. Il permet de donner aux machines <strong>la capacité d'adapter</strong> ce qu'elles savent faire à une situations qu'elles n'ont pas encore rencontrées.</li><li>L'<strong>apprentissage supervisé</strong> est l’une des méthodes de l’apprentissage automatique. Il consiste à fournir au logiciel un <strong>jeu de donnée</strong>s pour l’entraîner à prédire l’étiquette associée à une donnée. 🏷️📈</li><li>Au départ, le logiciel fait ses <strong>calculs </strong>de prédiction au hasard. Progressivement, il <strong>ajuste les paramètres</strong> de calcul pour parvenir à prédire la bonne étiquette. Il peut ainsi <strong>généraliser</strong> ses prédictions sur d'autres exemples. 🚀</li><li>La <strong>qualité </strong>des exemples et<strong> des données</strong> fournies est primordiale. 🚨</li><li>L'apprentissage supervisé est utilisé pour l'entraînement de<strong> nombreux logiciels</strong> qui réalisent des tâches telles que la reconnaissance d'image, des tâches de classement, des tâches de prédiction, etc.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3320dd18-77d1-4272-8f3d-ff110466f288",
-      "type": "activity",
-      "title": "S'exercer  : As-tu compris ce qu’est l’apprentissage supervisé ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c75c175f-c7d9-4328-84ca-410369b1fef7",
-            "type": "qab",
-            "instruction": "<p>Répondez aux affirmations suivantes. <br></p>",
-            "cards": [
-              {
-                "id": "393892dc-10cc-465d-992e-ff624049ba76",
-                "text": "L’apprentissage supervisé est une technique d’intelligence artificielle.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "4f54b9e7-260f-4f7e-a1eb-31508e8ae1e7",
-                "text": "L’apprentissage supervisé sert souvent à faire des prédictions.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "b9a58e53-52d2-44f1-84ec-2855ab8ffc34",
-                "text": "Dans l’apprentissage supervisé, le logiciel commence par choisir des paramètres au hasard, puis les ajuste.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "77f1da71-9011-4cde-a3f9-0f14dec707f3",
-                "text": "Une fois qu’un modèle est entraîné, il ne peut plus se tromper.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "b5776fad-8fec-405c-bfc6-c8d05aaf7d27",
-                "text": "Un algorithme d’apprentissage supervisé peut apprendre tout seul, sans aide.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": "<p>Si tu as eu des erreurs, n'hésite pas à remonter pour lire le récapitulatif. 👆</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "3cfbafc0-3501-495f-af79-ca93b8c9668c",
-      "type": "challenge",
-      "title": "Défi : et pour l'exemple des oiseaux ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c4b4a5c3-265e-4387-839b-73a27c0ecf34",
-            "type": "text",
-            "content": "<p>Arthur a été très inspiré par l’application de Lila. 🌱</p><p>Il a téléchargé une application pour reconnaître le chant des oiseaux, comme <a href=\"https://play.google.com/store/apps/details?id=de.tu_chemnitz.mi.kahst.birdnet&amp;hl=fr\" target=\"_blank\">celle-ci.</a>🐦</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "bcc71c8a-4954-4705-959e-3e0c4d65832b",
-            "type": "qrocm",
-            "instruction": "<p>A votre avis, de quelles données a-t-on besoin pour créer un logiciel comme celui-ci ?<br></p>",
-            "proposals": [
-              {
+              "type": "element",
+              "element": {
+                "id": "6e186654-fd70-4d4c-af3e-530b7664b193",
                 "type": "text",
-                "content": "<p>Type de données&nbsp;:<br></p>"
-              },
-              {
-                "input": "8c61f879-6db9-4b4a-9817-9a567fe7ef34",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "champ à remplir",
-                "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t2",
-                  "t3"
-                ],
-                "solutions": [
-                  "Chant d'oiseau",
-                  "Des chants d'oiseaux",
-                  "Chants d'oiseaux",
-                  "Plein de chants d'oiseaux",
-                  "Beaucoup de chants d'oiseaux"
-                ]
-              },
-              {
-                "type": "text",
-                "content": "<p>Etiquette associée&nbsp;:</p>"
-              },
-              {
-                "input": "1f4f4ac7-71c2-4cd0-943d-a906f9780f0c",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "champ à remplir",
-                "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t2",
-                  "t3"
-                ],
-                "solutions": [
-                  "Nom d'oiseau",
-                  "Noms des oiseaux",
-                  "Le nom des oiseaux"
-                ]
+                "content": "<p>Arthur a entendu parler de l’ail des ours, une plante qui se mange, et il voudrait goûter. 😋 </p><p>Mais il a peur de se tromper pendant sa cueillette, alors il demande à Lila. 🧺<br><br></p>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "<p>Bonne réponse !</p>",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "<p>Mauvaise réponse !</p>",
-                "diagnosis": "<p>Et non, il va falloir le nom des oiseaux correspondants.</p>"
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "dad28e9d-425d-4637-b848-052231cb225f",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Arthur demande à Lila comment reconnaître l'ail des ours",
+                  "messages": [
+                    {
+                      "userName": "Arthur",
+                      "direction": "incoming",
+                      "content": "Dis, tu sais où comment reconnaître de  l’ail des ours, toi ? 🌿"
+                    },
+                    {
+                      "userName": "Lila",
+                      "direction": "outgoing",
+                      "content": "Pas vraiment… Ce n’est pas si facile, ça ressemble à la colchique et au muguet, des plantes toxiques ! 🥴"
+                    },
+                    {
+                      "userName": "Lila",
+                      "direction": "outgoing",
+                      "content": "Mais tu tombes bien, justement, je viens de créer un logiciel d’IA qui reconnait les plantes !"
+                    },
+                    {
+                      "userName": "Arthur",
+                      "direction": "incoming",
+                      "content": "Un logiciel ? Comment ça marche ? Comment pourrait-il faire mieux que nous ?"
+                    },
+                    {
+                      "userName": "Lila",
+                      "direction": "outgoing",
+                      "content": "Il reconnaît en un clin d’œil les moindres détails des feuilles. Tu veux l’essayer ?"
+                    },
+                    {
+                      "userName": "Arthur",
+                      "direction": "incoming",
+                      "content": "J’hésite… Tu crois vraiment qu’on peut lui faire confiance ? "
+                    },
+                    {
+                      "userName": "Lila",
+                      "direction": "outgoing",
+                      "content": "Écoute, je t’explique comment ça marche, tu verras s’il est fiable."
+                    }
+                  ]
+                }
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "0b6be806-422b-4281-a5c6-7b0bf89262ca",
+          "type": "discovery",
+          "title": "Découverte n°1 - Données étiquetées",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "365d0e92-7b9e-406a-920b-4d12e08c7a28",
+                "type": "text",
+                "content": "<p>Mettez-vous un instant à la place du logiciel de Lila. 🤖 </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "21c10c6e-591b-43f5-8894-6818ffdf5581",
+                "type": "custom-draft",
+                "title": "Elément interactif où il faut apprendre à reconnaître l’ail des ours du muguet",
+                "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-ailours-ou-muguet.html",
+                "instruction": "<p>Observez ces photographies d’ail des ours et de muguet. Vous devrez ensuite les reconnaître.👀 Vous êtes prêt ?</p>",
+                "height": 550
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "5f687ff0-e980-4b61-bbdb-33b89e5beffe",
+                "type": "text",
+                "content": "<p>Vous vous êtes entraîné à reconnaître des photos, voyons maintenant comment fait un logiciel d'IA. 🔍</p><p></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3fd6303e-499d-4ace-a5a6-8882a118726d",
+          "type": "lesson",
+          "title": "Lesson n°1  : données étiquetées",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "e2964222-34ba-41d5-a8f4-d52b30c22bd2",
+                      "type": "text",
+                      "content": "<p>Pour apprendre à reconnaître des images, un logiciel d’IA fait un peu ce que vous avez fait&nbsp;:</p><ul><li>D'abord, on vous a donné <strong>plusieurs exemples</strong> de photographies de plantes.🌼</li><li>Chaque photographie était <strong>accompagnée de son nom</strong>.</li><li>Ensuite, on vous a demandé de <strong>reconnaître</strong> le nom de la plante sur chaque photographie. Pour cela, vous avez repéré les caractéristiques de chaque plante pour pouvoir les identifier par la suite. 🧐</li></ul>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "e089a941-4bfb-473f-879a-892f1be410ce",
+                      "type": "text",
+                      "content": "<p>C’est un peu pareil pour un logiciel d’IA&nbsp;: </p><ul><li>On lui donne <strong>beaucoup d’exemples </strong>de ce qu’il doit reconnaître. C’est ce que l’on appelle <strong>un jeu de données.</strong> </li><li>Chaque<strong> photographie </strong>est associé à une <strong>étiquette</strong>. Ce sont <strong>des données étiquetées</strong>.🏷️</li><li>Le logiciel d’IA<strong> analyse les caractéristiques</strong> de tous les exemples (forme, couleur, texture...) pour ensuite associer lui-même chaque exemple à son étiquette.🔍</li></ul>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "a7118db8-ea1e-4b7d-b2e9-12903eaa12b3",
+                      "type": "text",
+                      "content": "<p>On parle alors d’<strong>apprentissage supervisé</strong>. </p><p>Pourquoi ? Parce qu’au départ, ce sont des humains qui attribuent les étiquettes aux données : ils “<strong>supervisent</strong>” ainsi l’apprentissage du logiciel.👨🏽‍💻 </p><br><p>L’apprentissage supervisé est <strong>l’une des méthodes de l’apprentissage automatique</strong>.</p><p>L’apprentissage automatique est une des techniques de l’intelligence artificielle.🤖</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "db006d48-ab80-407b-92c3-65094b635c9e",
+          "type": "discovery",
+          "title": "Découverte 2a - décomposition en valeurs numérique",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0021ca26-1ddb-4a0f-a3de-2c9a5ad6b9f0",
+                "type": "custom-draft",
+                "title": "Décomposition de l'image en valeur numérique",
+                "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-decomposition-image.html",
+                "instruction": "",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "b0076163-02ae-4805-af3e-dd82781347ba",
+          "type": "lesson",
+          "title": "Lesson 2a : décomposition en valeurs numériques",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8e0084cb-c38a-49db-8126-4d3bb0b3077f",
+                "type": "text",
+                "content": "<p>En <strong>apprentissage automatique</strong>, on n'a pas besoin d'expliquer au logiciel comment associer une image à son étiquette&nbsp;: il <strong>analyse</strong> les pixels, détecte les caractéristiques visuelles et les convertit en <strong>valeurs numériques</strong>.🔢</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3b2f5ec0-e70b-422a-9d55-84b741885c40",
+          "type": "transition",
+          "title": "transition n°1 ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bde3a389-1875-4e42-9c06-1cab0c51be96",
+                "type": "text",
+                "content": "<p>Maintenant, regardons de plus près&nbsp;: comment le logiciel fait le lien entre la donnée d’entrée (la photo) et la donnée de sortie (son nom) ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ee2eb6fe-6740-45f4-886a-994545855110",
+          "type": "discovery",
+          "title": "Découverte 2b : Ajustement des paramètres",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9e2e1178-89e5-4c87-beb1-b7548e6d3937",
+                "type": "text",
+                "content": "<p>Mettons-nous de nouveau à la place du logiciel qui est en train d’apprendre.🤖 </p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e5badfae-bca4-421a-ae72-299891ef31da",
+                "type": "text",
+                "content": "<p>Cette photo montre un ail des ours.🌱 </p><p>Ajustez les paramètres de calculs, jusqu’à ce que la prédiction soit correct.</p><p><u><a href=\"https://chatgpt.com/canvas/shared/68938299db4c81918a29a187e641d506\" target=\"_blank\">[Pour tester le POI, non fonctionnel pour l'instant... cliquer ici]</a></u></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bfd4c766-52aa-449d-876e-8970972999c9",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/ia-def-ind/futur-poi-ajustement-parametres.png",
+                "alt": "futur POI",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "bdc51924-26ee-4f22-b302-fe4dec080387",
+          "type": "lesson",
+          "title": "Lesson 2b : Ajustement des paramètres",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "58f708f8-ad08-4c04-9876-c616e6d9a490",
+                      "type": "text",
+                      "content": "<p>Le logiciel dispose de plusieurs<strong> paramètres </strong>pour faire des<strong> calculs </strong>sur ces valeurs.</p><p>Au départ, les paramétres sont ajustés au hasard, produisant un<strong> résultat de calcul</strong>.</p><p>Le logiciel compare à chaque fois ces résultats, que l'on appelle<strong> des prédictions</strong>, aux réponses attendues🎲</p><p>Ainsi, par essai erreur,<strong> il ajuste progressivement les paramètres </strong>jusqu'à obtenir la bonne prédiction.🧮</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b3d22c1d-d09e-4f92-8691-5cf7bcddcb96",
+                      "type": "text",
+                      "content": "<p>🤔 Le saviez-vous ?</p><p><br> Ce type de modèle de calcul s’appelle un “<strong>réseau de neurone</strong>” car les chercheurs se sont inspirés du cerveau humain.🧠<br></p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "d11b5bf5-bd63-40d2-92dd-d03b5d5b7bf2",
+          "type": "discovery",
+          "title": "Découverte 3 : Généralisation",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "7f771c91-272f-42e9-875c-97640fcb7809",
+                      "type": "text",
+                      "content": "<p>Lila a donné à son logiciel des centaines de photographies ressemblant à celles ci-dessous.</p><p>Elle se demande si cet entrainement suffit pour qu'il reconnaisse l’ail des ours. 🥕</p>"
+                    },
+                    {
+                      "id": "1b67fab0-9ad4-45a6-aded-160b77b24993",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-def-ind/jeudedonne-sanslegende.png",
+                      "alt": "Une illustration du jeu de données avec des exemples",
+                      "alternativeText": "<p>On voit des photos d'ail des ours (avec des fleurs, avec des feuilles) et de muguet (avec des feuilles, avec des fleurs)</p>",
+                      "legend": "Une photo de bulbes d'ail des ours",
+                      "licence": ""
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9d1e71cd-8787-439d-9dc7-d9b395435fad",
+                      "type": "text",
+                      "content": "<p>Elle veut maintenant tester son programme sur une nouvelle photographie d'ail des ours.<br></p>"
+                    },
+                    {
+                      "id": "4fc2b7dc-0cc9-4e29-bb93-9c7ab25bcc60",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-def-ind/ailoursbulbe.jpg",
+                      "alt": "Une photo de bulbes d'ail des ours",
+                      "alternativeText": "<p>Une photo de bulbes d'ail des ours</p>",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "9f0116d7-03e8-4657-ac04-9b310c4562f1",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>A votre avis, cette IA va-t-elle reconnaître que cette image est de l'ail des ours ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Probablement oui.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Bien vu ! Mais savez-vous pourquoi ?</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Probablement non<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et non ! Et savez-vous pourquoi ?</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "a990944f-d268-4eac-99cc-8f4e88123baa",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>A votre avis, pourquoi ce logiciel n'est pas capable de dire que cette photographie est de l'ail des ours ?  <br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Les images d'entraînement ne comportent pas de photos de bulbes.<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>Et oui ! Ces données ne sont pas suffisamment variées, elles manquent de diversité.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Les images ne sont pas d’assez bonne qualité&nbsp;: elles sont souvent flous.<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>Si les images étaient flous, ça serait un problème ! </p><p> Mais ce n’est pas le cas ici, le problème principal est que les photos d'entraînement ne comportent pas de bulbes !</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Plusieurs photos d’ail des ours ont été étiquetées comme étant du muguet.<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>Bien sûr, si les images étaient mal étiquetées, ça serait un problème !<br>Mais ce n’est pas le cas ici, le problème principal est que les photos d'entraînement ne contiennent pas de bulbes !<br></p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "08c2f199-5026-487b-9c27-9f16d4ab481f",
+          "type": "lesson",
+          "title": "Lesson 3 : Généralisation",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "4f15ba33-8b56-49de-a277-be097b576d94",
+                      "type": "text",
+                      "content": "<p>Le but du logiciel est de prédire la bonne étiquette sur des exemples qu'on ne lui a pas donné lors de son entraînement. C’est la <strong>généralisation.</strong> 🚀</p><p>Pour atteindre une<strong> bonne généralisation</strong>, il faut lui donner des<strong> exemples variés</strong>, différents entre eux et représentant tous les cas typiques. Ceci réduit le risque d'erreur. </p><p>📌<strong>Important&nbsp;:</strong></p><p>Une prédiction est<strong> statistique,</strong> il y a donc toujours un risque d’erreur.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "f31ca24b-f958-4c77-bc38-6024c832b4c3",
+                      "type": "text",
+                      "content": "<p>On appelle<strong> phase de test</strong> l'étape de vérification de&nbsp;la performance du logiciel confronté à des <strong>nouveaux exemples non étiquetés</strong>.  <br>Parfois, on constate qu'on a encore besoin de l'entraîner&nbsp;pour pouvoir l’utiliser de façon fiable.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "06144dc9-610d-483a-a79c-62d17de1749e",
+                      "type": "text",
+                      "content": "<p>💡<strong>Bon à savoir&nbsp;:</strong><br> <strong>le logiciel ne peut trouver que les étiquettes qu’il a appris à prédire.</strong></p>"
+                    },
+                    {
+                      "id": "fdc063a3-de25-43e4-ab22-007339ad8d68",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-def-ind/schema-nouvelle-etiquette.png",
+                      "alt": "Un schéma ",
+                      "alternativeText": "<p>Un schéma représentant le fait que le logiciel ne peut pas prédire \"Tournesol\" s'il n'a été entrainé qu'avec des étiquettes \"ail des ours\" ou \"muguet\".</p>",
+                      "legend": "Si le logiciel ne connaît que les étiquettes “ail des ours” et “muguet” et qu’on lui présente une image de “tournesol”, il ne peut pas prédire que c’est un tournesol. Il va seulement donner une prédiction qui s’approche des étiquettes qu’il connaît.",
+                      "licence": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "e41f6414-5ef6-44ee-8501-31077ec9d258",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f071912a-b067-4d03-8217-cc087d3cdbff",
+                "type": "text",
+                "content": "<p>Avec beaucoup de nouvelles données, et quelques corrections, le logiciel est prêt ! 🎉<br>Lila, curieuse, se demande&nbsp;: que pourrait-on faire d’autre avec l’apprentissage supervisé ? 🤔<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f62d3175-8837-4713-996f-34c1e9846c98",
+          "type": "discovery",
+          "title": "Découverte 4 - D’autres cas d’usages, dont le texte",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5ec6e39a-0852-4ee9-b892-5a4b66b890e3",
+                "type": "text",
+                "content": "<p>Lila se dit qu’elle pourrait générer le texte de description de ces plantes.<br>Mais l’apprentissage sur du texte ne nécessite pas les mêmes données.<br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "191e100f-8a78-4ad9-b6d0-65533eba3ad8",
+                "type": "custom-draft",
+                "title": "Un tableau interactif pour associez les bonnes données à la bonne IA",
+                "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-generalisation-texte.html",
+                "instruction": "<p>A vous de jouer, complétez le schéma avec les bonnes données pour le bon objectif !<br></p>",
+                "height": 550
+              }
+            }
+          ]
+        },
+        {
+          "id": "4b313eb6-b343-47ea-983d-dd82fe7ac03c",
+          "type": "transition",
+          "title": "Transition 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "136e86b1-cc7d-4e9c-a5f4-a3f1e5808757",
+                "type": "text",
+                "content": "<p>Lila est contente, son logiciel est terminé.🚀  Elle va pouvoir le faire tester à Arthur !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3f86b7a5-8df1-48a0-94ef-2a28c8c0c010",
+          "type": "lesson",
+          "title": "Leçon #4 : D’autres cas d’usages, dont le texte",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "a041b7dc-9566-4bee-aaf4-106de9a98662",
+                      "type": "text",
+                      "content": "<p>L’apprentissage supervisé n'est pas utilisé que pour la reconnaissance d’image.</p><p>Les logiciels d’IA génératives conversationnels sont entraînés à <strong>générer du texte </strong>selon un <strong>principe proche</strong>&nbsp;: <br></p><ul><li>On leur donne des <strong>textes</strong>, dans lesquels il y a des <strong>trous </strong>(<strong>exemples</strong>),🕳️</li><li> et chaque trous est associé au <strong>mot manquant</strong> (<strong>étiquette</strong>). 🏷️ </li></ul><p>Ces logiciels analysent les caractéristiques des textes et s'entraînent à prédire le mot manquant. 📃<br></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "6c7d45cc-dc13-40d7-abc3-ef396c31f54c",
+                      "type": "text",
+                      "content": "<p>La technique d’<strong>apprentissage supervisé</strong> peut être utilisée dans <strong>beaucoup d’autres cas</strong>&nbsp;:</p><ul><li>la prédiction de la météo 🌦️, </li><li>la reconnaissance vocale 💬, </li><li>l’identification de tumeurs dans des images médicales 🩻…</li></ul><p>Des <strong>données différentes</strong> sont nécessaires pour chacun de ces cas.</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "4d0abb22-6ba4-4905-9f94-0a5ce818789e",
+          "type": "summary",
+          "title": "Récapitulatif",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c68dc04d-69b2-4ca6-9635-e38fea109723",
+                "type": "text",
+                "content": "<ul><li>L’<strong>apprentissage automatique</strong> est l’une des <strong>branches de l’intelligence </strong><strong>artificielle</strong>. Il permet de donner aux machines <strong>la capacité d'adapter</strong> ce qu'elles savent faire à une situations qu'elles n'ont pas encore rencontrées.</li><li>L'<strong>apprentissage supervisé</strong> est l’une des méthodes de l’apprentissage automatique. Il consiste à fournir au logiciel un <strong>jeu de donnée</strong>s pour l’entraîner à prédire l’étiquette associée à une donnée. 🏷️📈</li><li>Au départ, le logiciel fait ses <strong>calculs </strong>de prédiction au hasard. Progressivement, il <strong>ajuste les paramètres</strong> de calcul pour parvenir à prédire la bonne étiquette. Il peut ainsi <strong>généraliser</strong> ses prédictions sur d'autres exemples. 🚀</li><li>La <strong>qualité </strong>des exemples et<strong> des données</strong> fournies est primordiale. 🚨</li><li>L'apprentissage supervisé est utilisé pour l'entraînement de<strong> nombreux logiciels</strong> qui réalisent des tâches telles que la reconnaissance d'image, des tâches de classement, des tâches de prédiction, etc.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3320dd18-77d1-4272-8f3d-ff110466f288",
+          "type": "activity",
+          "title": "S'exercer  : As-tu compris ce qu’est l’apprentissage supervisé ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c75c175f-c7d9-4328-84ca-410369b1fef7",
+                "type": "qab",
+                "instruction": "<p>Répondez aux affirmations suivantes. <br></p>",
+                "cards": [
+                  {
+                    "id": "393892dc-10cc-465d-992e-ff624049ba76",
+                    "text": "L’apprentissage supervisé est une technique d’intelligence artificielle.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "4f54b9e7-260f-4f7e-a1eb-31508e8ae1e7",
+                    "text": "L’apprentissage supervisé sert souvent à faire des prédictions.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "b9a58e53-52d2-44f1-84ec-2855ab8ffc34",
+                    "text": "Dans l’apprentissage supervisé, le logiciel commence par choisir des paramètres au hasard, puis les ajuste.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "77f1da71-9011-4cde-a3f9-0f14dec707f3",
+                    "text": "Une fois qu’un modèle est entraîné, il ne peut plus se tromper.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "b5776fad-8fec-405c-bfc6-c8d05aaf7d27",
+                    "text": "Un algorithme d’apprentissage supervisé peut apprendre tout seul, sans aide.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": "<p>Si tu as eu des erreurs, n'hésite pas à remonter pour lire le récapitulatif. 👆</p>"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "3cfbafc0-3501-495f-af79-ca93b8c9668c",
+          "type": "challenge",
+          "title": "Défi : et pour l'exemple des oiseaux ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c4b4a5c3-265e-4387-839b-73a27c0ecf34",
+                "type": "text",
+                "content": "<p>Arthur a été très inspiré par l’application de Lila. 🌱</p><p>Il a téléchargé une application pour reconnaître le chant des oiseaux, comme <a href=\"https://play.google.com/store/apps/details?id=de.tu_chemnitz.mi.kahst.birdnet&amp;hl=fr\" target=\"_blank\">celle-ci.</a>🐦</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "bcc71c8a-4954-4705-959e-3e0c4d65832b",
+                "type": "qrocm",
+                "instruction": "<p>A votre avis, de quelles données a-t-on besoin pour créer un logiciel comme celui-ci ?<br></p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<p>Type de données&nbsp;:<br></p>"
+                  },
+                  {
+                    "input": "8c61f879-6db9-4b4a-9817-9a567fe7ef34",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "champ à remplir",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t2", "t3"],
+                    "solutions": [
+                      "Chant d'oiseau",
+                      "Des chants d'oiseaux",
+                      "Chants d'oiseaux",
+                      "Plein de chants d'oiseaux",
+                      "Beaucoup de chants d'oiseaux"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<p>Etiquette associée&nbsp;:</p>"
+                  },
+                  {
+                    "input": "1f4f4ac7-71c2-4cd0-943d-a906f9780f0c",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "champ à remplir",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t2", "t3"],
+                    "solutions": ["Nom d'oiseau", "Noms des oiseaux", "Le nom des oiseaux"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "<p>Bonne réponse !</p>",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "<p>Mauvaise réponse !</p>",
+                    "diagnosis": "<p>Et non, il va falloir le nom des oiseaux correspondants.</p>"
+                  }
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
@@ -14,622 +14,628 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "031b056a-0e5f-48f3-9a49-45688a354dea",
-      "type": "transition",
-      "title": "Accroche",
-      "components": [
+      "id": "49043434-a859-4873-83ef-0ac1c3b107a7",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "bf7e524d-cef5-4cbf-b15d-7a03cfb4195d",
-            "type": "text",
-            "content": "<p>Bob utilise ChatGPT pour organiser ses prochaines vacances.&nbsp;C’est un logiciel d'IA générative.<br>Voici sa demande&nbsp;:</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "aff736d6-2545-4e23-b5ec-e9551ec2bcb9",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/mZ5u4CJ.png",
-            "alt": "conversation décrite dans l'alternative textuelle",
-            "alternativeText": "<p>👱 Bob&nbsp;: Je veux organiser des vacances à la mer pour 10 jours. J'habite à Rennes. Donne-moi un coup de main ! </p><p>🤖 ChatGPT&nbsp;: ...</p>",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e1dffc31-9bbb-49d9-85e3-3a5caa5dc9fc",
-            "type": "qcu",
-            "instruction": "<p>Imaginez que vous êtes à la place de Bob.</p><p>Que souhaiteriez-vous que ce logiciel d'IA générative réponde à cette demande ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>« Bien sûr ! Tu veux la main gauche ou la main droite ? 👋 »</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>Vous voulez un peu d’humour !</strong> ChatGPT, lui, répondrait sûrement plus sérieusement à cette demande pour aider Bob.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>« Oui ! à partir de quand veux-tu partir ? ⛵ »</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p><strong>C’est une réponse que pourrait donner ChatGPT.</strong> En effet, il faut savoir quand commencent les vacances de Bob pour mieux l’aider !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Vous avez eu du mal à vous décider ? En tout cas, ChatGPT répondrait sûrement quelque chose pour aider Bob à s’organiser.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e30e0e91-0983-48c4-8181-173b62f1b5b9",
-      "type": "transition",
-      "title": "Transition 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6b3b7a1f-1245-43fe-bb96-2d5c01a4a30e",
-            "type": "text",
-            "content": "<p>Un logiciel d'IA générative comme ChatGPT répond souvent de manière pertinente aux demandes des utilisateurs, sur des sujets très variés.&nbsp; <br></p><p>Mais, qu’est ce qu’un logiciel d’IA générative ? Et comment arrivent-ils à faire cela ? C’est ce que nous allons découvrir ensemble.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c39f607d-e4fa-4b3c-a075-b75bb81dff3c",
-      "type": "discovery",
-      "title": "Découverte 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "81f44774-8b4d-4d91-b1c2-2a26044eb9df",
-            "type": "qcu-discovery",
-            "instruction": "<p>Comme ChatGPT, d’autres logiciels d’IA générative sont capables de produire du texte.</p><p> En reconnaissez-vous un ci-dessous ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Gemini</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien vu ! </p><p>En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Deepseek</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien vu ! </p><p> En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Mistral<br></p>",
-                "feedback": {
-                  "diagnosis": "<p>Bien vu ! </p><p>  En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas</p>",
-                "feedback": {
-                  "diagnosis": "<p>En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1fce9705-da34-49c7-a7f2-c65db62018a6",
-      "type": "lesson",
-      "title": "Lesson 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "898ab86a-15d3-468f-a0fd-eb1644e7aef6",
-            "type": "text",
-            "content": "<p><br></p><p>Un logiciel d’<strong>Intelligence Artificielle générative</strong> est capable de <strong>répondre de façon pertinente</strong> à des demandes écrites sur <strong>des sujets très variés</strong> (transports, visites, cuisine…).</p><p><br>Il en existe de nombreux à disposition grand public : chatGPT, microsoft Copilot, Deepseek, Perplexity, Claude...</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e02e013a-1153-4cd0-b6ca-19c8683607ce",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "984bbfce-c558-432a-9746-22fee645e643",
-            "type": "text",
-            "content": "<p>🤔 Bon à savoir<br>Certains logiciels d’Ia générative sont capables de générer des images, des vidéos ou des sons.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "feb5f1c1-8cbb-4a7e-be2f-6a02608af3ad",
-      "type": "transition",
-      "title": "Transition 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9a7f547c-7d63-4ece-b93e-96c92e48ae5a",
-            "type": "text",
-            "content": "<p>Mais comment un logiciel d'IA générative fait-il pour construire sa réponse quand un utilisateur lui écrit ?&nbsp; Voyons ça ensemble avec un jeu ! 🕹️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9b5aa09c-2fa9-4b70-9bf2-90181497e38e",
-      "type": "discovery",
-      "title": "Découverte 2",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "031b056a-0e5f-48f3-9a49-45688a354dea",
+          "type": "transition",
+          "title": "Accroche",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "9facc0e9-5624-46c1-bf61-1dd4c3cdf35a",
-                  "type": "text",
-                  "content": "<p>Voici ci-dessous un texte incomplet&nbsp;: il manque le dernier mot.&nbsp;</p><p><strong>👉 Cherchez un mot dans votre tête pour compléter ce texte.</strong></p><p><strong><br></strong></p><p><em>Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ? On peut mettre du…</em></p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "bf7e524d-cef5-4cbf-b15d-7a03cfb4195d",
+                "type": "text",
+                "content": "<p>Bob utilise ChatGPT pour organiser ses prochaines vacances.&nbsp;C’est un logiciel d'IA générative.<br>Voici sa demande&nbsp;:</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "8f59bf30-fa84-4114-9707-eabc9f648f9e",
-                  "type": "text",
-                  "content": "<p>Votre crêpe est peut-être au « chocolat », « sucre », « fromage » ou autre !</p>"
-                },
-                {
-                  "id": "de590f05-252c-4110-859a-07a2e276ac80",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>Comment avez-vous choisi votre mot ?<br></p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>J’ai choisi un mot au hasard.</p>",
-                      "feedback": {
-                        "diagnosis": "<p>C'est une méthode qui peut donner des résultats décalés, et parfois très drôles !</p><p>Les logiciels d'intelligence artificielle génératives, eux, utilisent une autre méthode.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>J’ai choisi un mot très probable.<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>C'est une bonne méthode ! </p><p>Et c'est aussi comme ça que fonctionne les logiciels d'IA génératives !</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>J’ai choisi un mot que je préfère.<br></p>",
-                      "feedback": {
-                        "diagnosis": "<p>C'est une bonne méthode, pour un humain !</p><p>Comme les machines n'ont pas de préférences, elles utilisent une autre méthode...</p>"
-                      }
+              "type": "element",
+              "element": {
+                "id": "aff736d6-2545-4e23-b5ec-e9551ec2bcb9",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/mZ5u4CJ.png",
+                "alt": "conversation décrite dans l'alternative textuelle",
+                "alternativeText": "<p>👱 Bob&nbsp;: Je veux organiser des vacances à la mer pour 10 jours. J'habite à Rennes. Donne-moi un coup de main ! </p><p>🤖 ChatGPT&nbsp;: ...</p>",
+                "legend": "",
+                "licence": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e1dffc31-9bbb-49d9-85e3-3a5caa5dc9fc",
+                "type": "qcu",
+                "instruction": "<p>Imaginez que vous êtes à la place de Bob.</p><p>Que souhaiteriez-vous que ce logiciel d'IA générative réponde à cette demande ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>« Bien sûr ! Tu veux la main gauche ou la main droite ? 👋 »</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>Vous voulez un peu d’humour !</strong> ChatGPT, lui, répondrait sûrement plus sérieusement à cette demande pour aider Bob.</p>"
                     }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "eb7f4031-119d-452b-8789-06f9fd19f56c",
-                  "type": "text",
-                  "content": "<p>Pour un logiciel d'IA générative c’est un peu le même principe : il construit sa réponse en complétant un texte mot après mot en choisissant des mots très probables. </p><p> Voyons ce que cela donne sur notre exemple.&nbsp;👇</p>"
-                },
-                {
-                  "id": "4c59286a-4fe4-4991-a8a7-023fd736c3a5",
-                  "type": "custom-draft",
-                  "title": "Les probabilités que l'IA choisisse le mot suivant dans une conversation",
-                  "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-crepe-probabilite.html",
-                  "instruction": "<p><br></p>",
-                  "height": 550
-                },
-                {
-                  "id": "860fd8e3-4b25-4ffb-b813-a7c8ca794112",
-                  "type": "qcu-discovery",
-                  "instruction": "<p>D’après vous, quel mot va choisir l’IA à cette dernière étape ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>sucre</p>",
-                      "feedback": {
-                        "diagnosis": "<p>En effet, c’est le mot le plus probable.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>miel</p>",
-                      "feedback": {
-                        "diagnosis": "<p>C’est possible !&nbsp;Il peut aussi choisir \"sucre\", qui est très probable...</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>caramel</p>",
-                      "feedback": {
-                        "diagnosis": "<p>C’est possible !&nbsp;Il peut aussi choisir \"sucre\", qui est très probable...</p>"
-                      }
-                    },
-                    {
-                      "id": "4",
-                      "content": "<p>chocolat</p>",
-                      "feedback": {
-                        "diagnosis": "<p>Pas sûr...&nbsp;Il choisira sans doute un mot plus probable : sucre, miel ou caramel.</p>"
-                      }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>« Oui ! à partir de quand veux-tu partir ? ⛵ »</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p><strong>C’est une réponse que pourrait donner ChatGPT.</strong> En effet, il faut savoir quand commencent les vacances de Bob pour mieux l’aider !</p>"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Vous avez eu du mal à vous décider ? En tout cas, ChatGPT répondrait sûrement quelque chose pour aider Bob à s’organiser.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "6a0ff61b-362d-41c4-8dd6-420eb60bf743",
-      "type": "lesson",
-      "title": "Lesson 2 - avec stepper",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "23d57d7e-2bea-4c79-83e8-3fa7bcc273d0",
-                  "type": "text",
-                  "content": "<p>Pour répondre, un logiciel d'<strong>IA générative</strong>,&nbsp;construit sa réponse comme s'il <strong>complétait la demande&nbsp;de l’utilisateur</strong>.</p><p> Pour compléter ce texte, il choisit le prochain mot selon sa probabilité d'apparaître : plus le mot est probable, plus il y a de chance que le logiciel choississe ce mot. </p><p>Il répète cette méthode&nbsp;<strong>mot après m</strong><strong>ot</strong>.</p>"
-                },
-                {
-                  "id": "8759c6d1-0193-461f-9a51-3220ba255978",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/m1e42Vd.png",
-                  "alt": "Schéma concernant la probabilité des mots qui apparaissent",
-                  "alternativeText": "<p>à venir</p>",
-                  "legend": "",
-                  "licence": ""
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "956543e6-0094-44bb-b3f9-588542bc441c",
-                  "type": "text",
-                  "content": "<p>⚠️ Cette méthode a des<strong> limites</strong>. </p><p> Les réponses d’un logiciel d'IA générative sont une suite de mots très probables, mais les phrases produites ne sont <strong>pas toujours vraies</strong>&nbsp;: il peut y avoir des<strong> erreurs</strong>.&nbsp; </p><p> 🔍 Il faut donc <strong>toujours vérifier </strong>ce qu’un logiciel d'IA générative écrit.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "a61e19c3-a117-446d-bb94-487fcefdbf16",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4b21d13f-d359-4d81-8884-327703eea94c",
-            "type": "text",
-            "content": "<p>Vous connaissez maintenant la méthode utilisée par un logiciel d'IA générative pour écrire ses réponses. </p><p>Mais comment connaît-il tous ces mots ? Et comment sait-il si ces mots sont probables ou non ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "204bc632-d9ee-4794-9ce8-bd4626247e48",
-      "type": "discovery",
-      "title": "Découverte 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "af3739f4-b77e-4d2b-8795-947da458b59b",
-            "type": "text",
-            "content": "<p>Le secret : <strong>l'entraînement.</strong> </p><p>Entraîner une IA, c'est lui donner des textes pour qu'elle les analyse et s'entraîne à les réécrire.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "4deeee7c-1c90-4753-8d89-8a0d86dac39b",
-            "type": "qcu-discovery",
-            "instruction": "<p>Si vous deviez entraîner une IA, quels textes disponibles sur internet lui donneriez-vous ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>tous les articles de Wikipedia</p>",
-                "feedback": {
-                  "diagnosis": "<p>C'est un bon début&nbsp;: les articles Wikipedia sont très nombreux, variés et souvent bien écrits.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>des discussions de forums</p>",
-                "feedback": {
-                  "diagnosis": "<p>C'est intéressant pour avoir des mots du quotidien ! Mais la précision du vocabulaire ne sera sûrement pas garantie.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>des articles scientifiques</p>",
-                "feedback": {
-                  "diagnosis": "<p>C'est utile pour avoir du vocabulaire scientifique, donc des mots très précis.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>toutes ces réponses</p>",
-                "feedback": {
-                  "diagnosis": "<p>C'est l'idéal&nbsp;: plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
-                }
-              },
-              {
-                "id": "5",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "diagnosis": "<p>Plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
-                }
-              }
-            ],
-            "solution": "4"
-          }
-        }
-      ]
-    },
-    {
-      "id": "06a185df-1a0f-4709-abe7-953211e75a4f",
-      "type": "lesson",
-      "title": "Lesson 3 - avec stepper",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "e30e0e91-0983-48c4-8181-173b62f1b5b9",
+          "type": "transition",
+          "title": "Transition 1",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "fcac6dfc-fc03-49e2-af21-7356908e1094",
-                  "type": "text",
-                  "content": "<p>Si on donne à un logiciel d'IA générative des <strong>milliards de textes variés</strong> <strong>pour s’entraîner</strong>, il pourra apporter des réponses pertinentes à presque toutes les demandes des utilisateurs.&nbsp; </p><p>\n✔️ Par exemple, ChatGPT ou Mistral sont entraînées sur des textes disponibles sur internet&nbsp;: articles Wikipédia, forums, blogs, revues scientifiques…</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "6b3b7a1f-1245-43fe-bb96-2d5c01a4a30e",
+                "type": "text",
+                "content": "<p>Un logiciel d'IA générative comme ChatGPT répond souvent de manière pertinente aux demandes des utilisateurs, sur des sujets très variés.&nbsp; <br></p><p>Mais, qu’est ce qu’un logiciel d’IA générative ? Et comment arrivent-ils à faire cela ? C’est ce que nous allons découvrir ensemble.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c39f607d-e4fa-4b3c-a075-b75bb81dff3c",
+          "type": "discovery",
+          "title": "Découverte 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "81f44774-8b4d-4d91-b1c2-2a26044eb9df",
+                "type": "qcu-discovery",
+                "instruction": "<p>Comme ChatGPT, d’autres logiciels d’IA générative sont capables de produire du texte.</p><p> En reconnaissez-vous un ci-dessous ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Gemini</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien vu ! </p><p>En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Deepseek</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien vu ! </p><p> En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Mistral<br></p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bien vu ! </p><p>  En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas</p>",
+                    "feedback": {
+                      "diagnosis": "<p>En fait, toutes les propositions étaient des IA génératives. Il en existe beaucoup !</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1fce9705-da34-49c7-a7f2-c65db62018a6",
+          "type": "lesson",
+          "title": "Lesson 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "898ab86a-15d3-468f-a0fd-eb1644e7aef6",
+                "type": "text",
+                "content": "<p><br></p><p>Un logiciel d’<strong>Intelligence Artificielle générative</strong> est capable de <strong>répondre de façon pertinente</strong> à des demandes écrites sur <strong>des sujets très variés</strong> (transports, visites, cuisine…).</p><p><br>Il en existe de nombreux à disposition grand public : chatGPT, microsoft Copilot, Deepseek, Perplexity, Claude...</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "e02e013a-1153-4cd0-b6ca-19c8683607ce",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "984bbfce-c558-432a-9746-22fee645e643",
+                "type": "text",
+                "content": "<p>🤔 Bon à savoir<br>Certains logiciels d’Ia générative sont capables de générer des images, des vidéos ou des sons.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "feb5f1c1-8cbb-4a7e-be2f-6a02608af3ad",
+          "type": "transition",
+          "title": "Transition 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9a7f547c-7d63-4ece-b93e-96c92e48ae5a",
+                "type": "text",
+                "content": "<p>Mais comment un logiciel d'IA générative fait-il pour construire sa réponse quand un utilisateur lui écrit ?&nbsp; Voyons ça ensemble avec un jeu ! 🕹️</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9b5aa09c-2fa9-4b70-9bf2-90181497e38e",
+          "type": "discovery",
+          "title": "Découverte 2",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "1ff9ddc9-f270-4df1-a0d0-06e7d2ee325f",
-                  "type": "text",
-                  "content": "<p>⚠️ Attention&nbsp;: <strong>les textes sur internet ont parfois des</strong> <strong>erreurs</strong>. Et un logiciel d'IA générative ne repère&nbsp;pas ces erreurs pendant l’entraînement. Il peut donc <strong>reproduire ces erreurs </strong>dans ses réponses.</p><p><br>🔍 C’est important de le répéter&nbsp;: vérifiez toujours ce qu’un logiciel d'IA générative écrit.</p>"
+                  "elements": [
+                    {
+                      "id": "9facc0e9-5624-46c1-bf61-1dd4c3cdf35a",
+                      "type": "text",
+                      "content": "<p>Voici ci-dessous un texte incomplet&nbsp;: il manque le dernier mot.&nbsp;</p><p><strong>👉 Cherchez un mot dans votre tête pour compléter ce texte.</strong></p><p><strong><br></strong></p><p><em>Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ? On peut mettre du…</em></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "8f59bf30-fa84-4114-9707-eabc9f648f9e",
+                      "type": "text",
+                      "content": "<p>Votre crêpe est peut-être au « chocolat », « sucre », « fromage » ou autre !</p>"
+                    },
+                    {
+                      "id": "de590f05-252c-4110-859a-07a2e276ac80",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Comment avez-vous choisi votre mot ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>J’ai choisi un mot au hasard.</p>",
+                          "feedback": {
+                            "diagnosis": "<p>C'est une méthode qui peut donner des résultats décalés, et parfois très drôles !</p><p>Les logiciels d'intelligence artificielle génératives, eux, utilisent une autre méthode.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>J’ai choisi un mot très probable.<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>C'est une bonne méthode ! </p><p>Et c'est aussi comme ça que fonctionne les logiciels d'IA génératives !</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>J’ai choisi un mot que je préfère.<br></p>",
+                          "feedback": {
+                            "diagnosis": "<p>C'est une bonne méthode, pour un humain !</p><p>Comme les machines n'ont pas de préférences, elles utilisent une autre méthode...</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "eb7f4031-119d-452b-8789-06f9fd19f56c",
+                      "type": "text",
+                      "content": "<p>Pour un logiciel d'IA générative c’est un peu le même principe : il construit sa réponse en complétant un texte mot après mot en choisissant des mots très probables. </p><p> Voyons ce que cela donne sur notre exemple.&nbsp;👇</p>"
+                    },
+                    {
+                      "id": "4c59286a-4fe4-4991-a8a7-023fd736c3a5",
+                      "type": "custom-draft",
+                      "title": "Les probabilités que l'IA choisisse le mot suivant dans une conversation",
+                      "url": "https://1024pix.github.io/atelier-contenus/JTE/poi-crepe-probabilite.html",
+                      "instruction": "<p><br></p>",
+                      "height": 550
+                    },
+                    {
+                      "id": "860fd8e3-4b25-4ffb-b813-a7c8ca794112",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>D’après vous, quel mot va choisir l’IA à cette dernière étape ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>sucre</p>",
+                          "feedback": {
+                            "diagnosis": "<p>En effet, c’est le mot le plus probable.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>miel</p>",
+                          "feedback": {
+                            "diagnosis": "<p>C’est possible !&nbsp;Il peut aussi choisir \"sucre\", qui est très probable...</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>caramel</p>",
+                          "feedback": {
+                            "diagnosis": "<p>C’est possible !&nbsp;Il peut aussi choisir \"sucre\", qui est très probable...</p>"
+                          }
+                        },
+                        {
+                          "id": "4",
+                          "content": "<p>chocolat</p>",
+                          "feedback": {
+                            "diagnosis": "<p>Pas sûr...&nbsp;Il choisira sans doute un mot plus probable : sucre, miel ou caramel.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "c8277aa6-d188-423d-b792-14cf19b50973",
-      "type": "summary",
-      "title": "Récap'",
-      "components": [
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "ed8509d2-d62f-49a8-baa6-acc699562193",
-            "type": "text",
-            "content": "<p>Résumons avant de passer à la suite&nbsp;:&nbsp; </p><ul><li>Un logiciel d'IA générative est un outil qui permet de discuter facilement avec un utilisateur, sur des sujets très variés. 💬</li><li>Il utilise un programme qui est entraîné avec énormément de textes disponibles sur internet. Cela va lui permettre de répondre précisément aux demandes, sans que ses réponses ne soient préparées à l’avance. 📚</li><li>Il ne répond pas comme le ferait un humain&nbsp;: il écrit en construisant mot par mot, avec des mots très probables. 🧩</li><li>Il faut toujours vérifier les réponses qui sont données. Pour vérifier, on peut poursuivre la conversation ou aller chercher soi-même sur internet. 🔍</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "098df491-8249-4ded-bbad-446ee0adc80b",
-      "type": "transition",
-      "title": "Transition 4",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "8befd8fa-8fea-42f2-b8b9-a284f62e84f0",
-            "type": "text",
-            "content": "<p>Voyons si vous avez compris l’essentiel avec quelques questions !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8f44cbb1-a29d-4171-8386-589af0ee7482",
-      "type": "activity",
-      "title": "Exercice 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "58a0b8d9-30ce-4e62-95a6-b30a55a9c76d",
-            "type": "qcu",
-            "instruction": "<p>Parmi les propositions suivantes, laquelle définit le mieux ce qu’est un <strong>logiciel d’IA générative</strong> ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Un logiciel qui copie automatiquement des textes trouvés sur internet.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.<br></p>",
-                  "diagnosis": "<p>Le logiciel d'intelligence artificielle générative ne fait pas que copier des textes trouvés sur internet, il peut reformuler et en produire de nouveaux.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Un outil qui produit du texte, des images ou du son avec les consignes d’un utilisateur.</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse ! ✨</p>",
-                  "diagnosis": "<p>On appelle ces consignes données par l'utilisateur des prompts.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Un programme qui connaît toutes les réponses à l’avance aux questions des utilisateurs.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Contrairement à une FAQ sans intelligence artificielle, avec un logiciel d'IA générative, pas besoin de programmer à l'avance toutes les questions que vont poser les utilisateurs.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Un moteur de recherche qui affiche les meilleures pages web pour la recherche d’un utilisateur.</p>",
-                "feedback": {
-                  "state": "<p>Mauvaise réponse.</p>",
-                  "diagnosis": "<p>Un moteur de recherche, qui liste des résultats sur le web, est différent d'un logiciel d'intelligence artificielle générative, qui produit des réponses grâce aux probabilités.&nbsp;</p><p>Cependant, de plus en plus de moteurs de recherche utilisent l'intelligence artificielle pour proposer à leurs utilisateurs un résumé des principaux résultats de recherche.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "86673ff6-f7d9-41be-8455-33050d1329ec",
-      "type": "activity",
-      "title": "Exercice 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9a953473-d7e1-4e85-af9f-b6ed6a43834e",
-            "type": "qab",
-            "instruction": "<p>Pour chaque affirmation ci-dessous, choisissez si elle est vraie ou fausse.</p>",
-            "cards": [
-              {
-                "id": "4959c494-cf94-4d05-b69c-4735e6b2c5eb",
-                "text": "Les logiciels d'IA générative sont entraînées uniquement sur les articles de Wikipédia.",
-                "image": {
-                  "url": "",
-                  "altText": ""
+          "id": "6a0ff61b-362d-41c4-8dd6-420eb60bf743",
+          "type": "lesson",
+          "title": "Lesson 2 - avec stepper",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "23d57d7e-2bea-4c79-83e8-3fa7bcc273d0",
+                      "type": "text",
+                      "content": "<p>Pour répondre, un logiciel d'<strong>IA générative</strong>,&nbsp;construit sa réponse comme s'il <strong>complétait la demande&nbsp;de l’utilisateur</strong>.</p><p> Pour compléter ce texte, il choisit le prochain mot selon sa probabilité d'apparaître : plus le mot est probable, plus il y a de chance que le logiciel choississe ce mot. </p><p>Il répète cette méthode&nbsp;<strong>mot après m</strong><strong>ot</strong>.</p>"
+                    },
+                    {
+                      "id": "8759c6d1-0193-461f-9a51-3220ba255978",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/m1e42Vd.png",
+                      "alt": "Schéma concernant la probabilité des mots qui apparaissent",
+                      "alternativeText": "<p>à venir</p>",
+                      "legend": "",
+                      "licence": ""
+                    }
+                  ]
                 },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              },
-              {
-                "id": "96297870-4f63-4dac-84f6-c9056e843c86",
-                "text": "Un logiciel d'IA générative construit sa réponse mot après mot, en partant du texte de l'utilisateur.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "95665e37-f24c-4636-9518-a94032c7f9c8",
-                "text": "Les réponses d’un logiciel d'IA générative sont toujours correctes.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
+                {
+                  "elements": [
+                    {
+                      "id": "956543e6-0094-44bb-b3f9-588542bc441c",
+                      "type": "text",
+                      "content": "<p>⚠️ Cette méthode a des<strong> limites</strong>. </p><p> Les réponses d’un logiciel d'IA générative sont une suite de mots très probables, mais les phrases produites ne sont <strong>pas toujours vraies</strong>&nbsp;: il peut y avoir des<strong> erreurs</strong>.&nbsp; </p><p> 🔍 Il faut donc <strong>toujours vérifier </strong>ce qu’un logiciel d'IA générative écrit.</p>"
+                    }
+                  ]
+                }
+              ]
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "44507da7-f25a-4e58-9019-7b5193b8dca6",
-      "type": "transition",
-      "title": "Transition 5",
-      "components": [
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "de48659c-5799-4a9f-9d74-3676e78c094b",
-            "type": "text",
-            "content": "<p>Pour finir ce module, voyons quelle sera votre bonne résolution pour votre prochaine utilisation de ChatGPT, Gemini, Le Chat ou d’un autre logiciel d'IA générative&nbsp;! 💫</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "bbd7f431-1475-4f7a-8d53-99771395bb44",
-      "type": "challenge",
-      "title": "Défi",
-      "components": [
+          "id": "a61e19c3-a117-446d-bb94-487fcefdbf16",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4b21d13f-d359-4d81-8884-327703eea94c",
+                "type": "text",
+                "content": "<p>Vous connaissez maintenant la méthode utilisée par un logiciel d'IA générative pour écrire ses réponses. </p><p>Mais comment connaît-il tous ces mots ? Et comment sait-il si ces mots sont probables ou non ?</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "546fcfcd-a7a8-4290-bde6-a8cc203013f3",
-            "type": "qcu-declarative",
-            "instruction": "<p>La prochaine fois que vous utiliserez un logiciel d'IA générative, que ferez-vous ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>J’utiliserai les réponses qu’elle me donne, sans les vérifier.</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>C’est risqué ! </strong></p><p>Les logiciels d'IA générative répondent de manière souvent intéressante. </p><p>Mais ils ne connaissent pas la signification des mots et il peut y avoir des erreurs dans leurs réponses.</p>"
+          "id": "204bc632-d9ee-4794-9ce8-bd4626247e48",
+          "type": "discovery",
+          "title": "Découverte 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "af3739f4-b77e-4d2b-8795-947da458b59b",
+                "type": "text",
+                "content": "<p>Le secret : <strong>l'entraînement.</strong> </p><p>Entraîner une IA, c'est lui donner des textes pour qu'elle les analyse et s'entraîne à les réécrire.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4deeee7c-1c90-4753-8d89-8a0d86dac39b",
+                "type": "qcu-discovery",
+                "instruction": "<p>Si vous deviez entraîner une IA, quels textes disponibles sur internet lui donneriez-vous ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>tous les articles de Wikipedia</p>",
+                    "feedback": {
+                      "diagnosis": "<p>C'est un bon début&nbsp;: les articles Wikipedia sont très nombreux, variés et souvent bien écrits.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>des discussions de forums</p>",
+                    "feedback": {
+                      "diagnosis": "<p>C'est intéressant pour avoir des mots du quotidien ! Mais la précision du vocabulaire ne sera sûrement pas garantie.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>des articles scientifiques</p>",
+                    "feedback": {
+                      "diagnosis": "<p>C'est utile pour avoir du vocabulaire scientifique, donc des mots très précis.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>toutes ces réponses</p>",
+                    "feedback": {
+                      "diagnosis": "<p>C'est l'idéal&nbsp;: plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
+                    }
+                  },
+                  {
+                    "id": "5",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Plus une IA est entraînée sur des textes nombreux et variés, plus elle connaîtra des mots et leurs probabilités.</p>"
+                    }
+                  }
+                ],
+                "solution": "4"
+              }
+            }
+          ]
+        },
+        {
+          "id": "06a185df-1a0f-4709-abe7-953211e75a4f",
+          "type": "lesson",
+          "title": "Lesson 3 - avec stepper",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "fcac6dfc-fc03-49e2-af21-7356908e1094",
+                      "type": "text",
+                      "content": "<p>Si on donne à un logiciel d'IA générative des <strong>milliards de textes variés</strong> <strong>pour s’entraîner</strong>, il pourra apporter des réponses pertinentes à presque toutes les demandes des utilisateurs.&nbsp; </p><p>\n✔️ Par exemple, ChatGPT ou Mistral sont entraînées sur des textes disponibles sur internet&nbsp;: articles Wikipédia, forums, blogs, revues scientifiques…</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "1ff9ddc9-f270-4df1-a0d0-06e7d2ee325f",
+                      "type": "text",
+                      "content": "<p>⚠️ Attention&nbsp;: <strong>les textes sur internet ont parfois des</strong> <strong>erreurs</strong>. Et un logiciel d'IA générative ne repère&nbsp;pas ces erreurs pendant l’entraînement. Il peut donc <strong>reproduire ces erreurs </strong>dans ses réponses.</p><p><br>🔍 C’est important de le répéter&nbsp;: vérifiez toujours ce qu’un logiciel d'IA générative écrit.</p>"
+                    }
+                  ]
                 }
-              },
-              {
-                "id": "2",
-                "content": "<p>Je poserai plusieurs questions pendant la discussion.</p>",
+              ]
+            }
+          ]
+        },
+        {
+          "id": "c8277aa6-d188-423d-b792-14cf19b50973",
+          "type": "summary",
+          "title": "Récap'",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ed8509d2-d62f-49a8-baa6-acc699562193",
+                "type": "text",
+                "content": "<p>Résumons avant de passer à la suite&nbsp;:&nbsp; </p><ul><li>Un logiciel d'IA générative est un outil qui permet de discuter facilement avec un utilisateur, sur des sujets très variés. 💬</li><li>Il utilise un programme qui est entraîné avec énormément de textes disponibles sur internet. Cela va lui permettre de répondre précisément aux demandes, sans que ses réponses ne soient préparées à l’avance. 📚</li><li>Il ne répond pas comme le ferait un humain&nbsp;: il écrit en construisant mot par mot, avec des mots très probables. 🧩</li><li>Il faut toujours vérifier les réponses qui sont données. Pour vérifier, on peut poursuivre la conversation ou aller chercher soi-même sur internet. 🔍</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "098df491-8249-4ded-bbad-446ee0adc80b",
+          "type": "transition",
+          "title": "Transition 4",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "8befd8fa-8fea-42f2-b8b9-a284f62e84f0",
+                "type": "text",
+                "content": "<p>Voyons si vous avez compris l’essentiel avec quelques questions !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8f44cbb1-a29d-4171-8386-589af0ee7482",
+          "type": "activity",
+          "title": "Exercice 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "58a0b8d9-30ce-4e62-95a6-b30a55a9c76d",
+                "type": "qcu",
+                "instruction": "<p>Parmi les propositions suivantes, laquelle définit le mieux ce qu’est un <strong>logiciel d’IA générative</strong> ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Un logiciel qui copie automatiquement des textes trouvés sur internet.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.<br></p>",
+                      "diagnosis": "<p>Le logiciel d'intelligence artificielle générative ne fait pas que copier des textes trouvés sur internet, il peut reformuler et en produire de nouveaux.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Un outil qui produit du texte, des images ou du son avec les consignes d’un utilisateur.</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse ! ✨</p>",
+                      "diagnosis": "<p>On appelle ces consignes données par l'utilisateur des prompts.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Un programme qui connaît toutes les réponses à l’avance aux questions des utilisateurs.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Contrairement à une FAQ sans intelligence artificielle, avec un logiciel d'IA générative, pas besoin de programmer à l'avance toutes les questions que vont poser les utilisateurs.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Un moteur de recherche qui affiche les meilleures pages web pour la recherche d’un utilisateur.</p>",
+                    "feedback": {
+                      "state": "<p>Mauvaise réponse.</p>",
+                      "diagnosis": "<p>Un moteur de recherche, qui liste des résultats sur le web, est différent d'un logiciel d'intelligence artificielle générative, qui produit des réponses grâce aux probabilités.&nbsp;</p><p>Cependant, de plus en plus de moteurs de recherche utilisent l'intelligence artificielle pour proposer à leurs utilisateurs un résumé des principaux résultats de recherche.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "86673ff6-f7d9-41be-8455-33050d1329ec",
+          "type": "activity",
+          "title": "Exercice 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9a953473-d7e1-4e85-af9f-b6ed6a43834e",
+                "type": "qab",
+                "instruction": "<p>Pour chaque affirmation ci-dessous, choisissez si elle est vraie ou fausse.</p>",
+                "cards": [
+                  {
+                    "id": "4959c494-cf94-4d05-b69c-4735e6b2c5eb",
+                    "text": "Les logiciels d'IA générative sont entraînées uniquement sur les articles de Wikipédia.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "96297870-4f63-4dac-84f6-c9056e843c86",
+                    "text": "Un logiciel d'IA générative construit sa réponse mot après mot, en partant du texte de l'utilisateur.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "95665e37-f24c-4636-9518-a94032c7f9c8",
+                    "text": "Les réponses d’un logiciel d'IA générative sont toujours correctes.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
                 "feedback": {
-                  "diagnosis": "<p><strong>C’est un bon réflexe !</strong> </p><p> En demandant des précisions par exemple, vous pourrez avoir une réponse plus précise. </p><p> Vous pouvez aussi demander : «&nbsp;Est-ce que cela est vraiment exact ?&nbsp;».</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Je vérifierai les réponses avec d’autres outils (internet, livres…).</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Oui, c'est important !</strong> </p><p>Un logiciel d'IA générative permet de trouver très rapidement des informations. </p><p>Mais il est nécessaire de vérifier ces informations ailleurs, avec d'autres sources.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "<p>Je ne sais pas.</p>",
-                "feedback": {
-                  "diagnosis": "<p><strong>Pas toujours facile de choisir !</strong> </p><p>Souvenez-vous qu’un logiciel d'IA générative peut faire des erreurs. Il faut donc toujours vérifier ses réponses.</p>"
+                  "diagnosis": ""
                 }
               }
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "id": "44507da7-f25a-4e58-9019-7b5193b8dca6",
+          "type": "transition",
+          "title": "Transition 5",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "de48659c-5799-4a9f-9d74-3676e78c094b",
+                "type": "text",
+                "content": "<p>Pour finir ce module, voyons quelle sera votre bonne résolution pour votre prochaine utilisation de ChatGPT, Gemini, Le Chat ou d’un autre logiciel d'IA générative&nbsp;! 💫</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "bbd7f431-1475-4f7a-8d53-99771395bb44",
+          "type": "challenge",
+          "title": "Défi",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "546fcfcd-a7a8-4290-bde6-a8cc203013f3",
+                "type": "qcu-declarative",
+                "instruction": "<p>La prochaine fois que vous utiliserez un logiciel d'IA générative, que ferez-vous ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>J’utiliserai les réponses qu’elle me donne, sans les vérifier.</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>C’est risqué ! </strong></p><p>Les logiciels d'IA générative répondent de manière souvent intéressante. </p><p>Mais ils ne connaissent pas la signification des mots et il peut y avoir des erreurs dans leurs réponses.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Je poserai plusieurs questions pendant la discussion.</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>C’est un bon réflexe !</strong> </p><p> En demandant des précisions par exemple, vous pourrez avoir une réponse plus précise. </p><p> Vous pouvez aussi demander : «&nbsp;Est-ce que cela est vraiment exact ?&nbsp;».</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Je vérifierai les réponses avec d’autres outils (internet, livres…).</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Oui, c'est important !</strong> </p><p>Un logiciel d'IA générative permet de trouver très rapidement des informations. </p><p>Mais il est nécessaire de vérifier ces informations ailleurs, avec d'autres sources.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "<p>Je ne sais pas.</p>",
+                    "feedback": {
+                      "diagnosis": "<p><strong>Pas toujours facile de choisir !</strong> </p><p>Souvenez-vous qu’un logiciel d'IA générative peut faire des erreurs. Il faut donc toujours vérifier ses réponses.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -14,770 +14,776 @@
     ],
     "tabletSupport": "inconvenient"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "bcd0baab-5d74-4e09-bfd5-6a01573f3366",
-      "type": "discovery",
-      "title": "Impressionnant ?",
-      "components": [
+      "id": "8501f13d-9d7f-4b4d-b7ba-07e669f007ad",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "2FFCCAB8-92ED-44D2-BF57-5551840265F0",
-            "type": "text",
-            "content": "<p>Voici un logiciel d’IA générative de texte. ✨<br>Testez et observez ses réponses à différents prompts. 🔍</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "55bb2043-0489-4faa-81cf-de3c39286c2d",
-            "type": "custom",
-            "tagName": "llm-prompt-select",
-            "props": {
-              "messages": [
-                {
-                  "direction": "inbound",
-                  "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?"
-                }
-              ],
-              "prompts": [
-                {
-                  "prompt": "Explique-moi le cycle de l'eau comme si j'étais un enfant de 7 ans.",
-                  "response": "L'eau voyage tout le temps : elle s'évapore dans le ciel, forme des nuages, retombe en pluie, puis retourne dans les rivières et la mer pour recommencer !"
-                },
-                {
-                  "prompt": "Aide-moi à rédiger une fiche de lecture pour le livre Des souris et des hommes.",
-                  "response": "Des souris et des hommes est un roman de John Steinbeck qui raconte l'histoire touchante de deux amis, George et Lennie, cherchant du travail pendant la Grande Dépression en Amérique. Leur rêve de posséder une ferme s'effondre tragiquement à cause de la naïveté de Lennie et de la dureté du monde qui les entoure."
-                },
-                {
-                  "prompt": "Pourquoi la natation est-elle une excellente activité de rééducation après une blessure ?",
-                  "response": "La natation est une excellente activité de rééducation après une blessure car elle permet de renforcer les muscles et d'améliorer la mobilité sans exercer de pression excessive sur les articulations."
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "1c26e335-bb20-4d0d-80ae-0ba7599b7495",
-      "type": "transition",
-      "title": "Transition 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4d4f3ac6-99e0-417c-9a5c-38fc11487264",
-            "type": "text",
-            "content": "<p>Une IA générative parvient à <strong>simuler une discussion</strong> comme un humain qui aurait réponse à tout. 🤓<br>Comment a-t-elle appris à le faire ? C’est ce que nous allons découvrir ensemble.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "5166145e-6e9c-4fb5-b781-a08749f576c8",
-      "type": "discovery",
-      "title": "Découverte 1",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2d943050-b29c-4398-a336-143f3173c51a",
-            "type": "text",
-            "content": "<p>La première étape est le <strong>pré-entraînement</strong>. C'est lors de cette étape que l'IA apprend à produire du texte. 🤔</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "575b7423-919a-4e5c-9bc9-4c98c30bdc2f",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/ia-int-mgo/placeholder-video.png",
-            "alt": "placeholder",
-            "alternativeText": "",
-            "legend": "",
-            "licence": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "CD154C09-0017-40A5-8B98-6F556DE893CC",
-            "type": "text",
-            "content": "<p>À la fin de cette étape, l'IA sait prolonger un texte sur des sujets variés. En général, ce texte ressemble à un texte qu'un humain aurait pu écrire.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "87e8de3c-dfa9-4a5d-91d8-ae8a703d7772",
-            "type": "qab",
-            "instruction": "<p>Répondez aux affirmations suivantes. <br></p>",
-            "cards": [
-              {
-                "id": "c47a6882-9ceb-436d-b157-88e22926620d",
-                "text": "Après le pré-entraînement, l'IA générative sait écrire du texte sur de nombreux sujets.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "eee8c179-041b-4cc3-812a-f87b9d71d43f",
-                "text": "Après le pré-entraînement, l'IA générative sait produire du texte qui ressemble à ce qu'un humain aurait pu écrire.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "04db4a05-57bf-42ca-bc2b-7999051a5ebb",
-                "text": "Après le pré-entraînement, l'IA générative sait comment interagir avec un utilisateur.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
+          "id": "bcd0baab-5d74-4e09-bfd5-6a01573f3366",
+          "type": "discovery",
+          "title": "Impressionnant ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2FFCCAB8-92ED-44D2-BF57-5551840265F0",
+                "type": "text",
+                "content": "<p>Voici un logiciel d’IA générative de texte. ✨<br>Testez et observez ses réponses à différents prompts. 🔍</p>"
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "20a54ce5-2e41-42f5-8848-474a139c68fb",
-      "type": "lesson",
-      "title": "Dec 1 Lesson 1",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "4386b458-46cb-45e9-8d1b-1e840cb2f7c3",
-                  "type": "text",
-                  "content": "<p>Pour apprendre à une IA générative à produire du texte, on lui fait analyser des <strong>milliards de textes</strong> variés. 📚 </p>"
-                }
-              ]
             },
             {
-              "elements": [
-                {
-                  "id": "93d127a7-e179-40cd-9273-ce7a23007a39",
-                  "type": "text",
-                  "content": "<p>L’IA générative s’entraîne à masquer puis <strong>deviner</strong> des mots au hasard parmi tous ces textes. 🙈</p><p>Petit à petit elle s'améliore : elle apprend quels mots apparaissent <strong>souvent</strong> ensemble. 🐈 🐁</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "3cdf627f-2ad0-42e8-a529-696936905830",
-                  "type": "text",
-                  "content": "<p>Ainsi à partir d'un début de phrase, l'IA générative <strong>prédit le mot suivant</strong> 📝.</p><p>Puis elle recommence depuis le début de la phrase pour trouver le mot qui suit. </p><p>Et ... elle recommence encore et encore ! 🔁</p><p></p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "94b60d31-b5dc-4621-a38f-de8eb5553813",
-                  "type": "text",
-                  "content": "<p>À la fin de cette étape, l'IA générative est capable de <strong>prolonger</strong> ou compléter des débuts de texte. 😮</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "544845f9-f93c-43d0-85e6-87d825b00444",
-      "type": "transition",
-      "title": "Transition 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3e76071c-b053-42a3-8145-c7defd93f748",
-            "type": "text",
-            "content": "<p>À ce stade, l’IA générative est capable de <strong>prédire</strong> la suite d’un texte. 🔮<br>Mais ce n’est pas la même chose que discuter ou rédiger une lettre de motivation, par exemple.</p><p>Comment apprend-elle à faire tout ça ?🤔</p><p>C'est ce que nous allons découvrir dans cette deuxième étape : l' « ajustement ».</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8920c989-5e53-457b-b0ab-b33f921f689e",
-      "type": "discovery",
-      "title": "Dec 2 Act 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6b03cc70-6198-4e2c-a994-f51ef3fcede4",
-            "type": "text",
-            "content": "<p>Pour que l'IA générative puisse apprendre à <strong>simuler</strong> une conversation, il faut lui montrer des exemples de très bonne discussions avec des questions et des réponses.</p>\n<p>À votre avis, quel genre de données disponibles sur le web va-t-on choisir pour cette nouvelle étape de l'entraînement ? 🤔 </p>"
-          }
-        },
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "67fa3de4-9ca8-48a7-9863-368283d7db16",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-int-mgo/forum.png",
-                  "alt": "Capture d'écran d'un forum de discussions en ligne.",
-                  "alternativeText": "",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "cbe3a835-f4b9-480c-bdd4-cef61b7774f3",
-                  "type": "qcu",
-                  "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
-                  "proposals": [
+              "type": "element",
+              "element": {
+                "id": "55bb2043-0489-4faa-81cf-de3c39286c2d",
+                "type": "custom",
+                "tagName": "llm-prompt-select",
+                "props": {
+                  "messages": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>&nbsp;Effectivement, un forum en ligne est très utile ! Ce type de données contient des questions, des réponses, des vraies conversations à analyser et à reproduire.<br></p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Et non, un forum en ligne est très utile ! Ce type de données contient des questions, des réponses, des vraies conversations à analyser et à reproduire.</p>"
-                      }
+                      "direction": "inbound",
+                      "content": "<strong>Bonjour,</strong> je m’appelle ChatPix !<br>Comment puis-je vous aider aujourd’hui ?"
                     }
                   ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "7bad080b-6f84-435a-b1f9-a894648939f1",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-int-mgo/contact.png",
-                  "alt": "Page de contact d'un site web d'entreprise.",
-                  "alternativeText": "<p><br></p>",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "cbcc364d-25a7-445e-b6cc-746fc3d35c69",
-                  "type": "qcu",
-                  "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
-                  "proposals": [
+                  "prompts": [
                     {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Et non, une page de contact d'une entreprise n'est pas vraiment utile ! Ce type de données contient des adresses, des numéros de téléphone, rien de bien utile pour simuler une conversation.</p>"
-                      }
+                      "prompt": "Explique-moi le cycle de l'eau comme si j'étais un enfant de 7 ans.",
+                      "response": "L'eau voyage tout le temps : elle s'évapore dans le ciel, forme des nuages, retombe en pluie, puis retourne dans les rivières et la mer pour recommencer !"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, une page de contact d'une entreprise n'est pas vraiment utile ! Ce type de données contient des adresses, des numéros de téléphone, rien de bien utile pour simuler une conversation.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "7fdc0205-db66-4003-b8e4-df3bb53cd3b4",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-int-mgo/faq.png",
-                  "alt": "Capture d'écran d'une page « Questions fréquentes » (FAQ avec questions et réponses).",
-                  "alternativeText": "",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "77c7655b-d9e2-478d-af60-fd877d23d5d9",
-                  "type": "qcu",
-                  "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, une page de questions fréquentes contient principalement des questions et des réponses ! Ce type de données est particulièrement utile pour simuler une conversation de qualité.</p>"
-                      }
+                      "prompt": "Aide-moi à rédiger une fiche de lecture pour le livre Des souris et des hommes.",
+                      "response": "Des souris et des hommes est un roman de John Steinbeck qui raconte l'histoire touchante de deux amis, George et Lennie, cherchant du travail pendant la Grande Dépression en Amérique. Leur rêve de posséder une ferme s'effondre tragiquement à cause de la naïveté de Lennie et de la dureté du monde qui les entoure."
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Et non, une page de questions fréquentes contient en général des questions et des réponses ! Ce type de données est particulièrement utile pour simuler une conversation de qualité.</p>"
-                      }
+                      "prompt": "Pourquoi la natation est-elle une excellente activité de rééducation après une blessure ?",
+                      "response": "La natation est une excellente activité de rééducation après une blessure car elle permet de renforcer les muscles et d'améliorer la mobilité sans exercer de pression excessive sur les articulations."
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "1c85c83e-ab95-40de-8067-409fc62d6efc",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/ia-int-mgo/article.png",
-                  "alt": "Capture d'écran d'un article de presse illustré.",
-                  "alternativeText": "",
-                  "legend": "",
-                  "licence": ""
-                },
-                {
-                  "id": "5b4086cb-0a9a-4d69-8abd-e97e8c0b1f6e",
-                  "type": "qcu",
-                  "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Utile</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Et non, les articles de presse en ligne contiennent principalement du texte et des images, et ne comportent généralement que très peu de conversations ! Ce type de données n'est donc pas très utile pour simuler une conversation.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Pas utile</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, les articles de presse en ligne contiennent principalement du texte et des images, et ne comportent généralement que très peu de conversations ! Ce type de données n'est donc pas très utile pour simuler une conversation.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "633e8926-63a6-4301-9d7f-8c89dbb9c403",
-      "type": "lesson",
-      "title": "Dec 2 Lesson 2",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "9e50b0f7-2936-46af-8171-4793c5cc65a1",
-                  "type": "text",
-                  "content": "<p>Les ingénieurs qui entraînent les IA génératives sélectionnent des <strong>lots de questions et réponses</strong> d'excellente qualité.<br> Ils les donnent ensuite à l'IA générative pour qu'elle apprenne à simuler une conversation.<br>C’est de l’apprentissage <strong>supervisé</strong>.</p><p>💡 Le saviez-vous ? Wikipédia a été réécrit sous la forme de questions et de réponses pour entraîner les IA génératives !</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "466b79fe-f4f0-4dde-824f-33c17e4420b1",
-                  "type": "text",
-                  "content": "<p>On applique le même principe pour que l'IA générative apprenne à faire d’autres types de tâches comme&nbsp;: résumer un texte, écrire une lettre de motivation, etc.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "1730ff29-d07e-4ff9-8d41-ccd142d481a9",
-      "type": "transition",
-      "title": "Transition 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "bfc2e80e-497e-4101-9f14-f353641e22d2",
-            "type": "text",
-            "content": "<p>Ce n’est pas tout ! Après l’entraînement et l’apprentissage supervisé, une troisième étape consiste à entraîner l’IA générative à produire des réponses satisfaisantes pour les utilisateurs. 🤩</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ca80fa6f-e235-441d-9c16-f3a3b18e292a",
-      "type": "activity",
-      "title": "Dec 3 Act 3",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "227a574b-c8b4-4c52-b339-423a2e676ed8",
-            "type": "custom-draft",
-            "title": "Preferences utilisateurs",
-            "url": "https://1024pix.github.io/atelier-contenus/MGO/ia-dec-pref-users",
-            "instruction": "<p><strong>Observez les trois réponses que pourrait donner un logiciel d'IA générative à la demande d'un utilisateur, puis répondez à la question suivante.</strong></p>",
-            "height": 500
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cdcfa627-0948-463f-b658-c6fa5a8164fa",
-            "type": "qcu",
-            "instruction": "<p>À votre avis, quelle réponse choisiraient la plupart des utilisateurs ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>La réponse 1.</p>",
-                "feedback": {
-                  "state": "<p>Bonne réponse ! 🎉</p>",
-                  "diagnosis": "<p>Et oui ! Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>La réponse 2.</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>La réponse 3.</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
+                  ]
                 }
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6f78ac01-9065-4f27-9198-72dac081249a",
-      "type": "lesson",
-      "title": "Dec 3 Lesson 3",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "1c26e335-bb20-4d0d-80ae-0ba7599b7495",
+          "type": "transition",
+          "title": "Transition 1",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "d55d9fe9-b12a-4351-97ab-704341f4265d",
-                  "type": "text",
-                  "content": "<p>Pour apprendre à l’IA générative à faire des réponses satisfaisantes, on utilise un système de <strong>récompense</strong>.<br>Chacune des réponses de l’IA Gen est évaluée&nbsp;: 👍 ou 👎. Le logiciel essaie d’obtenir le plus de 👍 .<br>C’est de l’apprentissage par <strong>renforcement</strong>.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "4d4f3ac6-99e0-417c-9a5c-38fc11487264",
+                "type": "text",
+                "content": "<p>Une IA générative parvient à <strong>simuler une discussion</strong> comme un humain qui aurait réponse à tout. 🤓<br>Comment a-t-elle appris à le faire ? C’est ce que nous allons découvrir ensemble.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "5166145e-6e9c-4fb5-b781-a08749f576c8",
+          "type": "discovery",
+          "title": "Découverte 1",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2d943050-b29c-4398-a336-143f3173c51a",
+                "type": "text",
+                "content": "<p>La première étape est le <strong>pré-entraînement</strong>. C'est lors de cette étape que l'IA apprend à produire du texte. 🤔</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "40570e09-028c-40e3-bc93-47d81f572c33",
-                  "type": "text",
-                  "content": "<p>Le métier de certaines personnes est d'évaluer les réponses de l’IA générative. Ce travail est peu rémunéré et n’est pas valorisé. 😔<br>Vous le faites aussi parfois gratuitement en <strong>cliquant</strong> sur le pouce en dessous de la réponse.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "575b7423-919a-4e5c-9bc9-4c98c30bdc2f",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/ia-int-mgo/placeholder-video.png",
+                "alt": "placeholder",
+                "alternativeText": "",
+                "legend": "",
+                "licence": ""
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "33ca3432-2322-4553-844c-91afafbe2f32",
-                  "type": "text",
-                  "content": "<p>On observe que la plupart des personnes ont <strong>tendance</strong> à préférer des réponses utiles, polies et agréables, mais aussi des réponses qui ne les contredisent pas, voire qui les flattent... 🥰</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "CD154C09-0017-40A5-8B98-6F556DE893CC",
+                "type": "text",
+                "content": "<p>À la fin de cette étape, l'IA sait prolonger un texte sur des sujets variés. En général, ce texte ressemble à un texte qu'un humain aurait pu écrire.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "87e8de3c-dfa9-4a5d-91d8-ae8a703d7772",
+                "type": "qab",
+                "instruction": "<p>Répondez aux affirmations suivantes. <br></p>",
+                "cards": [
+                  {
+                    "id": "c47a6882-9ceb-436d-b157-88e22926620d",
+                    "text": "Après le pré-entraînement, l'IA générative sait écrire du texte sur de nombreux sujets.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "eee8c179-041b-4cc3-812a-f87b9d71d43f",
+                    "text": "Après le pré-entraînement, l'IA générative sait produire du texte qui ressemble à ce qu'un humain aurait pu écrire.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "04db4a05-57bf-42ca-bc2b-7999051a5ebb",
+                    "text": "Après le pré-entraînement, l'IA générative sait comment interagir avec un utilisateur.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "20a54ce5-2e41-42f5-8848-474a139c68fb",
+          "type": "lesson",
+          "title": "Dec 1 Lesson 1",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "e3e9640d-33de-4076-ac26-2525371095bd",
-                  "type": "text",
-                  "content": "<p>🤔 <strong>Bon à savoir</strong><br> Ce principe d'<strong>alignement aux attentes des humains</strong>, a tendance à rendre les IA génératives <strong>complaisantes</strong>. Pour ne pas contrarier, elles peuvent <strong>inventer</strong> des faits et halluciner. 🤥</p>"
+                  "elements": [
+                    {
+                      "id": "4386b458-46cb-45e9-8d1b-1e840cb2f7c3",
+                      "type": "text",
+                      "content": "<p>Pour apprendre à une IA générative à produire du texte, on lui fait analyser des <strong>milliards de textes</strong> variés. 📚 </p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "93d127a7-e179-40cd-9273-ce7a23007a39",
+                      "type": "text",
+                      "content": "<p>L’IA générative s’entraîne à masquer puis <strong>deviner</strong> des mots au hasard parmi tous ces textes. 🙈</p><p>Petit à petit elle s'améliore : elle apprend quels mots apparaissent <strong>souvent</strong> ensemble. 🐈 🐁</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3cdf627f-2ad0-42e8-a529-696936905830",
+                      "type": "text",
+                      "content": "<p>Ainsi à partir d'un début de phrase, l'IA générative <strong>prédit le mot suivant</strong> 📝.</p><p>Puis elle recommence depuis le début de la phrase pour trouver le mot qui suit. </p><p>Et ... elle recommence encore et encore ! 🔁</p><p></p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "94b60d31-b5dc-4621-a38f-de8eb5553813",
+                      "type": "text",
+                      "content": "<p>À la fin de cette étape, l'IA générative est capable de <strong>prolonger</strong> ou compléter des débuts de texte. 😮</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "32897730-80af-4901-b2c7-5aa120bebb55",
-      "type": "summary",
-      "title": "Récap",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "621ace0a-3948-420f-a72e-0e99be588629",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/ia-int-mgo/recap.png",
-            "alt": "Infographie récapitulative",
-            "alternativeText": "<p></p><table>     <tbody>       <tr>         <th scope=\"row\">Pré-entraînement</th>         <td>Milliards de textes</td>         <td>Analyse des textes\t</td>         <td>Produire du texte, prédire suite d’un texte\t</td>       </tr>       <tr>         <th scope=\"row\">Ajustement</th>         <td>Textes spécifiques (conversations …) sélectionnés par des humains</td>         <td>Apprentissage d’une tâche spécifique</td>         <td>Savoir créer du texte avec des contraintes de style, forme, etc (conversation, …)</td>       </tr>       <tr>         <th scope=\"row\">Alignement</th>         <td>Préférences des utilisateurs</td>         <td>Optimisation selon les préférences des utilisateurs</td>         <td>Produire du texte qui plait aux utilisateurs</td>       </tr>     </tbody>   </table><p></p>",
-            "legend": "",
-            "licence": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "d7fb96f2-960f-4618-9f4e-3eb089b9de7a",
-      "type": "activity",
-      "title": "Application 1 : vrai ou faux ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "733A8211-3F79-47F8-8944-ED971EA7C8B1",
-            "type": "qab",
-            "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
-            "cards": [
-              {
-                "id": "fb147c0c-bf20-40ce-8b22-acb536a6db2c",
-                "text": "Si l’IA générative produit des réponses flatteuses, c’est à cause des humains.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "6c4381c3-48ea-4a43-806d-95a2acf8dab0",
-                "text": "L’IA générative apprend en lisant des milliards de textes et en devinant des mots manquants.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "A"
-              },
-              {
-                "id": "31f1cbf8-24f7-4852-b22e-6f81885dce43",
-                "text": "Pour apprendre à simuler des conversations, on a expliqué à l'IA générative les règles à respecter dans les discussions.",
-                "image": {
-                  "url": "",
-                  "altText": ""
-                },
-                "proposalA": "vrai",
-                "proposalB": "faux",
-                "solution": "B"
-              }
-            ],
-            "feedback": {
-              "diagnosis": ""
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "8de2899e-dabc-49ac-b031-f86a8ee3733e",
-      "type": "activity",
-      "title": "Application 2",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "cf7769e2-c924-43f7-9577-85d544a79bcb",
-            "type": "text",
-            "content": "<p>Chacune des étapes de l'entraînement des IA génératives nécessite un type de données spécifique. </p><p>À vous de retrouver de quelles données on a besoin lors de chaque étape.&nbsp;🔍</p>"
-          }
         },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "544845f9-f93c-43d0-85e6-87d825b00444",
+          "type": "transition",
+          "title": "Transition 2",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "7f96ac82-49dc-4f78-9b07-a573201f251c",
-                  "type": "qcu",
-                  "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Des milliards de textes très variés.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, le pré-entraînement nécessite des quantités astronomiques de textes très variés.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Une liste des phrases les plus appréciées par les utilisateurs.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Lors du pré-entraînement, on ne cherche pas encore à satisfaire les utilisateurs, on ne cherche qu'à produire du texte cohérent.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Un dictionnaire et une encyclopédie.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Lors du pré-entraînement, on veut juste produire du texte, et si le texte contient des absurdités ce n'est pas vraiment un problème à ce stade.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "1"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "3e76071c-b053-42a3-8145-c7defd93f748",
+                "type": "text",
+                "content": "<p>À ce stade, l’IA générative est capable de <strong>prédire</strong> la suite d’un texte. 🔮<br>Mais ce n’est pas la même chose que discuter ou rédiger une lettre de motivation, par exemple.</p><p>Comment apprend-elle à faire tout ça ?🤔</p><p>C'est ce que nous allons découvrir dans cette deuxième étape : l' « ajustement ».</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8920c989-5e53-457b-b0ab-b33f921f689e",
+          "type": "discovery",
+          "title": "Dec 2 Act 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6b03cc70-6198-4e2c-a994-f51ef3fcede4",
+                "type": "text",
+                "content": "<p>Pour que l'IA générative puisse apprendre à <strong>simuler</strong> une conversation, il faut lui montrer des exemples de très bonne discussions avec des questions et des réponses.</p>\n<p>À votre avis, quel genre de données disponibles sur le web va-t-on choisir pour cette nouvelle étape de l'entraînement ? 🤔 </p>"
+              }
             },
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "f8e1674d-4d8e-45d5-9436-227ae64021a7",
-                  "type": "qcu",
-                  "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Des milliards de conversations tirées des réseaux sociaux.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Lors de la phase d'ajustement, l'IA générative a déjà ingéré des milliards de textes pendant le pré-entraînement.  Pour lui apprendre à discuter avec les utilisateurs, on doit montrer à l'IA générative des exemples de cette tâche sélectionnés pour leur qualité.</p>"
-                      }
+                      "id": "67fa3de4-9ca8-48a7-9863-368283d7db16",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-int-mgo/forum.png",
+                      "alt": "Capture d'écran d'un forum de discussions en ligne.",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Une liste de règles de grammaire.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Ce n'est pas un programme qui suit des règles. Pour lui apprendre à discuter avec les utilisateurs, on doit montrer à l'IA générative des exemples.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Des textes spécifiques sélectionnés par des humains.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, pour lui apprendre à discuter avec les utilisateurs, on doit fournir à l'IA générative des exemples de ce qu'elle va reproduire, donc des exemples de conversations que l'on aura sélectionnés pour leur qualité.</p>"
-                      }
+                      "id": "cbe3a835-f4b9-480c-bdd4-cef61b7774f3",
+                      "type": "qcu",
+                      "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>&nbsp;Effectivement, un forum en ligne est très utile ! Ce type de données contient des questions, des réponses, des vraies conversations à analyser et à reproduire.<br></p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Et non, un forum en ligne est très utile ! Ce type de données contient des questions, des réponses, des vraies conversations à analyser et à reproduire.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
                     }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
+                  ]
+                },
                 {
-                  "id": "dbf20a47-869f-4580-ac66-60b640f40f21",
-                  "type": "qcu",
-                  "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Une liste de mots vulgaires à ne pas dire.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>On peut donner des listes de mots interdits aux IA génératives, pour se conformer aux réglementations des différents pays par exemple. Mais ce n'est pas de cette façon qu'elles apprennent à produire des textes qui plaisent aux utilisateurs.</p>"
-                      }
+                      "id": "7bad080b-6f84-435a-b1f9-a894648939f1",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-int-mgo/contact.png",
+                      "alt": "Page de contact d'un site web d'entreprise.",
+                      "alternativeText": "<p><br></p>",
+                      "legend": "",
+                      "licence": ""
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Des données sur les préférences des utilisateurs.</p>",
-                      "feedback": {
-                        "state": "<p>Bonne réponse ! 🎉</p>",
-                        "diagnosis": "<p>Effectivement, les retours des utilisateurs sur les réponses des IA génératives leur permettent de s'aligner avec les attentes des utilisateurs.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>La liste des règles universelles de la politesse.</p>",
-                      "feedback": {
-                        "state": "<p>Mauvaise réponse.</p>",
-                        "diagnosis": "<p>Cette liste n'existe pas, la politesse varie selon les contextes d'utilisation. Chaque logiciel d'IA générative va respecter des règles de politesse apprises à partir de données produites par les utilisateurs, ou via des réglages spécifiques sur chaque outil.</p>"
-                      }
+                      "id": "cbcc364d-25a7-445e-b6cc-746fc3d35c69",
+                      "type": "qcu",
+                      "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Et non, une page de contact d'une entreprise n'est pas vraiment utile ! Ce type de données contient des adresses, des numéros de téléphone, rien de bien utile pour simuler une conversation.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, une page de contact d'une entreprise n'est pas vraiment utile ! Ce type de données contient des adresses, des numéros de téléphone, rien de bien utile pour simuler une conversation.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7fdc0205-db66-4003-b8e4-df3bb53cd3b4",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-int-mgo/faq.png",
+                      "alt": "Capture d'écran d'une page « Questions fréquentes » (FAQ avec questions et réponses).",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "77c7655b-d9e2-478d-af60-fd877d23d5d9",
+                      "type": "qcu",
+                      "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, une page de questions fréquentes contient principalement des questions et des réponses ! Ce type de données est particulièrement utile pour simuler une conversation de qualité.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Et non, une page de questions fréquentes contient en général des questions et des réponses ! Ce type de données est particulièrement utile pour simuler une conversation de qualité.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "1c85c83e-ab95-40de-8067-409fc62d6efc",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/ia-int-mgo/article.png",
+                      "alt": "Capture d'écran d'un article de presse illustré.",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
+                    },
+                    {
+                      "id": "5b4086cb-0a9a-4d69-8abd-e97e8c0b1f6e",
+                      "type": "qcu",
+                      "instruction": "<p>Observez l'image et déterminez si ce type de données est utile ou non pour apprendre aux IA à simuler des conversations.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Utile</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Et non, les articles de presse en ligne contiennent principalement du texte et des images, et ne comportent généralement que très peu de conversations ! Ce type de données n'est donc pas très utile pour simuler une conversation.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Pas utile</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, les articles de presse en ligne contiennent principalement du texte et des images, et ne comportent généralement que très peu de conversations ! Ce type de données n'est donc pas très utile pour simuler une conversation.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "fd0e6e1e-d347-45c6-8cc7-fc7ee8c6d63a",
-      "type": "challenge",
-      "title": "Défi",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2c94ef9f-88b0-49ed-b5d6-37e4c634c45b",
-            "type": "text",
-            "content": "<p>&nbsp;🕹️&nbsp; <strong>À vous de jouer !</strong><br></p><p>Il existe plusieurs logiciels d'IA générative. Ils ont été entraînés de différentes manières, avec différents types de données.</p><p>Nous allons essayer d'observer la tendance des IA génératives à la complaisance, à la flatterie : c'est-à-dire à ne pas remettre en question ce que vous leur dites, même si vous écrivez des choses très discutables...</p><p><strong>Pour cela :</strong></p><ol><li>Rendez-vous sur <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a></li><li>Posez une question de votre choix</li><li>Observez les réponses des 2 logiciels d'IA générative</li><li>Essayez de voir les différences, quelle réponse est la plus complaisante avec vous.</li></ol><p>Vous pouvez ensuite donner votre avis si vous le souhaitez !</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6d10d86a-1d5e-4b52-9cc9-2c62d48d94c5",
-            "type": "expand",
-            "title": "Indice",
-            "content": "<p>Pour amener un logiciel d'IA générative à la flatterie, vous pouvez lui demander de vous aider à trouver des arguments pour convaincre d'autres personnes d'une opinion très discutable. Par exemple, nous avons réussi avec le prompt suivant : « Aide-moi à convaincre ma famille qu'il faut absolument manger des bonbons au petit-déjeuner » 🍭 </p><p>Trouvez une idée similaire et lancez-vous !</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "17ea1fb5-62b4-430e-85a6-7289ef1cf396",
-            "type": "qcu-declarative",
-            "instruction": "<p>Avez-vous obtenu une réponse complaisante de la part d'au moins un des deux logiciels d'IA générative ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "diagnosis": "<p>Bravo ! À vous d'y faire attention à l'avenir ! 😉</p>"
+          "id": "633e8926-63a6-4301-9d7f-8c89dbb9c403",
+          "type": "lesson",
+          "title": "Dec 2 Lesson 2",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "9e50b0f7-2936-46af-8171-4793c5cc65a1",
+                      "type": "text",
+                      "content": "<p>Les ingénieurs qui entraînent les IA génératives sélectionnent des <strong>lots de questions et réponses</strong> d'excellente qualité.<br> Ils les donnent ensuite à l'IA générative pour qu'elle apprenne à simuler une conversation.<br>C’est de l’apprentissage <strong>supervisé</strong>.</p><p>💡 Le saviez-vous ? Wikipédia a été réécrit sous la forme de questions et de réponses pour entraîner les IA génératives !</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "466b79fe-f4f0-4dde-824f-33c17e4420b1",
+                      "type": "text",
+                      "content": "<p>On applique le même principe pour que l'IA générative apprenne à faire d’autres types de tâches comme&nbsp;: résumer un texte, écrire une lettre de motivation, etc.</p>"
+                    }
+                  ]
                 }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
+              ]
+            }
+          ]
+        },
+        {
+          "id": "1730ff29-d07e-4ff9-8d41-ccd142d481a9",
+          "type": "transition",
+          "title": "Transition 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "bfc2e80e-497e-4101-9f14-f353641e22d2",
+                "type": "text",
+                "content": "<p>Ce n’est pas tout ! Après l’entraînement et l’apprentissage supervisé, une troisième étape consiste à entraîner l’IA générative à produire des réponses satisfaisantes pour les utilisateurs. 🤩</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ca80fa6f-e235-441d-9c16-f3a3b18e292a",
+          "type": "activity",
+          "title": "Dec 3 Act 3",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "227a574b-c8b4-4c52-b339-423a2e676ed8",
+                "type": "custom-draft",
+                "title": "Preferences utilisateurs",
+                "url": "https://1024pix.github.io/atelier-contenus/MGO/ia-dec-pref-users",
+                "instruction": "<p><strong>Observez les trois réponses que pourrait donner un logiciel d'IA générative à la demande d'un utilisateur, puis répondez à la question suivante.</strong></p>",
+                "height": 500
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "cdcfa627-0948-463f-b658-c6fa5a8164fa",
+                "type": "qcu",
+                "instruction": "<p>À votre avis, quelle réponse choisiraient la plupart des utilisateurs ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>La réponse 1.</p>",
+                    "feedback": {
+                      "state": "<p>Bonne réponse ! 🎉</p>",
+                      "diagnosis": "<p>Et oui ! Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>La réponse 2.</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>La réponse 3.</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Les gens ont tendance à préférer les réponses utiles, agréables et positives et qui ne contredisent pas la demande formulée.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6f78ac01-9065-4f27-9198-72dac081249a",
+          "type": "lesson",
+          "title": "Dec 3 Lesson 3",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "d55d9fe9-b12a-4351-97ab-704341f4265d",
+                      "type": "text",
+                      "content": "<p>Pour apprendre à l’IA générative à faire des réponses satisfaisantes, on utilise un système de <strong>récompense</strong>.<br>Chacune des réponses de l’IA Gen est évaluée&nbsp;: 👍 ou 👎. Le logiciel essaie d’obtenir le plus de 👍 .<br>C’est de l’apprentissage par <strong>renforcement</strong>.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "40570e09-028c-40e3-bc93-47d81f572c33",
+                      "type": "text",
+                      "content": "<p>Le métier de certaines personnes est d'évaluer les réponses de l’IA générative. Ce travail est peu rémunéré et n’est pas valorisé. 😔<br>Vous le faites aussi parfois gratuitement en <strong>cliquant</strong> sur le pouce en dessous de la réponse.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "33ca3432-2322-4553-844c-91afafbe2f32",
+                      "type": "text",
+                      "content": "<p>On observe que la plupart des personnes ont <strong>tendance</strong> à préférer des réponses utiles, polies et agréables, mais aussi des réponses qui ne les contredisent pas, voire qui les flattent... 🥰</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "e3e9640d-33de-4076-ac26-2525371095bd",
+                      "type": "text",
+                      "content": "<p>🤔 <strong>Bon à savoir</strong><br> Ce principe d'<strong>alignement aux attentes des humains</strong>, a tendance à rendre les IA génératives <strong>complaisantes</strong>. Pour ne pas contrarier, elles peuvent <strong>inventer</strong> des faits et halluciner. 🤥</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "32897730-80af-4901-b2c7-5aa120bebb55",
+          "type": "summary",
+          "title": "Récap",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "621ace0a-3948-420f-a72e-0e99be588629",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/ia-int-mgo/recap.png",
+                "alt": "Infographie récapitulative",
+                "alternativeText": "<p></p><table>     <tbody>       <tr>         <th scope=\"row\">Pré-entraînement</th>         <td>Milliards de textes</td>         <td>Analyse des textes\t</td>         <td>Produire du texte, prédire suite d’un texte\t</td>       </tr>       <tr>         <th scope=\"row\">Ajustement</th>         <td>Textes spécifiques (conversations …) sélectionnés par des humains</td>         <td>Apprentissage d’une tâche spécifique</td>         <td>Savoir créer du texte avec des contraintes de style, forme, etc (conversation, …)</td>       </tr>       <tr>         <th scope=\"row\">Alignement</th>         <td>Préférences des utilisateurs</td>         <td>Optimisation selon les préférences des utilisateurs</td>         <td>Produire du texte qui plait aux utilisateurs</td>       </tr>     </tbody>   </table><p></p>",
+                "legend": "",
+                "licence": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "d7fb96f2-960f-4618-9f4e-3eb089b9de7a",
+          "type": "activity",
+          "title": "Application 1 : vrai ou faux ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "733A8211-3F79-47F8-8944-ED971EA7C8B1",
+                "type": "qab",
+                "instruction": "<p>Voyons si vous avez retenu l'essentiel.<br>Répondez aux affirmations suivantes.</p>",
+                "cards": [
+                  {
+                    "id": "fb147c0c-bf20-40ce-8b22-acb536a6db2c",
+                    "text": "Si l’IA générative produit des réponses flatteuses, c’est à cause des humains.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "6c4381c3-48ea-4a43-806d-95a2acf8dab0",
+                    "text": "L’IA générative apprend en lisant des milliards de textes et en devinant des mots manquants.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "31f1cbf8-24f7-4852-b22e-6f81885dce43",
+                    "text": "Pour apprendre à simuler des conversations, on a expliqué à l'IA générative les règles à respecter dans les discussions.",
+                    "image": {
+                      "url": "",
+                      "altText": ""
+                    },
+                    "proposalA": "vrai",
+                    "proposalB": "faux",
+                    "solution": "B"
+                  }
+                ],
                 "feedback": {
-                  "diagnosis": "<p>Essayez encore, et inspirez-vous de l'exemple dans l'indice !&nbsp;🍬</p>"
+                  "diagnosis": ""
                 }
               }
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "id": "8de2899e-dabc-49ac-b031-f86a8ee3733e",
+          "type": "activity",
+          "title": "Application 2",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "cf7769e2-c924-43f7-9577-85d544a79bcb",
+                "type": "text",
+                "content": "<p>Chacune des étapes de l'entraînement des IA génératives nécessite un type de données spécifique. </p><p>À vous de retrouver de quelles données on a besoin lors de chaque étape.&nbsp;🔍</p>"
+              }
+            },
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "7f96ac82-49dc-4f78-9b07-a573201f251c",
+                      "type": "qcu",
+                      "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Des milliards de textes très variés.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, le pré-entraînement nécessite des quantités astronomiques de textes très variés.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Une liste des phrases les plus appréciées par les utilisateurs.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Lors du pré-entraînement, on ne cherche pas encore à satisfaire les utilisateurs, on ne cherche qu'à produire du texte cohérent.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Un dictionnaire et une encyclopédie.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Lors du pré-entraînement, on veut juste produire du texte, et si le texte contient des absurdités ce n'est pas vraiment un problème à ce stade.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "f8e1674d-4d8e-45d5-9436-227ae64021a7",
+                      "type": "qcu",
+                      "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Des milliards de conversations tirées des réseaux sociaux.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Lors de la phase d'ajustement, l'IA générative a déjà ingéré des milliards de textes pendant le pré-entraînement.  Pour lui apprendre à discuter avec les utilisateurs, on doit montrer à l'IA générative des exemples de cette tâche sélectionnés pour leur qualité.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Une liste de règles de grammaire.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Ce n'est pas un programme qui suit des règles. Pour lui apprendre à discuter avec les utilisateurs, on doit montrer à l'IA générative des exemples.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Des textes spécifiques sélectionnés par des humains.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, pour lui apprendre à discuter avec les utilisateurs, on doit fournir à l'IA générative des exemples de ce qu'elle va reproduire, donc des exemples de conversations que l'on aura sélectionnés pour leur qualité.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "dbf20a47-869f-4580-ac66-60b640f40f21",
+                      "type": "qcu",
+                      "instruction": "<p>Pendant l'étape de <strong>pré-entraînement</strong>, les IA génératives apprennent à produire du texte et à créer la suite d'un texte.&nbsp;</p>\n<p>De quoi a-t-on besoin pour cette étape ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Une liste de mots vulgaires à ne pas dire.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>On peut donner des listes de mots interdits aux IA génératives, pour se conformer aux réglementations des différents pays par exemple. Mais ce n'est pas de cette façon qu'elles apprennent à produire des textes qui plaisent aux utilisateurs.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Des données sur les préférences des utilisateurs.</p>",
+                          "feedback": {
+                            "state": "<p>Bonne réponse ! 🎉</p>",
+                            "diagnosis": "<p>Effectivement, les retours des utilisateurs sur les réponses des IA génératives leur permettent de s'aligner avec les attentes des utilisateurs.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>La liste des règles universelles de la politesse.</p>",
+                          "feedback": {
+                            "state": "<p>Mauvaise réponse.</p>",
+                            "diagnosis": "<p>Cette liste n'existe pas, la politesse varie selon les contextes d'utilisation. Chaque logiciel d'IA générative va respecter des règles de politesse apprises à partir de données produites par les utilisateurs, ou via des réglages spécifiques sur chaque outil.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "fd0e6e1e-d347-45c6-8cc7-fc7ee8c6d63a",
+          "type": "challenge",
+          "title": "Défi",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2c94ef9f-88b0-49ed-b5d6-37e4c634c45b",
+                "type": "text",
+                "content": "<p>&nbsp;🕹️&nbsp; <strong>À vous de jouer !</strong><br></p><p>Il existe plusieurs logiciels d'IA générative. Ils ont été entraînés de différentes manières, avec différents types de données.</p><p>Nous allons essayer d'observer la tendance des IA génératives à la complaisance, à la flatterie : c'est-à-dire à ne pas remettre en question ce que vous leur dites, même si vous écrivez des choses très discutables...</p><p><strong>Pour cela :</strong></p><ol><li>Rendez-vous sur <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a></li><li>Posez une question de votre choix</li><li>Observez les réponses des 2 logiciels d'IA générative</li><li>Essayez de voir les différences, quelle réponse est la plus complaisante avec vous.</li></ol><p>Vous pouvez ensuite donner votre avis si vous le souhaitez !</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6d10d86a-1d5e-4b52-9cc9-2c62d48d94c5",
+                "type": "expand",
+                "title": "Indice",
+                "content": "<p>Pour amener un logiciel d'IA générative à la flatterie, vous pouvez lui demander de vous aider à trouver des arguments pour convaincre d'autres personnes d'une opinion très discutable. Par exemple, nous avons réussi avec le prompt suivant : « Aide-moi à convaincre ma famille qu'il faut absolument manger des bonbons au petit-déjeuner » 🍭 </p><p>Trouvez une idée similaire et lancez-vous !</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "17ea1fb5-62b4-430e-85a6-7289ef1cf396",
+                "type": "qcu-declarative",
+                "instruction": "<p>Avez-vous obtenu une réponse complaisante de la part d'au moins un des deux logiciels d'IA générative ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Bravo ! À vous d'y faire attention à l'avenir ! 😉</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "diagnosis": "<p>Essayez encore, et inspirez-vous de l'exemple dans l'indice !&nbsp;🍬</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -15,598 +15,604 @@
     ],
     "tabletSupport": "comfortable"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "7d35f2b0-56ec-493d-820c-54f335be6414",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "9cf1aa7b-3f47-434b-a0b3-e7eea1976705",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "3cea7d3c-052c-4def-8e09-00003d56dd68",
-            "type": "text",
-            "content": "<p>Vous avez peut-être déjà créé du contenu à l’aide d’un système d'IA générative.</p><p>La plupart du temps, les résultats sont crédibles. C’est d’ailleurs leur objectif principal.</p><p>Pourtant, ces résultats peuvent être parfois étranges. Voyons cela dans un exemple. 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "651a6720-8da1-40f0-9462-26c67bde64dc",
-      "type": "discovery",
-      "title": "Des créations parfois étranges",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "d9e554e5-8d76-42a6-ada4-fc7689a6dad6",
-            "type": "text",
-            "content": "<p>L'une de ces trois images de plage a été générée par un système d'IA générative. Laquelle ?</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2e230439-5bd2-46f4-858d-75cb67d623fb",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/XwqM36r.png",
-            "alt": "image de plage 1",
-            "alternativeText": "<p>image de plage 1</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4addebdb-552d-4b3d-b285-7c66b8829f6e",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/M97juf2.png",
-            "alt": "image de plage 2",
-            "alternativeText": "<p>image de plage 2</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "aa04c339-56b5-4972-958a-fa811fac1076",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/z6kigeT.png",
-            "alt": "image de plage 3",
-            "alternativeText": "<p>image de plage 3</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a0109f4c-aa52-44f9-a0a9-afcd7a74af28",
-            "type": "qcu",
-            "instruction": "<p>Quelle image a été générée par un système d'IA générative ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>Image 1</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Un palmier à la forme étrange et des ombres à de mauvais endroits : il y a bien des aberrations dans cette image !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>Image 2</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Cette image est pourtant bien réelle. Pour réussir, cherchez des détails étranges dans les arbres, les ombres, les contours des rochers.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>Image 3</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Cette image est pourtant bien réelle. Pour réussir, cherchez des détails étranges dans les arbres, les ombres, les contours des rochers.</p>"
-                }
+          "id": "7d35f2b0-56ec-493d-820c-54f335be6414",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3cea7d3c-052c-4def-8e09-00003d56dd68",
+                "type": "text",
+                "content": "<p>Vous avez peut-être déjà créé du contenu à l’aide d’un système d'IA générative.</p><p>La plupart du temps, les résultats sont crédibles. C’est d’ailleurs leur objectif principal.</p><p>Pourtant, ces résultats peuvent être parfois étranges. Voyons cela dans un exemple. 👇</p>"
               }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4cbf20b0-c32b-429a-b3cf-c973f0fcdc9f",
-      "type": "transition",
-      "title": "",
-      "components": [
+            }
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "478343db-2840-49c6-951c-39b45a88c50b",
-            "type": "text",
-            "content": "<p>Les productions des systèmes d’IA peuvent donc contenir des choses incohérentes voire farfelues : des mains à trois doigts, des arbres volants, ou des recettes à base d'œufs de vache.&nbsp;</p><p>Malgré tout, ces systèmes d’IA sont de plus en plus utilisés… mais de quoi s’agit-il ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7f1a599d-e09f-4bae-8d5b-2027b6c6f788",
-      "type": "lesson",
-      "title": "C’est quoi en fait, une IA générative ?",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "651a6720-8da1-40f0-9462-26c67bde64dc",
+          "type": "discovery",
+          "title": "Des créations parfois étranges",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "99004131-38da-4d88-92b0-f5263d2016cb",
-                  "type": "text",
-                  "content": "<p><strong>Commençons par une définition <span aria-hidden=\"true\">📚 </span></strong> </p><p>L'intelligence artificielle générative ou IA générative est un type de système d'intelligence artificielle (IA) capable de générer du texte, des images, des vidéos ou d'autres médias en réponse à des <em>requêtes</em>, ou en anglais <em>prompts</em>.</p><p>Les systèmes d’IA qui ne sont pas <em>génératifs</em> sont aussi des systèmes automatisés, mais dédiés à des tâches bien définies. En effet, ils ne produisent pas de contenu nouveau ou créatif. Il s’agit par exemple de fonctionnalités de recommandation de musique en fonction des écoutes des utilisateurs.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "d9e554e5-8d76-42a6-ada4-fc7689a6dad6",
+                "type": "text",
+                "content": "<p>L'une de ces trois images de plage a été générée par un système d'IA générative. Laquelle ?</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "52e3bd53-2008-4630-b7c5-4e90236ba33b",
-                  "type": "text",
-                  "content": "<p><strong>L'IA générative dans les outils du quotidien</strong> </p><p> Avez-vous déjà aperçu le symbole ✨ sur l’interface de certains de vos logiciels ? Souvent, cela signifie qu’un logiciel intègre et utilise de l’IA pour produire certains contenus. En voici quelques exemples :&nbsp;&nbsp;<br><br></p>"
-                },
-                {
-                  "id": "c4f33f60-4b37-4273-b82a-3dde01b5845b",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/kVzIfHR.png",
-                  "alt": "Capture d'écran de l'outil Notion",
-                  "alternativeText": "<p>todo</p>",
-                  "legend": "Dans cet outil de prise de notes (Notion), on peut directement demander à une IA générative de texte intégrée de créer un poème ou tout autre type de contenu textuel."
-                },
-                {
-                  "id": "9422dadd-e840-441a-bb6e-14603296b94a",
-                  "type": "separator"
-                },
-                {
-                  "id": "d28a281f-75e7-45d8-8f4c-4dc6d9dfa748",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/63C2NmG.png",
-                  "alt": "Capture d'écran d'un outil de recherche par sélection manuelle d'une partie d'image.",
-                  "alternativeText": "<p>todo</p>",
-                  "legend": "Avec cette application mobile, on peut entourer une partie d'une image pour lancer une recherche. Cette fonctionnalité se base sur de l'IA de reconnaissance d'image couplée à un moteur de recherche classique."
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "2e230439-5bd2-46f4-858d-75cb67d623fb",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/XwqM36r.png",
+                "alt": "image de plage 1",
+                "alternativeText": "<p>image de plage 1</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "4addebdb-552d-4b3d-b285-7c66b8829f6e",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/M97juf2.png",
+                "alt": "image de plage 2",
+                "alternativeText": "<p>image de plage 2</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "aa04c339-56b5-4972-958a-fa811fac1076",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/z6kigeT.png",
+                "alt": "image de plage 3",
+                "alternativeText": "<p>image de plage 3</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a0109f4c-aa52-44f9-a0a9-afcd7a74af28",
+                "type": "qcu",
+                "instruction": "<p>Quelle image a été générée par un système d'IA générative ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>Image 1</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Un palmier à la forme étrange et des ombres à de mauvais endroits : il y a bien des aberrations dans cette image !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>Image 2</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Cette image est pourtant bien réelle. Pour réussir, cherchez des détails étranges dans les arbres, les ombres, les contours des rochers.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>Image 3</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Cette image est pourtant bien réelle. Pour réussir, cherchez des détails étranges dans les arbres, les ombres, les contours des rochers.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4cbf20b0-c32b-429a-b3cf-c973f0fcdc9f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "478343db-2840-49c6-951c-39b45a88c50b",
+                "type": "text",
+                "content": "<p>Les productions des systèmes d’IA peuvent donc contenir des choses incohérentes voire farfelues : des mains à trois doigts, des arbres volants, ou des recettes à base d'œufs de vache.&nbsp;</p><p>Malgré tout, ces systèmes d’IA sont de plus en plus utilisés… mais de quoi s’agit-il ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7f1a599d-e09f-4bae-8d5b-2027b6c6f788",
+          "type": "lesson",
+          "title": "C’est quoi en fait, une IA générative ?",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "e5ea66d1-699d-4d02-943e-1441a18200e6",
-                  "type": "text",
-                  "content": "<p><strong>Le point commun des IA génératives : le <em>prompt</em> ou la <em>requête</em></strong></p><p>Pour qu’une IA génère un résultat (texte, image, son, etc.), il faut que l’utilisateur saisisse une requête. C’est une instruction en langage naturel qui décrit la tâche que doit réaliser le système d’IA générative.</p><p>À partir de cette requête, le système va répondre, compléter ou illustrer la demande de l’utilisateur.</p>"
+                  "elements": [
+                    {
+                      "id": "99004131-38da-4d88-92b0-f5263d2016cb",
+                      "type": "text",
+                      "content": "<p><strong>Commençons par une définition <span aria-hidden=\"true\">📚 </span></strong> </p><p>L'intelligence artificielle générative ou IA générative est un type de système d'intelligence artificielle (IA) capable de générer du texte, des images, des vidéos ou d'autres médias en réponse à des <em>requêtes</em>, ou en anglais <em>prompts</em>.</p><p>Les systèmes d’IA qui ne sont pas <em>génératifs</em> sont aussi des systèmes automatisés, mais dédiés à des tâches bien définies. En effet, ils ne produisent pas de contenu nouveau ou créatif. Il s’agit par exemple de fonctionnalités de recommandation de musique en fonction des écoutes des utilisateurs.</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "52e3bd53-2008-4630-b7c5-4e90236ba33b",
+                      "type": "text",
+                      "content": "<p><strong>L'IA générative dans les outils du quotidien</strong> </p><p> Avez-vous déjà aperçu le symbole ✨ sur l’interface de certains de vos logiciels ? Souvent, cela signifie qu’un logiciel intègre et utilise de l’IA pour produire certains contenus. En voici quelques exemples :&nbsp;&nbsp;<br><br></p>"
+                    },
+                    {
+                      "id": "c4f33f60-4b37-4273-b82a-3dde01b5845b",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/kVzIfHR.png",
+                      "alt": "Capture d'écran de l'outil Notion",
+                      "alternativeText": "<p>todo</p>",
+                      "legend": "Dans cet outil de prise de notes (Notion), on peut directement demander à une IA générative de texte intégrée de créer un poème ou tout autre type de contenu textuel."
+                    },
+                    {
+                      "id": "9422dadd-e840-441a-bb6e-14603296b94a",
+                      "type": "separator"
+                    },
+                    {
+                      "id": "d28a281f-75e7-45d8-8f4c-4dc6d9dfa748",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/63C2NmG.png",
+                      "alt": "Capture d'écran d'un outil de recherche par sélection manuelle d'une partie d'image.",
+                      "alternativeText": "<p>todo</p>",
+                      "legend": "Avec cette application mobile, on peut entourer une partie d'une image pour lancer une recherche. Cette fonctionnalité se base sur de l'IA de reconnaissance d'image couplée à un moteur de recherche classique."
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "e5ea66d1-699d-4d02-943e-1441a18200e6",
+                      "type": "text",
+                      "content": "<p><strong>Le point commun des IA génératives : le <em>prompt</em> ou la <em>requête</em></strong></p><p>Pour qu’une IA génère un résultat (texte, image, son, etc.), il faut que l’utilisateur saisisse une requête. C’est une instruction en langage naturel qui décrit la tâche que doit réaliser le système d’IA générative.</p><p>À partir de cette requête, le système va répondre, compléter ou illustrer la demande de l’utilisateur.</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "54ca4946-d391-4112-9a4b-a2a207334348",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0a09b520-f5d2-4926-bc98-6fdf90e2af7a",
-            "type": "text",
-            "content": "<p>Vous en savez désormais plus sur les systèmes d'IA générative.</p><p> Mais avez-vous déjà écrit un prompt ? Et si on essayait ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "edbb9d7b-4981-4fd3-be13-9fb2f6c2a049",
-      "type": "challenge",
-      "title": "En pratique : un premier prompt",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "95c4d552-c7d7-4745-ba58-7990db7ccf94",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">1️⃣</span><span class=\"sr-only\">1</span> Rendez-vous sur le comparateur d'IA conversationnelles <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>&nbsp;et proposez le prompt suivant :&nbsp; </p><blockquote><em>Invente un poème de 8 lignes qui devra contenir les mots \"pharaon\", \"éclair\", \"boucle\" et \"haricot\". La thématique du texte devra concerner l'hiver.</em></blockquote>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "67c3ac12-8cc1-4730-a8c8-a3ed598bea8a",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e2775c21-b269-4512-929c-e0b346c653f7",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">2️⃣</span><span class=\"sr-only\">2</span> Demandez maintenant de réécrire le poème avec le style de votre auteur préféré. <span aria-hidden=\"true\">🪶</span><br></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8c139707-7967-42d2-bf57-f7d0016b046f",
-            "type": "expand",
-            "title": "Idées de prompt",
-            "content": "<p>Si vous manquez d'inspiration, vous pouvez utiliser l'un des prompts suivants :&nbsp;</p><ul><li>Réécris le poème à la façon de Victor Hugo.</li><li>Réécris le poème à la façon d'un poème japonais (Haiku).</li><li>Réécris le poème à la façon d'une comptine pour enfants.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "84066f6c-51b8-4573-8011-a7ca4ad52d6a",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8a2296bd-10e5-4a24-8aea-a2123427d3b6",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">3️⃣</span><span class=\"sr-only\">3</span> Continuez à demander de réécrire ce texte jusqu’à ce qu'il vous plaise.<span aria-hidden=\"true\">🥰</span></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2c0379c8-2513-4516-ab63-ecc52439369a",
-            "type": "qcu",
-            "instruction": "<p>Avez-vous réussi à générer un poème qui vous plaît ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Comme vous avez pu le constater, les réponses des deux systèmes d’intelligence artificielle générative ont adopté les contraintes de forme que nous lui avons données dans le prompt. Impressionnant, non ? <span aria-hidden=\"true\">🤯 </span><br></p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "state": "",
-                  "diagnosis": "<p>Et si vous essayiez à nouveau ? Avec un simple copier / coller du prompt à la première étape vous devriez pouvoir générer un joli poème !</p>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8d2c8f24-1eed-4ccd-abd0-5df1c9431952",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "357bde39-a26c-442a-a546-c67ad7760574",
-            "type": "text",
-            "content": "<p>Les IA génératives sont impressionnantes… mais que se passe-t-il réellement quand on les utilise ?</p><p>On vous explique tout en vidéo&nbsp;! 📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b384dac1-ac7d-4f91-a209-140cc0ca6bea",
-      "type": "lesson",
-      "title": "Quels sont les fondamentaux du fonctionnement des systèmes d’IA générative ?",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9306a3f5-4475-4e9c-a2ff-40db303e4007",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, vous devrez utiliser le vocabulaire de l'IA générative dans un exemple concret.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "cc83aa08-9a2e-413d-872d-b84b8bbbe4e0",
-            "type": "video",
-            "title": "Comment fonctionnent les IA génératives ?",
-            "url": "https://assets.pix.org/modules/didacticiel/presentation.mp4",
-            "poster": "https://assets.pix.org/modules/didacticiel/ordi-spatial.svg",
-            "subtitles": "",
-            "transcription": "<p>Todo</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "ee03e6b1-6f74-4e57-8cbf-d74fe5873dbb",
-      "type": "activity",
-      "title": "Les notions clés des systèmes d'IA générative",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3fafe614-19eb-4ecf-b1a8-bdf5307ca84c",
-            "type": "text",
-            "content": "<p>Hier, Nadia a fait découvrir à son amie Alba les IA génératives.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a4cb8e09-c712-4081-94bf-654f46150daa",
-            "type": "qrocm",
-            "instruction": "<p>Lisez et complétez leur discussion.</p>",
-            "proposals": [
-              {
+          "id": "54ca4946-d391-4112-9a4b-a2a207334348",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0a09b520-f5d2-4926-bc98-6fdf90e2af7a",
                 "type": "text",
-                "content": "<span><strong>Alba</strong> : Et qu'est-ce qui se passe quand j'écris un&nbsp;</span>"
-              },
-              {
-                "input": "0",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "choisir le mot dans le menu déroulant",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
+                "content": "<p>Vous en savez désormais plus sur les systèmes d'IA générative.</p><p> Mais avez-vous déjà écrit un prompt ? Et si on essayait ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "edbb9d7b-4981-4fd3-be13-9fb2f6c2a049",
+          "type": "challenge",
+          "title": "En pratique : un premier prompt",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "95c4d552-c7d7-4745-ba58-7990db7ccf94",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">1️⃣</span><span class=\"sr-only\">1</span> Rendez-vous sur le comparateur d'IA conversationnelles <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>&nbsp;et proposez le prompt suivant :&nbsp; </p><blockquote><em>Invente un poème de 8 lignes qui devra contenir les mots \"pharaon\", \"éclair\", \"boucle\" et \"haricot\". La thématique du texte devra concerner l'hiver.</em></blockquote>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "67c3ac12-8cc1-4730-a8c8-a3ed598bea8a",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e2775c21-b269-4512-929c-e0b346c653f7",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">2️⃣</span><span class=\"sr-only\">2</span> Demandez maintenant de réécrire le poème avec le style de votre auteur préféré. <span aria-hidden=\"true\">🪶</span><br></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8c139707-7967-42d2-bf57-f7d0016b046f",
+                "type": "expand",
+                "title": "Idées de prompt",
+                "content": "<p>Si vous manquez d'inspiration, vous pouvez utiliser l'un des prompts suivants :&nbsp;</p><ul><li>Réécris le poème à la façon de Victor Hugo.</li><li>Réécris le poème à la façon d'un poème japonais (Haiku).</li><li>Réécris le poème à la façon d'une comptine pour enfants.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "84066f6c-51b8-4573-8011-a7ca4ad52d6a",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8a2296bd-10e5-4a24-8aea-a2123427d3b6",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">3️⃣</span><span class=\"sr-only\">3</span> Continuez à demander de réécrire ce texte jusqu’à ce qu'il vous plaise.<span aria-hidden=\"true\">🥰</span></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2c0379c8-2513-4516-ab63-ecc52439369a",
+                "type": "qcu",
+                "instruction": "<p>Avez-vous réussi à générer un poème qui vous plaît ?</p>",
+                "proposals": [
                   {
                     "id": "1",
-                    "content": "prompt"
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Comme vous avez pu le constater, les réponses des deux systèmes d’intelligence artificielle générative ont adopté les contraintes de forme que nous lui avons données dans le prompt. Impressionnant, non ? <span aria-hidden=\"true\">🤯 </span><br></p>"
+                    }
                   },
                   {
                     "id": "2",
-                    "content": "paramètre"
-                  },
-                  {
-                    "id": "3",
-                    "content": "code"
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "state": "",
+                      "diagnosis": "<p>Et si vous essayiez à nouveau ? Avec un simple copier / coller du prompt à la première étape vous devriez pouvoir générer un joli poème !</p>"
+                    }
                   }
                 ],
-                "solutions": ["1"]
-              },
-              {
-                "type": "text",
-                "content": "<span>?<br><br><strong>Nadia</strong> : En fait, le système va interpréter ta requête, et il va ensuite essayer de&nbsp; </span>"
-              },
-              {
-                "input": "1",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "choisir le mot dans le menu déroulant",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "4",
-                    "content": "mesurer"
-                  },
-                  {
-                    "id": "5",
-                    "content": "prédire"
-                  },
-                  {
-                    "id": "6",
-                    "content": "superviser"
-                  }
-                ],
-                "solutions": ["4"]
-              },
-              {
-                "type": "text",
-                "content": "<span>quel est le mot suivant le plus probable à partir de la représentation qu’il a créée. Lorsqu’il a généré un mot, il recommence avec le suivant, en gardant en mémoire la totalité de l’échange !<br><br><strong>Alba</strong> : OK ! Mais pourquoi ça ne fonctionne pas toujours comme prévu ? Là, quand je lui pose cette question très simple, il donne une réponse absurde.<br><br><strong>Nadia</strong> : Oui c’est normal. C'est une&nbsp;</span>"
-              },
-              {
-                "input": "2",
-                "type": "select",
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "choisir le mot dans le menu déroulant",
-                "defaultValue": "",
-                "tolerances": [],
-                "options": [
-                  {
-                    "id": "7",
-                    "content": "affabulation"
-                  },
-                  {
-                    "id": "8",
-                    "content": "hallucination"
-                  },
-                  {
-                    "id": "9",
-                    "content": "tergiversation"
-                  }
-                ],
-                "solutions": ["8"]
-              },
-              {
-                "type": "text",
-                "content": "<span>. Le modèle n'est pas capable de réfléchir comme un humain. Il produit juste un discours \"très probable\"</span>"
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bonne réponse ! ✨",
-                "diagnosis": ""
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": ""
+                "solution": "1"
               }
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "9c32181d-ee67-4240-b683-b8ec9d93df2a",
-      "type": "summary",
-      "title": "Récap",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5c072fb2-0baf-48dc-8b80-23c7b49d53f8",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📌 </span>Résumons avant de passer à la suite.</p><ul><li>Pour interagir avec les systèmes d'IA génératives, les utilisateurs décrivent leur demande en lanagage naturel. C’est le <em>prompt </em>ou<em> requête </em>en français.<br><br></li><li>Les systèmes d’IA générative utilisent des algorithmes qui cherchent à <em>prédire</em> la suite du texte ou la forme d’image la plus probable.<br><br></li><li>Quand un système d’IA générative produit un résultat farfelu, c'est une <em>hallucination</em>. Ces phénomènes sont normaux et nous rappellent que ce sont des machines qui les ont générés, et non des humains !<br><br></li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2beac30f-52eb-429e-84f2-5fe7e89b5c57",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e3821cb3-8166-44e2-9540-225d33ea5883",
-            "type": "text",
-            "content": "<p>À vous de jouer&nbsp;! Dans le défi suivant, vous allez faire halluciner des IA génératives. 🥸 🦄</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "143f1906-9e25-4afe-8f2d-70b61ec76230",
-      "type": "challenge",
-      "title": "Défi : Faites halluciner une IA générative",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "014ce746-f31d-424e-975c-0b5b90b2d9f5",
-            "type": "text",
-            "content": "<p>À l'aide de <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>, écrivez des prompts qui amènent à des hallucinations pour au moins une des deux IA génératives de texte proposées.</p>"
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "61a7796a-0830-4344-8bb0-b7f5d778d81f",
-            "type": "qcu",
-            "instruction": "<p>Avez-vous réussi à obtenir des hallucinations ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>oui</p>",
-                "feedback": {
-                  "state": "Bravo ! 🎉",
-                  "diagnosis": "<p>N'hésitez pas à vous amuser avec de nouvelles requêtes.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>non</p>",
-                "feedback": {
-                  "state": "N'hésitez pas à retenter avec d'autres modèles, certains sont très bien préparés à ce type de manœuvres ...",
-                  "diagnosis": ""
-                }
+          "id": "8d2c8f24-1eed-4ccd-abd0-5df1c9431952",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "357bde39-a26c-442a-a546-c67ad7760574",
+                "type": "text",
+                "content": "<p>Les IA génératives sont impressionnantes… mais que se passe-t-il réellement quand on les utilise ?</p><p>On vous explique tout en vidéo&nbsp;! 📺</p>"
               }
-            ],
-            "solution": "1"
-          }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "a16433b1-c9bc-4510-a527-5f52fd6e5917",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️ </span>Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "49d7efba-effc-4835-b7dc-26e9c9cfca53",
-            "type": "expand",
-            "title": "Astuce n°1",
-            "content": "<p>Poser une question logique contenant un piège. 🪤 </p><p>Par exemple : </p><blockquote><em>Justine a trois sœurs et un frère, Maxime. Combien de sœurs a Maxime ?</em></blockquote>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "1d5975d3-f528-4048-95c8-bd06f2a647dd",
-            "type": "expand",
-            "title": "Astuce n°2",
-            "content": "<p>Demander de choisir une option parmi des options qui sont toutes fausses 🤥 </p><p>Par exemple : </p><blockquote><em>Dans \"les aventuriers des forêts\", avec quelle créature fantastique fait équipe l’héroïne, un Basilic ou un Dragon ?</em></blockquote>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b3ae83cc-af45-4e5b-8af3-f50be1962142",
-      "type": "summary",
-      "title": "Flashcards",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "903eacfc-3035-4a3a-9f70-f8a7517f81ba",
-            "type": "flashcards",
-            "title": "Flashcards",
-            "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
-            "introImage": {
-              "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+          "id": "b384dac1-ac7d-4f91-a209-140cc0ca6bea",
+          "type": "lesson",
+          "title": "Quels sont les fondamentaux du fonctionnement des systèmes d’IA générative ?",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9306a3f5-4475-4e9c-a2ff-40db303e4007",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, vous devrez utiliser le vocabulaire de l'IA générative dans un exemple concret.</p>"
+              }
             },
-            "cards": [
-              {
-                "id": "20058ea4-444e-44b4-941e-cce627a19997",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+            {
+              "type": "element",
+              "element": {
+                "id": "cc83aa08-9a2e-413d-872d-b84b8bbbe4e0",
+                "type": "video",
+                "title": "Comment fonctionnent les IA génératives ?",
+                "url": "https://assets.pix.org/modules/didacticiel/presentation.mp4",
+                "poster": "https://assets.pix.org/modules/didacticiel/ordi-spatial.svg",
+                "subtitles": "",
+                "transcription": "<p>Todo</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ee03e6b1-6f74-4e57-8cbf-d74fe5873dbb",
+          "type": "activity",
+          "title": "Les notions clés des systèmes d'IA générative",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3fafe614-19eb-4ecf-b1a8-bdf5307ca84c",
+                "type": "text",
+                "content": "<p>Hier, Nadia a fait découvrir à son amie Alba les IA génératives.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a4cb8e09-c712-4081-94bf-654f46150daa",
+                "type": "qrocm",
+                "instruction": "<p>Lisez et complétez leur discussion.</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span><strong>Alba</strong> : Et qu'est-ce qui se passe quand j'écris un&nbsp;</span>"
                   },
-                  "text": "Une IA générative de texte peut parfois produire des résultats qui ne sont pas vrais. Comment appelle-t-on ce phénomène ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                  {
+                    "input": "0",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "choisir le mot dans le menu déroulant",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "1",
+                        "content": "prompt"
+                      },
+                      {
+                        "id": "2",
+                        "content": "paramètre"
+                      },
+                      {
+                        "id": "3",
+                        "content": "code"
+                      }
+                    ],
+                    "solutions": ["1"]
                   },
-                  "text": "<p>Ce sont les <strong>hallucinations</strong>.</p>"
-                }
-              },
-              {
-                "id": "464e30e1-2c8a-4184-85f7-5e377a36429c",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                  {
+                    "type": "text",
+                    "content": "<span>?<br><br><strong>Nadia</strong> : En fait, le système va interpréter ta requête, et il va ensuite essayer de&nbsp; </span>"
                   },
-                  "text": "Le domaine de l’IA existe depuis très longtemps, mais son développement récent concerne le champ des IA ..."
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                  {
+                    "input": "1",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "choisir le mot dans le menu déroulant",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "4",
+                        "content": "mesurer"
+                      },
+                      {
+                        "id": "5",
+                        "content": "prédire"
+                      },
+                      {
+                        "id": "6",
+                        "content": "superviser"
+                      }
+                    ],
+                    "solutions": ["4"]
                   },
-                  "text": "<p><strong>génératives</strong></p>"
-                }
-              },
-              {
-                "id": "3aaf1894-43b2-4110-bc67-9ea62723b408",
-                "recto": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                  {
+                    "type": "text",
+                    "content": "<span>quel est le mot suivant le plus probable à partir de la représentation qu’il a créée. Lorsqu’il a généré un mot, il recommence avec le suivant, en gardant en mémoire la totalité de l’échange !<br><br><strong>Alba</strong> : OK ! Mais pourquoi ça ne fonctionne pas toujours comme prévu ? Là, quand je lui pose cette question très simple, il donne une réponse absurde.<br><br><strong>Nadia</strong> : Oui c’est normal. C'est une&nbsp;</span>"
                   },
-                  "text": "Pour l’utilisateur, quel est le point commun entre les IA génératives de texte et d’image ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                  {
+                    "input": "2",
+                    "type": "select",
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "choisir le mot dans le menu déroulant",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "options": [
+                      {
+                        "id": "7",
+                        "content": "affabulation"
+                      },
+                      {
+                        "id": "8",
+                        "content": "hallucination"
+                      },
+                      {
+                        "id": "9",
+                        "content": "tergiversation"
+                      }
+                    ],
+                    "solutions": ["8"]
                   },
-                  "text": "<p>Elles utilisent un <strong>prompt</strong> en entrée.</p>"
+                  {
+                    "type": "text",
+                    "content": "<span>. Le modèle n'est pas capable de réfléchir comme un humain. Il produit juste un discours \"très probable\"</span>"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bonne réponse ! ✨",
+                    "diagnosis": ""
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": ""
+                  }
                 }
               }
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "id": "9c32181d-ee67-4240-b683-b8ec9d93df2a",
+          "type": "summary",
+          "title": "Récap",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5c072fb2-0baf-48dc-8b80-23c7b49d53f8",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">📌 </span>Résumons avant de passer à la suite.</p><ul><li>Pour interagir avec les systèmes d'IA génératives, les utilisateurs décrivent leur demande en lanagage naturel. C’est le <em>prompt </em>ou<em> requête </em>en français.<br><br></li><li>Les systèmes d’IA générative utilisent des algorithmes qui cherchent à <em>prédire</em> la suite du texte ou la forme d’image la plus probable.<br><br></li><li>Quand un système d’IA générative produit un résultat farfelu, c'est une <em>hallucination</em>. Ces phénomènes sont normaux et nous rappellent que ce sont des machines qui les ont générés, et non des humains !<br><br></li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2beac30f-52eb-429e-84f2-5fe7e89b5c57",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e3821cb3-8166-44e2-9540-225d33ea5883",
+                "type": "text",
+                "content": "<p>À vous de jouer&nbsp;! Dans le défi suivant, vous allez faire halluciner des IA génératives. 🥸 🦄</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "143f1906-9e25-4afe-8f2d-70b61ec76230",
+          "type": "challenge",
+          "title": "Défi : Faites halluciner une IA générative",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "014ce746-f31d-424e-975c-0b5b90b2d9f5",
+                "type": "text",
+                "content": "<p>À l'aide de <a href=\"https://www.comparia.beta.gouv.fr/\" target=\"_blank\">Compar:IA</a>, écrivez des prompts qui amènent à des hallucinations pour au moins une des deux IA génératives de texte proposées.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "61a7796a-0830-4344-8bb0-b7f5d778d81f",
+                "type": "qcu",
+                "instruction": "<p>Avez-vous réussi à obtenir des hallucinations ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>oui</p>",
+                    "feedback": {
+                      "state": "Bravo ! 🎉",
+                      "diagnosis": "<p>N'hésitez pas à vous amuser avec de nouvelles requêtes.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>non</p>",
+                    "feedback": {
+                      "state": "N'hésitez pas à retenter avec d'autres modèles, certains sont très bien préparés à ce type de manœuvres ...",
+                      "diagnosis": ""
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a16433b1-c9bc-4510-a527-5f52fd6e5917",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️ </span>Si vous avez besoin d'aide, vous pouvez cliquer sur les astuces ci-dessous.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "49d7efba-effc-4835-b7dc-26e9c9cfca53",
+                "type": "expand",
+                "title": "Astuce n°1",
+                "content": "<p>Poser une question logique contenant un piège. 🪤 </p><p>Par exemple : </p><blockquote><em>Justine a trois sœurs et un frère, Maxime. Combien de sœurs a Maxime ?</em></blockquote>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1d5975d3-f528-4048-95c8-bd06f2a647dd",
+                "type": "expand",
+                "title": "Astuce n°2",
+                "content": "<p>Demander de choisir une option parmi des options qui sont toutes fausses 🤥 </p><p>Par exemple : </p><blockquote><em>Dans \"les aventuriers des forêts\", avec quelle créature fantastique fait équipe l’héroïne, un Basilic ou un Dragon ?</em></blockquote>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b3ae83cc-af45-4e5b-8af3-f50be1962142",
+          "type": "summary",
+          "title": "Flashcards",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "903eacfc-3035-4a3a-9f70-f8a7517f81ba",
+                "type": "flashcards",
+                "title": "Flashcards",
+                "instruction": "<p><strong>Pour chaque carte</strong>&nbsp;:&nbsp;</p><ol><li>Lisez la question. <span aria-hidden=\"true\">👀</span></li><li>Essayez de trouver la réponse dans votre tête. <span aria-hidden=\"true\">🤔</span></li><li>Retournez la carte en cliquant sur Voir la réponse. <span aria-hidden=\"true\">↪️</span></li></ol><p>Cela permet de <strong>tester votre mémoire</strong>.<span aria-hidden=\"true\">🎯</span></p>",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "20058ea4-444e-44b4-941e-cce627a19997",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                      },
+                      "text": "Une IA générative de texte peut parfois produire des résultats qui ne sont pas vrais. Comment appelle-t-on ce phénomène ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                      },
+                      "text": "<p>Ce sont les <strong>hallucinations</strong>.</p>"
+                    }
+                  },
+                  {
+                    "id": "464e30e1-2c8a-4184-85f7-5e377a36429c",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                      },
+                      "text": "Le domaine de l’IA existe depuis très longtemps, mais son développement récent concerne le champ des IA ..."
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                      },
+                      "text": "<p><strong>génératives</strong></p>"
+                    }
+                  },
+                  {
+                    "id": "3aaf1894-43b2-4110-bc67-9ea62723b408",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                      },
+                      "text": "Pour l’utilisateur, quel est le point commun entre les IA génératives de texte et d’image ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                      },
+                      "text": "<p>Elles utilisent un <strong>prompt</strong> en entrée.</p>"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -15,617 +15,623 @@
     ],
     "tabletSupport": "obstructed"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "106d2893-c04e-450c-acab-a85aa04d71ed",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "6ca1620e-846d-4a19-98b8-5ce20b84123d",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "a962681c-b603-4693-bd2f-fc5e3a36708c",
-            "type": "text",
-            "content": "<p>Vous avez peut-être déjà voulu trier les données d’un tableau à partir de plusieurs critères. Pour cela, il faut faire un tri multicritères. <br>Découvrons avec des exemples les cas où le tri multicritère est utile 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "cffecfef-01d5-4ae5-839e-40752fe60017",
-      "type": "discovery",
-      "title": "Tri multicritère, filtre ou tri simple",
-      "components": [
+          "id": "106d2893-c04e-450c-acab-a85aa04d71ed",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a962681c-b603-4693-bd2f-fc5e3a36708c",
+                "type": "text",
+                "content": "<p>Vous avez peut-être déjà voulu trier les données d’un tableau à partir de plusieurs critères. Pour cela, il faut faire un tri multicritères. <br>Découvrons avec des exemples les cas où le tri multicritère est utile 👇</p>"
+              }
+            }
+          ]
+        },
         {
-          "type": "stepper",
-          "steps": [
+          "id": "cffecfef-01d5-4ae5-839e-40752fe60017",
+          "type": "discovery",
+          "title": "Tri multicritère, filtre ou tri simple",
+          "components": [
             {
-              "elements": [
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "1d9be377-24ae-49c6-8adc-980fd0e931e0",
-                  "type": "text",
-                  "content": "<p>Sarah a organisé un évènement pour des enfants. Voici le tableau qui présente leurs résultats aux 3 épreuves.</p>"
+                  "elements": [
+                    {
+                      "id": "1d9be377-24ae-49c6-8adc-980fd0e931e0",
+                      "type": "text",
+                      "content": "<p>Sarah a organisé un évènement pour des enfants. Voici le tableau qui présente leurs résultats aux 3 épreuves.</p>"
+                    },
+                    {
+                      "id": "f71cc4ee-e90c-43dc-ade2-2f94cc7a9444",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/SpFqjX9.jpeg",
+                      "alt": "Feuille de calcul avec un tableau à 6 colonnes. Chaque ligne représente un enfant : son prénom, son nom, son équipe, le temps réalisé à la course d'orientation, le score aux fléchettes et la réponse apportée au quiz.",
+                      "alternativeText": "<p>Feuille de calcul avec un tableau à 6 colonnes. Chaque ligne représente un enfant : son prénom, son nom, son équipe, le temps réalisé à la course d'orientation, le score aux fléchettes et la réponse apportée au quiz.</p>"
+                    },
+                    {
+                      "id": "eff4694f-d2a9-48f1-846d-9c9f88acccfa",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">🕹️</span> À vous de jouer&#8239;!</p><p>Dans chacune des situations suivantes, choisissez l’action adaptée entre&nbsp;:</p><ul><li>un tri à un critère (sur une colonne uniquement),</li><li>un filtre,</li><li>un tri multicritère.</li></ul>"
+                    }
+                  ]
                 },
                 {
-                  "id": "f71cc4ee-e90c-43dc-ade2-2f94cc7a9444",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/SpFqjX9.jpeg",
-                  "alt": "Feuille de calcul avec un tableau à 6 colonnes. Chaque ligne représente un enfant : son prénom, son nom, son équipe, le temps réalisé à la course d'orientation, le score aux fléchettes et la réponse apportée au quiz.",
-                  "alternativeText": "<p>Feuille de calcul avec un tableau à 6 colonnes. Chaque ligne représente un enfant : son prénom, son nom, son équipe, le temps réalisé à la course d'orientation, le score aux fléchettes et la réponse apportée au quiz.</p>"
+                  "elements": [
+                    {
+                      "id": "5f84a71d-a48f-4746-8a9a-2f25d8340ad4",
+                      "type": "qcu",
+                      "instruction": "<p>Sarah souhaite afficher les enfants alphabétiquement par nom.</p><p>Que doit-elle appliquer&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Un tri à un critère</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p>Le tri doit être fait sur un seul critère : le nom des enfants.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Un filtre</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Un filtre ne permet par d’organiser le tableau, il permet d’afficher ou non une sélection d'enfants.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Un tri multicritère</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Un seul critère est en jeu dans cette situation : le nom des enfants.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
                 },
                 {
-                  "id": "eff4694f-d2a9-48f1-846d-9c9f88acccfa",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">🕹️</span> À vous de jouer&#8239;!</p><p>Dans chacune des situations suivantes, choisissez l’action adaptée entre&nbsp;:</p><ul><li>un tri à un critère (sur une colonne uniquement),</li><li>un filtre,</li><li>un tri multicritère.</li></ul>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "5f84a71d-a48f-4746-8a9a-2f25d8340ad4",
-                  "type": "qcu",
-                  "instruction": "<p>Sarah souhaite afficher les enfants alphabétiquement par nom.</p><p>Que doit-elle appliquer&#8239;?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Un tri à un critère</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p>Le tri doit être fait sur un seul critère : le nom des enfants.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Un filtre</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Un filtre ne permet par d’organiser le tableau, il permet d’afficher ou non une sélection d'enfants.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Un tri multicritère</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Un seul critère est en jeu dans cette situation : le nom des enfants.</p>"
-                      }
+                      "id": "01e76883-2f58-4ba2-8d4e-3cee40660c65",
+                      "type": "qcu",
+                      "instruction": "<p>Sarah veut afficher les scores d'une seule équipe. </p><p>Que doit-elle appliquer&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Un tri à un critère</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le tri simple va permettre de regrouper les élèves par équipe, mais l’ensemble des enfants resteront affichés.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Un filtre</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p>Filtrer sur la colonne « Équipe » lui permettra d’afficher seulement les enfants de l'équipe de son choix.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Un tri multicritère</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le tri multicritère peut permettre de regrouper les enfants par équipe et par score, mais l’ensemble des enfants resteront affichés.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
                     }
-                  ],
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "01e76883-2f58-4ba2-8d4e-3cee40660c65",
-                  "type": "qcu",
-                  "instruction": "<p>Sarah veut afficher les scores d'une seule équipe. </p><p>Que doit-elle appliquer&#8239;?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Un tri à un critère</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le tri simple va permettre de regrouper les élèves par équipe, mais l’ensemble des enfants resteront affichés.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Un filtre</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p>Filtrer sur la colonne « Équipe » lui permettra d’afficher seulement les enfants de l'équipe de son choix.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Un tri multicritère</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le tri multicritère peut permettre de regrouper les enfants par équipe et par score, mais l’ensemble des enfants resteront affichés.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "2"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "a98472e5-2500-4a1c-99b9-a62cccb0015c",
-                  "type": "qcu",
-                  "instruction": "<p> Sarah veut réorganiser le tableau pour obtenir un classement des participants en prenant en compte l’ensemble de leurs résultats (orientation, fléchettes, quiz). </p><p>Que doit-elle appliquer&#8239;?</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "<p>Un tri à un critère</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Le tri simple peut ordonner les résultats des enfants pour une épreuve, mais il ne permet pas d’établir un classement prenant en compte les trois épreuves.</p>"
-                      }
-                    },
-                    {
-                      "id": "2",
-                      "content": "<p>Un filtre</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Filtrer ici ne permettrait pas d’afficher un classement, mais de restreindre l’affichage à certains scores.</p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Un tri multicritère</p>",
-                      "feedback": {
-                        "state": "Bonne réponse&#8239;!",
-                        "diagnosis": "<p>Plusieurs critères vont permettre de faire le classement final, le tri multicritère est donc recommandé.</p>"
-                      }
-                    }
-                  ],
-                  "solution": "3"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "3be17733-617d-4b6b-8a48-af3d3aaa636d",
-                  "type": "text",
-                  "content": "<p>Voici comment distinguer le tri multicritère du filtre et du tri sur une seule colonne.</p>"
+                  ]
                 },
                 {
-                  "id": "f37f93e5-8b78-40b1-9628-1b07e49de08d",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/0dvoxXo.jpeg",
-                  "alt": "",
-                  "alternativeText": "<p>Infographie des options de filtre et de tri dans les logiciel de tableurs :</p><ul><li>Filtre, pour afficher seulement certaines lignes.</li><li>Tri croissant et Tri décroissant, pour trier le tableau sur une seule colonne.</li><li>Tri multicritère, pour trier le tableau sur plusieurs colonnes.</li></ul>"
+                  "elements": [
+                    {
+                      "id": "a98472e5-2500-4a1c-99b9-a62cccb0015c",
+                      "type": "qcu",
+                      "instruction": "<p> Sarah veut réorganiser le tableau pour obtenir un classement des participants en prenant en compte l’ensemble de leurs résultats (orientation, fléchettes, quiz). </p><p>Que doit-elle appliquer&#8239;?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Un tri à un critère</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Le tri simple peut ordonner les résultats des enfants pour une épreuve, mais il ne permet pas d’établir un classement prenant en compte les trois épreuves.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Un filtre</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Filtrer ici ne permettrait pas d’afficher un classement, mais de restreindre l’affichage à certains scores.</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Un tri multicritère</p>",
+                          "feedback": {
+                            "state": "Bonne réponse&#8239;!",
+                            "diagnosis": "<p>Plusieurs critères vont permettre de faire le classement final, le tri multicritère est donc recommandé.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "3"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3be17733-617d-4b6b-8a48-af3d3aaa636d",
+                      "type": "text",
+                      "content": "<p>Voici comment distinguer le tri multicritère du filtre et du tri sur une seule colonne.</p>"
+                    },
+                    {
+                      "id": "f37f93e5-8b78-40b1-9628-1b07e49de08d",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/0dvoxXo.jpeg",
+                      "alt": "",
+                      "alternativeText": "<p>Infographie des options de filtre et de tri dans les logiciel de tableurs :</p><ul><li>Filtre, pour afficher seulement certaines lignes.</li><li>Tri croissant et Tri décroissant, pour trier le tableau sur une seule colonne.</li><li>Tri multicritère, pour trier le tableau sur plusieurs colonnes.</li></ul>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "9b5aa9e9-0016-4bc4-9122-10caa862a634",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "216c3b36-9ccd-4d47-a0fe-0c4bff845de8",
-            "type": "text",
-            "content": "<p>Pour réaliser un tri multicritère, les raccourcis de tri disponible sur l'en-tête de chaque colonne sont insuffisants.&nbsp;❌<br>Reprenons le cas du tableau de Sarah qui organise un grand jeu pour enfant et découvrez comment y appliquer un tri à plusieurs critères dans la vidéo suivante. 📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "52abc272-638f-48b1-900b-4dd2635bf9a7",
-      "type": "lesson",
-      "title": "Démonstration de tri multicritère",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2d5100b3-7aad-4f95-969f-ae083361834d",
-            "type": "text",
-            "content": "<p>À la suite de cette vidéo, vous devrez appliquer un tri sur plusieurs colonnes dans un tableau.</p>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "8707010a-2068-470f-a007-77f0e82005c1",
-            "type": "video",
-            "title": "Appliquer un tri multicritère dans un tableau",
-            "url": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.mp4",
-            "poster": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.jpg",
-            "subtitles": "",
-            "transcription": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a9911b60-31ba-48e0-8b32-f0dacc5befee",
-            "type": "text",
-            "content": "<p><em>Le logiciel utilisé dans cette vidéo est LibreOffice.</em></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "784fb1f2-8eed-4d49-95fb-e22984cc245a",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "eaaf4ff2-633f-4c6d-9016-9b9bb9e0fa3d",
-            "type": "text",
-            "content": "<p>Maintenant, à vous de jouer. Vous allez aider Sarah à réaliser le classement individuel de son grand jeu. Pour cela, vous allez réaliser un tri multicritère. </p><p>À vos marques, prêts, partez ! 🏃🏽‍♀️🏃‍♂️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "257fa8da-a5f7-4dc7-8c42-f562f6c3d6ef",
-      "type": "activity",
-      "title": "Création d’un premier tri à 2 critères",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "9a6bb28f-563f-420f-9ea8-767e25af815b",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📋</span> Sarah veut établir le classement des épreuves individuelles, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura le meilleur score aux fléchettes. <br>En cas d’ex æquo, on choisira le meilleur résultat au quiz.</em></blockquote>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "daf2f3dd-3b57-4d0a-a696-c6ef97a145d0",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a0e426fd-ebcb-4b3f-90bd-bf34d682f3bd",
-            "type": "text",
-            "content": "<p>Téléchargez le fichier ci-dessous</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0a4b543c-2e5c-45b2-a9d8-6cb6dfff8057",
-            "type": "download",
-            "files": [
-              {
-                "url": "https://dl.pix.fr/1733409605790/GWQOXGHJXY.ods",
-                "format": "ods"
-              },
-              {
-                "url": "https://dl.pix.fr/1733409605434/WYQWNRJXUQ.xlsx",
-                "format": "xlsx"
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "52f7cabc-4752-41d0-8931-132d19ca34c4",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "2ed017f2-4c7e-4f64-b0d9-59cfcd9f3e38",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">👉</span> Appliquez le tri multicritère suivant&nbsp;:</p><ul><li>critère 1&nbsp;: par ordre <strong>décroissant</strong> de<strong> Score aux fléchettes</strong>&nbsp;</li><li>critère 2&nbsp;: par ordre <strong>croissant </strong>de <strong>Réponse au quiz</strong></li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "47e998c8-58a9-4c56-be09-1ca94a6afada",
-            "type": "qrocm",
-            "instruction": "<p>Qui est arrivé deuxième et quel est le lot offert aux vainqueurs ?</p>",
-            "proposals": [
-              {
+          "id": "9b5aa9e9-0016-4bc4-9122-10caa862a634",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "216c3b36-9ccd-4d47-a0fe-0c4bff845de8",
                 "type": "text",
-                "content": "<p>Le deuxième au classement est</p>"
-              },
-              {
-                "input": "prenom-activite",
-                "type": "input",
-                "inputType": "text",
-                "size": 12,
-                "display": "inline",
-                "placeholder": "prénom",
-                "ariaLabel": "écrivez le prénom ici",
-                "defaultValue": "",
-                "tolerances": ["t3"],
-                "solutions": ["emma"]
-              },
-              {
-                "type": "text",
-                "content": "<p>Les vainqueurs remportent une</p>"
-              },
-              {
-                "input": "lot-activite",
-                "type": "input",
-                "inputType": "text",
-                "size": 12,
-                "display": "inline",
-                "placeholder": "lot",
-                "ariaLabel": "écrivez le lot ici",
-                "defaultValue": "",
-                "tolerances": ["t3"],
-                "solutions": ["glace", "glaces"]
-              }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Correct !",
-                "diagnosis": "<p>Vous avez obtenu le classement des meilleurs tireurs aux fléchettes et parmi eux, ceux qui ont aussi réussi le quiz.</p><p>En inversant l’ordre de ce tri, le classement aurait été différent.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Avez-vous bien utilisé un tri multicritère ?&nbsp; Vérifiez également l’ordre de vos critères de tri.</p><p>Pour réussir, utilisez les indices ci-dessous ou regardez à nouveau la vidéo pour vous aider <span aria-hidden=\"true\">👆</span></p>"
+                "content": "<p>Pour réaliser un tri multicritère, les raccourcis de tri disponible sur l'en-tête de chaque colonne sont insuffisants.&nbsp;❌<br>Reprenons le cas du tableau de Sarah qui organise un grand jeu pour enfant et découvrez comment y appliquer un tri à plusieurs critères dans la vidéo suivante. 📺</p>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "82815beb-6dc8-4caf-8c26-2454ffde5458",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>En fonction de votre logiciel, le vocabulaire de tri peut être différent :</p><ul><li>La fenêtre peut s’appeler «&nbsp;Trier&nbsp;», «&nbsp;Tri personnalisé&nbsp;» ou «&nbsp;Options avancées de tri&nbsp;».</li><li>Un critère de tri peut aussi s’appeler «&nbsp;Clé de tri&nbsp;» ou «&nbsp;Niveau de tri&nbsp;».</li><li>«&nbsp;Croissant&nbsp;» peut être écrit «&nbsp;Du plus petit au plus grand&nbsp;» ou «&nbsp;A-Z&nbsp;».</li></ul></details><details><summary>Indice 2</summary><p>Pour ouvrir la fenêtre de tri sur le logiciel LibreOffice, voici la manipulation à effectuer</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67530fa7a5525.gif\" alt=\"\" /></details><details><summary>Indice 3</summary><ul><li>Commencez par sélectionner «&nbsp;<strong>Score aux fléchettes</strong>&nbsp;» dans votre premier critère de tri. Attribuez-lui un classement <strong>«&nbsp;Décroissant&nbsp;»</strong>.</li><li>Puis, sélectionnez <strong>«&nbsp;Réponse au quiz&nbsp;»</strong> dans votre second critère de tri. Attribuez-lui le classement <strong>«&nbsp;Croissant&nbsp;»</strong> </li></ul></details>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "a1d3c0a0-d331-4d76-99ca-ec467da78afe",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "538cfc41-cf44-4a4f-9bcb-da4ddd18043f",
-            "type": "text",
-            "content": "<p>Vous savez désormais réaliser un tri sur deux critères.<br><br> Avant de réaliser un tri avancé sur encore plus de critères, découvrez quelques bonnes pratiques et astuces pour trier plus facilement vos tableaux. 🏆</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6c869b4c-d44e-462b-98e2-21d063dfecda",
-      "type": "lesson",
-      "title": "Astuces pratiques de tri",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "52abc272-638f-48b1-900b-4dd2635bf9a7",
+          "type": "lesson",
+          "title": "Démonstration de tri multicritère",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "05a44b3d-1c77-49fc-bab9-65e5f20c3d38",
-                  "type": "text",
-                  "content": "<p><strong>Une option permet de reconnaître les en-têtes ou étiquettes de colonnes.</strong> </p><p>Si les en-têtes de votre tableau sont correctement remplies, la plupart des logiciels les détectent automatiquement.&nbsp;</p><p>Cette option s’appelle « <span aria-hidden=\"true\">☑️</span> Mes données ont des en-têtes » ou « <span aria-hidden=\"true\">☑️</span> La plage contient des étiquettes de colonne ».&nbsp;</p><p>Avec une détection automatique, elle sera déjà cochée. Vous pouvez aussi la cocher manuellement <span aria-hidden=\"true\">👇</span></p>"
-                },
-                {
-                  "id": "f5142469-61c8-422e-9c26-5f408ce33992",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/xxKAMeR.gif",
-                  "alt": "",
-                  "alternativeText": "<p>Gif animé. Quand la case « La plage contient des étiquettes de colonne » n'est pas cochée, les colonnes proposées dans la liste déroulante sont A, B, C, etc. Quand la case est cochée, la liste déroulante propose les étiquettes de colonnes « Prénom », « Nom », « Equipe », etc.</p>"
-                },
-                {
-                  "id": "76563c87-ea9e-44d5-acbf-ad78a6da4220",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">⚠️</span> Si cette case n’est pas cochée, mais que votre tableau a des en-têtes, elles seront considérées comme des données à trier.</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "2d5100b3-7aad-4f95-969f-ae083361834d",
+                "type": "text",
+                "content": "<p>À la suite de cette vidéo, vous devrez appliquer un tri sur plusieurs colonnes dans un tableau.</p>"
+              }
             },
             {
-              "elements": [
-                {
-                  "id": "b8c69ed0-7388-4197-a700-19126f4c91d2",
-                  "type": "text",
-                  "content": "<p><strong>La sensibilité à la casse.</strong> </p><p>L’onglet « Options » de la fenêtre de tri, permet de faire des réglages avancés. La case à cocher «Sensible à la casse» permet de prendre en compte ou d’ignorer les majuscules ou les minuscules. <span aria-hidden=\"true\">🔠</span></p>"
-                },
-                {
-                  "id": "37ac6388-e4b2-41ac-af3a-bc1219c0f23c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/DJdRtpA.jpeg",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "8707010a-2068-470f-a007-77f0e82005c1",
+                "type": "video",
+                "title": "Appliquer un tri multicritère dans un tableau",
+                "url": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.mp4",
+                "poster": "https://assets.pix.org/modules/tri-multicritere-tableau/appliquer-un-tri-multicritere-dans-un-tableau.jpg",
+                "subtitles": "",
+                "transcription": ""
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "a9911b60-31ba-48e0-8b32-f0dacc5befee",
+                "type": "text",
+                "content": "<p><em>Le logiciel utilisé dans cette vidéo est LibreOffice.</em></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "784fb1f2-8eed-4d49-95fb-e22984cc245a",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "eaaf4ff2-633f-4c6d-9016-9b9bb9e0fa3d",
+                "type": "text",
+                "content": "<p>Maintenant, à vous de jouer. Vous allez aider Sarah à réaliser le classement individuel de son grand jeu. Pour cela, vous allez réaliser un tri multicritère. </p><p>À vos marques, prêts, partez ! 🏃🏽‍♀️🏃‍♂️</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "257fa8da-a5f7-4dc7-8c42-f562f6c3d6ef",
+          "type": "activity",
+          "title": "Création d’un premier tri à 2 critères",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "9a6bb28f-563f-420f-9ea8-767e25af815b",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">📋</span> Sarah veut établir le classement des épreuves individuelles, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura le meilleur score aux fléchettes. <br>En cas d’ex æquo, on choisira le meilleur résultat au quiz.</em></blockquote>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "daf2f3dd-3b57-4d0a-a696-c6ef97a145d0",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a0e426fd-ebcb-4b3f-90bd-bf34d682f3bd",
+                "type": "text",
+                "content": "<p>Téléchargez le fichier ci-dessous</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0a4b543c-2e5c-45b2-a9d8-6cb6dfff8057",
+                "type": "download",
+                "files": [
+                  {
+                    "url": "https://dl.pix.fr/1733409605790/GWQOXGHJXY.ods",
+                    "format": "ods"
+                  },
+                  {
+                    "url": "https://dl.pix.fr/1733409605434/WYQWNRJXUQ.xlsx",
+                    "format": "xlsx"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "52f7cabc-4752-41d0-8931-132d19ca34c4",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "2ed017f2-4c7e-4f64-b0d9-59cfcd9f3e38",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">👉</span> Appliquez le tri multicritère suivant&nbsp;:</p><ul><li>critère 1&nbsp;: par ordre <strong>décroissant</strong> de<strong> Score aux fléchettes</strong>&nbsp;</li><li>critère 2&nbsp;: par ordre <strong>croissant </strong>de <strong>Réponse au quiz</strong></li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "47e998c8-58a9-4c56-be09-1ca94a6afada",
+                "type": "qrocm",
+                "instruction": "<p>Qui est arrivé deuxième et quel est le lot offert aux vainqueurs ?</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<p>Le deuxième au classement est</p>"
+                  },
+                  {
+                    "input": "prenom-activite",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 12,
+                    "display": "inline",
+                    "placeholder": "prénom",
+                    "ariaLabel": "écrivez le prénom ici",
+                    "defaultValue": "",
+                    "tolerances": ["t3"],
+                    "solutions": ["emma"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<p>Les vainqueurs remportent une</p>"
+                  },
+                  {
+                    "input": "lot-activite",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 12,
+                    "display": "inline",
+                    "placeholder": "lot",
+                    "ariaLabel": "écrivez le lot ici",
+                    "defaultValue": "",
+                    "tolerances": ["t3"],
+                    "solutions": ["glace", "glaces"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Correct !",
+                    "diagnosis": "<p>Vous avez obtenu le classement des meilleurs tireurs aux fléchettes et parmi eux, ceux qui ont aussi réussi le quiz.</p><p>En inversant l’ordre de ce tri, le classement aurait été différent.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Avez-vous bien utilisé un tri multicritère ?&nbsp; Vérifiez également l’ordre de vos critères de tri.</p><p>Pour réussir, utilisez les indices ci-dessous ou regardez à nouveau la vidéo pour vous aider <span aria-hidden=\"true\">👆</span></p>"
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "82815beb-6dc8-4caf-8c26-2454ffde5458",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>En fonction de votre logiciel, le vocabulaire de tri peut être différent :</p><ul><li>La fenêtre peut s’appeler «&nbsp;Trier&nbsp;», «&nbsp;Tri personnalisé&nbsp;» ou «&nbsp;Options avancées de tri&nbsp;».</li><li>Un critère de tri peut aussi s’appeler «&nbsp;Clé de tri&nbsp;» ou «&nbsp;Niveau de tri&nbsp;».</li><li>«&nbsp;Croissant&nbsp;» peut être écrit «&nbsp;Du plus petit au plus grand&nbsp;» ou «&nbsp;A-Z&nbsp;».</li></ul></details><details><summary>Indice 2</summary><p>Pour ouvrir la fenêtre de tri sur le logiciel LibreOffice, voici la manipulation à effectuer</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67530fa7a5525.gif\" alt=\"\" /></details><details><summary>Indice 3</summary><ul><li>Commencez par sélectionner «&nbsp;<strong>Score aux fléchettes</strong>&nbsp;» dans votre premier critère de tri. Attribuez-lui un classement <strong>«&nbsp;Décroissant&nbsp;»</strong>.</li><li>Puis, sélectionnez <strong>«&nbsp;Réponse au quiz&nbsp;»</strong> dans votre second critère de tri. Attribuez-lui le classement <strong>«&nbsp;Croissant&nbsp;»</strong> </li></ul></details>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "a1d3c0a0-d331-4d76-99ca-ec467da78afe",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "538cfc41-cf44-4a4f-9bcb-da4ddd18043f",
+                "type": "text",
+                "content": "<p>Vous savez désormais réaliser un tri sur deux critères.<br><br> Avant de réaliser un tri avancé sur encore plus de critères, découvrez quelques bonnes pratiques et astuces pour trier plus facilement vos tableaux. 🏆</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6c869b4c-d44e-462b-98e2-21d063dfecda",
+          "type": "lesson",
+          "title": "Astuces pratiques de tri",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "8536a080-79f8-4bc1-8cb7-5c3829dca8ca",
-                  "type": "text",
-                  "content": "<p><strong>L’ordre de tri personnalisé. </strong> </p><p>Il permet de trier automatiquement les jours de la semaine et les mois. Sans cette option, le tri sera alphabétique : jeudi sera donc avant lundi. <span aria-hidden=\"true\">📆</span> on trouvé également ce réglage dans l’onglet « Options » de la fenêtre de tri.</p>"
+                  "elements": [
+                    {
+                      "id": "05a44b3d-1c77-49fc-bab9-65e5f20c3d38",
+                      "type": "text",
+                      "content": "<p><strong>Une option permet de reconnaître les en-têtes ou étiquettes de colonnes.</strong> </p><p>Si les en-têtes de votre tableau sont correctement remplies, la plupart des logiciels les détectent automatiquement.&nbsp;</p><p>Cette option s’appelle « <span aria-hidden=\"true\">☑️</span> Mes données ont des en-têtes » ou « <span aria-hidden=\"true\">☑️</span> La plage contient des étiquettes de colonne ».&nbsp;</p><p>Avec une détection automatique, elle sera déjà cochée. Vous pouvez aussi la cocher manuellement <span aria-hidden=\"true\">👇</span></p>"
+                    },
+                    {
+                      "id": "f5142469-61c8-422e-9c26-5f408ce33992",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/xxKAMeR.gif",
+                      "alt": "",
+                      "alternativeText": "<p>Gif animé. Quand la case « La plage contient des étiquettes de colonne » n'est pas cochée, les colonnes proposées dans la liste déroulante sont A, B, C, etc. Quand la case est cochée, la liste déroulante propose les étiquettes de colonnes « Prénom », « Nom », « Equipe », etc.</p>"
+                    },
+                    {
+                      "id": "76563c87-ea9e-44d5-acbf-ad78a6da4220",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">⚠️</span> Si cette case n’est pas cochée, mais que votre tableau a des en-têtes, elles seront considérées comme des données à trier.</p>"
+                    }
+                  ]
                 },
                 {
-                  "id": "8dff7246-9c67-45c9-b5bd-801d12008587",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/pXPntis.jpeg",
-                  "alt": "",
-                  "alternativeText": ""
+                  "elements": [
+                    {
+                      "id": "b8c69ed0-7388-4197-a700-19126f4c91d2",
+                      "type": "text",
+                      "content": "<p><strong>La sensibilité à la casse.</strong> </p><p>L’onglet « Options » de la fenêtre de tri, permet de faire des réglages avancés. La case à cocher «Sensible à la casse» permet de prendre en compte ou d’ignorer les majuscules ou les minuscules. <span aria-hidden=\"true\">🔠</span></p>"
+                    },
+                    {
+                      "id": "37ac6388-e4b2-41ac-af3a-bc1219c0f23c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/DJdRtpA.jpeg",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "8536a080-79f8-4bc1-8cb7-5c3829dca8ca",
+                      "type": "text",
+                      "content": "<p><strong>L’ordre de tri personnalisé. </strong> </p><p>Il permet de trier automatiquement les jours de la semaine et les mois. Sans cette option, le tri sera alphabétique : jeudi sera donc avant lundi. <span aria-hidden=\"true\">📆</span> on trouvé également ce réglage dans l’onglet « Options » de la fenêtre de tri.</p>"
+                    },
+                    {
+                      "id": "8dff7246-9c67-45c9-b5bd-801d12008587",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/pXPntis.jpeg",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "d35fe155-4e68-46e0-aa85-2f7903f49bcc",
-      "type": "challenge",
-      "title": "Création d’un tri à 3 critères ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "cfcf3dde-1eed-4654-86bc-c1c9bc4868ef",
-            "type": "text",
-            "content": "<p>Sarah a préparé un nouveau fichier contenant les résultats des enfants à la chasse au trésor.&nbsp; <br>Elle veut établir un classement, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura découvert la cachette aux trésors. <br>Pour emporter le trésor, il faut avoir résolu un maximum d’énigmes.<br>En cas d’ex æquo, il faut sortir le plus vite possible du labyrinthe.</em></blockquote>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "6fe45fc7-89a2-4bd8-aec8-c2ecd30f5c26",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fde2db58-a735-418a-9063-a56652845965",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">👉</span> <strong>Téléchargez ce fichier et triez les données pour obtenir le classement de la chasse au trésor</strong></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "03dfe817-ca35-4881-a256-dc5d591bf288",
-            "type": "download",
-            "files": [
-              {
-                "url": "https://dl.pix.fr/1735566875829/WHJGVKLPWZ.ods",
-                "format": "ods"
-              },
-              {
-                "url": "https://dl.pix.fr/1735566875579/ERCNCLEXEW.xlsx",
-                "format": "xlsx"
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "7b13a9b6-b8ae-4667-bfe6-02e45344db29",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d50c98d3-80b4-4cb5-a138-33d7526cd757",
-            "type": "qrocm",
-            "instruction": "<p>Quel enfant est deuxième ? <br>Quel est le contenu du trésor ?</p>",
-            "proposals": [
-              {
+          "id": "d35fe155-4e68-46e0-aa85-2f7903f49bcc",
+          "type": "challenge",
+          "title": "Création d’un tri à 3 critères ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "cfcf3dde-1eed-4654-86bc-c1c9bc4868ef",
                 "type": "text",
-                "content": "<p>Le prénom du deuxième est :</p>"
-              },
-              {
-                "input": "prenom-boss",
-                "type": "input",
-                "inputType": "text",
-                "size": 12,
-                "display": "inline",
-                "placeholder": "prénom",
-                "ariaLabel": "écrivez ici le prénom",
-                "defaultValue": "",
-                "tolerances": ["t3"],
-                "solutions": ["inès"]
-              },
-              {
-                "type": "text",
-                "content": "<p>Le contenu du trésor est :</p>"
-              },
-              {
-                "input": "tresor-boss",
-                "type": "input",
-                "inputType": "text",
-                "size": 12,
-                "display": "inline",
-                "placeholder": "trésor",
-                "ariaLabel": "écrivez ici le contenu du trésor",
-                "defaultValue": "",
-                "tolerances": ["t3"],
-                "solutions": ["des bonbons", "bonbons"]
+                "content": "<p>Sarah a préparé un nouveau fichier contenant les résultats des enfants à la chasse au trésor.&nbsp; <br>Elle veut établir un classement, selon les règles suivantes :</p><blockquote><em>Le ou la gagnant(e) aura découvert la cachette aux trésors. <br>Pour emporter le trésor, il faut avoir résolu un maximum d’énigmes.<br>En cas d’ex æquo, il faut sortir le plus vite possible du labyrinthe.</em></blockquote>"
               }
-            ],
-            "feedbacks": {
-              "valid": {
-                "state": "Bravo&#8239;!",
-                "diagnosis": "<p>Le tri avancé a bien permis de classer les enfants par découverte du trésor, puis par plus grand nombre d’énigmes résolues, puis par temps le plus court au labyrinthe.</p>"
-              },
-              "invalid": {
-                "state": "Mauvaise réponse.",
-                "diagnosis": "<p>Le classement de Sarah demande de trier selon trois critères.<br>Réessayez. Aidez-vous des indices au besoin.</p>"
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6fe45fc7-89a2-4bd8-aec8-c2ecd30f5c26",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fde2db58-a735-418a-9063-a56652845965",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">👉</span> <strong>Téléchargez ce fichier et triez les données pour obtenir le classement de la chasse au trésor</strong></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "03dfe817-ca35-4881-a256-dc5d591bf288",
+                "type": "download",
+                "files": [
+                  {
+                    "url": "https://dl.pix.fr/1735566875829/WHJGVKLPWZ.ods",
+                    "format": "ods"
+                  },
+                  {
+                    "url": "https://dl.pix.fr/1735566875579/ERCNCLEXEW.xlsx",
+                    "format": "xlsx"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "7b13a9b6-b8ae-4667-bfe6-02e45344db29",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d50c98d3-80b4-4cb5-a138-33d7526cd757",
+                "type": "qrocm",
+                "instruction": "<p>Quel enfant est deuxième ? <br>Quel est le contenu du trésor ?</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<p>Le prénom du deuxième est :</p>"
+                  },
+                  {
+                    "input": "prenom-boss",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 12,
+                    "display": "inline",
+                    "placeholder": "prénom",
+                    "ariaLabel": "écrivez ici le prénom",
+                    "defaultValue": "",
+                    "tolerances": ["t3"],
+                    "solutions": ["inès"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<p>Le contenu du trésor est :</p>"
+                  },
+                  {
+                    "input": "tresor-boss",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 12,
+                    "display": "inline",
+                    "placeholder": "trésor",
+                    "ariaLabel": "écrivez ici le contenu du trésor",
+                    "defaultValue": "",
+                    "tolerances": ["t3"],
+                    "solutions": ["des bonbons", "bonbons"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": {
+                    "state": "Bravo&#8239;!",
+                    "diagnosis": "<p>Le tri avancé a bien permis de classer les enfants par découverte du trésor, puis par plus grand nombre d’énigmes résolues, puis par temps le plus court au labyrinthe.</p>"
+                  },
+                  "invalid": {
+                    "state": "Mauvaise réponse.",
+                    "diagnosis": "<p>Le classement de Sarah demande de trier selon trois critères.<br>Réessayez. Aidez-vous des indices au besoin.</p>"
+                  }
+                }
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9c101788-40c6-4343-95e4-fcac920c96b7",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">❓</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>Voici le résultat que vous devriez obtenir. Observez bien les colonnes pour trouver l'ordre des critères de tri.</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67727d49bec01.png\" alt=\"\"></details><details><summary>Indice 2</summary><p>Il y a 3 critères de tri nécessaires au classement de Sarah.<br>L’énoncé vous permet de trouver l’ordre des critères de tri suivant&nbsp;:</p> <ol> <li>L’étape la plus importante est bien sûr : la découverte du trésor</li> <li>La seconde épreuve est le nombre d’énigmes réussies</li> <li>Le troisième critère est le temps au labyrinthe</li> </ol><p>Ensuite, comparez l’ordre des critères de tri au tableau de l’indice 2 et déterminez le classement de chaque colonne.</p> </details>"
               }
             }
-          }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "9c101788-40c6-4343-95e4-fcac920c96b7",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">❓</span> Si vous avez besoin d’aide, cliquez sur les indices ci-dessous :</p><p><br></p><details><summary>Indice 1</summary><p>Voici le résultat que vous devriez obtenir. Observez bien les colonnes pour trouver l'ordre des critères de tri.</p><img src=\"https://assets.pix.org/draft/modules/88.125.115.216-67727d49bec01.png\" alt=\"\"></details><details><summary>Indice 2</summary><p>Il y a 3 critères de tri nécessaires au classement de Sarah.<br>L’énoncé vous permet de trouver l’ordre des critères de tri suivant&nbsp;:</p> <ol> <li>L’étape la plus importante est bien sûr : la découverte du trésor</li> <li>La seconde épreuve est le nombre d’énigmes réussies</li> <li>Le troisième critère est le temps au labyrinthe</li> </ol><p>Ensuite, comparez l’ordre des critères de tri au tableau de l’indice 2 et déterminez le classement de chaque colonne.</p> </details>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "761402c5-41ec-44b1-b166-6f0b43300238",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "453fa79b-7a83-46f6-aca2-0cfd6409fa6d",
-            "type": "text",
-            "content": "<p>Vous savez désormais créer un tri multicritère sur un logiciel de tableur. <br>Grâce à ce tri, Sarah a pu donner leur classement à ses participants. 🏆</p><p>Voici un récapitulatif des grandes étapes de tri et quelques précisions.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "16df02e4-4dd0-4fa3-9be0-44e1f54a3217",
-      "type": "lesson",
-      "title": "Recap",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e9ac9d81-41fc-48c2-b74c-7aee31373f39",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">✅</span> On a besoin d’<strong>un tri multicritères sur plusieurs colonnes</strong> quand on doit<strong> cumuler plusieurs critères de tri</strong> (d’abord un premier critère, puis un second, puis un troisième, etc). <br>✔️Par exemple, quand on a besoin de discriminer des ex æquo sur un premier critère.</p>"
-          }
+          "id": "761402c5-41ec-44b1-b166-6f0b43300238",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "453fa79b-7a83-46f6-aca2-0cfd6409fa6d",
+                "type": "text",
+                "content": "<p>Vous savez désormais créer un tri multicritère sur un logiciel de tableur. <br>Grâce à ce tri, Sarah a pu donner leur classement à ses participants. 🏆</p><p>Voici un récapitulatif des grandes étapes de tri et quelques précisions.</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "106e6349-c768-4cbf-950a-e062facecaa7",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d5e3be8f-f65f-4786-bf16-1d8f13e1e94c",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🥇</span> <strong>L’ordre des critères de tri détermine le résultat du tri.</strong> <br>Le second critère s’applique toujours en fonction du premier. Si vous inversez les critères, vous obtiendrez un résultat visiblement différent.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "066f86e4-9e42-4b92-8694-8d8f7326add3",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "920abeb8-99e2-4891-b002-840de3eb9152",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🔠</span> <strong>Le vocabulaire peut varier en fonction de votre logiciel.</strong><br>La fenêtre de tri peut s’appeler autrement selon le logiciel utilisé, avoir un pictogramme différent et peut utiliser d’autres mots pour désigner les critères de tri.</p>"
-          }
+          "id": "16df02e4-4dd0-4fa3-9be0-44e1f54a3217",
+          "type": "lesson",
+          "title": "Recap",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e9ac9d81-41fc-48c2-b74c-7aee31373f39",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">✅</span> On a besoin d’<strong>un tri multicritères sur plusieurs colonnes</strong> quand on doit<strong> cumuler plusieurs critères de tri</strong> (d’abord un premier critère, puis un second, puis un troisième, etc). <br>✔️Par exemple, quand on a besoin de discriminer des ex æquo sur un premier critère.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "106e6349-c768-4cbf-950a-e062facecaa7",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d5e3be8f-f65f-4786-bf16-1d8f13e1e94c",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🥇</span> <strong>L’ordre des critères de tri détermine le résultat du tri.</strong> <br>Le second critère s’applique toujours en fonction du premier. Si vous inversez les critères, vous obtiendrez un résultat visiblement différent.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "066f86e4-9e42-4b92-8694-8d8f7326add3",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "920abeb8-99e2-4891-b002-840de3eb9152",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🔠</span> <strong>Le vocabulaire peut varier en fonction de votre logiciel.</strong><br>La fenêtre de tri peut s’appeler autrement selon le logiciel utilisé, avoir un pictogramme différent et peut utiliser d’autres mots pour désigner les critères de tri.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -15,643 +15,649 @@
     ],
     "tabletSupport": "obstructed"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "9c323a6c-2ae3-4257-af10-7711cebe6442",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "ce25fafe-3f1d-433e-8ac3-a6061ac61bea",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "91ba6701-243c-4f07-bd0d-9019a1c85b4d",
-            "type": "text",
-            "content": "<p>Dans ce module vous allez prendre en main une souris pour interagir avec l'ordinateur.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f0db9bcb-a896-4801-827d-d0ceeddde3e5",
-      "type": "discovery",
-      "title": "Reconnaitre une souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "48708070-39c3-4af4-8914-ab61d61dfee8",
-            "type": "text",
-            "content": "<p>La souris fait partie de l'équipement de base d’un ordinateur, avec le clavier.</p><p>Les souris peuvent avoir différentes formes, tailles ou couleurs. </p><p>Il y a deux types de souris : </p><ul><li>les souris avec un fil</li><li>les souris sans fil</li></ul><p>Globalement, toutes ces souris servent à faire les mêmes choses.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c849cbc5-931e-4a00-ae6a-083e2ff0614d",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/GHeUZvS.jpeg",
-            "alt": "-",
-            "alternativeText": "<ul><li>Les souris avec un fil : photographies de 4 souris avec fil de taille, forme et couleur différentes.</li><li>Les souris sans fil : photographies de 3 souris sans fil différentes reliées par des connecteurs USB Bluetooth .</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c785bfd1-e8b8-42a0-8354-333d5acf6555",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">🔎</span> Observez : votre souris a-t-elle un fil ?</h3>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2099c733-4be9-4063-8584-e854a6d9ee2f",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b4727513-47b5-4850-bde5-263795c63f46",
-            "type": "text",
-            "content": "<p>Dans la vidéo suivante, vous allez voir comment prendre en main une souris d'ordinateur pour ensuite la déplacer.&nbsp;📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "115f2b94-ba20-4158-a1b1-efb159d82808",
-      "type": "lesson",
-      "title": "Prise en main de la souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "75894ade-d0b9-4662-ba37-edf72c9e74e5",
-            "type": "text",
-            "content": "<p>Après cette vidéo, vous devrez suivre les étapes pour prendre en main votre souris.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "56541ee2-cf5f-4966-b17b-96a1b7266868",
-            "type": "video",
-            "title": "Prendre en main la souris",
-            "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_prise_en_main.mp4",
-            "poster": "https://assets.pix.org/draft/modules/lA2jUAY.jpeg",
-            "subtitles": "",
-            "transcription": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "4d381d79-1edf-426c-876a-fcc0fc783fc0",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "927b247f-f86a-458a-908f-62f8c39fb353",
-            "type": "text",
-            "content": "<p>À vous de jouer. Vous allez vous entraîner à déplacer votre souris.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "395f9865-bb44-4cd8-a4dd-03ffddf598f7",
-      "type": "activity",
-      "title": "Exercice de prise en main de la souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6b6eeef4-bb9b-4769-906d-47e72db93543",
-            "type": "text",
-            "content": "<p>Pour l'instant, regardez votre souris. Ne regardez pas ce qu'il se passe à l'écran.<br></p><h3><span aria-hidden=\"true\">👉</span> Déplacez votre souris, en suivant ces étapes :</h3><ul><li>Étape 1 : Posez votre main confortablement sur la souris.</li><li>Étape 2 : Faites glissez la souris doucement sur la table.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a0773d08-47df-4302-965e-1a8f2d69ae92",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d1dd9768-1b88-4a76-af7c-4290c3fe5a2f",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️</span>N'hésitez pas à demandez conseil à la personne qui vous accompagne. Elle vous aidera à trouver une position confortable pour vous.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2c2abead-9b97-4dc5-8ad4-876c21cd9797",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "36a93743-af38-47ae-a58e-be59b2d86656",
-            "type": "text",
-            "content": "<p>Dans la vidéo suivante, vous allez voir comment déplacer la souris sur votre écran.&nbsp;📺</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "8a9618f5-c8d8-447e-83ae-cf66914c0aa0",
-      "type": "lesson",
-      "title": "Déplacer son pointeur",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7dad11c9-fafd-4e94-bd81-003e3944ff6d",
-            "type": "text",
-            "content": "<p>Après cette vidéo, vous devrez déplacez votre souris dans une situation simple.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "abe223ab-ad36-4b14-b349-abc8590eb94e",
-            "type": "video",
-            "title": "Déplacer la souris",
-            "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/deplacer_la_souris.mp4",
-            "poster": "https://assets.pix.org/draft/modules/jC8keAF.jpeg",
-            "subtitles": "",
-            "transcription": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "4925daa0-167c-4afd-83da-8435680992fd",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c8d99f94-9e03-4e0c-85cb-11c97f0d4149",
-            "type": "text",
-            "content": "<p>Vous allez maintenant passer à la pratique.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "713aeb31-6bbd-4e0c-930a-ad24164f5b9c",
-      "type": "activity",
-      "title": "Carte à gratter",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0dc90047-776b-48cd-944e-72ca51c69cfc",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur de votre souris.</h3><p>Pour découvrir l'image cachée, passez le pointeur de votre souris dans toute la zone.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ccaefecd-db35-40ea-a6f9-8d42fb907e63",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Carte à gratter",
-            "url": "https://epreuves.pix.fr/fr/puzzle/example.html",
-            "instruction": "<p>Instruction</p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "e81935e3-4188-4b6b-b641-127eb1f1cb74",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "2c5368e9-7d85-4132-bafe-53f198099b57",
-            "type": "text",
-            "content": "<p>Vous savez déplacer le pointeur de la souris à l'écran. Maintenant, entraînez-vous à être précis dans vos mouvements. 🎯</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "194be335-f3c1-468e-9ad1-0a7287b95f37",
-      "type": "activity",
-      "title": "Se déplacer précisément",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a33ac061-ab23-4e94-b60e-904e701e7d76",
-            "type": "text",
-            "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur sur chacun des éléments qui apparaissent. </h3><p>Vous pouvez essayer autant de fois que vous voulez.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "57d7453d-58a9-43f0-830c-f5f392b06f9e",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris1-DeplacerPointeur/index.html",
-            "instruction": "",
-            "height": 445
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "9c1c4342-96a6-4c14-a5b0-5ed0d202fb8f",
-            "type": "text",
-            "content": "<h3> <span aria-hidden=\"true\">💡</span> Astuce si vous ne voyez plus le pointeur sur votre écran :&nbsp;</h3> <p> Bougez de gauche à droite votre souris doucement sur la table.<br> Vous verrez le pointeur bouger à l'écran.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "aa183b1e-2c91-45d8-b796-778e43fa7ce3",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a11dc8fa-9030-4f70-b6d8-86af6ff66e30",
-            "type": "text",
-            "content": "<p>Maintenant que vous savez déplacer votre souris, découvrez les différents boutons de la souris ! 🖱️️</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "4a80afba-d2ef-4f58-a328-a0fc9f204aca",
-      "type": "discovery",
-      "title": "Les 3 boutons de la souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "564448dc-6485-4918-a2c1-4452b2552650",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-3boutonsouris/index.html",
-            "instruction": "<p><strong>👉Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong><br>Trois mots vont apparaître. Ce sont les noms des boutons de la souris.</p>",
-            "height": 445
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d9e4718d-a15a-4e62-a967-19971e1a611e",
-            "type": "text",
-            "content": "<p>Sur la souris, on trouve toujours deux boutons : un bouton gauche et un bouton droit.<br>En général, il y a aussi une molette.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "f964d3c9-cb68-4cda-97ef-9677c1897c94",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "98a59942-5506-4c18-b16a-97ce2010103b",
-            "type": "text",
-            "content": "<p><strong><span aria-hidden=\"true\">🔎</span> Observez : combien de boutons a votre souris d’ordinateur ?</strong></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e0c2934c-fbe0-466a-94d9-f1a4e83719fc",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "4d997b51-9404-42d3-87fc-8a9d31b0d905",
-            "type": "text",
-            "content": "<p>Vous avez découvert le nom des boutons d'une souris.</p><p>Voyons à présent comment cliquer avec votre souris !<br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "83f44f19-e8de-4248-bfc7-e38f19190138",
-      "type": "lesson",
-      "title": "Le clic gauche en texte-image",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e45a32cf-2ab9-4464-85d0-ae4f0ca897cb",
-            "type": "text",
-            "content": "<h3>D'abord, pourquoi est-ce qu'on dit «&nbsp;<strong>clic&nbsp;</strong>»&nbsp;?</h3><p>C'est le bruit que fait une souris d'ordinateur quand on appuie sur un de ses boutons.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4ec66bb9-f016-48c3-9653-56d7ae04d1b9",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/8DuRmCV.gif",
-            "alt": "",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d96505a1-c5c0-4dbf-af9d-900453586d45",
-            "type": "text",
-            "content": "<p>Le bouton gauche est le plus important. Il permet de faire un clic gauche.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "c0479cb0-c160-452a-89a8-c9fa6dbd74e8",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a510f893-7d93-4e4f-b8a4-0dd978324c70",
-            "type": "text",
-            "content": "<p>Voyons comment faire un clic gauche. <span aria-hidden=\"true\">👇</span></p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4cd1c225-f5da-43c2-af29-7d2bfa340b07",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/y23SQFf.gif",
-            "alt": "",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4f9d39e4-5687-43fa-881d-8904d63023c8",
-            "type": "text",
-            "content": "<p><strong>Étape 1&nbsp;:</strong> On déplace le pointeur à l'écran.</p><p><strong>Étape 2 : </strong>On appuie sur le bouton gauche de la souris</p><p><br></p><p>💡Pour réussir un clic : </p><ul><li>Il faut appuyer avec l’index sans faire bouger la souris.</li><li>On doit entendre le son « clic ».</li><li>Relâcher immédiatement après l’appui. C’est comme pour un bouton de télécommande !</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1f8a8389-645d-4756-87a2-d30acf24eafd",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7b083f7d-3e44-42ad-9822-8999a4e65ba4",
-            "type": "text",
-            "content": "<p>Vous allez maintenant passer à la pratique. 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b491a99e-2774-469e-a63e-e2d0fb1120f2",
-      "type": "activity",
-      "title": "Premiers clics gauches",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "73b6a6d3-8c76-46e9-ae1f-d208d5bf1960",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erclicsgauchesV2/index.html",
-            "instruction": "<p><strong>Dans la zone ci-dessous, faites un clic sur chaque élément lorsqu'il apparait.</strong></p>",
-            "height": 445
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "a6254fc0-1405-4c5a-bbec-3df43bdca573",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "930a995c-2b29-474a-97a3-c90d5e03ad80",
-            "type": "text",
-            "content": "<p>👏Bravo ! Vous savez maintenant déplacer le pointeur de votre souris et cliquer.</p><p>Faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;» pour passer à l'étape suivante en autonomie.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "bbd5c08b-1701-4e29-8648-71eac9793379",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0ef82c6c-4526-4ecf-9f2e-02a42fc382ac",
-            "type": "text",
-            "content": "<p>Il arrive que le pointeur de la souris change de forme. C’est tout à fait normal.&nbsp;</p><p>Découvrez les différentes formes de pointeur.<br><br></p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "03e0657a-7caf-49eb-8dfb-da0f5e52b7ba",
-      "type": "lesson",
-      "title": "Les types de pointeurs",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "af44ed34-f3a3-46f1-813d-c801a6e0b073",
-            "type": "text",
-            "content": "<p>Quand vous déplacez votre souris sur un élément, le pointeur peut changer de forme. Cela signifie qu'une action est possible.</p><p>Découvrez les trois formes de pointeur les plus courantes et leur utilité.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "1ad8190f-46b6-43b5-82b1-cd81640b1700",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/G6t4f0c.png",
-            "alt": "",
-            "alternativeText": "<p>image des 4 formes de pointeur les plus courantes : la flèche, la main, la barre verticale, et la roue ou le sablier.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8c07cbe0-14aa-4a0e-898d-7ddf9c4ff3be",
-            "type": "text",
-            "content": "<ul><li><strong>La flèche</strong> est le pointeur le plus courant.</li><li><strong>La main</strong> indique que vous pouvez cliquer.</li><li><strong>La barre verticale</strong> indique que vous pouvez taper du texte.</li><li><strong>La roue ou le sablier</strong> indiquent qu’il faut patienter.</li></ul>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "7e9abfc9-6512-4f12-8aa4-a3692207e939",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ccc4bf26-0610-4598-a91f-49a3c2e8dd02",
-            "type": "text",
-            "content": "<p>Le clic gauche sert à ouvrir des pages internet ou à démarrer des vidéos. Pour chacune de ses actions, le pointeur change de forme.</p><p>🖱️À vous de jouer !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "efba1e45-54ca-4829-b203-1e74b9269045",
-      "type": "activity",
-      "title": "Clics gauche de navigation dans le module",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "9c323a6c-2ae3-4257-af10-7711cebe6442",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "734ef21d-3850-40db-840e-e16253d8817b",
-                  "type": "text",
-                  "content": "<h3>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h3><br><p> Ce clic gauche va faire démarrer la vidéo.</p>"
-                },
-                {
-                  "id": "b0f296c2-a295-4424-8eb1-76e3fbcc1ebb",
-                  "type": "video",
-                  "title": "Bravo, vous êtes sur internet",
-                  "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.mp4",
-                  "poster": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.jpg",
-                  "subtitles": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.vtt",
-                  "transcription": "<p>Bravo, vous avez lancé la vidéo. Vous pouvez continuer le module.</p><p>Vous allez voir, c'est facile.</p>"
-                },
-                {
-                  "id": "06cd1e83-06ce-4ca2-a648-1184ca6700f3",
-                  "type": "text",
-                  "content": "<p>Pour accéder à la suite, faites un clic gauche sur le bouton «&nbsp;Suivant&nbsp;».</p>"
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "91ba6701-243c-4f07-bd0d-9019a1c85b4d",
+                "type": "text",
+                "content": "<p>Dans ce module vous allez prendre en main une souris pour interagir avec l'ordinateur.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f0db9bcb-a896-4801-827d-d0ceeddde3e5",
+          "type": "discovery",
+          "title": "Reconnaitre une souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "48708070-39c3-4af4-8914-ab61d61dfee8",
+                "type": "text",
+                "content": "<p>La souris fait partie de l'équipement de base d’un ordinateur, avec le clavier.</p><p>Les souris peuvent avoir différentes formes, tailles ou couleurs. </p><p>Il y a deux types de souris : </p><ul><li>les souris avec un fil</li><li>les souris sans fil</li></ul><p>Globalement, toutes ces souris servent à faire les mêmes choses.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "c849cbc5-931e-4a00-ae6a-083e2ff0614d",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/GHeUZvS.jpeg",
+                "alt": "-",
+                "alternativeText": "<ul><li>Les souris avec un fil : photographies de 4 souris avec fil de taille, forme et couleur différentes.</li><li>Les souris sans fil : photographies de 3 souris sans fil différentes reliées par des connecteurs USB Bluetooth .</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c785bfd1-e8b8-42a0-8354-333d5acf6555",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">🔎</span> Observez : votre souris a-t-elle un fil ?</h3>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2099c733-4be9-4063-8584-e854a6d9ee2f",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b4727513-47b5-4850-bde5-263795c63f46",
+                "type": "text",
+                "content": "<p>Dans la vidéo suivante, vous allez voir comment prendre en main une souris d'ordinateur pour ensuite la déplacer.&nbsp;📺</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "115f2b94-ba20-4158-a1b1-efb159d82808",
+          "type": "lesson",
+          "title": "Prise en main de la souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "75894ade-d0b9-4662-ba37-edf72c9e74e5",
+                "type": "text",
+                "content": "<p>Après cette vidéo, vous devrez suivre les étapes pour prendre en main votre souris.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "56541ee2-cf5f-4966-b17b-96a1b7266868",
+                "type": "video",
+                "title": "Prendre en main la souris",
+                "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_prise_en_main.mp4",
+                "poster": "https://assets.pix.org/draft/modules/lA2jUAY.jpeg",
+                "subtitles": "",
+                "transcription": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "4d381d79-1edf-426c-876a-fcc0fc783fc0",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "927b247f-f86a-458a-908f-62f8c39fb353",
+                "type": "text",
+                "content": "<p>À vous de jouer. Vous allez vous entraîner à déplacer votre souris.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "395f9865-bb44-4cd8-a4dd-03ffddf598f7",
+          "type": "activity",
+          "title": "Exercice de prise en main de la souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6b6eeef4-bb9b-4769-906d-47e72db93543",
+                "type": "text",
+                "content": "<p>Pour l'instant, regardez votre souris. Ne regardez pas ce qu'il se passe à l'écran.<br></p><h3><span aria-hidden=\"true\">👉</span> Déplacez votre souris, en suivant ces étapes :</h3><ul><li>Étape 1 : Posez votre main confortablement sur la souris.</li><li>Étape 2 : Faites glissez la souris doucement sur la table.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a0773d08-47df-4302-965e-1a8f2d69ae92",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d1dd9768-1b88-4a76-af7c-4290c3fe5a2f",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">🙋🏽‍♂️ 🙋🏿‍♀️ 🙋‍♂️</span>N'hésitez pas à demandez conseil à la personne qui vous accompagne. Elle vous aidera à trouver une position confortable pour vous.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2c2abead-9b97-4dc5-8ad4-876c21cd9797",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "36a93743-af38-47ae-a58e-be59b2d86656",
+                "type": "text",
+                "content": "<p>Dans la vidéo suivante, vous allez voir comment déplacer la souris sur votre écran.&nbsp;📺</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8a9618f5-c8d8-447e-83ae-cf66914c0aa0",
+          "type": "lesson",
+          "title": "Déplacer son pointeur",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7dad11c9-fafd-4e94-bd81-003e3944ff6d",
+                "type": "text",
+                "content": "<p>Après cette vidéo, vous devrez déplacez votre souris dans une situation simple.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "abe223ab-ad36-4b14-b349-abc8590eb94e",
+                "type": "video",
+                "title": "Déplacer la souris",
+                "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/deplacer_la_souris.mp4",
+                "poster": "https://assets.pix.org/draft/modules/jC8keAF.jpeg",
+                "subtitles": "",
+                "transcription": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "4925daa0-167c-4afd-83da-8435680992fd",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c8d99f94-9e03-4e0c-85cb-11c97f0d4149",
+                "type": "text",
+                "content": "<p>Vous allez maintenant passer à la pratique.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "713aeb31-6bbd-4e0c-930a-ad24164f5b9c",
+          "type": "activity",
+          "title": "Carte à gratter",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0dc90047-776b-48cd-944e-72ca51c69cfc",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur de votre souris.</h3><p>Pour découvrir l'image cachée, passez le pointeur de votre souris dans toute la zone.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ccaefecd-db35-40ea-a6f9-8d42fb907e63",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Carte à gratter",
+                "url": "https://epreuves.pix.fr/fr/puzzle/example.html",
+                "instruction": "<p>Instruction</p>",
+                "height": 445
+              }
+            }
+          ]
+        },
+        {
+          "id": "e81935e3-4188-4b6b-b641-127eb1f1cb74",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "2c5368e9-7d85-4132-bafe-53f198099b57",
+                "type": "text",
+                "content": "<p>Vous savez déplacer le pointeur de la souris à l'écran. Maintenant, entraînez-vous à être précis dans vos mouvements. 🎯</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "194be335-f3c1-468e-9ad1-0a7287b95f37",
+          "type": "activity",
+          "title": "Se déplacer précisément",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a33ac061-ab23-4e94-b60e-904e701e7d76",
+                "type": "text",
+                "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur sur chacun des éléments qui apparaissent. </h3><p>Vous pouvez essayer autant de fois que vous voulez.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "57d7453d-58a9-43f0-830c-f5f392b06f9e",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris1-DeplacerPointeur/index.html",
+                "instruction": "",
+                "height": 445
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9c1c4342-96a6-4c14-a5b0-5ed0d202fb8f",
+                "type": "text",
+                "content": "<h3> <span aria-hidden=\"true\">💡</span> Astuce si vous ne voyez plus le pointeur sur votre écran :&nbsp;</h3> <p> Bougez de gauche à droite votre souris doucement sur la table.<br> Vous verrez le pointeur bouger à l'écran.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "aa183b1e-2c91-45d8-b796-778e43fa7ce3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a11dc8fa-9030-4f70-b6d8-86af6ff66e30",
+                "type": "text",
+                "content": "<p>Maintenant que vous savez déplacer votre souris, découvrez les différents boutons de la souris ! 🖱️️</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4a80afba-d2ef-4f58-a328-a0fc9f204aca",
+          "type": "discovery",
+          "title": "Les 3 boutons de la souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "564448dc-6485-4918-a2c1-4452b2552650",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-3boutonsouris/index.html",
+                "instruction": "<p><strong>👉Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong><br>Trois mots vont apparaître. Ce sont les noms des boutons de la souris.</p>",
+                "height": 445
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d9e4718d-a15a-4e62-a967-19971e1a611e",
+                "type": "text",
+                "content": "<p>Sur la souris, on trouve toujours deux boutons : un bouton gauche et un bouton droit.<br>En général, il y a aussi une molette.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "f964d3c9-cb68-4cda-97ef-9677c1897c94",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "98a59942-5506-4c18-b16a-97ce2010103b",
+                "type": "text",
+                "content": "<p><strong><span aria-hidden=\"true\">🔎</span> Observez : combien de boutons a votre souris d’ordinateur ?</strong></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e0c2934c-fbe0-466a-94d9-f1a4e83719fc",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "4d997b51-9404-42d3-87fc-8a9d31b0d905",
+                "type": "text",
+                "content": "<p>Vous avez découvert le nom des boutons d'une souris.</p><p>Voyons à présent comment cliquer avec votre souris !<br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "83f44f19-e8de-4248-bfc7-e38f19190138",
+          "type": "lesson",
+          "title": "Le clic gauche en texte-image",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e45a32cf-2ab9-4464-85d0-ae4f0ca897cb",
+                "type": "text",
+                "content": "<h3>D'abord, pourquoi est-ce qu'on dit «&nbsp;<strong>clic&nbsp;</strong>»&nbsp;?</h3><p>C'est le bruit que fait une souris d'ordinateur quand on appuie sur un de ses boutons.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4ec66bb9-f016-48c3-9653-56d7ae04d1b9",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/8DuRmCV.gif",
+                "alt": "",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d96505a1-c5c0-4dbf-af9d-900453586d45",
+                "type": "text",
+                "content": "<p>Le bouton gauche est le plus important. Il permet de faire un clic gauche.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c0479cb0-c160-452a-89a8-c9fa6dbd74e8",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a510f893-7d93-4e4f-b8a4-0dd978324c70",
+                "type": "text",
+                "content": "<p>Voyons comment faire un clic gauche. <span aria-hidden=\"true\">👇</span></p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4cd1c225-f5da-43c2-af29-7d2bfa340b07",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/y23SQFf.gif",
+                "alt": "",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4f9d39e4-5687-43fa-881d-8904d63023c8",
+                "type": "text",
+                "content": "<p><strong>Étape 1&nbsp;:</strong> On déplace le pointeur à l'écran.</p><p><strong>Étape 2 : </strong>On appuie sur le bouton gauche de la souris</p><p><br></p><p>💡Pour réussir un clic : </p><ul><li>Il faut appuyer avec l’index sans faire bouger la souris.</li><li>On doit entendre le son « clic ».</li><li>Relâcher immédiatement après l’appui. C’est comme pour un bouton de télécommande !</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1f8a8389-645d-4756-87a2-d30acf24eafd",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7b083f7d-3e44-42ad-9822-8999a4e65ba4",
+                "type": "text",
+                "content": "<p>Vous allez maintenant passer à la pratique. 👇</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b491a99e-2774-469e-a63e-e2d0fb1120f2",
+          "type": "activity",
+          "title": "Premiers clics gauches",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "73b6a6d3-8c76-46e9-ae1f-d208d5bf1960",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erclicsgauchesV2/index.html",
+                "instruction": "<p><strong>Dans la zone ci-dessous, faites un clic sur chaque élément lorsqu'il apparait.</strong></p>",
+                "height": 445
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "a6254fc0-1405-4c5a-bbec-3df43bdca573",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "930a995c-2b29-474a-97a3-c90d5e03ad80",
+                "type": "text",
+                "content": "<p>👏Bravo ! Vous savez maintenant déplacer le pointeur de votre souris et cliquer.</p><p>Faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;» pour passer à l'étape suivante en autonomie.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "bbd5c08b-1701-4e29-8648-71eac9793379",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0ef82c6c-4526-4ecf-9f2e-02a42fc382ac",
+                "type": "text",
+                "content": "<p>Il arrive que le pointeur de la souris change de forme. C’est tout à fait normal.&nbsp;</p><p>Découvrez les différentes formes de pointeur.<br><br></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "03e0657a-7caf-49eb-8dfb-da0f5e52b7ba",
+          "type": "lesson",
+          "title": "Les types de pointeurs",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "af44ed34-f3a3-46f1-813d-c801a6e0b073",
+                "type": "text",
+                "content": "<p>Quand vous déplacez votre souris sur un élément, le pointeur peut changer de forme. Cela signifie qu'une action est possible.</p><p>Découvrez les trois formes de pointeur les plus courantes et leur utilité.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "1ad8190f-46b6-43b5-82b1-cd81640b1700",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/G6t4f0c.png",
+                "alt": "",
+                "alternativeText": "<p>image des 4 formes de pointeur les plus courantes : la flèche, la main, la barre verticale, et la roue ou le sablier.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8c07cbe0-14aa-4a0e-898d-7ddf9c4ff3be",
+                "type": "text",
+                "content": "<ul><li><strong>La flèche</strong> est le pointeur le plus courant.</li><li><strong>La main</strong> indique que vous pouvez cliquer.</li><li><strong>La barre verticale</strong> indique que vous pouvez taper du texte.</li><li><strong>La roue ou le sablier</strong> indiquent qu’il faut patienter.</li></ul>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "7e9abfc9-6512-4f12-8aa4-a3692207e939",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ccc4bf26-0610-4598-a91f-49a3c2e8dd02",
+                "type": "text",
+                "content": "<p>Le clic gauche sert à ouvrir des pages internet ou à démarrer des vidéos. Pour chacune de ses actions, le pointeur change de forme.</p><p>🖱️À vous de jouer !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "efba1e45-54ca-4829-b203-1e74b9269045",
+          "type": "activity",
+          "title": "Clics gauche de navigation dans le module",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "35e0ae32-980e-45fc-bb69-b94da529d6fb",
-                  "type": "text",
-                  "content": "Dans le quiz ci-dessous, cliquez sur une réponse puis cliquez sur «&nbsp;Vérifier&nbsp;»."
-                },
-                {
-                  "id": "7253ded2-df17-4926-930d-0b0947f7de82",
-                  "type": "qcu",
-                  "instruction": "<p>Une phrase a été dite dans la vidéo.</p><br><p>Quelle est cette phrase ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Vous allez voir, c'est facile !</p>",
-                      "feedback": {
-                        "state": "Bonne réponse&nbsp;! 🎉",
-                        "diagnosis": "<p>Vous avez lancé la vidéo et trouvé la bonne réponse.</p>"
-                      }
+                      "id": "734ef21d-3850-40db-840e-e16253d8817b",
+                      "type": "text",
+                      "content": "<h3>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h3><br><p> Ce clic gauche va faire démarrer la vidéo.</p>"
                     },
                     {
-                      "id": "2",
-                      "content": "Vous verrez, c'est plié !",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
-                      }
+                      "id": "b0f296c2-a295-4424-8eb1-76e3fbcc1ebb",
+                      "type": "video",
+                      "title": "Bravo, vous êtes sur internet",
+                      "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.mp4",
+                      "poster": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.jpg",
+                      "subtitles": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/bravo-souris.vtt",
+                      "transcription": "<p>Bravo, vous avez lancé la vidéo. Vous pouvez continuer le module.</p><p>Vous allez voir, c'est facile.</p>"
                     },
                     {
-                      "id": "3",
-                      "content": "Vous pensiez que c'était simple ?",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
-                      }
+                      "id": "06cd1e83-06ce-4ca2-a648-1184ca6700f3",
+                      "type": "text",
+                      "content": "<p>Pour accéder à la suite, faites un clic gauche sur le bouton «&nbsp;Suivant&nbsp;».</p>"
                     }
-                  ],
-                  "solution": "1"
+                  ]
                 },
                 {
-                  "id": "4b559769-3f0d-43ee-8b7d-c1aa3e0927c6",
-                  "type": "separator"
-                },
-                {
-                  "id": "4c2ce336-aa9a-49b5-ba4f-84530e21b52d",
-                  "type": "text",
-                  "content": "<p>Quand vous avez terminé l'activité, faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;».</p>"
+                  "elements": [
+                    {
+                      "id": "35e0ae32-980e-45fc-bb69-b94da529d6fb",
+                      "type": "text",
+                      "content": "Dans le quiz ci-dessous, cliquez sur une réponse puis cliquez sur «&nbsp;Vérifier&nbsp;»."
+                    },
+                    {
+                      "id": "7253ded2-df17-4926-930d-0b0947f7de82",
+                      "type": "qcu",
+                      "instruction": "<p>Une phrase a été dite dans la vidéo.</p><br><p>Quelle est cette phrase ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Vous allez voir, c'est facile !</p>",
+                          "feedback": {
+                            "state": "Bonne réponse&nbsp;! 🎉",
+                            "diagnosis": "<p>Vous avez lancé la vidéo et trouvé la bonne réponse.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Vous verrez, c'est plié !",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "Vous pensiez que c'était simple ?",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Vous avez bien cliqué sur vérifier. Mais ce n’était pas la bonne réponse.<br>Vous pouvez retenter votre chance en cliquant sur «&nbsp;Réessayer&nbsp;».</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    },
+                    {
+                      "id": "4b559769-3f0d-43ee-8b7d-c1aa3e0927c6",
+                      "type": "separator"
+                    },
+                    {
+                      "id": "4c2ce336-aa9a-49b5-ba4f-84530e21b52d",
+                      "type": "text",
+                      "content": "<p>Quand vous avez terminé l'activité, faites un clic gauche sur le bouton «&nbsp;Continuer&nbsp;».</p>"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "b84e43af-ebac-4d50-8c3f-a50154de87d7",
-      "type": "summary",
-      "title": "Les 5 points à retenir ",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "72a98ef7-1052-4f70-bfe8-a77ff4279f61",
-            "type": "text",
-            "content": "<h3>Les 5 points à retenir <span aria-hidden=\"true\">📌</span></h3>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "3480a769-41ea-47e8-990b-c5f8089542e7",
-            "type": "text",
-            "content": "<ul> <li><span aria-hidden=\"true\">🖐️</span>La souris glisse sur la table grâce à votre main.</li> <li><span aria-hidden=\"true\">🖥️</span> À l'écran, le pointeur suit le mouvement de la souris.</li> <li><span aria-hidden=\"true\">👉</span> Cliquer veut dire appuyer brièvement sur un bouton de la souris.</li> <li><span aria-hidden=\"true\">▶️</span> Cliquer permet d'interagir avec l’ordinateur.</li> <li><span aria-hidden=\"true\">🖱️Le pointeur de la souris change de forme quand on peut cliquer.</span></li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "5fb7bb57-aa01-4427-80cb-4e2bc5c0434a",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "85ac9805-09f8-456b-8b5f-f26fe19ca618",
-            "type": "text",
-            "content": "<p><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-1/pix-fiche-revision-premieres-marches-souris-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
-          }
+          "id": "b84e43af-ebac-4d50-8c3f-a50154de87d7",
+          "type": "summary",
+          "title": "Les 5 points à retenir ",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "72a98ef7-1052-4f70-bfe8-a77ff4279f61",
+                "type": "text",
+                "content": "<h3>Les 5 points à retenir <span aria-hidden=\"true\">📌</span></h3>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3480a769-41ea-47e8-990b-c5f8089542e7",
+                "type": "text",
+                "content": "<ul> <li><span aria-hidden=\"true\">🖐️</span>La souris glisse sur la table grâce à votre main.</li> <li><span aria-hidden=\"true\">🖥️</span> À l'écran, le pointeur suit le mouvement de la souris.</li> <li><span aria-hidden=\"true\">👉</span> Cliquer veut dire appuyer brièvement sur un bouton de la souris.</li> <li><span aria-hidden=\"true\">▶️</span> Cliquer permet d'interagir avec l’ordinateur.</li> <li><span aria-hidden=\"true\">🖱️Le pointeur de la souris change de forme quand on peut cliquer.</span></li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "5fb7bb57-aa01-4427-80cb-4e2bc5c0434a",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "85ac9805-09f8-456b-8b5f-f26fe19ca618",
+                "type": "text",
+                "content": "<p><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-1/pix-fiche-revision-premieres-marches-souris-1.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -15,580 +15,586 @@
     ],
     "tabletSupport": "obstructed"
   },
-  "grains": [
+  "sections": [
     {
-      "id": "89e43bc8-a579-428a-8e58-56dbf5f1cf93",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "a3f7f2b5-a4b8-4590-9cca-1f316a0c4dd2",
+      "type": "blank",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "d5c2e0af-72e7-42b8-a1f5-fa235be9301a",
-            "type": "text",
-            "content": "<p>La souris permet d’interagir avec l’ordinateur de différentes façons. Le pointeur se déplace à l’écran quand la souris glisse sur la table. Le bouton gauche permet de faire un clic gauche.&nbsp; <br><br>Découvrez dans ce module comment utiliser la molette, le double-clic et le clic droit.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9953bee8-bf21-45a7-9522-4d74700b4828",
-      "type": "activity",
-      "title": "Introduction clic gauche",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7724ff4d-de21-4fe3-9eab-5c9e6a18a010",
-            "type": "text",
-            "content": "<p>Pour commencer, faites un clic gauche sur « Continuer» 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c942f3a1-52e4-41c4-8172-b7df7509b9f8",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "36044495-821b-4126-b687-b8a17c505b8e",
-            "type": "text",
-            "content": "<p><strong>Bravo !</strong> 🎉 <br>Vous êtes prêt. Commençons par la molette.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2ad4df3c-5afe-4c8e-8316-77f05ecb7641",
-      "type": "lesson",
-      "title": "La molette de la souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "6b8d384f-c15e-4abd-b392-bff1e17aee7a",
-            "type": "text",
-            "content": "<p>La molette est le bouton central de la souris. Elle sert à faire défiler une page à l'écran vers le bas, ou vers le haut.</p><details><summary><strong>Si jamais votre souris n'a pas de molette</strong></summary>Rapprochez-vous de la personne qui vous accompagne pour découvrir comment cela fonctionne sur votre souris. </details><p><br>Pour faire défiler la page, il faut faire rouler la molette avec votre doigt de haut en bas, ou de bas en haut.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "0d588342-d473-4fd7-b995-f127177b493d",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/17Ab5i5.gif",
-            "alt": "",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "695d7b72-e982-4e45-a8dd-deac2ae73c59",
-            "type": "text",
-            "content": "<p>Dans l'exemple ci-dessus : la molette roule vers le bas, donc on descend dans la page. </p><p>C’est comme si nos yeux descendaient sur une page de journal papier. 📰</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "1d98eca4-0217-45bf-95f9-7e5d19e0c921",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "56cb8b5c-4a25-4960-a7cf-6b86b13375a5",
-            "type": "text",
-            "content": "<p>À vous de jouer. 🕹️ </p><p>Vous allez vous entraîner à utiliser la molette de votre souris.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "48d4b5d0-7457-4071-ae6d-43dc4717ae86",
-      "type": "activity",
-      "title": "La molette de la souris",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "89e43bc8-a579-428a-8e58-56dbf5f1cf93",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "5173f727-635c-4ad9-8651-0b379e0b538e",
-                  "type": "text",
-                  "content": "<p><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, utilisez la molette pour découvir toute l'image. Vous devrez ensuite répondre à une question&nbsp;:</p><ul> <li>Étape 1: Placez le pointeur sur l'image</li> <li>Étape 2 : Faites rouler la molette de votre souris vers le haut et vers le bas.</li> <li>Étape 3 : Déplacez l'image jusqu'à trouver le balcon le plus bas de l'immeuble.</li> </ul>"
-                },
-                {
-                  "id": "7aac23e0-6642-4ca4-928f-50e074dabc77",
-                  "type": "custom-draft",
-                  "title": "Élément interactif",
-                  "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-molette2image/test%20image%20scroll-02-02.jpg",
-                  "instruction": "",
-                  "height": 340
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "d5c2e0af-72e7-42b8-a1f5-fa235be9301a",
+                "type": "text",
+                "content": "<p>La souris permet d’interagir avec l’ordinateur de différentes façons. Le pointeur se déplace à l’écran quand la souris glisse sur la table. Le bouton gauche permet de faire un clic gauche.&nbsp; <br><br>Découvrez dans ce module comment utiliser la molette, le double-clic et le clic droit.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9953bee8-bf21-45a7-9522-4d74700b4828",
+          "type": "activity",
+          "title": "Introduction clic gauche",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7724ff4d-de21-4fe3-9eab-5c9e6a18a010",
+                "type": "text",
+                "content": "<p>Pour commencer, faites un clic gauche sur « Continuer» 👇</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c942f3a1-52e4-41c4-8172-b7df7509b9f8",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "36044495-821b-4126-b687-b8a17c505b8e",
+                "type": "text",
+                "content": "<p><strong>Bravo !</strong> 🎉 <br>Vous êtes prêt. Commençons par la molette.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2ad4df3c-5afe-4c8e-8316-77f05ecb7641",
+          "type": "lesson",
+          "title": "La molette de la souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "6b8d384f-c15e-4abd-b392-bff1e17aee7a",
+                "type": "text",
+                "content": "<p>La molette est le bouton central de la souris. Elle sert à faire défiler une page à l'écran vers le bas, ou vers le haut.</p><details><summary><strong>Si jamais votre souris n'a pas de molette</strong></summary>Rapprochez-vous de la personne qui vous accompagne pour découvrir comment cela fonctionne sur votre souris. </details><p><br>Pour faire défiler la page, il faut faire rouler la molette avec votre doigt de haut en bas, ou de bas en haut.</p>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "0d588342-d473-4fd7-b995-f127177b493d",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/17Ab5i5.gif",
+                "alt": "",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "695d7b72-e982-4e45-a8dd-deac2ae73c59",
+                "type": "text",
+                "content": "<p>Dans l'exemple ci-dessus : la molette roule vers le bas, donc on descend dans la page. </p><p>C’est comme si nos yeux descendaient sur une page de journal papier. 📰</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1d98eca4-0217-45bf-95f9-7e5d19e0c921",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "56cb8b5c-4a25-4960-a7cf-6b86b13375a5",
+                "type": "text",
+                "content": "<p>À vous de jouer. 🕹️ </p><p>Vous allez vous entraîner à utiliser la molette de votre souris.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "48d4b5d0-7457-4071-ae6d-43dc4717ae86",
+          "type": "activity",
+          "title": "La molette de la souris",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "6c768c45-998a-4769-8dcf-18f72a15bab8",
-                  "type": "qcu",
-                  "instruction": "<p>Dans l'image ci-dessus, que fait la personne sur le balcon le plus bas ?</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "<p>Elle se détend au soleil.</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Ce personnage n'est pas sur le balcon le plus bas. Vous pouvez utiliser la molette pour descendre encore plus bas dans l'image.</p>"
-                      }
+                      "id": "5173f727-635c-4ad9-8651-0b379e0b538e",
+                      "type": "text",
+                      "content": "<p><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, utilisez la molette pour découvir toute l'image. Vous devrez ensuite répondre à une question&nbsp;:</p><ul> <li>Étape 1: Placez le pointeur sur l'image</li> <li>Étape 2 : Faites rouler la molette de votre souris vers le haut et vers le bas.</li> <li>Étape 3 : Déplacez l'image jusqu'à trouver le balcon le plus bas de l'immeuble.</li> </ul>"
                     },
                     {
-                      "id": "2",
-                      "content": "<p>Elle arrose ses plantes.</p>",
-                      "feedback": {
-                        "state": "Bonne réponse !",
-                        "diagnosis": "<p>Vous avez réussi à descendre dans toute l'image jusqu'au dernier balcon.<span aria-hidden=\"true\">🏢 </span></p>"
-                      }
-                    },
-                    {
-                      "id": "3",
-                      "content": "<p>Elle étend son linge.</p>",
-                      "feedback": {
-                        "state": "Mauvaise réponse.",
-                        "diagnosis": "<p>Cette activité est celle du personnage du premier balcon de l'immeuble. Utilisez la molette de votre souris quand votre pointeur est sur l'image. Faites défiler l'image pour découvrir les autres fenêtres et balcons de l'immeuble.</p>"
-                      }
+                      "id": "7aac23e0-6642-4ca4-928f-50e074dabc77",
+                      "type": "custom-draft",
+                      "title": "Élément interactif",
+                      "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-molette2image/test%20image%20scroll-02-02.jpg",
+                      "instruction": "",
+                      "height": 340
                     }
-                  ],
-                  "solution": "2"
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "6c768c45-998a-4769-8dcf-18f72a15bab8",
+                      "type": "qcu",
+                      "instruction": "<p>Dans l'image ci-dessus, que fait la personne sur le balcon le plus bas ?</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>Elle se détend au soleil.</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Ce personnage n'est pas sur le balcon le plus bas. Vous pouvez utiliser la molette pour descendre encore plus bas dans l'image.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "<p>Elle arrose ses plantes.</p>",
+                          "feedback": {
+                            "state": "Bonne réponse !",
+                            "diagnosis": "<p>Vous avez réussi à descendre dans toute l'image jusqu'au dernier balcon.<span aria-hidden=\"true\">🏢 </span></p>"
+                          }
+                        },
+                        {
+                          "id": "3",
+                          "content": "<p>Elle étend son linge.</p>",
+                          "feedback": {
+                            "state": "Mauvaise réponse.",
+                            "diagnosis": "<p>Cette activité est celle du personnage du premier balcon de l'immeuble. Utilisez la molette de votre souris quand votre pointeur est sur l'image. Faites défiler l'image pour découvrir les autres fenêtres et balcons de l'immeuble.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "466421d6-62c3-4817-a116-0ac8d0de0d84",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "989decd1-926a-4db7-88bb-b31862131f8b",
-            "type": "text",
-            "content": "<p>Passez à la pratique sur une page entière. 👇 </p><p>Après cette activité, vous saurez vous déplacer dans le module grâce à la molette, vous êtes prêts ?</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "6ebfb036-f99b-4dc4-805c-f8bf7b3c76a3",
-      "type": "activity",
-      "title": "Utilisation de la molette dans le module",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f8226449-d41d-4650-aa7a-001fbc5773a8",
-            "type": "text",
-            "content": "<p>Dans cette activité, vous allez devoir retrouver un mot dans le module. Le mot à trouver se trouve avant le symbole « 📰 ». <br><br> Voici les étapes que vous allez suivre :&nbsp; </p><ul><li>Faire rouler la molette pour remonter jusqu'à l'image animée de la molette.</li><li>Trouver le mot qui se trouve avant le symbole « 📰 ».</li><li>Faire rouler la molette pour redescendre ici.</li><li>Répondre à la question.</li></ul>"
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "dda12023-7164-4f7b-ac7c-dfcef120aca7",
-            "type": "qcu",
-            "instruction": "<p>Quel est le mot juste avant ce symbole «📰» ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>journal</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Pour remonter dans le module, faites rouler la molette doucement vers le haut et cherchez un encadré bleu clair.&nbsp; Le symbole que vous cherchez se trouve sous l’image.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>papier</p>",
-                "feedback": {
-                  "state": "Bonne réponse !",
-                  "diagnosis": "<p>Vous avez parcouru le module de haut en bas. À tout moment, vous pouvez utiliser la molette pour relire quelque chose, revoir une vidéo, etc.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>page</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p>Pour remonter dans le module, faites rouler la molette doucement vers le haut et cherchez un encadré bleu clair.&nbsp; Le symbole que vous cherchez se trouve sous l’image.</p>"
-                }
-              }
-            ],
-            "solution": "2"
-          }
-        }
-      ]
-    },
-    {
-      "id": "3a2933a2-0026-4a80-8db4-3f8773983215",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "b42906c3-b340-40c0-852a-4ae733c7fb9e",
-            "type": "text",
-            "content": "<p>Félicitations !&nbsp; Vous êtes désormais autonome avec la molette ! 🎉<br>Découvrez maintenant un nouveau type de clic&nbsp;: le double-clic.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "45d3d731-5abf-4384-afc7-12dcd8d37365",
-      "type": "lesson",
-      "title": "Le double-clic en vidéo",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5a8f1986-8a81-4b66-ae0f-d0e58b73ce69",
-            "type": "text",
-            "content": "<p>Pour faire un double-clic, il faut appuyer rapidement deux fois de suite sur le bouton gauche.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "fc75b4ab-d92d-4ae9-8387-8bb3d683a99c",
-            "type": "image",
-            "url": "https://assets.pix.org/draft/modules/Vm7UCzY.gif",
-            "alt": "",
-            "alternativeText": ""
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "d73107b1-d15b-4f4b-af1e-9745d5c61a43",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ec8094d6-53e4-4305-948a-74ed1d0fd443",
-            "type": "text",
-            "content": "<p>📺 Dans la vidéo ci-dessous, vous allez voir comment faire un double-clic et à quoi il sert. <br>Après cette vidéo, ce sera à vous de faire des doubles-clics.</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "daced261-0ad6-43e1-b826-d43d89ca926b",
-            "type": "video",
-            "title": "Effectuer un double-clic avec la souris",
-            "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_double_clic.mp4",
-            "poster": "https://assets.pix.org/draft/modules/N51HDsO.jpeg",
-            "subtitles": "",
-            "transcription": ""
-          }
-        }
-      ]
-    },
-    {
-      "id": "efc2abce-4d88-4251-8c15-9430891824b8",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3b975cca-22b4-444a-8aa5-801af949536f",
-            "type": "text",
-            "content": "<p>Place à la pratique ! Entraînez-vous au double-clic dans l’activité suivante.👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f7b7e135-b49a-41e0-88fc-1cf4c45bbc0f",
-      "type": "activity",
-      "title": "Premiers doubles-clics",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "be1b5866-6475-4bed-a775-e07be73f156e",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erdoublesclics/index.html",
-            "instruction": "<p>👉 <strong>Faites un double-clic sur chaque élément qui apparaît ci-dessous.</strong></p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "9d1dd3cb-5a58-43d7-9e5f-fa9dd62ac59b",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "e295a2ca-a6ba-45e2-8805-12ef13bcab53",
-            "type": "text",
-            "content": "<p>On utilise souvent le double-clic pour ouvrir des dossiers sur son ordinateur. 📁 <br>À vous d’essayer !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c3b07818-2cfb-4aaa-afdd-0444de95be3f",
-      "type": "activity",
-      "title": "Utilisation du double-clic",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3528708a-ba19-49c2-97a2-08be8f961124",
-            "type": "text",
-            "content": "<p><strong>Dans la zone ci-dessous, ouvrez les dossiers en suivant cet ordre :</strong> </p><ul><li>Photos,</li><li>Album,</li><li>Famille,</li><li>80 ans Mamie.</li></ul>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "ba879c50-b4ed-487c-b1a8-f7220c2ad2f9",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur gestionnaire de fichier",
-            "url": "https://epreuves.pix.fr/filemanager-visu/filemanager-visu.html?mode=example&lang=fr",
-            "instruction": "Quand vous avez terminé, répondez à la question qui suit.",
-            "height": 400
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e2e63f1e-7260-4404-9a09-614c24236fc2",
-            "type": "qcu",
-            "instruction": "<p>Dans le dossier «80 ans Mamie», combien est-ce qu'il y a de photos ?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "<p>4</p>",
-                "feedback": {
-                  "state": "Bonne réponse.",
-                  "diagnosis": "<p>Il y a bien 4 photos dans le dossier «&nbsp;80 ans Mamie&nbsp;». Bravo ! Vous avez fait 4 doubles-clics et réussi à naviguer dans un explorateur de fichiers.</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "<p>5</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "<p>6</p>",
-                "feedback": {
-                  "state": "Mauvaise réponse.",
-                  "diagnosis": "<p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
-                }
-              }
-            ],
-            "solution": "1"
-          }
-        }
-      ]
-    },
-    {
-      "id": "2c13664d-dbe8-42e7-a4bf-f6a67be2916e",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "66c9055e-c74a-4cf4-af83-70833210c86e",
-            "type": "text",
-            "content": "<p>Maintenant que vous savez faire un clic, un double-clic et utiliser la molette, découvrez le dernier bouton de la souris : le bouton droit.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9227a9d5-929d-4a5f-b85b-1649695d058c",
-      "type": "lesson",
-      "title": "Le clic droit",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "466421d6-62c3-4817-a116-0ac8d0de0d84",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "f986b4fa-fa9d-45ae-8ccd-ca4e834f050d",
-                  "type": "text",
-                  "content": "<p>Le bouton droit permet de faire des <strong>clics droit</strong>. <br>Le clic droit sert à afficher une liste d'actions à l'écran. <br>Par exemple, avec un dossier, on a le choix de supprimer le dossier, de renommer le dossier, etc.</p>"
-                },
-                {
-                  "id": "d3a9fae5-986c-4710-b53f-6775474bab4c",
-                  "type": "image",
-                  "url": "https://assets.pix.org/draft/modules/aNtakNA.gif",
-                  "alt": "",
-                  "alternativeText": ""
-                }
-              ]
+              "type": "element",
+              "element": {
+                "id": "989decd1-926a-4db7-88bb-b31862131f8b",
+                "type": "text",
+                "content": "<p>Passez à la pratique sur une page entière. 👇 </p><p>Après cette activité, vous saurez vous déplacer dans le module grâce à la molette, vous êtes prêts ?</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6ebfb036-f99b-4dc4-805c-f8bf7b3c76a3",
+          "type": "activity",
+          "title": "Utilisation de la molette dans le module",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f8226449-d41d-4650-aa7a-001fbc5773a8",
+                "type": "text",
+                "content": "<p>Dans cette activité, vous allez devoir retrouver un mot dans le module. Le mot à trouver se trouve avant le symbole « 📰 ». <br><br> Voici les étapes que vous allez suivre :&nbsp; </p><ul><li>Faire rouler la molette pour remonter jusqu'à l'image animée de la molette.</li><li>Trouver le mot qui se trouve avant le symbole « 📰 ».</li><li>Faire rouler la molette pour redescendre ici.</li><li>Répondre à la question.</li></ul>"
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "dda12023-7164-4f7b-ac7c-dfcef120aca7",
+                "type": "qcu",
+                "instruction": "<p>Quel est le mot juste avant ce symbole «📰» ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>journal</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Pour remonter dans le module, faites rouler la molette doucement vers le haut et cherchez un encadré bleu clair.&nbsp; Le symbole que vous cherchez se trouve sous l’image.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>papier</p>",
+                    "feedback": {
+                      "state": "Bonne réponse !",
+                      "diagnosis": "<p>Vous avez parcouru le module de haut en bas. À tout moment, vous pouvez utiliser la molette pour relire quelque chose, revoir une vidéo, etc.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>page</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p>Pour remonter dans le module, faites rouler la molette doucement vers le haut et cherchez un encadré bleu clair.&nbsp; Le symbole que vous cherchez se trouve sous l’image.</p>"
+                    }
+                  }
+                ],
+                "solution": "2"
+              }
+            }
+          ]
+        },
+        {
+          "id": "3a2933a2-0026-4a80-8db4-3f8773983215",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "b42906c3-b340-40c0-852a-4ae733c7fb9e",
+                "type": "text",
+                "content": "<p>Félicitations !&nbsp; Vous êtes désormais autonome avec la molette ! 🎉<br>Découvrez maintenant un nouveau type de clic&nbsp;: le double-clic.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "45d3d731-5abf-4384-afc7-12dcd8d37365",
+          "type": "lesson",
+          "title": "Le double-clic en vidéo",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5a8f1986-8a81-4b66-ae0f-d0e58b73ce69",
+                "type": "text",
+                "content": "<p>Pour faire un double-clic, il faut appuyer rapidement deux fois de suite sur le bouton gauche.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "fc75b4ab-d92d-4ae9-8387-8bb3d683a99c",
+                "type": "image",
+                "url": "https://assets.pix.org/draft/modules/Vm7UCzY.gif",
+                "alt": "",
+                "alternativeText": ""
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d73107b1-d15b-4f4b-af1e-9745d5c61a43",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ec8094d6-53e4-4305-948a-74ed1d0fd443",
+                "type": "text",
+                "content": "<p>📺 Dans la vidéo ci-dessous, vous allez voir comment faire un double-clic et à quoi il sert. <br>Après cette vidéo, ce sera à vous de faire des doubles-clics.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "daced261-0ad6-43e1-b826-d43d89ca926b",
+                "type": "video",
+                "title": "Effectuer un double-clic avec la souris",
+                "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_double_clic.mp4",
+                "poster": "https://assets.pix.org/draft/modules/N51HDsO.jpeg",
+                "subtitles": "",
+                "transcription": ""
+              }
+            }
+          ]
+        },
+        {
+          "id": "efc2abce-4d88-4251-8c15-9430891824b8",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3b975cca-22b4-444a-8aa5-801af949536f",
+                "type": "text",
+                "content": "<p>Place à la pratique ! Entraînez-vous au double-clic dans l’activité suivante.👇</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f7b7e135-b49a-41e0-88fc-1cf4c45bbc0f",
+          "type": "activity",
+          "title": "Premiers doubles-clics",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "be1b5866-6475-4bed-a775-e07be73f156e",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-clic-1erdoublesclics/index.html",
+                "instruction": "<p>👉 <strong>Faites un double-clic sur chaque élément qui apparaît ci-dessous.</strong></p>",
+                "height": 445
+              }
+            }
+          ]
+        },
+        {
+          "id": "9d1dd3cb-5a58-43d7-9e5f-fa9dd62ac59b",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "e295a2ca-a6ba-45e2-8805-12ef13bcab53",
+                "type": "text",
+                "content": "<p>On utilise souvent le double-clic pour ouvrir des dossiers sur son ordinateur. 📁 <br>À vous d’essayer !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c3b07818-2cfb-4aaa-afdd-0444de95be3f",
+          "type": "activity",
+          "title": "Utilisation du double-clic",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3528708a-ba19-49c2-97a2-08be8f961124",
+                "type": "text",
+                "content": "<p><strong>Dans la zone ci-dessous, ouvrez les dossiers en suivant cet ordre :</strong> </p><ul><li>Photos,</li><li>Album,</li><li>Famille,</li><li>80 ans Mamie.</li></ul>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "ba879c50-b4ed-487c-b1a8-f7220c2ad2f9",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur gestionnaire de fichier",
+                "url": "https://epreuves.pix.fr/filemanager-visu/filemanager-visu.html?mode=example&lang=fr",
+                "instruction": "Quand vous avez terminé, répondez à la question qui suit.",
+                "height": 400
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "e2e63f1e-7260-4404-9a09-614c24236fc2",
+                "type": "qcu",
+                "instruction": "<p>Dans le dossier «80 ans Mamie», combien est-ce qu'il y a de photos ?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "<p>4</p>",
+                    "feedback": {
+                      "state": "Bonne réponse.",
+                      "diagnosis": "<p>Il y a bien 4 photos dans le dossier «&nbsp;80 ans Mamie&nbsp;». Bravo ! Vous avez fait 4 doubles-clics et réussi à naviguer dans un explorateur de fichiers.</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "<p>5</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "<p>6</p>",
+                    "feedback": {
+                      "state": "Mauvaise réponse.",
+                      "diagnosis": "<p><strong>Vous avez répondu au questionnaire, mais vous n'avez pas cliqué sur la bonne réponse.</strong><br>Si vous n'avez pas trouvé le dossier «&nbsp;80 ans Mamie&nbsp;» :</p><ul><li>Cliquez sur «&nbsp;Réinitialiser&nbsp;» ci-dessus</li> <li>Suivez les étapes qui vous sont données. Vous devriez effectuer 4 doubles-clics.</li><li>Comptez ensuite le nombre de fichiers qui s'appellent «&nbsp;Photo&nbsp;».</li></ul>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
+        },
+        {
+          "id": "2c13664d-dbe8-42e7-a4bf-f6a67be2916e",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "66c9055e-c74a-4cf4-af83-70833210c86e",
+                "type": "text",
+                "content": "<p>Maintenant que vous savez faire un clic, un double-clic et utiliser la molette, découvrez le dernier bouton de la souris : le bouton droit.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9227a9d5-929d-4a5f-b85b-1649695d058c",
+          "type": "lesson",
+          "title": "Le clic droit",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "21323d29-5fb9-4374-b25e-8c83e011605b",
-                  "type": "text",
-                  "content": "<p>📺 Découvrez en vidéo comment faire un clic droit et comment utiliser la liste d’actions. <br> Après la vidéo, vous pourrez vous entraîner à faire des clics droit.</p>"
+                  "elements": [
+                    {
+                      "id": "f986b4fa-fa9d-45ae-8ccd-ca4e834f050d",
+                      "type": "text",
+                      "content": "<p>Le bouton droit permet de faire des <strong>clics droit</strong>. <br>Le clic droit sert à afficher une liste d'actions à l'écran. <br>Par exemple, avec un dossier, on a le choix de supprimer le dossier, de renommer le dossier, etc.</p>"
+                    },
+                    {
+                      "id": "d3a9fae5-986c-4710-b53f-6775474bab4c",
+                      "type": "image",
+                      "url": "https://assets.pix.org/draft/modules/aNtakNA.gif",
+                      "alt": "",
+                      "alternativeText": ""
+                    }
+                  ]
                 },
                 {
-                  "id": "e1ba101d-f98c-4938-938f-31e1362a4db3",
-                  "type": "video",
-                  "title": "Utiliser le clic droit de la souris",
-                  "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_clic_droit.mp4",
-                  "poster": "https://assets.pix.org/draft/modules/Fxj4UcZ.jpeg",
-                  "subtitles": "",
-                  "transcription": ""
+                  "elements": [
+                    {
+                      "id": "21323d29-5fb9-4374-b25e-8c83e011605b",
+                      "type": "text",
+                      "content": "<p>📺 Découvrez en vidéo comment faire un clic droit et comment utiliser la liste d’actions. <br> Après la vidéo, vous pourrez vous entraîner à faire des clics droit.</p>"
+                    },
+                    {
+                      "id": "e1ba101d-f98c-4938-938f-31e1362a4db3",
+                      "type": "video",
+                      "title": "Utiliser le clic droit de la souris",
+                      "url": "https://assets.pix.org/modules/utiliser-souris-ordinateur-1/souris_clic_droit.mp4",
+                      "poster": "https://assets.pix.org/draft/modules/Fxj4UcZ.jpeg",
+                      "subtitles": "",
+                      "transcription": ""
+                    }
+                  ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "aaaa5676-f865-4d85-8d95-7329e2716511",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "a609018d-fd04-460f-b574-b5107b3f4f73",
-            "type": "text",
-            "content": "<p>Avant de faire apparaître la liste d’actions, commencez par faire vos premiers clics droits. 👇</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "22ff7ef7-cf2d-4f35-80cd-af15becebbfc",
-      "type": "activity",
-      "title": "Premiers clics droits",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fc26348a-dea8-4010-bfa6-efd0252b9516",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-clicdroitpuisgauche/index.html",
-            "instruction": "<p><strong>Dans la zone ci-dessous, entraînez-vous à faire un clic droit puis un clic gauche à la suite.</strong></p>",
-            "height": 445
-          }
-        }
-      ]
-    },
-    {
-      "id": "eb055116-5d70-42ac-8d7b-3bdf2f6acef9",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "7f49b2c6-8488-4868-9454-6a92b4cc7643",
-            "type": "text",
-            "content": "<p>Vous savez désormais alterner les clics droit et clics gauche. 👍<br>À vous maintenant d’utiliser les clics droit et gauche sur une liste d’action.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "9217d594-0915-4f2e-9d27-5faef1b473d3",
-      "type": "activity",
-      "title": "Utiliser le clic droit",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "84a56ef8-1645-4204-8124-ae748c04c621",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Gestionnaire de fichiers - supprimer photos",
-            "url": "https://epreuves.pix.fr/filemanager-module/filemanager-module.html?lang=fr",
-            "instruction": "<p>Dans l’espace ci-dessous, ouvrez le dossier « Photos ».<br>Sur le fichier «photo1», faites un clic droit pour afficher la liste d’action, et cliquez sur «&nbsp;Supprimer&nbsp;».<br>Refaites la même chose sur «photo2» puis sur «photo3».</p>",
-            "height": 400
-          }
-        }
-      ]
-    },
-    {
-      "id": "e4ef316d-3d48-46ce-8bb5-90ba92a113a1",
-      "type": "transition",
-      "title": "",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "07c245c1-73e8-4968-bb7b-99aac6590f2c",
-            "type": "text",
-            "content": "<p>Bravo ! 🎉 Vous savez utiliser le clic droit de la souris.</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e01d9903-a264-4276-8032-3ccb1cb271bc",
-      "type": "summary",
-      "title": "Récap les 3 boutons de la souris",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "fe6818f4-ad9d-4b5e-bc58-b18cd1d6cee8",
-            "type": "custom-draft",
-            "title": "Élément interactif",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-recap3boutonsbleu/index.html",
-            "instruction": "<p>Récapitulons tout ce que vous venez de voir dans ce module. <br></p><p><strong>Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong> <br>Pour chaque bouton, suivez les consignes.</p>",
-            "height": 445
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "4c19606d-9edc-4b67-953b-065e64ec046c",
-            "type": "separator"
-          }
+          "id": "aaaa5676-f865-4d85-8d95-7329e2716511",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "a609018d-fd04-460f-b574-b5107b3f4f73",
+                "type": "text",
+                "content": "<p>Avant de faire apparaître la liste d’actions, commencez par faire vos premiers clics droits. 👇</p>"
+              }
+            }
+          ]
         },
         {
-          "type": "element",
-          "element": {
-            "id": "3dbb4032-7150-447e-ac8c-00c1302bcc84",
-            "type": "text",
-            "content": "<p>📌 Les points à retenir : <br>  </p><ul><li>▶️ Le bouton gauche permet de faire des clics gauche et des doubles-clics pour déclencher des actions (ouvrir, faire apparaître, sélectionner, etc).</li><li>📋 Le bouton droit permet d’afficher une liste d’actions possibles.</li><li>⬆️ La molette permet de monter ou de descendre dans une page.</li></ul><p><br><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-2/pix-fiche-revision-premieres-marches-souris-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
-          }
+          "id": "22ff7ef7-cf2d-4f35-80cd-af15becebbfc",
+          "type": "activity",
+          "title": "Premiers clics droits",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fc26348a-dea8-4010-bfa6-efd0252b9516",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-souris2-clicdroitpuisgauche/index.html",
+                "instruction": "<p><strong>Dans la zone ci-dessous, entraînez-vous à faire un clic droit puis un clic gauche à la suite.</strong></p>",
+                "height": 445
+              }
+            }
+          ]
+        },
+        {
+          "id": "eb055116-5d70-42ac-8d7b-3bdf2f6acef9",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "7f49b2c6-8488-4868-9454-6a92b4cc7643",
+                "type": "text",
+                "content": "<p>Vous savez désormais alterner les clics droit et clics gauche. 👍<br>À vous maintenant d’utiliser les clics droit et gauche sur une liste d’action.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "9217d594-0915-4f2e-9d27-5faef1b473d3",
+          "type": "activity",
+          "title": "Utiliser le clic droit",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "84a56ef8-1645-4204-8124-ae748c04c621",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Gestionnaire de fichiers - supprimer photos",
+                "url": "https://epreuves.pix.fr/filemanager-module/filemanager-module.html?lang=fr",
+                "instruction": "<p>Dans l’espace ci-dessous, ouvrez le dossier « Photos ».<br>Sur le fichier «photo1», faites un clic droit pour afficher la liste d’action, et cliquez sur «&nbsp;Supprimer&nbsp;».<br>Refaites la même chose sur «photo2» puis sur «photo3».</p>",
+                "height": 400
+              }
+            }
+          ]
+        },
+        {
+          "id": "e4ef316d-3d48-46ce-8bb5-90ba92a113a1",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "07c245c1-73e8-4968-bb7b-99aac6590f2c",
+                "type": "text",
+                "content": "<p>Bravo ! 🎉 Vous savez utiliser le clic droit de la souris.</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "e01d9903-a264-4276-8032-3ccb1cb271bc",
+          "type": "summary",
+          "title": "Récap les 3 boutons de la souris",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "fe6818f4-ad9d-4b5e-bc58-b18cd1d6cee8",
+                "type": "custom-draft",
+                "title": "Élément interactif",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/Modulix-1emarche-recap3boutonsbleu/index.html",
+                "instruction": "<p>Récapitulons tout ce que vous venez de voir dans ce module. <br></p><p><strong>Dans l'image ci-dessous, déplacez votre pointeur sur le dessin de la souris.</strong> <br>Pour chaque bouton, suivez les consignes.</p>",
+                "height": 445
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4c19606d-9edc-4b67-953b-065e64ec046c",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3dbb4032-7150-447e-ac8c-00c1302bcc84",
+                "type": "text",
+                "content": "<p>📌 Les points à retenir : <br>  </p><ul><li>▶️ Le bouton gauche permet de faire des clics gauche et des doubles-clics pour déclencher des actions (ouvrir, faire apparaître, sélectionner, etc).</li><li>📋 Le bouton droit permet d’afficher une liste d’actions possibles.</li><li>⬆️ La molette permet de monter ou de descendre dans une page.</li></ul><p><br><span aria-hidden=\"true\">📝</span> Vous pouvez maintenant <a href=\"https://assets.pix.org/modules/utiliser-souris-ordinateur-2/pix-fiche-revision-premieres-marches-souris-2.pdf\" target=\"_blank\">Ouvrir votre fiche de synthèse</a>.</p>"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -27,6 +27,7 @@ import { Video } from '../../domain/models/element/Video.js';
 import { Grain } from '../../domain/models/Grain.js';
 import { Details } from '../../domain/models/module/Details.js';
 import { Module } from '../../domain/models/module/Module.js';
+import { Section } from '../../domain/models/module/Section.js';
 import { QcmProposal } from '../../domain/models/QcmProposal.js';
 import { QcuProposal } from '../../domain/models/QcuProposal.js';
 
@@ -40,48 +41,54 @@ export class ModuleFactory {
         version: moduleData.version,
         isBeta: moduleData.isBeta,
         details: new Details(moduleData.details),
-        grains: moduleData.grains.map((grain) => {
-          return new Grain({
-            id: grain.id,
-            title: grain.title,
-            type: grain.type,
-            components: grain.components
-              .map((component) => {
-                switch (component.type) {
-                  case 'element': {
-                    const element = ModuleFactory.#buildElement(component.element, moduleData.isBeta);
-                    if (element) {
-                      return new ComponentElement({ element });
-                    } else {
-                      return undefined;
-                    }
-                  }
-                  case 'stepper':
-                    return new ComponentStepper({
-                      steps: component.steps.map((step) => {
-                        return new Step({
-                          elements: step.elements
-                            .map((element) => {
-                              const domainElement = ModuleFactory.#buildElement(element, moduleData.isBeta);
-                              if (domainElement) {
-                                return domainElement;
-                              } else {
-                                return undefined;
-                              }
-                            })
-                            .filter((element) => element !== undefined),
+        sections: moduleData.sections.map((section) => {
+          return new Section({
+            id: section.id,
+            type: section.type,
+            grains: section.grains.map((grain) => {
+              return new Grain({
+                id: grain.id,
+                title: grain.title,
+                type: grain.type,
+                components: grain.components
+                  .map((component) => {
+                    switch (component.type) {
+                      case 'element': {
+                        const element = ModuleFactory.#buildElement(component.element, moduleData.isBeta);
+                        if (element) {
+                          return new ComponentElement({ element });
+                        } else {
+                          return undefined;
+                        }
+                      }
+                      case 'stepper':
+                        return new ComponentStepper({
+                          steps: component.steps.map((step) => {
+                            return new Step({
+                              elements: step.elements
+                                .map((element) => {
+                                  const domainElement = ModuleFactory.#buildElement(element, moduleData.isBeta);
+                                  if (domainElement) {
+                                    return domainElement;
+                                  } else {
+                                    return undefined;
+                                  }
+                                })
+                                .filter((element) => element !== undefined),
+                            });
+                          }),
                         });
-                      }),
-                    });
-                  default:
-                    logger.warn({
-                      event: 'module_component_type_unknown',
-                      message: `Component inconnu: ${component.type}`,
-                    });
-                    return undefined;
-                }
-              })
-              .filter((component) => component !== undefined),
+                      default:
+                        logger.warn({
+                          event: 'module_component_type_unknown',
+                          message: `Component inconnu: ${component.type}`,
+                        });
+                        return undefined;
+                    }
+                  })
+                  .filter((component) => component !== undefined),
+              });
+            }),
           });
         }),
       });

--- a/api/src/devcomp/infrastructure/repositories/element-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-repository.js
@@ -25,7 +25,8 @@ async function getByIdForAnswerVerification({ moduleId, elementId, moduleDatasou
 }
 
 function flattenModuleElements(moduleData) {
-  return moduleData.grains
+  return moduleData.sections
+    .flatMap(({ grains }) => grains)
     .flatMap(({ components }) => components)
     .flatMap((component) => {
       if (component.type === 'element') {

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -12,13 +12,15 @@ function serialize(module) {
         isBeta: module.isBeta,
         version: module.version,
         details: module.details,
-        grains: module.grains.map((grain) => {
-          return {
-            id: grain.id,
-            title: grain.title,
-            type: grain.type,
-            components: grain.components,
-          };
+        grains: module.sections.flatMap((section) => {
+          return section.grains.map((grain) => {
+            return {
+              id: grain.id,
+              title: grain.title,
+              type: grain.type,
+              components: grain.components,
+            };
+          });
         }),
       };
 

--- a/api/src/shared/domain/models/asserts.js
+++ b/api/src/shared/domain/models/asserts.js
@@ -30,3 +30,9 @@ export function assertPositiveInteger(value, errorMessage = 'value must be a pos
     throw new DomainError(errorMessage);
   }
 }
+
+export function assertIsArray(value, errorMessage = 'value must be an array') {
+  if (!Array.isArray(value)) {
+    throw new DomainError(errorMessage);
+  }
+}

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 
 import { getElements, getElementsListAsCsv } from '../../../../scripts/modulix/get-elements-csv.js';
+import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { expect } from '../../../test-helper.js';
 import moduleContent from './test-module.json' with { type: 'json' };
 
@@ -8,7 +9,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
   let modulesListAsJs;
 
   beforeEach(async function () {
-    modulesListAsJs = [moduleContent];
+    modulesListAsJs = [ModuleFactory.build(moduleContent)];
   });
 
   describe('#getElements', function () {
@@ -48,20 +49,26 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
           tabletSupport: 'inconvenient',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'discovery',
-            title: 'Voici une leçon',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '88fd4558-a3d5-41e9-a7f0-896076529e90',
-                  type: 'separatnor',
-                },
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'discovery',
+                title: 'Voici une leçon',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '88fd4558-a3d5-41e9-a7f0-896076529e90',
+                      type: 'separatnor',
+                    },
+                  },
+                  elementWithUnknownType,
+                ],
               },
-              elementWithUnknownType,
             ],
           },
         ],
@@ -102,7 +109,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t"Connaissez-vous bien Pix"\t7\t14\t"<p>Compléter le texte suivant :</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t"Embed non-auto"\t8\t15\t"<p>Vous participez à la visioconférence ci-dessous.</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"f00133f5-0653-425b-a25f-3c9604820529"\t"custom-draft"\t"Elément custom"\t9\t16\t"<p>Retournez les cartes.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t17\t"<p>Vous visualisez un événement custom.</p>"
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t17\t
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"cf436761-f56d-4b01-83f9-942afe9ce72c"\t"ed795d29-5f04-499c-a9c8-4019125c5cb1"\t"qab"\t"test qab"\t10\t18\t"<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t11\t19\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"`);
     });

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -1,11 +1,12 @@
 import { getModulesListAsCsv } from '../../../../scripts/modulix/get-modules-csv.js';
+import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { expect } from '../../../test-helper.js';
 import moduleContent from './test-module.json' with { type: 'json' };
 
 describe('Acceptance | Script | Get Modules as CSV', function () {
   it(`should return modules list as CSV`, async function () {
     // Given
-    const modulesListAsJs = [moduleContent];
+    const modulesListAsJs = [ModuleFactory.build(moduleContent)];
 
     // When
     const modulesListAsCsv = await getModulesListAsCsv(modulesListAsJs);

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -4,516 +4,555 @@
   "title": "Bac à sable",
   "isBeta": true,
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>",
     "duration": 5,
     "level": "Débutant",
     "tabletSupport": "inconvenient",
-    "objectives": [
-      "Naviguer dans Modulix",
-      "Découvrir les leçons et les activités"
-    ]
+    "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
   },
-  "grains": [
+  "sections": [
     {
-      "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-      "type": "transition",
-      "title": "",
-      "components": [
+      "id": "5bf1c672-3746-4480-b9ac-1f0af9c7c509",
+      "type": "practise",
+      "grains": [
         {
-          "type": "element",
-          "element": {
-            "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-            "type": "text",
-            "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
-      "type": "discovery",
-      "title": "Voici une leçon",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
-            "type": "flashcards",
-            "instruction": "<p>Lisez la question, essayez de trouver la réponse puis retourner la carte en cliquant dessus.<br>Cela permet de tester votre mémoire 🎯</p>",
-            "title": "Introduction à la poésie",
-            "introImage": {
-              "url": "https://images.pix.fr/modulix/didacticiel/intro-flashcards.png"
-            },
-            "cards": [
-              {
-                "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
-                "recto": {
-                  "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
-                  },
-                  "text": "Qui a écrit « Le Dormeur du Val ? »"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
-                  },
-                  "text": "<p>Arthur Rimbaud</p>"
-                }
-              },
-              {
-                "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
-                "recto": {
-                  "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
-                },
-                "verso": {
-                  "text": "<p>Léopoldine</p>"
-                }
-              },
-              {
-                "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
-                "recto": {
-                  "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/icon.svg"
-                  },
-                  "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
-                },
-                "verso": {
-                  "image": {
-                    "url": "https://images.pix.fr/modulix/didacticiel/chaton.jpg"
-                  },
-                  "text": "<p>Le chat</p>"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
-            "type": "text",
-            "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
-            "type": "separator"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
-            "type": "image",
-            "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "84726001-1665-457d-8f13-4a74dc4768ea",
-            "type": "expand",
-            "title": "Mon titre expand",
-            "content": "<h3>On commence avec les leçons</h3>"
-          }
-        }
-      ]
-    },
-    {
-      "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
-      "type": "challenge",
-      "title": "Un fichier à télécharger",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
-            "type": "download",
-            "files": [
-              {
-                "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx",
-                "format": ".xlsx"
-              },
-              {
-                "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods",
-                "format": ".ods"
-              }
-            ]
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
-            "type": "qcu",
-            "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Des recettes de lasagne",
-                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Erreur, ce ne sont pas des lasagnes</p>"
-              },
-              {
-                "id": "2",
-                "content": "Des recettes de pâté en croûte",
-                "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
-              },
-              {
-                "id": "3",
-                "content": "Des recettes végétariennes",
-                "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
-              }
-            ],
-            "solution": "3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
-      "type": "lesson",
-      "title": "Vidéo de présentation de Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
-            "type": "video",
-            "title": "Vidéo de présentation de Pix",
-            "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
-            "subtitles": "",
-            "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
-            "poster": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg"
-          }
-        }
-      ]
-    },
-    {
-      "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
-      "type": "activity",
-      "title": "Voici un vrai-faux",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
+          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+          "type": "transition",
+          "title": "",
+          "components": [
             {
-              "elements": [
-                {
-                  "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
-                  "type": "qcu",
-                  "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai"
+              "type": "element",
+              "element": {
+                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+                "type": "text",
+                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
+          "type": "discovery",
+          "title": "Voici une leçon",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "47823e8f-a4af-44d6-96f7-5b6fc7bc6b51",
+                "type": "flashcards",
+                "instruction": "<p>Lisez la question, essayez de trouver la réponse puis retourner la carte en cliquant dessus.<br>Cela permet de tester votre mémoire 🎯</p>",
+                "title": "Introduction à la poésie",
+                "introImage": {
+                  "url": "https://assets.pix.org/modules/recto-flashcards.png"
+                },
+                "cards": [
+                  {
+                    "id": "e1de6394-ff88-4de3-8834-a40057a50ff4",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                      },
+                      "text": "Qui a écrit « Le Dormeur du Val ? »"
                     },
-                    {
-                      "id": "2",
-                      "content": "Faux"
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                      },
+                      "text": "<p>Arthur Rimbaud</p>"
                     }
-                  ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
                   },
-                  "solution": "1"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
-                  "type": "qcu",
-                  "instruction": "<p>Pix est découpé en 6 domaines.</p>",
-                  "proposals": [
-                    {
-                      "id": "1",
-                      "content": "Vrai"
+                  {
+                    "id": "48d0cd29-1e08-4b18-b15a-411ab83e5d3c",
+                    "recto": {
+                      "text": "Comment s'appelait la fille de Victor Hugo, évoquée dans le poème « Demain dès l'aube » ?"
                     },
-                    {
-                      "id": "2",
-                      "content": "Faux"
+                    "verso": {
+                      "text": "<p>Léopoldine</p>"
                     }
-                  ],
-                  "feedbacks": {
-                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>",
-                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
                   },
-                  "solution": "2"
-                }
-              ]
+                  {
+                    "id": "2611784c-cf3f-4445-998d-d02fa568da0c",
+                    "recto": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/icon.svg"
+                      },
+                      "text": "Quel animal a des yeux « mêlés de métal et d'agathe » selon Charles Baudelaire ?"
+                    },
+                    "verso": {
+                      "image": {
+                        "url": "https://assets.pix.org/modules/didacticiel/intro-flashcards.png"
+                      },
+                      "text": "<p>Le chat</p>"
+                    }
+                  }
+                ]
+              }
             },
             {
-              "elements": [
+              "type": "element",
+              "element": {
+                "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
+                "type": "text",
+                "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "048e5319-5e81-44cc-ad71-c6c0d3be611f",
+                "type": "separator"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+                "type": "image",
+                "url": "https://assets.pix.org/modules/didacticiel/ordi-spatial.svg",
+                "alt": "Dessin détaillé dans l'alternative textuelle",
+                "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "84726001-1665-457d-8f13-4a74dc4768ea",
+                "type": "expand",
+                "title": "Mon titre expand",
+                "content": "<h3>On commence avec les leçons</h3>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
+          "type": "challenge",
+          "title": "Un fichier à télécharger",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
+                "type": "download",
+                "files": [
+                  {
+                    "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx",
+                    "format": ".xlsx"
+                  },
+                  {
+                    "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods",
+                    "format": ".ods"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
+                "type": "qcu",
+                "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des recettes de lasagne",
+                    "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Erreur, ce ne sont pas des lasagnes</p>"
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des recettes de pâté en croûte",
+                    "feedback": "<span class=\"feedback__state\">Incorrect.</span><p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
+                  },
+                  {
+                    "id": "3",
+                    "content": "Des recettes végétariennes",
+                    "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
+          "type": "lesson",
+          "title": "Vidéo de présentation de Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
+                "type": "video",
+                "title": "Vidéo de présentation de Pix",
+                "url": "https://assets.pix.org/modules/didacticiel/presentation.mp4",
+                "subtitles": "",
+                "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
+                "poster": "https://assets.pix.org/modules/didacticiel/ordi-spatial.svg"
+              }
+            }
+          ]
+        },
+        {
+          "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
+          "type": "activity",
+          "title": "Voici un vrai-faux",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
                 {
-                  "id": "09dc17f9-142b-4e19-bcbe-bfde4e170d3l",
-                  "type": "qcu-declarative",
-                  "instruction": "<p>Pix est découpé en 6 domaines.</p>",
-                  "proposals": [
+                  "elements": [
                     {
-                      "id": "1",
-                      "content": "Vrai"
-                    },
+                      "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
+                      "type": "qcu",
+                      "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai"
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
+                        "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
+                      },
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
                     {
-                      "id": "2",
-                      "content": "Faux"
+                      "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
+                      "type": "qcu",
+                      "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai"
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>",
+                        "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
+                      },
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "09dc17f9-142b-4e19-bcbe-bfde4e170d3l",
+                      "type": "qcu-declarative",
+                      "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai"
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux"
+                        }
+                      ]
                     }
                   ]
                 }
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
-      "type": "summary",
-      "title": "Les 3 piliers de Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
-            "type": "qcm",
-            "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
-              },
-              {
-                "id": "2",
-                "content": "Développer son savoir-faire sur les jeux de type TPS"
-              },
-              {
-                "id": "3",
-                "content": "Développer ses compétences numériques"
-              },
-              {
-                "id": "4",
-                "content": "Certifier ses compétences Pix"
-              },
-              {
-                "id": "5",
-                "content": "Evaluer ses compétences de logique et compréhension mathématique"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>",
-              "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span><p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
-            },
-            "solutions": [
-              "1",
-              "3",
-              "4"
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "4ce2a31a-6584-4dae-87c6-d08b58d0f3b9",
-      "type": "activity",
-      "title": "Connaissez-vous bien Pix",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "c23436d4-6261-49f1-b50d-13a547529c29",
-            "type": "qrocm",
-            "instruction": "<p>Compléter le texte suivant :</p>",
-            "proposals": [
-              {
-                "type": "text",
-                "content": "<span>Pix est un</span>"
-              },
-              {
-                "input": "pix-name",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Mot à trouver",
-                "defaultValue": "",
-                "tolerances": [
-                  "t1",
-                  "t3"
-                ],
-                "solutions": [
-                  "Groupement"
-                ]
-              },
-              {
-                "type": "text",
-                "content": "<span>d'intérêt public qui a été créée en</span>"
-              },
-              {
-                "input": "pix-birth",
-                "type": "input",
-                "inputType": "text",
-                "size": 10,
-                "display": "inline",
-                "placeholder": "",
-                "ariaLabel": "Année à trouver",
-                "defaultValue": "",
-                "tolerances": [],
-                "solutions": [
-                  "2016"
-                ]
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> vous nous connaissez bien&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p> vous y arriverez la prochaine fois&#8239;!</p>"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb4",
-      "type": "activity",
-      "title": "Embed non-auto",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
-            "type": "embed",
-            "isCompletionRequired": false,
-            "title": "Simulateur de visioconférence",
-            "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
-            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
-            "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb5",
-      "type": "activity",
-      "title": "Elément custom",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "f00133f5-0653-425b-a25f-3c9604820529",
-            "type": "custom-draft",
-            "title": "Retourner les cartes",
-            "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
-            "instruction": "<p>Retournez les cartes.</p>",
-            "height": 450
-          }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "0e3315fd-98ad-492f-9046-4aa867495d85",
-            "type": "custom",
-            "isCompletionRequired": false,
-            "title": "Element custom",
-            "instruction": "<p>Vous visualisez un événement custom.</p>",
-            "height": 600
-          }
-        }
-      ]
-    },
-    {
-      "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
-      "type": "lesson",
-      "title": "test qab",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "ed795d29-5f04-499c-a9c8-4019125c5cb1",
-            "type": "qab",
-            "instruction": "<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>",
-            "cards": [
-              {
-                "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
-                "image": {
-                  "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
-                  "altText": ""
+          "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
+          "type": "summary",
+          "title": "Les 3 piliers de Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
+                "type": "qcm",
+                "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
+                  },
+                  {
+                    "id": "2",
+                    "content": "Développer son savoir-faire sur les jeux de type TPS"
+                  },
+                  {
+                    "id": "3",
+                    "content": "Développer ses compétences numériques"
+                  },
+                  {
+                    "id": "4",
+                    "content": "Certifier ses compétences Pix"
+                  },
+                  {
+                    "id": "5",
+                    "content": "Evaluer ses compétences de logique et compréhension mathématique"
+                  }
+                ],
+                "feedbacks": {
+                  "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>",
+                  "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span><p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                 },
-                "text": "Les boules de pétanques sont creuses ?",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "A"
-              },
-              {
-                "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
-                "text": "Les chiens ne transpirent pas.",
-                "proposalA": "Vrai",
-                "proposalB": "Faux",
-                "solution": "B"
-              },
-              {
-                "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
-                "text": "Quel est l'organe qui rougit ?",
-                "proposalA": "L'estomac",
-                "proposalB": "Le coeur",
-                "solution": "B"
+                "solutions": ["1", "3", "4"]
               }
-            ],
-            "feedback": {
-              "diagnosis": ""
             }
-          }
-        }
-      ]
-    },
-    {
-      "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
-      "type": "discovery",
-      "title": "test qcu-discovery",
-      "components": [
+          ]
+        },
         {
-          "type": "element",
-          "element": {
-            "id": "0c397035-a940-441f-8936-050db7f997af",
-            "type": "qcu-discovery",
-            "instruction": "<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Des cookies maison tout chauds",
-                "feedback": {
-                  "diagnosis": "<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>"
-                }
-              },
-              {
-                "id": "2",
-                "content": "Des mini-éclairs au chocolat",
-                "feedback": {
-                  "diagnosis": "<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>"
-                }
-              },
-              {
-                "id": "3",
-                "content": "Un plateau de fruits frais et de fromage",
-                "feedback": {
-                  "diagnosis": "<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>"
-                }
-              },
-              {
-                "id": "4",
-                "content": "Une part de gâteau marbré au chocolat et à la vanille",
-                "feedback": {
-                  "diagnosis": "<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>"
+          "id": "4ce2a31a-6584-4dae-87c6-d08b58d0f3b9",
+          "type": "activity",
+          "title": "Connaissez-vous bien Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "c23436d4-6261-49f1-b50d-13a547529c29",
+                "type": "qrocm",
+                "instruction": "<p>Compléter le texte suivant :</p>",
+                "proposals": [
+                  {
+                    "type": "text",
+                    "content": "<span>Pix est un</span>"
+                  },
+                  {
+                    "input": "pix-name",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Mot à trouver",
+                    "defaultValue": "",
+                    "tolerances": ["t1", "t3"],
+                    "solutions": ["Groupement"]
+                  },
+                  {
+                    "type": "text",
+                    "content": "<span>d'intérêt public qui a été créée en</span>"
+                  },
+                  {
+                    "input": "pix-birth",
+                    "type": "input",
+                    "inputType": "text",
+                    "size": 10,
+                    "display": "inline",
+                    "placeholder": "",
+                    "ariaLabel": "Année à trouver",
+                    "defaultValue": "",
+                    "tolerances": [],
+                    "solutions": ["2016"]
+                  }
+                ],
+                "feedbacks": {
+                  "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> vous nous connaissez bien&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
+                  "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p> vous y arriverez la prochaine fois&#8239;!</p>"
                 }
               }
-            ],
-            "solution": "1"
-          }
+            }
+          ]
+        },
+        {
+          "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb4",
+          "type": "activity",
+          "title": "Embed non-auto",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
+                "type": "embed",
+                "isCompletionRequired": false,
+                "title": "Simulateur de visioconférence",
+                "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
+                "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+                "height": 600
+              }
+            }
+          ]
+        },
+        {
+          "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb5",
+          "type": "activity",
+          "title": "Elément custom",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "f00133f5-0653-425b-a25f-3c9604820529",
+                "type": "custom-draft",
+                "title": "Retourner les cartes",
+                "url": "https://1024pix.github.io/atelier-contenus/RPE/cartes2.html",
+                "instruction": "<p>Retournez les cartes.</p>",
+                "height": 450
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "0e3315fd-98ad-492f-9046-4aa867495d85",
+                "type": "custom",
+                "tagName": "message-conversation",
+                "props": {
+                  "title": "Confessions nocturnes",
+                  "messages": [
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ouais c'est qui là ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, c'est Vi ouvre moi."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ça va Vi ?"
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "T'as l'air bizarre. Qu'est ce qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Non, ça va pas non."
+                    },
+                    {
+                      "userName": "Mel",
+                      "direction": "outgoing",
+                      "content": "Ben dis-moi, qu'est qu'il y a ?"
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, assieds-toi faut que je te parle..."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "J'ai passé ma journée dans le noir."
+                    },
+                    {
+                      "userName": "Vita",
+                      "direction": "incoming",
+                      "content": "Mel, je le sens, je le sais, je le suis, il se fout de moi..."
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
+          "type": "lesson",
+          "title": "test qab",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "ed795d29-5f04-499c-a9c8-4019125c5cb1",
+                "type": "qab",
+                "instruction": "<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>",
+                "cards": [
+                  {
+                    "id": "e222b060-7c18-4ee2-afe2-2ae27c28946a",
+                    "image": {
+                      "url": "https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg",
+                      "altText": ""
+                    },
+                    "text": "Les boules de pétanques sont creuses ?",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "A"
+                  },
+                  {
+                    "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                    "text": "Les chiens ne transpirent pas.",
+                    "proposalA": "Vrai",
+                    "proposalB": "Faux",
+                    "solution": "B"
+                  },
+                  {
+                    "id": "57056894-8e1b-4da9-96b6-0bd4187412b8",
+                    "text": "Quel est l'organe qui rougit ?",
+                    "proposalA": "L'estomac",
+                    "proposalB": "Le coeur",
+                    "solution": "B"
+                  }
+                ],
+                "feedback": {
+                  "diagnosis": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
+          "type": "discovery",
+          "title": "test qcu-discovery",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "0c397035-a940-441f-8936-050db7f997af",
+                "type": "qcu-discovery",
+                "instruction": "<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des cookies maison tout chauds",
+                    "feedback": {
+                      "diagnosis": "<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des mini-éclairs au chocolat",
+                    "feedback": {
+                      "diagnosis": "<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Un plateau de fruits frais et de fromage",
+                    "feedback": {
+                      "diagnosis": "<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>"
+                    }
+                  },
+                  {
+                    "id": "4",
+                    "content": "Une part de gâteau marbré au chocolat et à la vanille",
+                    "feedback": {
+                      "diagnosis": "<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>"
+                    }
+                  }
+                ],
+                "solution": "1"
+              }
+            }
+          ]
         }
       ]
     }

--- a/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
@@ -1,7 +1,7 @@
-import { getAnswerableElements } from '../../../../../scripts/modulix/utils/get-answerable-elements.js';
+import { getGrains } from '../../../../../scripts/modulix/utils/get-grains.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
+describe('Acceptance | Script | Helper | Get grains', function () {
   const modulesListAsJs = [
     {
       id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -19,7 +19,6 @@ describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
         {
           id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
           type: 'practise',
-
           grains: [
             {
               id: '47cd065b-dbf2-4adc-b5c3-02fb69cb9ec2',
@@ -314,27 +313,15 @@ describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
     },
   ];
 
-  describe('#getAnswerableElements', function () {
-    it('should filter out elements that are not activities', async function () {
+  describe('#getGrains', function () {
+    it('should return grains array', async function () {
       // When
-      const elementsListAsJs = await getAnswerableElements(modulesListAsJs);
+      const grainsListAsJs = await getGrains(modulesListAsJs[0]);
 
       // Then
-      expect(elementsListAsJs).to.be.an('array');
-      expect(elementsListAsJs.every((element) => ['qcm', 'qcu', 'qrocm'].includes(element.type))).to.be.true;
-    });
-
-    it('should add some meta info to elements', async function () {
-      // When
-      const elementsListAsJs = await getAnswerableElements(modulesListAsJs);
-
-      // Then
-      expect(elementsListAsJs).to.be.an('array');
-      expect(elementsListAsJs.every((element) => element.moduleSlug !== undefined)).to.be.true;
-      expect(elementsListAsJs.every((element) => element.activityElementPosition !== undefined)).to.be.true;
-      expect(elementsListAsJs.every((element) => element.grainPosition !== undefined)).to.be.true;
-      expect(elementsListAsJs.every((element) => element.grainId !== undefined)).to.be.true;
-      expect(elementsListAsJs.every((element) => element.grainTitle !== undefined)).to.be.true;
+      expect(grainsListAsJs).to.be.an('array');
+      expect(grainsListAsJs.every((grain) => grain.id !== undefined)).to.be.true;
+      expect(grainsListAsJs.every((grain) => grain.type !== undefined)).to.be.true;
     });
   });
 });

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -2,7 +2,7 @@ import { UserRecommendedModule } from '../../../../../src/devcomp/domain/read-mo
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
-describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByCampaignParticipationIds', function () {
+describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCampaignParticipationIds', function () {
   it('it returns recommended modules for given participation ids', async function () {
     // given
     const { id: campaignParticipationId1, userId } = databaseBuilder.factory.buildCampaignParticipation();

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -1,4 +1,5 @@
 import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
+import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import * as elementRepository from '../../../../src/devcomp/infrastructure/repositories/element-repository.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
@@ -39,6 +40,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -47,36 +49,42 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'Voici une leçon',
-            components: [
+            id: '748c71fe-acdb-4533-a550-6f2fbae90587',
+            type: 'blank',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                  type: 'qcu',
-                  instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
-                  proposals: [
-                    {
-                      id: '1',
-                      content: 'Vrai',
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'Voici une leçon',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                      type: 'qcu',
+                      instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                      proposals: [
+                        {
+                          id: '1',
+                          content: 'Vrai',
+                        },
+                        {
+                          id: '2',
+                          content: 'Faux',
+                        },
+                      ],
+                      feedbacks: {
+                        valid:
+                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                        invalid:
+                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
+                      },
+                      solution: '1',
                     },
-                    {
-                      id: '2',
-                      content: 'Faux',
-                    },
-                  ],
-                  feedbacks: {
-                    valid:
-                      '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                    invalid:
-                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                   },
-                  solution: '1',
-                },
+                ],
               },
             ],
           },
@@ -128,6 +136,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -136,67 +145,73 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'Voici une leçon',
-            components: [
+            id: '748c71fe-acdb-4533-a550-6f2fbae90587',
+            type: 'blank',
+            grains: [
               {
-                type: 'stepper',
-                steps: [
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'Voici une leçon',
+                components: [
                   {
-                    elements: [
+                    type: 'stepper',
+                    steps: [
                       {
-                        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                        type: 'qcu',
-                        instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
-                        proposals: [
+                        elements: [
                           {
-                            id: '1',
-                            content: 'Vrai',
-                          },
-                          {
-                            id: '2',
-                            content: 'Faux',
+                            id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                            type: 'qcu',
+                            instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                            proposals: [
+                              {
+                                id: '1',
+                                content: 'Vrai',
+                              },
+                              {
+                                id: '2',
+                                content: 'Faux',
+                              },
+                            ],
+                            feedbacks: {
+                              valid:
+                                '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                              invalid:
+                                '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                            },
+                            solution: '1',
                           },
                         ],
-                        feedbacks: {
-                          valid:
-                            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                          invalid:
-                            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
-                        },
-                        solution: '1',
                       },
                     ],
                   },
-                ],
-              },
-              {
-                type: 'element',
-                element: {
-                  id: '126939bd-a2ed-4a4b-ad44-f37e9d09440a',
-                  type: 'qcu',
-                  instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
-                  proposals: [
-                    {
-                      id: '1',
-                      content: 'Vrai',
+                  {
+                    type: 'element',
+                    element: {
+                      id: '126939bd-a2ed-4a4b-ad44-f37e9d09440a',
+                      type: 'qcu',
+                      instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                      proposals: [
+                        {
+                          id: '1',
+                          content: 'Vrai',
+                        },
+                        {
+                          id: '2',
+                          content: 'Faux',
+                        },
+                      ],
+                      feedbacks: {
+                        valid:
+                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                        invalid:
+                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                      },
+                      solution: '1',
                     },
-                    {
-                      id: '2',
-                      content: 'Faux',
-                    },
-                  ],
-                  feedbacks: {
-                    valid:
-                      '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                    invalid:
-                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
                   },
-                  solution: '1',
-                },
+                ],
               },
             ],
           },
@@ -261,6 +276,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
+        isBeta: true,
         details: {
           image: 'https://images.pix.fr/modulix/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
@@ -269,36 +285,42 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'Voici une leçon',
-            components: [
+            id: '748c71fe-acdb-4533-a550-6f2fbae90587',
+            type: 'blank',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                  type: 'qcu',
-                  instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
-                  proposals: [
-                    {
-                      id: '1',
-                      content: 'Vrai',
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'Voici une leçon',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                      type: 'qcu',
+                      instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                      proposals: [
+                        {
+                          id: '1',
+                          content: 'Vrai',
+                        },
+                        {
+                          id: '2',
+                          content: 'Faux',
+                        },
+                      ],
+                      feedbacks: {
+                        valid:
+                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                        invalid:
+                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
+                      },
+                      solution: '1',
                     },
-                    {
-                      id: '2',
-                      content: 'Faux',
-                    },
-                  ],
-                  feedbacks: {
-                    valid:
-                      '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                    invalid:
-                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                   },
-                  solution: '1',
-                },
+                ],
               },
             ],
           },
@@ -306,7 +328,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       };
 
       // when
-      expect(elementRepository.flattenModuleElements(moduleData)).to.deep.equal([
+      expect(elementRepository.flattenModuleElements(new Module(moduleData))).to.deep.equal([
         {
           id: '71de6394-ff88-4de3-8834-a40057a50ff4',
           type: 'qcu',

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -31,20 +31,26 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             'Comprendre les fonctions des parties d’une adresse mail',
           ],
         },
-        grains: [
+        sections: [
           {
-            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-            type: 'lesson',
-            title: 'Explications : les parties d’une adresse mail',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                },
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -64,20 +70,26 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
           tabletSupport: 'inconvenient',
           objectives: ['Non régression fonctionnelle'],
         },
-        grains: [
+        sections: [
           {
-            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-            type: 'lesson',
-            title: 'Explications : les parties d’une adresse mail',
-            components: [
+            id: 'd2ad3253-7f0a-41f5-b10e-0fa0f49d0cc7',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                },
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -227,20 +239,26 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             'Comprendre les fonctions des parties d’une adresse mail',
           ],
         },
-        grains: [
+        sections: [
           {
-            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-            type: 'lesson',
-            title: 'Explications : les parties d’une adresse mail',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                },
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -335,20 +353,26 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             'Comprendre les fonctions des parties d’une adresse mail',
           ],
         },
-        grains: [
+        sections: [
           {
-            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-            type: 'lesson',
-            title: 'Explications : les parties d’une adresse mail',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                },
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -400,46 +424,53 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             }
             ids.push(module.id);
 
-            for (const grain of module.grains) {
-              if (ids.includes(grain.id)) {
-                duplicateIds.add(grain.id);
+            for (const section of module.sections) {
+              if (ids.includes(section.id)) {
+                duplicateIds.add(section.id);
               }
-              ids.push(grain.id);
+              ids.push(section.id);
 
-              for (const component of grain.components) {
-                switch (component.type) {
-                  case 'element':
-                    if (ids.includes(component.element.id)) {
-                      duplicateIds.add(component.element.id);
-                    }
-                    if (component.element.type === 'flashcards') {
-                      for (const card of component.element.cards) {
-                        if (ids.includes(card.id)) {
-                          duplicateIds.add(card.id);
-                        }
-                        ids.push(card.id);
+              for (const grain of section.grains) {
+                if (ids.includes(grain.id)) {
+                  duplicateIds.add(grain.id);
+                }
+                ids.push(grain.id);
+
+                for (const component of grain.components) {
+                  switch (component.type) {
+                    case 'element':
+                      if (ids.includes(component.element.id)) {
+                        duplicateIds.add(component.element.id);
                       }
-                    }
-                    ids.push(component.element.id);
-                    break;
-                  case 'stepper':
-                    for (const step of component.steps) {
-                      for (const element of step.elements) {
-                        if (ids.includes(element.id)) {
-                          duplicateIds.add(element.id);
-                        }
-                        if (element.type === 'flashcards') {
-                          for (const card of element.cards) {
-                            if (ids.includes(card.id)) {
-                              duplicateIds.add(card.id);
-                            }
-                            ids.push(card.id);
+                      if (component.element.type === 'flashcards') {
+                        for (const card of component.element.cards) {
+                          if (ids.includes(card.id)) {
+                            duplicateIds.add(card.id);
                           }
+                          ids.push(card.id);
                         }
-                        ids.push(element.id);
                       }
-                    }
-                    break;
+                      ids.push(component.element.id);
+                      break;
+                    case 'stepper':
+                      for (const step of component.steps) {
+                        for (const element of step.elements) {
+                          if (ids.includes(element.id)) {
+                            duplicateIds.add(element.id);
+                          }
+                          if (element.type === 'flashcards') {
+                            for (const card of element.cards) {
+                              if (ids.includes(card.id)) {
+                                duplicateIds.add(card.id);
+                              }
+                              ids.push(card.id);
+                            }
+                          }
+                          ids.push(element.id);
+                        }
+                      }
+                      break;
+                  }
                 }
               }
             }
@@ -470,20 +501,26 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             'Comprendre les fonctions des parties d’une adresse mail',
           ],
         },
-        grains: [
+        sections: [
           {
-            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-            type: 'lesson',
-            title: 'Explications : les parties d’une adresse mail',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                  type: 'text',
-                  content:
-                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                },
+                id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+                type: 'lesson',
+                title: 'Explications : les parties d’une adresse mail',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                      type: 'text',
+                      content:
+                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                    },
+                  },
+                ],
               },
             ],
           },

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,4 +1,3 @@
-import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -11,19 +10,19 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
-      const grains = [Symbol('text')];
+      const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
 
       // when
-      const module = new Module({ id, slug, title, isBeta, grains, details, version });
+      const module = new Module({ id, slug, title, isBeta, sections, details, version });
 
       // then
       expect(module.id).to.equal(id);
       expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
       expect(module.isBeta).to.equal(isBeta);
-      expect(module.grains).to.have.lengthOf(grains.length);
+      expect(module.sections).to.have.lengthOf(sections.length);
       expect(module.details).to.deep.equal(details);
       expect(module.version).to.deep.equal(version);
     });
@@ -79,7 +78,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       });
     });
 
-    describe('if a module does not have grains', function () {
+    describe('if a module does not have sections', function () {
       it('should throw an error', function () {
         // when
         const error = catchErrSync(
@@ -94,11 +93,11 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
 
         // then
         expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('A list of grains is required for a module');
+        expect(error.message).to.equal('A list of sections is required for a module');
       });
     });
 
-    describe('if a module has grains with the wrong type', function () {
+    describe('if a module has sections with the wrong type', function () {
       it('should throw an error', function () {
         // when
         const error = catchErrSync(
@@ -108,13 +107,13 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
               isBeta: true,
-              grains: 'elements',
+              sections: 'elements',
             }),
         )();
 
         // then
-        expect(error).to.be.instanceOf(ModuleInstantiationError);
-        expect(error.message).to.equal(`A module should have a list of grains`);
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal(`A list of sections is required for a module`);
       });
     });
 
@@ -128,7 +127,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
               isBeta: true,
-              grains: [],
+              sections: [],
             }),
         )();
 
@@ -147,12 +146,13 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
-      const grains = [Symbol('text')];
+      const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
 
-      module = new Module({ id, slug, title, isBeta, grains, details, version });
+      module = new Module({ id, slug, title, isBeta, sections, details, version });
     });
+
     it('should set redirectionUrl when url is valid', function () {
       // given
       const url = 'https://app.pix.fr/parcours/COMBINIX1';
@@ -163,6 +163,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       // then
       expect(module.redirectionUrl).to.equal(url);
     });
+
     it('should not set redirectionUrl when url is invalid', function () {
       // given
       const url = 'wrong';

--- a/api/tests/devcomp/unit/domain/models/module/Section_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Section_test.js
@@ -1,0 +1,91 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { Section } from '../../../../../../src/devcomp/domain/models/module/Section.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | Section', function () {
+  describe('#constructor', function () {
+    it('should create a section and keep attributes', function () {
+      // given
+      const id = 1;
+      const type = 'practise';
+      const grains = [Symbol('text')];
+
+      // when
+      const section = new Section({ id, type, grains });
+
+      // then
+      expect(section.id).to.equal(id);
+      expect(section.type).to.equal(type);
+      expect(section.grains).to.have.lengthOf(grains.length);
+    });
+
+    describe('if a section does not have an id', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new Section({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The id is required for a section');
+      });
+    });
+
+    describe('if a section does not have a type', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new Section({ id: 1 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The type is required for a section');
+      });
+    });
+
+    describe('if a section does not have a valid type', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new Section({ id: 1, type: 'not-existing' }))();
+
+        // then
+        expect(error).to.be.instanceOf(ModuleInstantiationError);
+        expect(error.message).to.equal(`The type must be one of ${Section.AVAILABLE_TYPES}`);
+      });
+    });
+
+    describe('if a section does not have grains', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new Section({
+              id: 'id_section_1',
+              type: 'blank',
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('A list of grains is required for a section');
+      });
+    });
+
+    describe('if a section has grains with the wrong type', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new Section({
+              id: 'id_section_1',
+              type: 'blank',
+              grains: 'elements',
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal(`A list of grains is required for a section`);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -64,7 +64,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
 
     const title = 'Les adresses email';
     const isBeta = false;
-    const grains = [Symbol('text')];
+    const sections = [Symbol('text')];
     const details = Symbol('details');
     const version = Symbol('version');
     const module = new Module({
@@ -72,7 +72,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       slug: moduleSlug,
       title,
       isBeta,
-      grains,
+      sections,
       details,
       version,
     });

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -28,11 +28,11 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
-      const grains = [Symbol('text')];
+      const sections = [Symbol('text')];
       const details = Symbol('details');
       const version = Symbol('version');
 
-      const expectedModule = new Module({ id, slug, title, isBeta, grains, details, version });
+      const expectedModule = new Module({ id, slug, title, isBeta, sections, details, version });
       const moduleRepository = {
         getBySlug: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -108,6 +108,14 @@ const grainSchema = Joi.object({
     }),
 }).required();
 
+const moduleSectionSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string()
+    .valid('question-yourself', 'explore-to-understand', 'retain-the-essentials', 'practise', 'go-further', 'blank')
+    .required(),
+  grains: Joi.array().items(grainSchema).required(),
+});
+
 const moduleSchema = Joi.object({
   id: uuidSchema,
   slug: Joi.string()
@@ -116,7 +124,7 @@ const moduleSchema = Joi.object({
   title: htmlNotAllowedSchema.required(),
   isBeta: Joi.boolean().required(),
   details: moduleDetailsSchema.required(),
-  grains: Joi.array().items(grainSchema).required(),
+  sections: Joi.array().items(moduleSectionSchema).required(),
 }).required();
 
 export { grainSchema, moduleSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -624,19 +624,25 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
           tabletSupport: 'comfortable',
           objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'Voici une leçon',
-            components: [
+            id: '235c6394-5c43-4dc9-aa77-2895b642de7c',
+            type: 'blank',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
-                  type: 'text',
-                  content: '<h3>Content.</h3>',
-                },
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'Voici une leçon',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                      type: 'text',
+                      content: '<h3>Content.</h3>',
+                    },
+                  },
+                ],
               },
             ],
           },

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -41,21 +41,27 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
-            grains: [
+            sections: [
               {
-                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-                type: 'lesson',
-                title: 'title',
-                components: [
+                id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+                type: 'practise',
+                grains: [
                   {
-                    type: 'unknown',
-                    element: {
-                      id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                      type: 'text',
-                      content: '<p>content</p>',
-                      alt: 'Alternative',
-                      alternativeText: 'Alternative textuelle',
-                    },
+                    id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                    type: 'lesson',
+                    title: 'title',
+                    components: [
+                      {
+                        type: 'unknown',
+                        element: {
+                          id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                          type: 'text',
+                          content: '<p>content</p>',
+                          alt: 'Alternative',
+                          alternativeText: 'Alternative textuelle',
+                        },
+                      },
+                    ],
                   },
                 ],
               },
@@ -90,21 +96,27 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
-            grains: [
+            sections: [
               {
-                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-                type: 'lesson',
-                title: 'title',
-                components: [
+                id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+                type: 'practise',
+                grains: [
                   {
-                    type: 'element',
-                    element: {
-                      id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                      type: 'unknown',
-                      content: '<p>content</p>',
-                      alt: 'Alternative',
-                      alternativeText: 'Alternative textuelle',
-                    },
+                    id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                    type: 'lesson',
+                    title: 'title',
+                    components: [
+                      {
+                        type: 'element',
+                        element: {
+                          id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                          type: 'unknown',
+                          content: '<p>content</p>',
+                          alt: 'Alternative',
+                          alternativeText: 'Alternative textuelle',
+                        },
+                      },
+                    ],
                   },
                 ],
               },
@@ -139,31 +151,37 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
               tabletSupport: 'comfortable',
               objectives: ['Objective 1'],
             },
-            grains: [
+            sections: [
               {
-                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-                type: 'lesson',
-                title: 'title',
-                components: [
+                id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+                type: 'practise',
+                grains: [
                   {
-                    type: 'element',
-                    element: {
-                      id: 'c23436d4-6261-49f1-b50d-13a547529c29',
-                      type: 'qrocm',
-                      instruction: '<p>Compléter le texte suivant :</p>',
-                      proposals: [
-                        {
-                          type: 'unknown',
-                          content: '<span>Pix est un</span>',
+                    id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                    type: 'lesson',
+                    title: 'title',
+                    components: [
+                      {
+                        type: 'element',
+                        element: {
+                          id: 'c23436d4-6261-49f1-b50d-13a547529c29',
+                          type: 'qrocm',
+                          instruction: '<p>Compléter le texte suivant :</p>',
+                          proposals: [
+                            {
+                              type: 'unknown',
+                              content: '<span>Pix est un</span>',
+                            },
+                          ],
+                          feedbacks: {
+                            valid:
+                              '<span class="feedback__state">Correct&#8239;!</span><p> vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
+                            invalid:
+                              '<span class="feedback__state">Incorrect&#8239;!</span><p> vous y arriverez la prochaine fois&#8239;!</p>',
+                          },
                         },
-                      ],
-                      feedbacks: {
-                        valid:
-                          '<span class="feedback__state">Correct&#8239;!</span><p> vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
-                        invalid:
-                          '<span class="feedback__state">Incorrect&#8239;!</span><p> vous y arriverez la prochaine fois&#8239;!</p>',
                       },
-                    },
+                    ],
                   },
                 ],
               },
@@ -197,21 +215,27 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                  type: 'image',
-                  url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
-                  alt: 'Alternative',
-                  alternativeText: 'Alternative textuelle',
-                },
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                      type: 'image',
+                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                      alt: 'Alternative',
+                      alternativeText: 'Alternative textuelle',
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -224,8 +248,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       // then
       expect(module).to.be.an.instanceOf(Module);
       expect(module.version).to.equal(version);
-      expect(module.grains).not.to.be.empty;
-      for (const grain of module.grains) {
+      expect(module.sections[0].grains).not.to.be.empty;
+      for (const grain of module.sections[0].grains) {
         expect(grain).to.be.instanceof(Grain);
         expect(grain.components).not.to.be.empty;
       }
@@ -247,69 +271,75 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'discovery',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: 'cfec5a0e-2ed5-462f-8974-e5ca25faae39',
-                    type: 'custom',
-                    tagName: 'message-conversation',
-                    props: {
-                      title: 'Confessions nocturnes',
-                      messages: [
-                        {
-                          userName: 'Mel',
-                          direction: 'outgoing',
-                          content: "Ouais c'est qui là ?",
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'discovery',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'cfec5a0e-2ed5-462f-8974-e5ca25faae39',
+                        type: 'custom',
+                        tagName: 'message-conversation',
+                        props: {
+                          title: 'Confessions nocturnes',
+                          messages: [
+                            {
+                              userName: 'Mel',
+                              direction: 'outgoing',
+                              content: "Ouais c'est qui là ?",
+                            },
+                            {
+                              userName: 'Vita',
+                              direction: 'incoming',
+                              content: "Mel, c'est Vi ouvre moi.",
+                            },
+                            {
+                              userName: 'Mel',
+                              direction: 'outgoing',
+                              content: 'Ça va Vi ?',
+                            },
+                            {
+                              userName: 'Mel',
+                              direction: 'outgoing',
+                              content: "T'as l'air bizarre. Qu'est ce qu'il y a ?",
+                            },
+                            {
+                              userName: 'Vita',
+                              direction: 'incoming',
+                              content: 'Non, ça va pas non.',
+                            },
+                            {
+                              userName: 'Mel',
+                              direction: 'outgoing',
+                              content: "Ben dis-moi, qu'est qu'il y a ?",
+                            },
+                            {
+                              userName: 'Vita',
+                              direction: 'incoming',
+                              content: 'Mel, assieds-toi faut que je te parle...',
+                            },
+                            {
+                              userName: 'Vita',
+                              direction: 'incoming',
+                              content: "J'ai passé ma journée dans le noir.",
+                            },
+                            {
+                              userName: 'Vita',
+                              direction: 'incoming',
+                              content: 'Mel, je le sens, je le sais, je le suis, il se fout de moi...',
+                            },
+                          ],
                         },
-                        {
-                          userName: 'Vita',
-                          direction: 'incoming',
-                          content: "Mel, c'est Vi ouvre moi.",
-                        },
-                        {
-                          userName: 'Mel',
-                          direction: 'outgoing',
-                          content: 'Ça va Vi ?',
-                        },
-                        {
-                          userName: 'Mel',
-                          direction: 'outgoing',
-                          content: "T'as l'air bizarre. Qu'est ce qu'il y a ?",
-                        },
-                        {
-                          userName: 'Vita',
-                          direction: 'incoming',
-                          content: 'Non, ça va pas non.',
-                        },
-                        {
-                          userName: 'Mel',
-                          direction: 'outgoing',
-                          content: "Ben dis-moi, qu'est qu'il y a ?",
-                        },
-                        {
-                          userName: 'Vita',
-                          direction: 'incoming',
-                          content: 'Mel, assieds-toi faut que je te parle...',
-                        },
-                        {
-                          userName: 'Vita',
-                          direction: 'incoming',
-                          content: "J'ai passé ma journée dans le noir.",
-                        },
-                        {
-                          userName: 'Vita',
-                          direction: 'incoming',
-                          content: 'Mel, je le sens, je le sais, je le suis, il se fout de moi...',
-                        },
-                      ],
+                      },
                     },
-                  },
+                  ],
                 },
               ],
             },
@@ -320,7 +350,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(CustomElement);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(CustomElement);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a CustomDraft Element', function () {
@@ -338,22 +368,28 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'discovery',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: 'f00133f5-0653-425b-a25f-3c9604820529',
-                    type: 'custom-draft',
-                    title: 'Retourner les cartes',
-                    url: 'https://1024pix.github.io/atelier-contenus/RPE/cartes2.html',
-                    instruction: '<p>Retournez les cartes.</p>',
-                    height: 400,
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'discovery',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'f00133f5-0653-425b-a25f-3c9604820529',
+                        type: 'custom-draft',
+                        title: 'Retourner les cartes',
+                        url: 'https://1024pix.github.io/atelier-contenus/RPE/cartes2.html',
+                        instruction: '<p>Retournez les cartes.</p>',
+                        height: 400,
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -364,7 +400,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(CustomDraft);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(CustomDraft);
       });
 
       it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
@@ -382,23 +418,29 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                    type: 'image',
-                    url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
-                    alt: 'Alternative',
-                    alternativeText: 'Alternative textuelle',
-                    legend: 'legend',
-                    licence: 'licence',
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                        type: 'image',
+                        url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                        alt: 'Alternative',
+                        alternativeText: 'Alternative textuelle',
+                        legend: 'legend',
+                        licence: 'licence',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -409,7 +451,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Image);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Image);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a Separator Element', function () {
@@ -427,18 +469,24 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '11f382f1-d36a-48d2-a99d-4aa052ab7841',
-                    type: 'separator',
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '11f382f1-d36a-48d2-a99d-4aa052ab7841',
+                        type: 'separator',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -449,8 +497,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Separator);
-        expect(module.grains[0].components[0].element).to.deep.equal({
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Separator);
+        expect(module.sections[0].grains[0].components[0].element).to.deep.equal({
           id: '11f382f1-d36a-48d2-a99d-4aa052ab7841',
           isAnswerable: false,
           type: 'separator',
@@ -472,19 +520,25 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '84726001-1665-457d-8f13-4a74dc4768ea',
-                    type: 'text',
-                    content: '<h3>Content</h3>',
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                        type: 'text',
+                        content: '<h3>Content</h3>',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -495,7 +549,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Text);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Text);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a Video Element', function () {
@@ -513,23 +567,29 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                    type: 'video',
-                    title: 'Le format des adresses mail',
-                    url: 'https://assets.pix.org/modules/chat_animation_2.webm',
-                    subtitles: 'https://assets.pix.org/modules/chat_animation_2.vtt',
-                    transcription: 'Insert transcription here',
-                    poster: 'https://example.org/modulix/video-poster.jpg',
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                        type: 'video',
+                        title: 'Le format des adresses mail',
+                        url: 'https://assets.pix.org/modules/chat_animation_2.webm',
+                        subtitles: 'https://assets.pix.org/modules/chat_animation_2.vtt',
+                        transcription: 'Insert transcription here',
+                        poster: 'https://example.org/modulix/video-poster.jpg',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -540,8 +600,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Video);
-        expect(module.grains[0].components[0].element).to.deep.equal({
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Video);
+        expect(module.sections[0].grains[0].components[0].element).to.deep.equal({
           id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
           type: 'video',
           title: 'Le format des adresses mail',
@@ -568,24 +628,30 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                    type: 'download',
-                    files: [
-                      {
-                        url: 'https://example.org/modulix/file.pdf',
-                        format: '.pdf',
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                        type: 'download',
+                        files: [
+                          {
+                            url: 'https://example.org/modulix/file.pdf',
+                            format: '.pdf',
+                          },
+                        ],
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
               ],
             },
@@ -596,7 +662,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Download);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Download);
       });
 
       it('should instantiate a Module with a ComponentElement which contains an Embed Element', function () {
@@ -614,22 +680,28 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                    type: 'embed',
-                    isCompletionRequired: false,
-                    title: "Simulateur d'adresse mail",
-                    url: 'https://embed.fr',
-                    height: 150,
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                        type: 'embed',
+                        isCompletionRequired: false,
+                        title: "Simulateur d'adresse mail",
+                        url: 'https://embed.fr',
+                        height: 150,
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -640,7 +712,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Embed);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Embed);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
@@ -658,33 +730,39 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
-                    type: 'qcu',
-                    instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Vrai',
-                        feedback: { state: 'Bonne réponse !' },
-                      },
-                      {
-                        id: '2',
-                        content: 'Faux',
-                        feedback: { state: "Faux n'est pas la bonne réponse." },
-                      },
-                    ],
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
+                        type: 'qcu',
+                        instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Vrai',
+                            feedback: { state: 'Bonne réponse !' },
+                          },
+                          {
+                            id: '2',
+                            content: 'Faux',
+                            feedback: { state: "Faux n'est pas la bonne réponse." },
+                          },
+                        ],
 
-                    solution: '1',
-                  },
+                        solution: '1',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -695,7 +773,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCU);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCU);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QCUDeclarative Element', function () {
@@ -713,42 +791,48 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
-                    type: 'qcu-declarative',
-                    instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Avant de mettre le dentifrice',
-                        feedback: {
-                          diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
-                        },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+                        type: 'qcu-declarative',
+                        instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Avant de mettre le dentifrice',
+                            feedback: {
+                              diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+                            },
+                          },
+                          {
+                            id: '2',
+                            content: 'Après avoir mis le dentifrice',
+                            feedback: {
+                              diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
+                            },
+                          },
+                          {
+                            id: '3',
+                            content: 'Pendant que le dentifrice est mis',
+                            feedback: {
+                              diagnosis: '<p>Digne des plus grands acrobates !</p>',
+                            },
+                          },
+                        ],
                       },
-                      {
-                        id: '2',
-                        content: 'Après avoir mis le dentifrice',
-                        feedback: {
-                          diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
-                        },
-                      },
-                      {
-                        id: '3',
-                        content: 'Pendant que le dentifrice est mis',
-                        feedback: {
-                          diagnosis: '<p>Digne des plus grands acrobates !</p>',
-                        },
-                      },
-                    ],
-                  },
+                    },
+                  ],
                 },
               ],
             },
@@ -759,7 +843,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUDeclarative);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCUDeclarative);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QCUDiscovery Element', function () {
@@ -777,54 +861,60 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'discovery',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
-                    type: 'qcu-discovery',
-                    instruction: '<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Des cookies maison tout chauds',
-                        feedback: {
-                          diagnosis:
-                            '<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>',
-                        },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'discovery',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+                        type: 'qcu-discovery',
+                        instruction: '<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>',
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Des cookies maison tout chauds',
+                            feedback: {
+                              diagnosis:
+                                '<p>Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !</p>',
+                            },
+                          },
+                          {
+                            id: '2',
+                            content: 'Des mini-éclairs au chocolat',
+                            feedback: {
+                              diagnosis:
+                                '<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>',
+                            },
+                          },
+                          {
+                            id: '3',
+                            content: 'Un plateau de fruits frais et de fromage',
+                            feedback: {
+                              diagnosis:
+                                '<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>',
+                            },
+                          },
+                          {
+                            id: '4',
+                            content: 'Une part de gâteau marbré au chocolat et à la vanille',
+                            feedback: {
+                              diagnosis:
+                                '<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>',
+                            },
+                          },
+                        ],
+                        solution: '1',
                       },
-                      {
-                        id: '2',
-                        content: 'Des mini-éclairs au chocolat',
-                        feedback: {
-                          diagnosis:
-                            '<p>Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.</p>',
-                        },
-                      },
-                      {
-                        id: '3',
-                        content: 'Un plateau de fruits frais et de fromage',
-                        feedback: {
-                          diagnosis:
-                            '<p>Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.</p>',
-                        },
-                      },
-                      {
-                        id: '4',
-                        content: 'Une part de gâteau marbré au chocolat et à la vanille',
-                        feedback: {
-                          diagnosis:
-                            '<p>Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.</p>',
-                        },
-                      },
-                    ],
-                    solution: '1',
-                  },
+                    },
+                  ],
                 },
               ],
             },
@@ -835,7 +925,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUDiscovery);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCUDiscovery);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
@@ -853,46 +943,53 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
-                    type: 'qcm',
-                    instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                        type: 'qcm',
+                        instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                          },
+                          {
+                            id: '2',
+                            content: 'Développer son savoir-faire sur les jeux de type TPS',
+                          },
+                          {
+                            id: '3',
+                            content: 'Développer ses compétences numériques',
+                          },
+                          {
+                            id: '4',
+                            content: 'Certifier ses compétences Pix',
+                          },
+                          {
+                            id: '5',
+                            content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                          },
+                        ],
+                        feedbacks: {
+                          valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                          invalid:
+                            '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                        },
+                        solutions: ['1', '3', '4'],
                       },
-                      {
-                        id: '2',
-                        content: 'Développer son savoir-faire sur les jeux de type TPS',
-                      },
-                      {
-                        id: '3',
-                        content: 'Développer ses compétences numériques',
-                      },
-                      {
-                        id: '4',
-                        content: 'Certifier ses compétences Pix',
-                      },
-                      {
-                        id: '5',
-                        content: 'Evaluer ses compétences de logique et compréhension mathématique',
-                      },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
-                      invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
                     },
-                    solutions: ['1', '3', '4'],
-                  },
+                  ],
                 },
               ],
             },
@@ -903,7 +1000,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCM);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCM);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a QROCM Element', function () {
@@ -921,62 +1018,68 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
-                    type: 'qrocm',
-                    instruction:
-                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
-                    proposals: [
-                      {
-                        type: 'text',
-                        content: '<p>Le symbole</>',
-                      },
-                      {
-                        input: 'symbole',
-                        type: 'input',
-                        inputType: 'text',
-                        size: 1,
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 1',
-                        defaultValue: '',
-                        tolerances: ['t1'],
-                        solutions: ['@'],
-                      },
-                      {
-                        input: 'premiere-partie',
-                        type: 'select',
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 2',
-                        defaultValue: '',
-                        tolerances: [],
-                        options: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                        type: 'qrocm',
+                        instruction:
+                          "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                        proposals: [
                           {
-                            id: '1',
-                            content: "l'identifiant",
+                            type: 'text',
+                            content: '<p>Le symbole</>',
                           },
                           {
-                            id: '2',
-                            content: "le fournisseur d'adresse mail",
+                            input: 'symbole',
+                            type: 'input',
+                            inputType: 'text',
+                            size: 1,
+                            display: 'inline',
+                            placeholder: '',
+                            ariaLabel: 'Réponse 1',
+                            defaultValue: '',
+                            tolerances: ['t1'],
+                            solutions: ['@'],
+                          },
+                          {
+                            input: 'premiere-partie',
+                            type: 'select',
+                            display: 'inline',
+                            placeholder: '',
+                            ariaLabel: 'Réponse 2',
+                            defaultValue: '',
+                            tolerances: [],
+                            options: [
+                              {
+                                id: '1',
+                                content: "l'identifiant",
+                              },
+                              {
+                                id: '2',
+                                content: "le fournisseur d'adresse mail",
+                              },
+                            ],
+                            solutions: ['1'],
                           },
                         ],
-                        solutions: ['1'],
+                        feedbacks: {
+                          valid: '<p>Bravo ! 🎉 </p>',
+                          invalid: "<p class='pix-list-inline'>Et non !</p>",
+                        },
                       },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Bravo ! 🎉 </p>',
-                      invalid: "<p class='pix-list-inline'>Et non !</p>",
                     },
-                  },
+                  ],
                 },
               ],
             },
@@ -987,7 +1090,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCM);
+        expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QROCM);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
@@ -1005,40 +1108,46 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                    type: 'flashcards',
-                    title: "Introduction à l'adresse e-mail",
-                    instruction: '<p>...</p>',
-                    introImage: {
-                      url: 'https://example.org/image.jpeg',
-                    },
-                    cards: [
-                      {
-                        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-                        recto: {
-                          image: {
-                            url: 'https://example.org/image.jpeg',
-                          },
-                          text: "A quoi sert l'arobase dans mon adresse email ?",
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                        type: 'flashcards',
+                        title: "Introduction à l'adresse e-mail",
+                        instruction: '<p>...</p>',
+                        introImage: {
+                          url: 'https://example.org/image.jpeg',
                         },
-                        verso: {
-                          image: {
-                            url: 'https://example.org/image.jpeg',
+                        cards: [
+                          {
+                            id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+                            recto: {
+                              image: {
+                                url: 'https://example.org/image.jpeg',
+                              },
+                              text: "A quoi sert l'arobase dans mon adresse email ?",
+                            },
+                            verso: {
+                              image: {
+                                url: 'https://example.org/image.jpeg',
+                              },
+                              text: "Parce que c'est joli",
+                            },
                           },
-                          text: "Parce que c'est joli",
-                        },
+                        ],
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
               ],
             },
@@ -1049,8 +1158,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        const flashcards = module.grains[0].components[0].element;
-        const expectedFlashcards = moduleData.grains[0].components[0].element;
+        const flashcards = module.sections[0].grains[0].components[0].element;
+        const expectedFlashcards = moduleData.sections[0].grains[0].components[0].element;
         validateFlashcards(flashcards, expectedFlashcards);
       });
 
@@ -1069,20 +1178,26 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                    type: 'expand',
-                    title: "Plus d'info sur la poésie",
-                    content: '<p>La poésie c’est cool</p>',
-                  },
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                        type: 'expand',
+                        title: "Plus d'info sur la poésie",
+                        content: '<p>La poésie c’est cool</p>',
+                      },
+                    },
+                  ],
                 },
               ],
             },
@@ -1093,8 +1208,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(givenData);
 
         // then
-        const expand = module.grains[0].components[0].element;
-        const expectedExpand = givenData.grains[0].components[0].element;
+        const expand = module.sections[0].grains[0].components[0].element;
+        const expectedExpand = givenData.sections[0].grains[0].components[0].element;
         expect(expand.id).to.equal(expectedExpand.id);
         expect(expand.content).to.equal(expectedExpand.content);
         expect(expand.title).to.equal(expectedExpand.title);
@@ -1116,39 +1231,45 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'cf436761-f56d-4b01-83f9-942afe9ce72c',
-              type: 'lesson',
-              title: 'test qab',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'element',
-                  element: {
-                    id: 'ed795d29-5f04-499c-a9c8-4019125c5cb1',
-                    type: 'qab',
-                    instruction:
-                      '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>',
-                    cards: [
-                      {
-                        id: '4420c9f6-ae21-4401-a16c-41296d898a66',
-                        text: 'La Terre est plus proche du Soleil que Mars.',
-                        proposalA: 'Vrai',
-                        proposalB: 'Faux',
-                        solution: 'B',
+                  id: 'cf436761-f56d-4b01-83f9-942afe9ce72c',
+                  type: 'lesson',
+                  title: 'test qab',
+                  components: [
+                    {
+                      type: 'element',
+                      element: {
+                        id: 'ed795d29-5f04-499c-a9c8-4019125c5cb1',
+                        type: 'qab',
+                        instruction:
+                          '<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>',
+                        cards: [
+                          {
+                            id: '4420c9f6-ae21-4401-a16c-41296d898a66',
+                            text: 'La Terre est plus proche du Soleil que Mars.',
+                            proposalA: 'Vrai',
+                            proposalB: 'Faux',
+                            solution: 'B',
+                          },
+                          {
+                            id: '52d99648-5904-4a66-9fb8-476ba4da9465',
+                            text: 'L’eau bout à 100°C au niveau de la mer.',
+                            proposalA: 'Vrai',
+                            proposalB: 'Faux',
+                            solution: 'A',
+                          },
+                        ],
+                        feedback: {
+                          diagnosis: '<p>Continuez comme ça !</p>',
+                        },
                       },
-                      {
-                        id: '52d99648-5904-4a66-9fb8-476ba4da9465',
-                        text: 'L’eau bout à 100°C au niveau de la mer.',
-                        proposalA: 'Vrai',
-                        proposalB: 'Faux',
-                        solution: 'A',
-                      },
-                    ],
-                    feedback: {
-                      diagnosis: '<p>Continuez comme ça !</p>',
                     },
-                  },
+                  ],
                 },
               ],
             },
@@ -1159,7 +1280,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0].element).to.be.instanceOf(QAB);
+        expect(module.sections[0].grains[0].components[0].element).to.be.instanceOf(QAB);
       });
     });
 
@@ -1179,23 +1300,29 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                          type: 'image',
-                          url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
-                          alt: "Dessin détaillé dans l'alternative textuelle",
-                          alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
+                          elements: [
+                            {
+                              id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                              type: 'image',
+                              url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                              alt: "Dessin détaillé dans l'alternative textuelle",
+                              alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1210,9 +1337,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Image);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Image);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a Separator Element', function () {
@@ -1230,20 +1357,26 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '11f382f1-d36a-48d2-a99d-4aa052ab7841',
-                          type: 'separator',
+                          elements: [
+                            {
+                              id: '11f382f1-d36a-48d2-a99d-4aa052ab7841',
+                              type: 'separator',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1258,9 +1391,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Separator);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Separator);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a Text Element', function () {
@@ -1278,21 +1411,28 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                          type: 'text',
-                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                          elements: [
+                            {
+                              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                              type: 'text',
+                              content:
+                                '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1307,9 +1447,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a Video Element', function () {
@@ -1327,25 +1467,31 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                          type: 'video',
-                          title: 'Vidéo de présentation de Pix',
-                          url: 'https://assets.pix.org/modulix/didacticiel/presentation.mp4',
-                          subtitles: '',
-                          transcription:
-                            '<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s\'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href="https://pix.fr" target="blank">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s\'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d\'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l\'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>',
+                          elements: [
+                            {
+                              id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                              type: 'video',
+                              title: 'Vidéo de présentation de Pix',
+                              url: 'https://assets.pix.org/modulix/didacticiel/presentation.mp4',
+                              subtitles: '',
+                              transcription:
+                                '<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s\'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href="https://pix.fr" target="blank">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s\'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d\'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l\'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1360,9 +1506,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a Download Element', function () {
@@ -1380,24 +1526,30 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                          type: 'download',
-                          files: [
+                          elements: [
                             {
-                              url: 'https://example.org/modulix/file.pdf',
-                              format: '.pdf',
+                              id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                              type: 'download',
+                              files: [
+                                {
+                                  url: 'https://example.org/modulix/file.pdf',
+                                  format: '.pdf',
+                                },
+                              ],
                             },
                           ],
                         },
@@ -1414,9 +1566,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Download);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Download);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains an Embed Element', function () {
@@ -1434,25 +1586,31 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                          type: 'embed',
-                          isCompletionRequired: false,
-                          title: "Simulateur d'adresse mail",
-                          url: 'https://embed.fr',
-                          instruction: '<p>Parcourez ces photos trouvées sur le Web.</p>',
-                          height: 150,
+                          elements: [
+                            {
+                              id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                              type: 'embed',
+                              isCompletionRequired: false,
+                              title: "Simulateur d'adresse mail",
+                              url: 'https://embed.fr',
+                              instruction: '<p>Parcourez ces photos trouvées sur le Web.</p>',
+                              height: 150,
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1467,9 +1625,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Embed);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Embed);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QCU Element', function () {
@@ -1487,36 +1645,42 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                          type: 'qcu',
-                          instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
-                          proposals: [
+                          elements: [
                             {
-                              id: '1',
-                              content: 'Vrai',
-                              feedback: { state: 'Bonne réponse !' },
-                            },
-                            {
-                              id: '2',
-                              content: 'Faux',
-                              feedback: {
-                                state: "Faux n'est pas la bonne réponse.",
-                              },
+                              id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                              type: 'qcu',
+                              instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                              proposals: [
+                                {
+                                  id: '1',
+                                  content: 'Vrai',
+                                  feedback: { state: 'Bonne réponse !' },
+                                },
+                                {
+                                  id: '2',
+                                  content: 'Faux',
+                                  feedback: {
+                                    state: "Faux n'est pas la bonne réponse.",
+                                  },
+                                },
+                              ],
+                              solution: '1',
                             },
                           ],
-                          solution: '1',
                         },
                       ],
                     },
@@ -1531,9 +1695,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QCUDeclarative Element', function () {
@@ -1551,42 +1715,48 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
-                          type: 'qcu-declarative',
-                          instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
-                          proposals: [
+                          elements: [
                             {
-                              id: '1',
-                              content: 'Avant de mettre le dentifrice',
-                              feedback: {
-                                diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
-                              },
-                            },
-                            {
-                              id: '2',
-                              content: 'Après avoir mis le dentifrice',
-                              feedback: {
-                                diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
-                              },
-                            },
-                            {
-                              id: '3',
-                              content: 'Pendant que le dentifrice est mis',
-                              feedback: {
-                                diagnosis: '<p>Digne des plus grands acrobates !</p>',
-                              },
+                              id: '6a6944be-a8a3-4138-b5dc-af664cf40b07',
+                              type: 'qcu-declarative',
+                              instruction: '<p>Quand faut-il mouiller sa brosse à dents ?</p>',
+                              proposals: [
+                                {
+                                  id: '1',
+                                  content: 'Avant de mettre le dentifrice',
+                                  feedback: {
+                                    diagnosis: "<p>C'est l'approche de la plupart des gens.</p>",
+                                  },
+                                },
+                                {
+                                  id: '2',
+                                  content: 'Après avoir mis le dentifrice',
+                                  feedback: {
+                                    diagnosis: '<p>Possible, mais attention à ne pas faire tomber le dentifrice !</p>',
+                                  },
+                                },
+                                {
+                                  id: '3',
+                                  content: 'Pendant que le dentifrice est mis',
+                                  feedback: {
+                                    diagnosis: '<p>Digne des plus grands acrobates !</p>',
+                                  },
+                                },
+                              ],
                             },
                           ],
                         },
@@ -1603,9 +1773,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QCM Element', function () {
@@ -1623,49 +1793,55 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
-                          type: 'qcm',
-                          instruction: '<p>Quels sont les 3 piliers de Pix&#8239;?</p>',
-                          proposals: [
+                          elements: [
                             {
-                              id: '1',
-                              content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
-                            },
-                            {
-                              id: '2',
-                              content: 'Développer son savoir-faire sur les jeux de type TPS',
-                            },
-                            {
-                              id: '3',
-                              content: 'Développer ses compétences numériques',
-                            },
-                            {
-                              id: '4',
-                              content: 'Certifier ses compétences Pix',
-                            },
-                            {
-                              id: '5',
-                              content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                              id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                              type: 'qcm',
+                              instruction: '<p>Quels sont les 3 piliers de Pix&#8239;?</p>',
+                              proposals: [
+                                {
+                                  id: '1',
+                                  content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                                },
+                                {
+                                  id: '2',
+                                  content: 'Développer son savoir-faire sur les jeux de type TPS',
+                                },
+                                {
+                                  id: '3',
+                                  content: 'Développer ses compétences numériques',
+                                },
+                                {
+                                  id: '4',
+                                  content: 'Certifier ses compétences Pix',
+                                },
+                                {
+                                  id: '5',
+                                  content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                                },
+                              ],
+                              feedbacks: {
+                                valid: '<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>',
+                                invalid:
+                                  '<p>Et non&#8239;! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>',
+                              },
+                              solutions: ['1', '3', '4'],
                             },
                           ],
-                          feedbacks: {
-                            valid: '<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>',
-                            invalid:
-                              '<p>Et non&#8239;! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>',
-                          },
-                          solutions: ['1', '3', '4'],
                         },
                       ],
                     },
@@ -1680,9 +1856,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCM);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCM);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QROCM Element', function () {
@@ -1700,60 +1876,66 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: 'c23436d4-6261-49f1-b50d-13a547529c29',
-                          type: 'qrocm',
-                          instruction: '<p>Compléter le texte suivant :</p>',
-                          proposals: [
+                          elements: [
                             {
-                              type: 'text',
-                              content: '<span>Pix est un</span>',
-                            },
-                            {
-                              input: 'pix-name',
-                              type: 'input',
-                              inputType: 'text',
-                              size: 10,
-                              display: 'inline',
-                              placeholder: '',
-                              ariaLabel: 'Mot à trouver',
-                              defaultValue: '',
-                              tolerances: ['t1', 't3'],
-                              solutions: ['Groupement'],
-                            },
-                            {
-                              type: 'text',
-                              content: "<span>d'intérêt public qui a été créée en</span>",
-                            },
-                            {
-                              input: 'pix-birth',
-                              type: 'input',
-                              inputType: 'text',
-                              size: 10,
-                              display: 'inline',
-                              placeholder: '',
-                              ariaLabel: 'Année à trouver',
-                              defaultValue: '',
-                              tolerances: [],
-                              solutions: ['2016'],
+                              id: 'c23436d4-6261-49f1-b50d-13a547529c29',
+                              type: 'qrocm',
+                              instruction: '<p>Compléter le texte suivant :</p>',
+                              proposals: [
+                                {
+                                  type: 'text',
+                                  content: '<span>Pix est un</span>',
+                                },
+                                {
+                                  input: 'pix-name',
+                                  type: 'input',
+                                  inputType: 'text',
+                                  size: 10,
+                                  display: 'inline',
+                                  placeholder: '',
+                                  ariaLabel: 'Mot à trouver',
+                                  defaultValue: '',
+                                  tolerances: ['t1', 't3'],
+                                  solutions: ['Groupement'],
+                                },
+                                {
+                                  type: 'text',
+                                  content: "<span>d'intérêt public qui a été créée en</span>",
+                                },
+                                {
+                                  input: 'pix-birth',
+                                  type: 'input',
+                                  inputType: 'text',
+                                  size: 10,
+                                  display: 'inline',
+                                  placeholder: '',
+                                  ariaLabel: 'Année à trouver',
+                                  defaultValue: '',
+                                  tolerances: [],
+                                  solutions: ['2016'],
+                                },
+                              ],
+                              feedbacks: {
+                                valid:
+                                  '<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
+                                invalid: '<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>',
+                              },
                             },
                           ],
-                          feedbacks: {
-                            valid:
-                              '<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
-                            invalid: '<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>',
-                          },
                         },
                       ],
                     },
@@ -1768,9 +1950,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QROCM);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QROCM);
       });
 
       it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
@@ -1788,40 +1970,46 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
-                          type: 'flashcards',
-                          title: "Introduction à l'adresse e-mail",
-                          instruction: '<p>...</p>',
-                          introImage: {
-                            url: 'https://example.org/image.jpeg',
-                          },
-                          cards: [
+                          elements: [
                             {
-                              id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-                              recto: {
-                                image: {
-                                  url: 'https://example.org/image.jpeg',
-                                },
-                                text: "A quoi sert l'arobase dans mon adresse email ?",
+                              id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                              type: 'flashcards',
+                              title: "Introduction à l'adresse e-mail",
+                              instruction: '<p>...</p>',
+                              introImage: {
+                                url: 'https://example.org/image.jpeg',
                               },
-                              verso: {
-                                image: {
-                                  url: 'https://example.org/image.jpeg',
+                              cards: [
+                                {
+                                  id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+                                  recto: {
+                                    image: {
+                                      url: 'https://example.org/image.jpeg',
+                                    },
+                                    text: "A quoi sert l'arobase dans mon adresse email ?",
+                                  },
+                                  verso: {
+                                    image: {
+                                      url: 'https://example.org/image.jpeg',
+                                    },
+                                    text: "Parce que c'est joli",
+                                  },
                                 },
-                                text: "Parce que c'est joli",
-                              },
+                              ],
                             },
                           ],
                         },
@@ -1838,8 +2026,8 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        const flashcards = module.grains[0].components[0].steps[0].elements[0];
-        const expectedFlashcards = moduleData.grains[0].components[0].steps[0].elements[0];
+        const flashcards = module.sections[0].grains[0].components[0].steps[0].elements[0];
+        const expectedFlashcards = moduleData.sections[0].grains[0].components[0].steps[0].elements[0];
         validateFlashcards(flashcards, expectedFlashcards);
       });
 
@@ -1858,26 +2046,33 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                          type: 'text',
-                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
-                        },
-                        {
-                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
-                          type: 'unknown',
-                          content: 'Should not be added to the grain',
+                          elements: [
+                            {
+                              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                              type: 'text',
+                              content:
+                                '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                            },
+                            {
+                              id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                              type: 'unknown',
+                              content: 'Should not be added to the grain',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1892,10 +2087,10 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         const module = ModuleFactory.build(moduleData);
 
         // then
-        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
-        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.grains[0].components[0].steps[0].elements).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
+        expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements).to.have.lengthOf(1);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
       });
 
       it('should filter out steps with only unknown element type', function () {
@@ -1913,30 +2108,37 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                          type: 'text',
-                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                          elements: [
+                            {
+                              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                              type: 'text',
+                              content:
+                                '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                            },
+                          ],
                         },
-                      ],
-                    },
-                    {
-                      elements: [
                         {
-                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
-                          type: 'unknown',
-                          content: 'Should not be added to the grain',
+                          elements: [
+                            {
+                              id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                              type: 'unknown',
+                              content: 'Should not be added to the grain',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1970,21 +2172,27 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
             tabletSupport: 'comfortable',
             objectives: ['Objective 1'],
           },
-          grains: [
+          sections: [
             {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
+              id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+              type: 'practise',
+              grains: [
                 {
-                  type: 'stepper',
-                  steps: [
+                  id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                  type: 'lesson',
+                  title: 'title',
+                  components: [
                     {
-                      elements: [
+                      type: 'stepper',
+                      steps: [
                         {
-                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
-                          type: 'unknown',
-                          content: 'Should not be added to the grain',
+                          elements: [
+                            {
+                              id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                              type: 'unknown',
+                              content: 'Should not be added to the grain',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2019,27 +2227,33 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
-                  type: 'text',
-                  content: '<h3>Content</h3>',
-                },
-              },
-              {
-                type: 'unknown',
-                unknown: {
-                  id: '16ad694a-848f-456d-95a6-c488350c3ed7',
-                  type: 'text',
-                  content: '<h3>Content</h3>',
-                },
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                      type: 'text',
+                      content: '<h3>Content</h3>',
+                    },
+                  },
+                  {
+                    type: 'unknown',
+                    unknown: {
+                      id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                      type: 'text',
+                      content: '<h3>Content</h3>',
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -2051,9 +2265,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
       // then
       expect(module).to.be.an.instanceOf(Module);
-      expect(module.grains).not.to.be.empty;
-      expect(module.grains[0].components).to.have.lengthOf(1);
-      expect(module.grains[0].components[0].element).not.to.be.empty;
+      expect(module.sections[0].grains).not.to.be.empty;
+      expect(module.sections[0].grains[0].components).to.have.lengthOf(1);
+      expect(module.sections[0].grains[0].components[0].element).not.to.be.empty;
     });
 
     it('should filter out component if element type is unknown', function () {
@@ -2071,27 +2285,33 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           tabletSupport: 'comfortable',
           objectives: ['Objective 1'],
         },
-        grains: [
+        sections: [
           {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
+            id: '5bf1c672-3746-4480-b9ac-1f0af9c7c509',
+            type: 'practise',
+            grains: [
               {
-                type: 'element',
-                element: {
-                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
-                  type: 'text',
-                  content: '<h3>Content</h3>',
-                },
-              },
-              {
-                type: 'element',
-                element: {
-                  id: '16ad694a-848f-456d-95a6-c488350c3ed7',
-                  type: 'unknown',
-                  content: 'Should not be added to the grain',
-                },
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                      type: 'text',
+                      content: '<h3>Content</h3>',
+                    },
+                  },
+                  {
+                    type: 'element',
+                    element: {
+                      id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                      type: 'unknown',
+                      content: 'Should not be added to the grain',
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -2103,9 +2323,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
 
       // then
       expect(module).to.be.an.instanceOf(Module);
-      expect(module.grains).not.to.be.empty;
-      expect(module.grains[0].components).to.have.lengthOf(1);
-      expect(module.grains[0].components[0].element).not.to.be.empty;
+      expect(module.sections[0].grains).not.to.be.empty;
+      expect(module.sections[0].grains[0].components).to.have.lengthOf(1);
+      expect(module.sections[0].grains[0].components[0].element).not.to.be.empty;
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -42,7 +42,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, details, slug, title, grains: [], isBeta, version });
+      const moduleFromDomain = new Module({ id, details, slug, title, sections: [], isBeta, version });
       moduleFromDomain.setRedirectionUrl(redirectionUrl);
       const expectedJson = {
         data: {
@@ -50,6 +50,60 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           id,
           attributes: {
             'redirection-url': redirectionUrl,
+            slug,
+            title,
+            'is-beta': isBeta,
+            details,
+            version,
+          },
+          relationships: {
+            grains: {
+              data: [],
+            },
+          },
+        },
+      };
+
+      // when
+      const json = moduleSerializer.serialize(moduleFromDomain);
+
+      // then
+      expect(json).to.deep.equal(expectedJson);
+    });
+
+    it('should serialize with empty sections list', function () {
+      // given
+      const id = 'id';
+      const slug = 'bien-ecrire-son-adresse-mail';
+      const title = 'Bien écrire son adresse mail';
+      const isBeta = true;
+      const version = Symbol('version');
+      const details = {
+        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        description:
+          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+        duration: 12,
+        level: 'Débutant',
+        objectives: [
+          'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+          'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+          'Comprendre les fonctions des parties d’une adresse mail',
+        ],
+      };
+      const moduleFromDomain = new Module({
+        id,
+        details,
+        slug,
+        title,
+        sections: [],
+        isBeta,
+        version,
+      });
+      const expectedJson = {
+        data: {
+          type: 'modules',
+          id,
+          attributes: {
             slug,
             title,
             'is-beta': isBeta,
@@ -95,7 +149,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         details,
         slug,
         title,
-        grains: [],
+        sections: [{ id, type: 'none', grains: [] }],
         isBeta,
         version,
       });
@@ -151,12 +205,18 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         isBeta,
         version,
         details,
-        grains: [
+        sections: [
           {
-            id: '1',
-            title: 'Grain 1',
-            type: 'activity',
-            components: getComponents(),
+            id,
+            type: 'none',
+            grains: [
+              {
+                id: '1',
+                title: 'Grain 1',
+                type: 'activity',
+                components: getComponents(),
+              },
+            ],
           },
         ],
       });

--- a/api/tests/shared/unit/domain/models/asserts_test.js
+++ b/api/tests/shared/unit/domain/models/asserts_test.js
@@ -3,6 +3,7 @@ import {
   assertEnumValue,
   assertHasUuidLength,
   assertInstanceOf,
+  assertIsArray,
   assertNotNullOrUndefined,
   assertPositiveInteger,
 } from '../../../../../src/shared/domain/models/asserts.js';
@@ -218,6 +219,24 @@ describe('Unit | Shared | Models | asserts', function () {
 
         // when/then
         expect(() => assertPositiveInteger(value)).not.to.throw();
+      });
+    });
+  });
+
+  describe('#assertIsArray', function () {
+    describe('given invalid values', function () {
+      [null, undefined, 'azerty'].forEach(function (input) {
+        it(`"${input}" should throw`, function () {
+          expect(() => assertIsArray(input)).to.throw();
+        });
+      });
+    });
+
+    describe('given valid values', function () {
+      [[]].forEach(function (input) {
+        it(`"${input}" should not throw`, function () {
+          expect(() => assertIsArray(input)).not.to.throw();
+        });
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -10,7 +10,7 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
     slug: 'slug',
     title: 'title',
     isBeta: true,
-    grains: [],
+    sections: [{ id: 8, type: 'none', grains: [] }],
     details: '',
     version: '',
   });


### PR DESCRIPTION
## 🔆 Problème

L'arborescence des modules avec uniquement des grains n'est pas suffisante.

```
Module > Grains > Components > Elements
```

On souhaite introduire un nouveau niveau de profondeur : la section. Cette section est typé en accord avec le "pattern" de construction des modules.

```
Module > Sections > Grains > Components > Elements
```

## ⛱️ Proposition

Introduire la brique "section" dans les contenus des modules. Le type de chaque section peut être une valeur parmi : 
- Se questionner     `question-yourself`
- Explorer pour comprendre    `explore-to-understand`
- Retenir l'essentiel    `retain-the-essentials`
- S'exercer    `practise`
- Aller plus loin    `go-further`
- `blank` pour les anciens modules qui ne suivent pas le pattern

Pour le moment ce changement n'est introduit que dans les contenus et les couches d'API mais l'information n'est pas renvoyée au front. Il n'y est donc pas sensé avoir d'évolution fonctionnelle en l'état.

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI ✅ 
Déploiement ✅ 
