### PR TITLE
[BUMP] Update dependency @1024pix/epreuves-components to 0.9.5

### DIFF
--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.9.3",
+        "@1024pix/epreuves-components": "^0.9.5",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.3.tgz",
-      "integrity": "sha512-Z/Wed94U8AzimIHah+s6ztw1BUY50s0DxT4JiwDDBjhvc+XRqM6ej1d815fMge9tWzXumDsBT9+l2js9RLy4wA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.5.tgz",
+      "integrity": "sha512-o6l166uayXul9+rklbIZk9HPpVQLMimboKWBQDeglALAPsLfDALBy9mxa4azZi8i8MQXE7vbazu/8jHNqvMDVw==",
       "dev": true,
       "license": "MIT"
     },

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.9.3",
+    "@1024pix/epreuves-components": "^0.9.5",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.9.3",
+        "@1024pix/epreuves-components": "^0.9.5",
         "@1024pix/eslint-plugin": "^2.1.7",
         "@1024pix/pix-ui": "^55.25.0",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.3.tgz",
-      "integrity": "sha512-Z/Wed94U8AzimIHah+s6ztw1BUY50s0DxT4JiwDDBjhvc+XRqM6ej1d815fMge9tWzXumDsBT9+l2js9RLy4wA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.5.tgz",
+      "integrity": "sha512-o6l166uayXul9+rklbIZk9HPpVQLMimboKWBQDeglALAPsLfDALBy9mxa4azZi8i8MQXE7vbazu/8jHNqvMDVw==",
       "dev": true,
       "license": "MIT"
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.9.3",
+    "@1024pix/epreuves-components": "^0.9.5",
     "@1024pix/eslint-plugin": "^2.1.7",
     "@1024pix/pix-ui": "^55.25.0",
     "@1024pix/stylelint-config": "^5.1.34",


### PR DESCRIPTION
## 🔆 Problème

La librairie `@1024pix/epreuves-components` n'est plus à jour.

## ⛱️ Proposition

Mise à jour de la librairie :

| Package | Update | Change |
|---|---|---|
| [@1024pix/epreuves-components](https://www.npmjs.com/package/@1024pix/epreuves-components)  | patch | `0.9.3` -> `0.9.5` |

---

### Release Notes

<details>
<summary>`@1024pix/epreuves-components`</summary>

### `0.9.5`

Mise à jour du style des POIs `llm-messages`, `llm-prompt-select` et `llm-compare-messages`.

</details>

## 🏄 Pour tester

- Se rendre sur [le module d'exposition des POIs](https://app-pr13193.review.pix.fr/modules/demo-epreuves-components/passage).
- Constater que les `llm-messages`, `llm-prompt-select` et `llm-compare-messages` ont un nouveau style.
