### PR TITLE
[FEATURE] Ajouter l'import JSON pour la création d'un référentiel cadre (PIX-19143).

### DIFF
--- a/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
@@ -78,6 +78,7 @@ export default class CreationForm extends Component {
             @displaySkillDifficultyAvailability={{true}}
             @displaySkillDifficultySelection={{false}}
             @displayDeviceCompatibility={{true}}
+            @displayJsonImportButton={{true}}
           />
           <ul class="framework-creation-form__buttons">
             <li>

--- a/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
@@ -43,6 +43,8 @@ module('Integration | Component | complementary-certifications/item/framework/cr
     await click(screen.getByLabelText('@tubeName1 : Tube 1'));
 
     // then
+    assert.ok(screen.getByRole('button', { name: 'Importer un fichier JSON' }));
+
     const table = screen.getByRole('table', { name: 'Sélection des sujets' });
     assert.ok(within(table).getByRole('columnheader', { name: 'Niveau' }));
     assert.ok(within(table).getByRole('columnheader', { name: 'Compatibilité' }));

--- a/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
@@ -8,14 +8,16 @@ import * as skillRepository from '../../../../shared/infrastructure/repositories
 import * as thematicRepository from '../../../../shared/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 
-export async function getFrameworkReferential({ challengeIds }) {
+async function getFrameworkReferential({ challengeIds }) {
   const challenges = await challengeRepository.getMany(challengeIds, FRENCH_SPOKEN);
 
   const skillIds = challenges.map((challenge) => challenge.skill.id);
-  const skills = await skillRepository.findByRecordIds(skillIds);
+  const uniqSkillIds = _.uniq(skillIds);
+  const skills = await skillRepository.findByRecordIds(uniqSkillIds);
 
   const tubeIds = skills.map((skill) => skill.tubeId);
-  const tubes = await tubeRepository.findByRecordIds(tubeIds, FRENCH_SPOKEN);
+  const uniqTubeIds = _.uniq(tubeIds);
+  const tubes = await tubeRepository.findByRecordIds(uniqTubeIds, FRENCH_SPOKEN);
   tubes.forEach((tube) => {
     tube.skills = skills.filter((skill) => {
       return skill.tubeId === tube.id;
@@ -43,7 +45,7 @@ export async function getFrameworkReferential({ challengeIds }) {
   });
 
   const allAreaIds = competences.map((competence) => competence.areaId);
-  const uniqAreaIds = _.uniqBy(allAreaIds, 'id');
+  const uniqAreaIds = _.uniq(allAreaIds);
   const areas = await areaRepository.findByRecordIds({
     areaIds: uniqAreaIds,
     locale: FRENCH_SPOKEN,
@@ -56,3 +58,5 @@ export async function getFrameworkReferential({ challengeIds }) {
 
   return areas;
 }
+
+export { getFrameworkReferential };

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/learning-content-repository.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/learning-content-repository.js
@@ -1,0 +1,92 @@
+import * as learningContentRepository from '../../../../../../../api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Integration | Infrastructure | Repository | LearningContentRepository', function () {
+  describe('#getFrameworkReferential', function () {
+    it('should return the expected framework referential', async function () {
+      // given
+      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
+      const areaId = databaseBuilder.factory.learningContent.buildArea({ id: 'area', frameworkId }).id;
+      const competenceId = databaseBuilder.factory.learningContent.buildCompetence({ id: 'competence', areaId }).id;
+      const thematicId = databaseBuilder.factory.learningContent.buildCompetence({ id: 'thematic', competenceId }).id;
+      const tubeId = databaseBuilder.factory.learningContent.buildTube({ id: 'tube', competenceId, thematicId }).id;
+      const skillId = databaseBuilder.factory.learningContent.buildSkill({ id: 'skill', tubeId, competenceId }).id;
+      const challenge1 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'chall1', skillId });
+      const challenge2 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'chall2', skillId });
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+      const frameworksChallenge1 = databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: challenge1.id,
+        calibrationId: 1,
+      });
+      const frameworksChallenge2 = databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: challenge2.id,
+        calibrationId: 1,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await learningContentRepository.getFrameworkReferential({
+        challengeIds: [frameworksChallenge1.challengeId, frameworksChallenge2.challengeId],
+      });
+
+      // then
+      expect(result).to.deep.have.members([
+        {
+          id: areaId,
+          frameworkId,
+          code: 'code Domaine A',
+          name: 'name Domaine A',
+          title: 'title FR Domaine A',
+          color: 'color Domaine A',
+          competences: [
+            {
+              id: competenceId,
+              name: 'name FR Compétence A',
+              index: 'index Compétence A',
+              description: 'description FR Compétence A',
+              origin: 'origin Compétence A',
+              areaId,
+              level: -1,
+              skillIds: [],
+              thematicIds: [],
+              tubes: [
+                {
+                  id: tubeId,
+                  practicalTitle: 'practicalTitle FR Tube A',
+                  practicalDescription: 'practicalDescription FR Tube A',
+                  isMobileCompliant: true,
+                  isTabletCompliant: true,
+                  skills: [
+                    {
+                      id: skillId,
+                      name: 'name Acquis A',
+                      pixValue: 2.9,
+                      competenceId,
+                      tutorialIds: [],
+                      learningMoreTutorialIds: [],
+                      tubeId,
+                      version: 5,
+                      difficulty: 2,
+                      status: 'status Acquis A',
+                      hintStatus: 'hintStatus Acquis A',
+                      hint: 'Un indice',
+                    },
+                  ],
+                  competenceId,
+                  thematicId,
+                  skillIds: [],
+                  name: 'name Tube A',
+                },
+              ],
+              thematics: [],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Jusqu'à présent, il ne nous était pas possible d’importer directement le référentiel d’un Profil Cible lors de la création d’un nouveau référentiel cadre.

## ⛱️ Proposition

- Dans le form de création d’un nouveau ref cadre, afficher le bouton d’import JSON
- Débugger côté API pour bien avoir le référentiel souhaité (problème de “uniqBy” dans le get du ref cadre)

## 🏄 Pour tester

- Sur Admin en RA, récupérer le JSON du référentiel d'un profil-cible existant
- Créer un nouveau référentiel cadre pour une des complémentaires en important ce JSON
- Vérifier que le référentiel affiché est bien le même que dans le profil-cible initial
