### PR TITLE
[BUGFIX] Eviter les timeouts lors des épreuves de prompt avec le LLM en relayant les pings émis depuis l'API poc-llm (PIX-19139)

### DIFF
--- a/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
@@ -8,8 +8,12 @@ export function getTransform(streamCapture) {
   return new Transform({
     objectMode: true,
     transform(chunk, _encoding, callback) {
-      const { message, isValid, usage, wasModerated } = chunk;
+      const { message, isValid, usage, wasModerated, ping } = chunk;
       let data = '';
+
+      if (ping) {
+        data += getPingEvent();
+      }
 
       if (isValid) {
         streamCapture.haveVictoryConditionsBeenFulfilled = true;
@@ -48,4 +52,8 @@ function getVictoryConditionsSuccessEvent() {
 
 function getMessageModeratedEvent() {
   return 'event: user-message-moderated\ndata: \n\n';
+}
+
+function getPingEvent() {
+  return 'event: ping\ndata: \n\n';
 }

--- a/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
+++ b/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
@@ -120,6 +120,26 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
       );
     });
 
+    it('should return a Transform that is capable of convert information "ping" into event stream event', async function () {
+      // given
+      const input = [
+        { message: 'Coucou les amis comment ça va ?' },
+        { pasMessage: 'Ca va super' },
+        { message: 'Et toi ?', ping: true },
+      ];
+      const readable = Readable.from(input);
+      const transform = getTransform(streamCapture);
+      let result = '';
+
+      // when
+      readable.pipe(transform);
+      transform.on('data', (str) => (result = result + str));
+      await finished(transform);
+
+      // then
+      expect(result).to.equal('data: Coucou les amis comment ça va ?\n\nevent: ping\ndata: \n\ndata: Et toi ?\n\n');
+    });
+
     context('streamCapture', function () {
       it('should store all the LLM response message parts in the streamCapture object while transforming', async function () {
         // given


### PR DESCRIPTION
## 🔆 Problème

Le navigateur avorte la requête pour cause de timeout car les premiers chunks de réponse du stream peuvent parfois mettre du temps à arriver.

## ⛱️ Proposition
Côté poc-llm on a mis des pings réguliers. Les relayer jusqu'au front

## 🌊 Remarques

Côté poc-llm : https://github.com/1024pix/poc-llm/pull/30

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
