### PR TITLE
[FEATURE] Suppression du message de perte d'éligibilité hors CléA sur l'espace surveillant (PIX-18854).

### DIFF
--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
@@ -14,6 +14,7 @@ class CertificationCandidateForSupervising {
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
+    enrolledDoubleCertification,
     stillValidBadgeAcquisitions = [],
     accessibilityAdjustmentNeeded,
     challengeLiveAlert,
@@ -30,6 +31,7 @@ class CertificationCandidateForSupervising {
     this.startDateTime = startDateTime;
     this.theoricalEndDateTime = theoricalEndDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
+    this.enrolledDoubleCertification = enrolledDoubleCertification;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
     this.accessibilityAdjustmentNeeded = accessibilityAdjustmentNeeded;
     this.challengeLiveAlert = challengeLiveAlert?.status ? challengeLiveAlert : null;
@@ -43,7 +45,7 @@ class CertificationCandidateForSupervising {
   get isStillEligibleToDoubleCertification() {
     return this.stillValidBadgeAcquisitions.some(
       (stillValidBadgeAcquisition) =>
-        stillValidBadgeAcquisition.complementaryCertificationKey === this.enrolledComplementaryCertification.key,
+        stillValidBadgeAcquisition.complementaryCertificationKey === this.enrolledDoubleCertification?.key,
     );
   }
 }

--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
@@ -40,7 +40,7 @@ class CertificationCandidateForSupervising {
     this.authorizedToStart = true;
   }
 
-  get isStillEligibleToComplementaryCertification() {
+  get isStillEligibleToDoubleCertification() {
     return this.stillValidBadgeAcquisitions.some(
       (stillValidBadgeAcquisition) =>
         stillValidBadgeAcquisition.complementaryCertificationKey === this.enrolledComplementaryCertification.key,

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -61,7 +61,7 @@ function _computeTheoricalEndDateTime(candidate) {
 
   let theoricalEndDateTime = startDateTime.add(DEFAULT_SESSION_DURATION_MINUTES, 'minute');
 
-  if (candidate.isStillEligibleToComplementaryCertification) {
+  if (candidate.isStillEligibleToDoubleCertification) {
     const extraMinutes = candidate.enrolledComplementaryCertification.certificationExtraTime ?? 0;
     theoricalEndDateTime = theoricalEndDateTime.add(extraMinutes, 'minute');
   }

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../shared/domain/constants.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
 /**
  * @typedef {import('./index.js').SessionForSupervisingRepository} SessionForSupervisingRepository
@@ -23,7 +24,7 @@ const getSessionForSupervising = async function ({
 
   await PromiseUtils.map(
     sessionForSupervising.certificationCandidates,
-    _computeComplementaryCertificationEligibility(certificationBadgesService),
+    _computeDoubleCertificationEligibility(certificationBadgesService),
     { concurrency: CONCURRENCY_HEAVY_OPERATIONS },
   );
 
@@ -39,9 +40,9 @@ export { getSessionForSupervising };
 /**
  * @param {CertificationBadgesService} certificationBadgesService
  */
-function _computeComplementaryCertificationEligibility(certificationBadgesService) {
+function _computeDoubleCertificationEligibility(certificationBadgesService) {
   return async (candidate) => {
-    if (candidate.enrolledComplementaryCertification?.key) {
+    if (candidate.enrolledComplementaryCertification?.key === ComplementaryCertificationKeys.CLEA) {
       candidate.stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
         userId: candidate.userId,
       });

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../shared/domain/constants.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
 /**
  * @typedef {import('./index.js').SessionForSupervisingRepository} SessionForSupervisingRepository
@@ -42,7 +41,7 @@ export { getSessionForSupervising };
  */
 function _computeDoubleCertificationEligibility(certificationBadgesService) {
   return async (candidate) => {
-    if (candidate.enrolledComplementaryCertification?.key === ComplementaryCertificationKeys.CLEA) {
+    if (candidate.enrolledDoubleCertification?.key) {
       candidate.stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions({
         userId: candidate.userId,
       });
@@ -50,9 +49,6 @@ function _computeDoubleCertificationEligibility(certificationBadgesService) {
   };
 }
 
-/**
- * @param {CertificationCandidateForAd} certificationBadgesService
- */
 function _computeTheoricalEndDateTime(candidate) {
   const startDateTime = dayjs(candidate.startDateTime || null);
   if (!startDateTime.isValid()) {
@@ -62,7 +58,7 @@ function _computeTheoricalEndDateTime(candidate) {
   let theoricalEndDateTime = startDateTime.add(DEFAULT_SESSION_DURATION_MINUTES, 'minute');
 
   if (candidate.isStillEligibleToDoubleCertification) {
-    const extraMinutes = candidate.enrolledComplementaryCertification.certificationExtraTime ?? 0;
+    const extraMinutes = candidate.enrolledDoubleCertification.certificationExtraTime ?? 0;
     theoricalEndDateTime = theoricalEndDateTime.add(extraMinutes, 'minute');
   }
 

--- a/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-for-supervising-repository.js
@@ -2,6 +2,7 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../shared/domain/models/CertificationCompanionLiveAlert.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { CertificationCandidateForSupervising } from '../../domain/models/CertificationCandidateForSupervising.js';
 import { ComplementaryCertificationForSupervising } from '../../domain/models/ComplementaryCertificationForSupervising.js';
 import { SessionForSupervising } from '../../domain/read-models/SessionForSupervising.js';
@@ -97,9 +98,18 @@ function _toDomainComplementaryCertification(complementaryCertification) {
 }
 
 function _buildCertificationCandidateForSupervising(candidateDto) {
+  if (candidateDto.complementaryCertification?.key === ComplementaryCertificationKeys.CLEA) {
+    return new CertificationCandidateForSupervising({
+      ...candidateDto,
+      enrolledDoubleCertification: _toDomainComplementaryCertification(candidateDto.complementaryCertification),
+      enrolledComplementaryCertification: null,
+    });
+  }
+
   return new CertificationCandidateForSupervising({
     ...candidateDto,
     enrolledComplementaryCertification: _toDomainComplementaryCertification(candidateDto.complementaryCertification),
+    enrolledDoubleCertification: null,
   });
 }
 

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -10,6 +10,7 @@ const serialize = function (sessions) {
 
       cloneSession.certificationCandidates.forEach((candidate) => {
         candidate.enrolledComplementaryCertificationLabel = candidate.enrolledComplementaryCertification?.label ?? null;
+        candidate.enrolledDoubleCertificationLabel = candidate.enrolledDoubleCertification?.label ?? null;
       });
 
       return cloneSession;
@@ -32,6 +33,7 @@ const serialize = function (sessions) {
         'startDateTime',
         'theoricalEndDateTime',
         'enrolledComplementaryCertificationLabel',
+        'enrolledDoubleCertificationLabel',
         'isStillEligibleToDoubleCertification',
         'challengeLiveAlert',
         'companionLiveAlert',

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -32,7 +32,7 @@ const serialize = function (sessions) {
         'startDateTime',
         'theoricalEndDateTime',
         'enrolledComplementaryCertificationLabel',
-        'isStillEligibleToComplementaryCertification',
+        'isStillEligibleToDoubleCertification',
         'challengeLiveAlert',
         'companionLiveAlert',
       ],

--- a/api/tests/certification/session-management/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -16,84 +16,34 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
     });
   });
 
-  describe('#isStillEligibleToComplementaryCertification', function () {
-    context('when candidate has a complementary certification', function () {
-      context(
-        'when candidate has still valid badge acquisition related to his complementary certification',
-        function () {
-          it('Should return true', function () {
-            // given
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-              key: 'aKey',
-            });
+  describe('#isStillEligibleToDoubleCertification', function () {
+    context('when candidate has a valid double certification badge acquisition', function () {
+      it('returns true', function () {
+        // given
+        const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+          key: 'aKey',
+        });
 
-            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-              enrolledComplementaryCertification: complementaryCertification,
-              stillValidBadgeAcquisitions: [
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationKey: 'aKey',
-                }),
-              ],
-            });
+        const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
+          enrolledComplementaryCertification: complementaryCertification,
+          stillValidBadgeAcquisitions: [
+            domainBuilder.buildCertifiableBadgeAcquisition({
+              complementaryCertificationKey: 'aKey',
+            }),
+          ],
+        });
 
-            // when
-            const isStillEligibleToComplementaryCertification =
-              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+        // when
+        const isStillEligibleToDoubleCertification =
+          certificationCandidateForSupervising.isStillEligibleToDoubleCertification;
 
-            // then
-            expect(isStillEligibleToComplementaryCertification).to.be.true;
-          });
-        },
-      );
-
-      context(
-        'when candidate has no still valid badge acquisition related to his complementary certification',
-        function () {
-          it('Should return false', function () {
-            // given
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
-            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-              enrolledComplementaryCertification: complementaryCertification,
-              stillValidBadgeAcquisitions: [],
-            });
-
-            // when
-            const isStillEligibleToComplementaryCertification =
-              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
-
-            // then
-            expect(isStillEligibleToComplementaryCertification).to.be.false;
-          });
-        },
-      );
-
-      context(
-        'when candidate has still valid badge acquisition  not related to his complementary certification',
-        function () {
-          it('Should return false', function () {
-            // given
-            const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-              enrolledComplementaryCertification: 'Une certif complémentaire',
-              stillValidBadgeAcquisitions: [
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationBadgeLabel: 'Une autre certif complémentaire',
-                }),
-              ],
-            });
-
-            // when
-            const isStillEligibleToComplementaryCertification =
-              certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
-
-            // then
-            expect(isStillEligibleToComplementaryCertification).to.be.false;
-          });
-        },
-      );
+        // then
+        expect(isStillEligibleToDoubleCertification).to.be.true;
+      });
     });
 
-    context('when candidate has no complementary certification', function () {
-      it('Should return false', function () {
+    context('when candidate has no double certification badge acquisition', function () {
+      it('returns false', function () {
         // given
         const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
           enrolledComplementaryCertification: null,
@@ -101,11 +51,11 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
         });
 
         // when
-        const isStillEligibleToComplementaryCertification =
-          certificationCandidateForSupervising.isStillEligibleToComplementaryCertification;
+        const isStillEligibleToDoubleCertification =
+          certificationCandidateForSupervising.isStillEligibleToDoubleCertification;
 
         // then
-        expect(isStillEligibleToComplementaryCertification).to.be.false;
+        expect(isStillEligibleToDoubleCertification).to.be.false;
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/models/CertificationCandidateForSupervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationCandidateForSupervising_test.js
@@ -1,3 +1,4 @@
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | Certification Candidate for supervising', function () {
@@ -21,14 +22,14 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
       it('returns true', function () {
         // given
         const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-          key: 'aKey',
+          key: ComplementaryCertificationKeys.CLEA,
         });
 
         const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-          enrolledComplementaryCertification: complementaryCertification,
+          enrolledDoubleCertification: complementaryCertification,
           stillValidBadgeAcquisitions: [
             domainBuilder.buildCertifiableBadgeAcquisition({
-              complementaryCertificationKey: 'aKey',
+              complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
             }),
           ],
         });
@@ -46,7 +47,7 @@ describe('Unit | Domain | Models | Certification Candidate for supervising', fun
       it('returns false', function () {
         // given
         const certificationCandidateForSupervising = domainBuilder.buildCertificationCandidateForSupervising({
-          enrolledComplementaryCertification: null,
+          enrolledDoubleCertification: null,
           stillValidBadgeAcquisitions: [],
         });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
@@ -2,7 +2,6 @@ import dayjs from 'dayjs';
 
 import { getSessionForSupervising } from '../../../../../../src/certification/session-management/domain/usecases/get-session-for-supervising.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
-import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 const START_DATETIME_STUB = new Date('2022-10-01T13:00:00Z');
@@ -125,12 +124,12 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             it("returns the session with the candidates' eligibility", async function () {
               // given
               const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+                complementaryCertificationKey: 'aKey',
                 complementaryCertificationBadgeLabel: 'une certif complémentaire',
               });
 
               const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-                key: ComplementaryCertificationKeys.CLEA,
+                key: 'aKey',
                 label: 'une certif complémentaire',
                 certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
               });
@@ -140,7 +139,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
                     startDateTime: START_DATETIME_STUB,
-                    enrolledComplementaryCertification: complementaryCertification,
+                    enrolledComplementaryCertification: null,
+                    enrolledDoubleCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
@@ -173,7 +173,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                         DEFAULT_SESSION_DURATION_MINUTES,
                         COMPLEMENTARY_EXTRATIME_STUB,
                       ]),
-                      enrolledComplementaryCertification: complementaryCertification,
+                      enrolledDoubleCertification: complementaryCertification,
+                      enrolledComplementaryCertification: null,
                       stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
                     }),
                   ],
@@ -183,11 +184,11 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
 
             it('gets a theorical end datetime with extra time', async function () {
               const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+                complementaryCertificationKey: 'aKey',
               });
 
               const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-                key: ComplementaryCertificationKeys.CLEA,
+                key: 'aKey',
                 certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
               });
 
@@ -202,7 +203,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                     domainBuilder.buildCertificationCandidateForSupervising({
                       userId: 1234,
                       startDateTime: START_DATETIME_STUB,
-                      enrolledComplementaryCertification: complementaryCertification,
+                      enrolledComplementaryCertification: null,
+                      enrolledDoubleCertification: complementaryCertification,
                       stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
                     }),
                   ],
@@ -237,7 +239,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
                     startDateTime: START_DATETIME_STUB,
-                    enrolledComplementaryCertification: complementaryCertification,
+                    enrolledComplementaryCertification: null,
+                    enrolledDoubleCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
@@ -267,7 +270,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                       theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
                         DEFAULT_SESSION_DURATION_MINUTES,
                       ]),
-                      enrolledComplementaryCertification: complementaryCertification,
+                      enrolledComplementaryCertification: null,
+                      enrolledDoubleCertification: complementaryCertification,
                       stillValidBadgeAcquisitions: [],
                     }),
                   ],

--- a/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import { getSessionForSupervising } from '../../../../../../src/certification/session-management/domain/usecases/get-session-for-supervising.js';
 import { DEFAULT_SESSION_DURATION_MINUTES } from '../../../../../../src/certification/shared/domain/constants.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 const START_DATETIME_STUB = new Date('2022-10-01T13:00:00Z');
@@ -43,8 +44,8 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
         });
       });
 
-      context('when the candidates have no complementary certifications', function () {
-        context('when the session has started', function () {
+      context('when the session has started', function () {
+        context('when candidates are registered to a core certification', function () {
           it('should get certification candidates with theorical end datetime', async function () {
             // given
             const sessionId = 1;
@@ -52,8 +53,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             const certificationCandidateWithNoComplementaryCertification =
               domainBuilder.buildCertificationCandidateForSupervising({
                 id: certificationCandidateId,
-                complementaryCertification: undefined,
-                complementaryCertificationKey: undefined,
+                enrolledComplementaryCertification: undefined,
               });
 
             const session = domainBuilder.buildSessionForSupervising({
@@ -81,173 +81,158 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             expect(certificationCandidate).to.have.deep.property('theoricalEndDateTime', expectedTheoricalEndDateTime);
           });
         });
-      });
 
-      context('when the candidates have complementary certifications', function () {
-        context('when some candidates are still eligible to complementary certifications', function () {
-          it("should return the session with the candidates' eligibility", async function () {
+        context('when candidates are registered to a complementary certification', function () {
+          it('should get certification candidates with theorical end datetime', async function () {
             // given
-            const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-              complementaryCertificationKey: 'aKey',
-              complementaryCertificationBadgeLabel: 'une certif complémentaire',
+            const sessionId = 1;
+            const certificationCandidateId = 51;
+            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
+            const certificationCandidateWithComplementaryCertification =
+              domainBuilder.buildCertificationCandidateForSupervising({
+                id: certificationCandidateId,
+                enrolledComplementaryCertification: complementaryCertification,
+              });
+
+            const session = domainBuilder.buildSessionForSupervising({
+              sessionId,
+              certificationCandidates: [certificationCandidateWithComplementaryCertification],
             });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-              key: 'aKey',
-              label: 'une certif complémentaire',
-              certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
-            });
-
-            const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
-              certificationCandidates: [
-                domainBuilder.buildCertificationCandidateForSupervising({
-                  userId: 1234,
-                  startDateTime: START_DATETIME_STUB,
-                  enrolledComplementaryCertification: complementaryCertification,
-                  stillValidBadgeAcquisitions: [],
-                }),
-              ],
-            });
-
-            sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
-
-            const certificationBadgesService = {
-              findStillValidBadgeAcquisitions: sinon.stub(),
-            };
-            certificationBadgesService.findStillValidBadgeAcquisitions
-              .withArgs({ userId: 1234 })
-              .resolves([stillValidBadgeAcquisition]);
+            sessionForSupervisingRepository.get.resolves(session);
+            const expectedTheoricalEndDateTime = dayjs(
+              certificationCandidateWithComplementaryCertification.startDateTime,
+            )
+              .add(DEFAULT_SESSION_DURATION_MINUTES, 'minute')
+              .toDate();
 
             // when
-            const actualSession = await getSessionForSupervising({
-              sessionId: 1,
+            const { certificationCandidates } = await getSessionForSupervising({
+              sessionId,
               sessionForSupervisingRepository,
-              certificationBadgesService,
             });
-
             // then
-            expect(actualSession).to.deep.equal(
-              domainBuilder.buildSessionForSupervising({
-                certificationCandidates: [
-                  domainBuilder.buildCertificationCandidateForSupervising({
-                    userId: 1234,
-                    startDateTime: START_DATETIME_STUB,
-                    theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
-                      DEFAULT_SESSION_DURATION_MINUTES,
-                      COMPLEMENTARY_EXTRATIME_STUB,
-                    ]),
-                    enrolledComplementaryCertification: complementaryCertification,
-                    stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
-                  }),
-                ],
-              }),
+            const [certificationCandidate] = certificationCandidates;
+            expect(certificationCandidate).to.have.deep.property(
+              'startDateTime',
+              certificationCandidateWithComplementaryCertification.startDateTime,
             );
-          });
-
-          it('should get a theorical end datetime with extra time', async function () {
-            const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
-              complementaryCertificationKey: 'aKey',
-            });
-
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-              key: 'aKey',
-              certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
-            });
-
-            sessionForSupervisingRepository.get.resolves(
-              domainBuilder.buildSessionForSupervising({
-                certificationCandidates: [
-                  domainBuilder.buildCertificationCandidateForSupervising({
-                    userId: 1234,
-                    startDateTime: START_DATETIME_STUB,
-                    enrolledComplementaryCertification: complementaryCertification,
-                    stillValidBadgeAcquisitions: [],
-                  }),
-                ],
-              }),
-            );
-
-            const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
-            certificationBadgesService.findStillValidBadgeAcquisitions
-              .withArgs({ userId: 1234 })
-              .resolves([stillValidBadgeAcquisition]);
-
-            // when
-            const actualSession = await getSessionForSupervising({
-              sessionId: 1,
-              sessionForSupervisingRepository,
-              certificationBadgesService,
-            });
-
-            // then
-            expect(actualSession.certificationCandidates).to.have.lengthOf(1);
-            expect(actualSession.certificationCandidates[0].startDateTime).to.deep.equal(START_DATETIME_STUB);
-            expect(actualSession.certificationCandidates[0].theoricalEndDateTime).to.deep.equal(
-              expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
-                DEFAULT_SESSION_DURATION_MINUTES,
-                COMPLEMENTARY_EXTRATIME_STUB,
-              ]),
-            );
+            expect(certificationCandidate).to.have.deep.property('theoricalEndDateTime', expectedTheoricalEndDateTime);
           });
         });
 
-        context('when some candidates are not eligible to complementary certifications', function () {
-          it("should return the session with the candidates' non eligibility", async function () {
-            // given
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
-            const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
-              certificationCandidates: [
-                domainBuilder.buildCertificationCandidateForSupervising({
-                  userId: 1234,
-                  startDateTime: START_DATETIME_STUB,
-                  enrolledComplementaryCertification: complementaryCertification,
-                  stillValidBadgeAcquisitions: [],
-                }),
-              ],
-            });
+        context('when candidates are registered to a double certification', function () {
+          context('when some candidates are still eligible', function () {
+            it("returns the session with the candidates' eligibility", async function () {
+              // given
+              const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+                complementaryCertificationBadgeLabel: 'une certif complémentaire',
+              });
 
-            sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+              const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+                key: ComplementaryCertificationKeys.CLEA,
+                label: 'une certif complémentaire',
+                certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+              });
 
-            const certificationBadgesService = {
-              findStillValidBadgeAcquisitions: sinon.stub(),
-            };
-            certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
-
-            // when
-            const actualSession = await getSessionForSupervising({
-              sessionId: 1,
-              sessionForSupervisingRepository,
-              certificationBadgesService,
-            });
-
-            // then
-            expect(actualSession).to.deep.equal(
-              domainBuilder.buildSessionForSupervising({
+              const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
                 certificationCandidates: [
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
                     startDateTime: START_DATETIME_STUB,
-                    theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
-                      DEFAULT_SESSION_DURATION_MINUTES,
-                    ]),
                     enrolledComplementaryCertification: complementaryCertification,
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
-              }),
-            );
+              });
+
+              sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+
+              const certificationBadgesService = {
+                findStillValidBadgeAcquisitions: sinon.stub(),
+              };
+              certificationBadgesService.findStillValidBadgeAcquisitions
+                .withArgs({ userId: 1234 })
+                .resolves([stillValidBadgeAcquisition]);
+
+              // when
+              const actualSession = await getSessionForSupervising({
+                sessionId: 1,
+                sessionForSupervisingRepository,
+                certificationBadgesService,
+              });
+
+              // then
+              expect(actualSession).to.deep.equal(
+                domainBuilder.buildSessionForSupervising({
+                  certificationCandidates: [
+                    domainBuilder.buildCertificationCandidateForSupervising({
+                      userId: 1234,
+                      startDateTime: START_DATETIME_STUB,
+                      theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
+                        DEFAULT_SESSION_DURATION_MINUTES,
+                        COMPLEMENTARY_EXTRATIME_STUB,
+                      ]),
+                      enrolledComplementaryCertification: complementaryCertification,
+                      stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
+                    }),
+                  ],
+                }),
+              );
+            });
+
+            it('gets a theorical end datetime with extra time', async function () {
+              const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+              });
+
+              const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+                key: ComplementaryCertificationKeys.CLEA,
+                certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+              });
+
+              const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
+              certificationBadgesService.findStillValidBadgeAcquisitions
+                .withArgs({ userId: 1234 })
+                .resolves([stillValidBadgeAcquisition]);
+
+              sessionForSupervisingRepository.get.resolves(
+                domainBuilder.buildSessionForSupervising({
+                  certificationCandidates: [
+                    domainBuilder.buildCertificationCandidateForSupervising({
+                      userId: 1234,
+                      startDateTime: START_DATETIME_STUB,
+                      enrolledComplementaryCertification: complementaryCertification,
+                      stillValidBadgeAcquisitions: [stillValidBadgeAcquisition],
+                    }),
+                  ],
+                }),
+              );
+
+              // when
+              const actualSession = await getSessionForSupervising({
+                sessionId: 1,
+                sessionForSupervisingRepository,
+                certificationBadgesService,
+              });
+
+              // then
+              expect(actualSession.certificationCandidates).to.have.lengthOf(1);
+              expect(actualSession.certificationCandidates[0].startDateTime).to.deep.equal(START_DATETIME_STUB);
+              expect(actualSession.certificationCandidates[0].theoricalEndDateTime).to.deep.equal(
+                expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
+                  DEFAULT_SESSION_DURATION_MINUTES,
+                  COMPLEMENTARY_EXTRATIME_STUB,
+                ]),
+              );
+            });
           });
 
-          it('should not get a theorical end datetime with extra time', async function () {
-            // given
-            const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
-              key: 'aKey',
-              label: 'une certif complémentaire',
-              certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
-            });
-
-            sessionForSupervisingRepository.get.resolves(
-              domainBuilder.buildSessionForSupervising({
+          context('when some candidates are not eligible to a double certification', function () {
+            it("returns the session with the candidates' non eligibility", async function () {
+              // given
+              const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising();
+              const retrievedSessionForSupervising = domainBuilder.buildSessionForSupervising({
                 certificationCandidates: [
                   domainBuilder.buildCertificationCandidateForSupervising({
                     userId: 1234,
@@ -256,25 +241,78 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                     stillValidBadgeAcquisitions: [],
                   }),
                 ],
-              }),
-            );
+              });
 
-            const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
-            certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+              sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
 
-            // when
-            const actualSession = await getSessionForSupervising({
-              sessionId: 1,
-              sessionForSupervisingRepository,
-              certificationBadgesService,
+              const certificationBadgesService = {
+                findStillValidBadgeAcquisitions: sinon.stub(),
+              };
+              certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+
+              // when
+              const actualSession = await getSessionForSupervising({
+                sessionId: 1,
+                sessionForSupervisingRepository,
+                certificationBadgesService,
+              });
+
+              // then
+              expect(actualSession).to.deep.equal(
+                domainBuilder.buildSessionForSupervising({
+                  certificationCandidates: [
+                    domainBuilder.buildCertificationCandidateForSupervising({
+                      userId: 1234,
+                      startDateTime: START_DATETIME_STUB,
+                      theoricalEndDateTime: expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [
+                        DEFAULT_SESSION_DURATION_MINUTES,
+                      ]),
+                      enrolledComplementaryCertification: complementaryCertification,
+                      stillValidBadgeAcquisitions: [],
+                    }),
+                  ],
+                }),
+              );
             });
 
-            // then
-            expect(actualSession.certificationCandidates).to.have.lengthOf(1);
-            expect(actualSession.certificationCandidates[0].startDateTime).to.deep.equal(START_DATETIME_STUB);
-            expect(actualSession.certificationCandidates[0].theoricalEndDateTime).to.deep.equal(
-              expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [DEFAULT_SESSION_DURATION_MINUTES]),
-            );
+            it('does not get a theorical end datetime with extra time', async function () {
+              // given
+              const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
+                key: 'aKey',
+                label: 'une certif complémentaire',
+                certificationExtraTime: COMPLEMENTARY_EXTRATIME_STUB,
+              });
+
+              sessionForSupervisingRepository.get.resolves(
+                domainBuilder.buildSessionForSupervising({
+                  certificationCandidates: [
+                    domainBuilder.buildCertificationCandidateForSupervising({
+                      userId: 1234,
+                      startDateTime: START_DATETIME_STUB,
+                      enrolledComplementaryCertification: complementaryCertification,
+                      stillValidBadgeAcquisitions: [],
+                    }),
+                  ],
+                }),
+              );
+
+              const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
+              certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
+
+              // when
+              const actualSession = await getSessionForSupervising({
+                sessionId: 1,
+                sessionForSupervisingRepository,
+                certificationBadgesService,
+              });
+
+              // then
+              expect(actualSession.certificationCandidates).to.have.lengthOf(1);
+              expect(actualSession.certificationCandidates[0].startDateTime).to.deep.equal(START_DATETIME_STUB);
+              expect(actualSession.certificationCandidates[0].theoricalEndDateTime).to.deep.equal(
+                expectedSessionEndDateTimeFromStartDateTime(START_DATETIME_STUB, [DEFAULT_SESSION_DURATION_MINUTES]),
+              );
+            });
           });
         });
       });

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
@@ -46,7 +46,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'start-date-time': new Date('2022-10-01T13:37:00Z'),
                 'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
                 'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
-                'is-still-eligible-to-complementary-certification': true,
+                'is-still-eligible-to-double-certification': true,
                 'user-id': 6789,
                 'challenge-live-alert': null,
                 'companion-live-alert': null,
@@ -138,7 +138,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'start-date-time': new Date('2022-10-01T13:37:00Z'),
                 'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
                 'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
-                'is-still-eligible-to-complementary-certification': true,
+                'is-still-eligible-to-double-certification': true,
                 'user-id': 6789,
                 'challenge-live-alert': {
                   type: 'challenge',

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
@@ -44,7 +44,8 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'assessment-status': Assessment.states.STARTED,
               'start-date-time': new Date('2022-10-01T13:37:00Z'),
               'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
-              'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
+              'enrolled-complementary-certification-label': null,
+              'enrolled-double-certification-label': 'Super Certification Complémentaire',
               'is-still-eligible-to-double-certification': true,
               'user-id': 6789,
               'challenge-live-alert': {
@@ -86,7 +87,8 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             assessmentStatus: Assessment.states.STARTED,
             startDateTime: new Date('2022-10-01T13:37:00Z'),
             theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
-            enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
+            enrolledComplementaryCertification: null,
+            enrolledDoubleCertification: domainBuilder.buildComplementaryCertificationForSupervising({
               key: 'aKey',
               label: 'Super Certification Complémentaire',
             }),

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
@@ -7,210 +7,116 @@ import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', function () {
   describe('#serialize()', function () {
-    describe('when session is v2', function () {
-      it('should convert a SessionForSupervising model object into JSON API data', function () {
-        // given
-        const expectedPayload = {
-          data: {
-            attributes: {
-              address: 'centre de certification 1',
-              'access-code': 'CODE12',
-              date: '2017-01-20',
-              examiner: 'Antoine Toutvenant',
-              room: '28D',
-              time: '14:30',
-            },
-            id: '12',
-            relationships: {
-              'certification-candidates': {
-                data: [
-                  {
-                    id: '1234',
-                    type: 'certification-candidate-for-supervising',
-                  },
-                ],
-              },
-            },
-            type: 'sessionForSupervising',
+    it('converts a SessionForSupervising model object into JSON API data', function () {
+      // given
+      const expectedPayload = {
+        data: {
+          attributes: {
+            address: 'centre de certification 1',
+            'access-code': 'CODE12',
+            date: '2017-01-20',
+            examiner: 'Antoine Toutvenant',
+            room: '28D',
+            time: '14:30',
           },
-          included: [
-            {
-              attributes: {
-                birthdate: '28/05/1984',
-                'extra-time-percentage': 33,
-                'first-name': 'toto',
-                id: 1234,
-                'last-name': 'tata',
-                'authorized-to-start': true,
-                'assessment-status': Assessment.states.STARTED,
-                'start-date-time': new Date('2022-10-01T13:37:00Z'),
-                'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
-                'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
-                'is-still-eligible-to-double-certification': true,
-                'user-id': 6789,
-                'challenge-live-alert': null,
-                'companion-live-alert': null,
-              },
-              id: '1234',
-              type: 'certification-candidate-for-supervising',
-            },
-          ],
-        };
-
-        const modelSession = domainBuilder.buildSessionForSupervising({
-          id: 12,
-          address: 'centre de certification 1',
-          room: '28D',
-          examiner: 'Antoine Toutvenant',
-          accessCode: 'CODE12',
-          date: '2017-01-20',
-          time: '14:30',
-          certificationCandidates: [
-            new CertificationCandidateForSupervising({
-              id: 1234,
-              userId: 6789,
-              firstName: 'toto',
-              lastName: 'tata',
-              birthdate: '28/05/1984',
-              extraTimePercentage: 33,
-              authorizedToStart: true,
-              assessmentStatus: Assessment.states.STARTED,
-              startDateTime: new Date('2022-10-01T13:37:00Z'),
-              theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
-              enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
-                key: 'aKey',
-                label: 'Super Certification Complémentaire',
-              }),
-              stillValidBadgeAcquisitions: [
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationKey: 'aKey',
-                  complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
-                }),
+          id: '12',
+          relationships: {
+            'certification-candidates': {
+              data: [
+                {
+                  id: '1234',
+                  type: 'certification-candidate-for-supervising',
+                },
               ],
-            }),
-          ],
-        });
-
-        // when
-        const actualPayload = serializer.serialize(modelSession);
-
-        // then
-        expect(actualPayload).to.deep.equal(expectedPayload);
-      });
-    });
-
-    describe('when session is v3', function () {
-      it('should convert a SessionForSupervising model object into JSON API data', function () {
-        // given
-        const expectedPayload = {
-          data: {
-            attributes: {
-              address: 'centre de certification 1',
-              'access-code': 'CODE12',
-              date: '2017-01-20',
-              examiner: 'Antoine Toutvenant',
-              room: '28D',
-              time: '14:30',
             },
-            id: '12',
-            relationships: {
-              'certification-candidates': {
-                data: [
-                  {
-                    id: '1234',
-                    type: 'certification-candidate-for-supervising',
-                  },
-                ],
-              },
-            },
-            type: 'sessionForSupervising',
           },
-          included: [
-            {
-              attributes: {
-                birthdate: '28/05/1984',
-                'extra-time-percentage': 33,
-                'first-name': 'toto',
-                id: 1234,
-                'last-name': 'tata',
-                'authorized-to-start': true,
-                'assessment-status': Assessment.states.STARTED,
-                'start-date-time': new Date('2022-10-01T13:37:00Z'),
-                'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
-                'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
-                'is-still-eligible-to-double-certification': true,
-                'user-id': 6789,
-                'challenge-live-alert': {
-                  type: 'challenge',
-                  status: CertificationChallengeLiveAlertStatus.ONGOING,
-                  hasAttachment: false,
-                  hasImage: false,
-                  hasEmbed: false,
-                  isFocus: false,
-                },
-                'companion-live-alert': {
-                  type: 'companion',
-                  status: CertificationCompanionLiveAlertStatus.ONGOING,
-                },
-              },
-              id: '1234',
-              type: 'certification-candidate-for-supervising',
-            },
-          ],
-        };
-
-        const modelSession = domainBuilder.buildSessionForSupervising({
-          id: 12,
-          address: 'centre de certification 1',
-          room: '28D',
-          examiner: 'Antoine Toutvenant',
-          accessCode: 'CODE12',
-          date: '2017-01-20',
-          time: '14:30',
-          certificationCandidates: [
-            new CertificationCandidateForSupervising({
-              id: 1234,
-              userId: 6789,
-              firstName: 'toto',
-              lastName: 'tata',
+          type: 'sessionForSupervising',
+        },
+        included: [
+          {
+            attributes: {
               birthdate: '28/05/1984',
-              extraTimePercentage: 33,
-              authorizedToStart: true,
-              assessmentStatus: Assessment.states.STARTED,
-              startDateTime: new Date('2022-10-01T13:37:00Z'),
-              theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
-              enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
-                key: 'aKey',
-                label: 'Super Certification Complémentaire',
-              }),
-              stillValidBadgeAcquisitions: [
-                domainBuilder.buildCertifiableBadgeAcquisition({
-                  complementaryCertificationKey: 'aKey',
-                  complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
-                }),
-              ],
-              challengeLiveAlert: {
+              'extra-time-percentage': 33,
+              'first-name': 'toto',
+              id: 1234,
+              'last-name': 'tata',
+              'authorized-to-start': true,
+              'assessment-status': Assessment.states.STARTED,
+              'start-date-time': new Date('2022-10-01T13:37:00Z'),
+              'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
+              'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
+              'is-still-eligible-to-double-certification': true,
+              'user-id': 6789,
+              'challenge-live-alert': {
                 type: 'challenge',
                 status: CertificationChallengeLiveAlertStatus.ONGOING,
-                hasImage: false,
                 hasAttachment: false,
+                hasImage: false,
                 hasEmbed: false,
                 isFocus: false,
               },
-              companionLiveAlert: {
+              'companion-live-alert': {
                 type: 'companion',
                 status: CertificationCompanionLiveAlertStatus.ONGOING,
               },
+            },
+            id: '1234',
+            type: 'certification-candidate-for-supervising',
+          },
+        ],
+      };
+
+      const modelSession = domainBuilder.buildSessionForSupervising({
+        id: 12,
+        address: 'centre de certification 1',
+        room: '28D',
+        examiner: 'Antoine Toutvenant',
+        accessCode: 'CODE12',
+        date: '2017-01-20',
+        time: '14:30',
+        certificationCandidates: [
+          new CertificationCandidateForSupervising({
+            id: 1234,
+            userId: 6789,
+            firstName: 'toto',
+            lastName: 'tata',
+            birthdate: '28/05/1984',
+            extraTimePercentage: 33,
+            authorizedToStart: true,
+            assessmentStatus: Assessment.states.STARTED,
+            startDateTime: new Date('2022-10-01T13:37:00Z'),
+            theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
+            enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
+              key: 'aKey',
+              label: 'Super Certification Complémentaire',
             }),
-          ],
-        });
-
-        // when
-        const actualPayload = serializer.serialize(modelSession);
-
-        // then
-        expect(actualPayload).to.deep.equal(expectedPayload);
+            stillValidBadgeAcquisitions: [
+              domainBuilder.buildCertifiableBadgeAcquisition({
+                complementaryCertificationKey: 'aKey',
+                complementaryCertificationBadgeLabel: 'Super Certification Complémentaire',
+              }),
+            ],
+            challengeLiveAlert: {
+              type: 'challenge',
+              status: CertificationChallengeLiveAlertStatus.ONGOING,
+              hasImage: false,
+              hasAttachment: false,
+              hasEmbed: false,
+              isFocus: false,
+            },
+            companionLiveAlert: {
+              type: 'companion',
+              status: CertificationCompanionLiveAlertStatus.ONGOING,
+            },
+          }),
+        ],
       });
+
+      // when
+      const actualPayload = serializer.serialize(modelSession);
+
+      // then
+      expect(actualPayload).to.deep.equal(expectedPayload);
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -12,6 +12,7 @@ const buildCertificationCandidateForSupervising = function ({
   startDateTime = new Date('2022-10-01T12:00:00Z'),
   theoricalEndDateTime,
   enrolledComplementaryCertification,
+  enrolledDoubleCertification,
   stillValidBadgeAcquisitions = [],
   accessibilityAdjustmentNeeded = false,
 } = {}) {
@@ -27,6 +28,7 @@ const buildCertificationCandidateForSupervising = function ({
     startDateTime,
     theoricalEndDateTime,
     enrolledComplementaryCertification,
+    enrolledDoubleCertification,
     stillValidBadgeAcquisitions,
     accessibilityAdjustmentNeeded,
   });

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -38,13 +38,13 @@
           />
           {{t
             "pages.session-supervising.candidate-in-list.complementary-certification-enrolment"
-            complementaryCertification=@candidate.enrolledComplementaryCertificationLabel
+            complementaryCertification=this.enrolledCertificationLabel
           }}
         </p>
       {{/if}}
       {{#if this.shouldDisplayNonEligibilityWarning}}
         <PixNotificationAlert @type="warning" @withIcon={{true}}>
-          {{t "pages.session-supervising.candidate-in-list.complementary-certification-non-eligibility-warning"}}
+          {{t "pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning"}}
         </PixNotificationAlert>
       {{/if}}
     </div>

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -47,7 +47,7 @@ export default class CandidateInList extends Component {
 
   _isNotEligibleToEnrolledComplementaryCertification() {
     return (
-      !this.args.candidate.isStillEligibleToComplementaryCertification &&
+      !this.args.candidate.isStillEligibleToDoubleCertification &&
       this.args.candidate.enrolledComplementaryCertificationLabel
     );
   }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -38,17 +38,23 @@ export default class CandidateInList extends Component {
   }
 
   get shouldDisplayEnrolledComplementaryCertification() {
-    return this.args.candidate.enrolledComplementaryCertificationLabel;
+    return Boolean(this.enrolledCertificationLabel);
   }
 
   get shouldDisplayNonEligibilityWarning() {
-    return this._isReconciliated() && this._isNotEligibleToEnrolledComplementaryCertification();
+    return this._isReconciliated() && this._isNotEligibleToEnrolledDoubleCertification();
   }
 
-  _isNotEligibleToEnrolledComplementaryCertification() {
+  _isNotEligibleToEnrolledDoubleCertification() {
     return (
-      !this.args.candidate.isStillEligibleToDoubleCertification &&
-      this.args.candidate.enrolledComplementaryCertificationLabel
+      !this.args.candidate.isStillEligibleToDoubleCertification && this.args.candidate.enrolledDoubleCertificationLabel
+    );
+  }
+
+  get enrolledCertificationLabel() {
+    return (
+      this.args.candidate.enrolledComplementaryCertificationLabel ??
+      this.args.candidate.enrolledDoubleCertificationLabel
     );
   }
 

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -18,6 +18,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('date') startDateTime;
   @attr('date') theoricalEndDateTime;
   @attr('string') enrolledComplementaryCertificationLabel;
+  @attr('string') enrolledDoubleCertificationLabel;
   @attr('string') userId;
   @attr('boolean') isStillEligibleToDoubleCertification;
   @attr() challengeLiveAlert;

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -19,7 +19,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('date') theoricalEndDateTime;
   @attr('string') enrolledComplementaryCertificationLabel;
   @attr('string') userId;
-  @attr('boolean') isStillEligibleToComplementaryCertification;
+  @attr('boolean') isStillEligibleToDoubleCertification;
   @attr() challengeLiveAlert;
   @attr() companionLiveAlert;
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -206,7 +206,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           id: '123',
           enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
           userId: 678,
-          isStillEligibleToComplementaryCertification: false,
+          isStillEligibleToDoubleCertification: false,
         });
 
         // when
@@ -230,7 +230,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           id: '123',
           enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
           userId: 678,
-          isStillEligibleToComplementaryCertification: true,
+          isStillEligibleToDoubleCertification: true,
         });
 
         // when
@@ -254,7 +254,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: '123',
         enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
-        isStillEligibleToComplementaryCertification: false,
+        isStillEligibleToDoubleCertification: false,
       });
 
       // when

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -16,10 +16,23 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     store = this.owner.lookup('service:store');
   });
 
-  test('should render the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
+  test('renders the enrolled complementary certification name of the candidate if he passes one', async function (assert) {
     this.candidate = store.createRecord('certification-candidate-for-supervising', {
       id: '123',
       enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+    });
+
+    // when
+    const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+    // then
+    assert.dom(screen.getByText('Inscription à Super Certification Complémentaire')).exists();
+  });
+
+  test('renders the double certification name of the candidate if he passes one', async function (assert) {
+    this.candidate = store.createRecord('certification-candidate-for-supervising', {
+      id: '123',
+      enrolledDoubleCertificationLabel: 'Super Certification Complémentaire',
     });
 
     // when
@@ -200,7 +213,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
   module('when the candidate is reconciliated before starting the session', function () {
     module('when the candidate is no longer eligible to the complementary certification', function () {
-      test('should render a warning message', async function (assert) {
+      test('does not render a warning message', async function (assert) {
         // given
         this.candidate = store.createRecord('certification-candidate-for-supervising', {
           id: '123',
@@ -215,20 +228,44 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         assert
           .dom(
+            screen.queryByText(
+              t('pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning'),
+            ),
+          )
+          .doesNotExist();
+      });
+    });
+
+    module('when the candidate is no longer eligible to the double certification', function () {
+      test('renders a warning message', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '123',
+          enrolledDoubleCertificationLabel: 'Super Certification Complémentaire',
+          userId: 678,
+          isStillEligibleToDoubleCertification: false,
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert
+          .dom(
             screen.getByText(
-              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+              t('pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning'),
             ),
           )
           .exists();
       });
     });
 
-    module('when the candidate is still eligible to the complementary certification', function () {
-      test('should not render a warning message', async function (assert) {
+    module('when the candidate is still eligible to the double certification', function () {
+      test('does not render a warning message', async function (assert) {
         // given
         this.candidate = store.createRecord('certification-candidate-for-supervising', {
           id: '123',
-          enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+          enrolledDoubleCertificationLabel: 'Super Certification Complémentaire',
           userId: 678,
           isStillEligibleToDoubleCertification: true,
         });
@@ -240,7 +277,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         assert
           .dom(
             screen.queryByText(
-              'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+              t('pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning'),
             ),
           )
           .doesNotExist();
@@ -249,11 +286,11 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when the candidate is not reconciliated before starting the session', function () {
-    test('should not render a warning message', async function (assert) {
+    test('does not render a warning message', async function (assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: '123',
-        enrolledComplementaryCertificationLabel: 'Super Certification Complémentaire',
+        enrolledCertificationLabel: 'Super Certification Complémentaire',
         isStillEligibleToDoubleCertification: false,
       });
 
@@ -264,7 +301,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert
         .dom(
           screen.queryByText(
-            'Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.',
+            t('pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning'),
           ),
         )
         .doesNotExist();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -468,9 +468,9 @@
         },
         "candidate-options": "Candidate's options",
         "complementary-certification-enrolment": "{complementaryCertification} enrolment",
-        "complementary-certification-non-eligibility-warning": "Candidate isn't or is no longer eligible for the additional certification. They are taking the Pix certification exam only.",
         "default-modal-title": "Information",
         "display-candidate-options": "Display the candidate's options",
+        "double-certification-non-eligibility-warning": "Candidate isn't or is no longer eligible for the CléA certification. They are taking the Pix certification exam only.",
         "end-date-time": "Theoretical ending time : ",
         "extratime": "+ extra time {extraTimePercentage}",
         "handle-live-alert-modal": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -468,9 +468,9 @@
         },
         "candidate-options": "Options du candidat",
         "complementary-certification-enrolment": "Inscription à {complementaryCertification}",
-        "complementary-certification-non-eligibility-warning": "Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.",
         "default-modal-title": "Information",
         "display-candidate-options": "Afficher les options du candidat",
+        "double-certification-non-eligibility-warning": "Candidat pas ou plus éligible à CléA Numérique. Il passe la certification Pix.",
         "end-date-time": "Fin théorique : ",
         "extratime": "+ temps majoré {extraTimePercentage}",
         "handle-live-alert-modal": {


### PR DESCRIPTION
## 🔆 Problème

Jusqu'à maintenant, si un candidat est inscrit pour une certification complémentaire mais qu’il se réconcilie avec un compte Pix App qui n’est pas éligible à cette certification complémentaire, alors un bandeau jaune s’affiche côté  surveillant pour l’en avertir (“Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix”).

Cet avertissement n'est plus nécessaire que pour les doubles certifications Pix/CléA

## ⛱️ Proposition

On fait émerger la notion de double certification pour gérer l'affichage ou non du bandeau d'avertissement

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Sur Pix-Admin (`superadmin@example.net`), rendre un centre habilité à faire passer des doubles certifications CléA et Pix+Droit ✅ 
- Sur Pix-Certif (`certif-prescriptor@example.net`), créer une session et y inscrire 3 candidats : 
 -> 1 candidat en pix coeur
 -> 1 candidat en Pix+Droit
 -> 1 candidat en double certif
- Sur pix-app, utiliser les comptes `certif-success@example.net`, `certifiable-contenu-user@example.net` et `perfect-profile-user@example.net` et rentrer en session de certification en vérifiant que chaque candidat ne soit pas éligible à la complémentaire qu'il va passer
- Côté espace surveillant, vérifier que seul le candidat inscrit à la double certification ait un message alertant de sa non éligibilité
