### PR TITLE
[FEATURE] Envoyer les sections de module au client (PIX-19149)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -17,6 +17,27 @@
       "type": "blank",
       "grains": [
         {
+          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+                "type": "text",
+                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "47d5fdea-8141-4184-a78e-c7f871de71fc",
+      "type": "question-yourself",
+      "grains": [
+        {
           "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
           "type": "discovery",
           "title": "test qcu-discovery",
@@ -184,7 +205,13 @@
               }
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "2cb5a4fa-a54f-4d94-9b1f-5f504821846a",
+      "type": "explore-to-understand",
+      "grains": [
         {
           "id": "628bd37d-e5da-411f-9b06-1035b073411b",
           "type": "lesson",
@@ -244,7 +271,13 @@
               }
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "ea5ebe5d-f29f-4b03-8e9f-7c77606a014f",
+      "type": "retain-the-essentials",
+      "grains": [
         {
           "id": "df111992-ff3a-4c3f-ae5a-78bc359af23c",
           "type": "lesson",
@@ -342,21 +375,6 @@
                 "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
                 "legend": "Faite avant le séminaire de juin 2023",
                 "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
-              }
-            }
-          ]
-        },
-        {
-          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-                "type": "text",
-                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
               }
             }
           ]
@@ -539,7 +557,13 @@
               }
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "b0d428ab-a4ae-45e0-83fd-786fbd9c03dc",
+      "type": "practise",
+      "grains": [
         {
           "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
           "type": "challenge",
@@ -760,7 +784,13 @@
               }
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "4a3c5230-3c60-4c1a-9395-7b65537dda25",
+      "type": "go-further",
+      "grains": [
         {
           "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
           "type": "summary",

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -12,15 +12,12 @@ function serialize(module) {
         isBeta: module.isBeta,
         version: module.version,
         details: module.details,
-        grains: module.sections.flatMap((section) => {
-          return section.grains.map((grain) => {
-            return {
-              id: grain.id,
-              title: grain.title,
-              type: grain.type,
-              components: grain.components,
-            };
-          });
+        sections: module.sections.map((section) => {
+          return {
+            id: section.id,
+            type: section.type,
+            grains: section.grains,
+          };
         }),
       };
 
@@ -30,15 +27,15 @@ function serialize(module) {
 
       return transformedModule;
     },
-    attributes: ['slug', 'title', 'isBeta', 'version', 'grains', 'details', 'redirectionUrl'],
-    grains: {
+    attributes: ['slug', 'title', 'isBeta', 'version', 'sections', 'details', 'redirectionUrl'],
+    sections: {
       ref: 'id',
       includes: true,
-      attributes: ['title', 'type', 'components'],
+      attributes: ['type', 'grains'],
     },
     typeForAttribute(attribute) {
-      if (attribute === 'grains') {
-        return 'grains';
+      if (attribute === 'sections') {
+        return 'sections';
       }
       if (attribute === 'module') {
         return 'modules';

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -57,7 +57,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             version,
           },
           relationships: {
-            grains: {
+            sections: {
               data: [],
             },
           },
@@ -111,7 +111,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             version,
           },
           relationships: {
-            grains: {
+            sections: {
               data: [],
             },
           },
@@ -149,7 +149,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         details,
         slug,
         title,
-        sections: [{ id, type: 'none', grains: [] }],
+        sections: [{ id: 'section1', type: 'none', grains: [] }],
         isBeta,
         version,
       });
@@ -165,11 +165,26 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             version,
           },
           relationships: {
-            grains: {
-              data: [],
+            sections: {
+              data: [
+                {
+                  id: 'section1',
+                  type: 'sections',
+                },
+              ],
             },
           },
         },
+        included: [
+          {
+            attributes: {
+              grains: [],
+              type: 'none',
+            },
+            id: 'section1',
+            type: 'sections',
+          },
+        ],
       };
 
       // when
@@ -207,7 +222,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         details,
         sections: [
           {
-            id,
+            id: 'section1',
             type: 'none',
             grains: [
               {
@@ -231,11 +246,11 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           },
           id: 'id',
           relationships: {
-            grains: {
+            sections: {
               data: [
                 {
-                  id: '1',
-                  type: 'grains',
+                  id: 'section1',
+                  type: 'sections',
                 },
               ],
             },
@@ -245,12 +260,18 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         included: [
           {
             attributes: {
-              title: 'Grain 1',
-              components: getAttributesComponents(),
-              type: 'activity',
+              type: 'none',
+              grains: [
+                {
+                  id: '1',
+                  title: 'Grain 1',
+                  components: getAttributesComponents(),
+                  type: 'activity',
+                },
+              ],
             },
-            id: '1',
-            type: 'grains',
+            id: 'section1',
+            type: 'sections',
           },
         ],
       };

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -17,7 +17,11 @@ export default class ModulePassage extends Component {
   @service modulixAutoScroll;
   @service passageEvents;
 
-  displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
+  get flatGrains() {
+    return this.args.module.sections.flatMap((section) => section.grains);
+  }
+
+  displayableGrains = this.flatGrains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
 
   @action

--- a/mon-pix/app/models/grain.js
+++ b/mon-pix/app/models/grain.js
@@ -1,9 +1,0 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
-
-export default class Grain extends Model {
-  @attr('string') title;
-  @attr({ defaultValue: () => [] }) components;
-  @attr('string') type;
-
-  @belongsTo('module', { async: false, inverse: 'grains' }) module;
-}

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -7,5 +7,5 @@ export default class Module extends Model {
   @attr() details;
   @attr('string') version;
   @attr('string') redirectionUrl;
-  @hasMany('grain', { async: false, inverse: 'module' }) grains;
+  @hasMany('section', { async: false, inverse: 'module' }) sections;
 }

--- a/mon-pix/app/models/section.js
+++ b/mon-pix/app/models/section.js
@@ -1,0 +1,8 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class Section extends Model {
+  @attr('string') type;
+  @attr({ defaultValue: () => [] }) grains;
+
+  @belongsTo('module', { async: false, inverse: 'sections' }) module;
+}

--- a/mon-pix/mirage/serializers/module.js
+++ b/mon-pix/mirage/serializers/module.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['grains'],
+  include: ['sections'],
 });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
@@ -19,7 +19,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
         id: 'bien-ecrire-son-adresse-mail',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
-        grains: [],
+        sections: [],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',
@@ -38,15 +38,17 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
     test('should navigate to passage page by clicking on start module button', async function (assert) {
       // given
-      const grain = server.create('grain', {
-        id: 'grain1',
+      const section = server.create('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ id: 'grain1', components: [] }],
       });
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
-        grains: [grain],
+        sections: [section],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -11,13 +11,13 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
   module('when user arrive on the module passage page', function () {
     test('should display only the first lesson grain', async function (assert) {
       // given
-      const grains = _createGrains(server);
+      const sections = _createSections(server);
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
-        grains,
+        sections,
       });
 
       server.create('passage', {
@@ -37,13 +37,13 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
     module('when the grain displayed is not the last', function () {
       test('should display the continue button', async function (assert) {
         // given
-        const grains = _createGrains(server);
+        const sections = _createSections(server);
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
           slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
-          grains,
+          sections,
         });
 
         // when
@@ -64,13 +64,13 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
     module('when the grain displayed is the last', function () {
       test('should not display continue button', async function (assert) {
         // given
-        const grains = _createGrains(server);
+        const sections = _createSections(server);
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
           slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
-          grains,
+          sections,
         });
 
         // when
@@ -95,13 +95,19 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         type: 'text',
         content: 'content-1',
       };
-      const grain1 = server.create('grain', {
-        id: 'grainId-1',
-        title: 'title grain 1',
-        components: [
+      const section1 = server.create('section', {
+        id: 'sectionId-1',
+        type: 'blank',
+        grains: [
           {
-            type: 'element',
-            element: text1,
+            id: 'grainId-1',
+            title: 'title grain 1',
+            components: [
+              {
+                type: 'element',
+                element: text1,
+              },
+            ],
           },
         ],
       });
@@ -109,7 +115,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         id: 'bien-ecrire-son-adresse-mail',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
-        grains: [grain1],
+        sections: [section1],
       });
       server.create('passage', {
         id: '122',
@@ -152,37 +158,49 @@ const text3 = {
   type: 'text',
   content: 'content-3',
 };
-function _createGrains(server) {
-  const grain1 = server.create('grain', {
-    id: 'grainId-1',
-    title: 'title grain 1',
-    components: [
+function _createSections(server) {
+  const section1 = server.create('section', {
+    id: 'sectionId-1',
+    type: 'blank',
+    grains: [
       {
-        type: 'element',
-        element: text1,
+        id: 'grainId-1',
+        title: 'title grain 1',
+        components: [
+          {
+            type: 'element',
+            element: text1,
+          },
+        ],
+      },
+      {
+        id: 'grainId-2',
+        title: 'title grain 2',
+        components: [
+          {
+            type: 'element',
+            element: text2,
+          },
+        ],
       },
     ],
   });
-  const grain2 = server.create('grain', {
-    id: 'grainId-2',
-    title: 'title grain 2',
-    components: [
+  const section2 = server.create('section', {
+    id: 'sectionId-2',
+    type: 'blank',
+    grains: [
       {
-        type: 'element',
-        element: text2,
-      },
-    ],
-  });
-  const grain3 = server.create('grain', {
-    id: 'grainId-3',
-    title: 'title grain 3',
-    components: [
-      {
-        type: 'element',
-        element: text3,
+        id: 'grainId-3',
+        title: 'title grain 3',
+        components: [
+          {
+            type: 'element',
+            element: text3,
+          },
+        ],
       },
     ],
   });
 
-  return [grain1, grain2, grain3];
+  return [section1, section2];
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -25,16 +25,19 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       };
       user = server.create('user', 'withEmail');
 
-      const grain = server.create('grain', {
-        id: 'grain1',
-        components: [{ type: 'element', element: text }],
+      const section = server.create('section', {
+        id: 'sectionId-1',
+        grains: {
+          id: 'grain1',
+          components: [{ type: 'element', element: text }],
+        },
       });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
-        grains: [grain],
+        sections: [section],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
       ],
     };
 
-    const grain1 = server.create('grain', {
+    const grain1 = {
       id: 'grainId1',
       title: 'title',
       components: [
@@ -30,7 +30,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
           element: qcu,
         },
       ],
-    });
+    };
 
     const text = {
       id: 'elementId-1',
@@ -39,7 +39,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
       isAnswerable: false,
     };
 
-    const grain2 = server.create('grain', {
+    const grain2 = {
       id: 'grainId2',
       title: 'title',
       components: [
@@ -48,6 +48,11 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
           element: text,
         },
       ],
+    };
+
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [grain1, grain2],
     });
 
     server.create('module', {
@@ -55,7 +60,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: { tabletSupport: 'comfortable' },
-      grains: [grain1, grain2],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -22,13 +22,18 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcm,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcm,
+            },
+          ],
         },
       ],
     });
@@ -37,7 +42,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {
@@ -91,13 +96,18 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcm,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcm,
+            },
+          ],
         },
       ],
     });
@@ -107,7 +117,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -29,24 +29,28 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
       ],
     };
 
-    const grain1 = server.create('grain', {
-      id: 'grainId1',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcu1,
+          id: 'grainId1',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcu1,
+            },
+          ],
         },
-      ],
-    });
-
-    const grain2 = server.create('grain', {
-      id: 'grainId2',
-      title: 'title',
-      components: [
         {
-          type: 'element',
-          element: qcu2,
+          id: 'grainId2',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcu2,
+            },
+          ],
         },
       ],
     });
@@ -56,7 +60,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
-      grains: [grain1, grain2],
+      sections: [section],
     });
 
     server.create('correction-response', {
@@ -115,26 +119,30 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
       ],
     };
 
-    const grain1 = server.create('grain', {
-      id: 'grainId1',
-      title: 'title',
-      type: 'activity',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcu1,
+          id: 'grainId1',
+          title: 'title',
+          type: 'activity',
+          components: [
+            {
+              type: 'element',
+              element: qcu1,
+            },
+          ],
         },
-      ],
-    });
-
-    const grain2 = server.create('grain', {
-      id: 'grainId2',
-      title: 'title',
-      type: 'activity',
-      components: [
         {
-          type: 'element',
-          element: qcu2,
+          id: 'grainId2',
+          title: 'title',
+          type: 'activity',
+          components: [
+            {
+              type: 'element',
+              element: qcu2,
+            },
+          ],
         },
       ],
     });
@@ -144,7 +152,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
-      grains: [grain1, grain2],
+      sections: [section],
     });
 
     // look at mirage

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -40,13 +40,18 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qrocm1,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qrocm1,
+            },
+          ],
         },
       ],
     });
@@ -56,7 +61,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {
@@ -161,13 +166,18 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qrocm1,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qrocm1,
+            },
+          ],
         },
       ],
     });
@@ -177,7 +187,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -33,17 +33,22 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcm1,
-        },
-        {
-          type: 'element',
-          element: qcm2,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcm1,
+            },
+            {
+              type: 'element',
+              element: qcm2,
+            },
+          ],
         },
       ],
     });
@@ -52,7 +57,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -29,17 +29,22 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qcu1,
-        },
-        {
-          type: 'element',
-          element: qcu2,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qcu1,
+            },
+            {
+              type: 'element',
+              element: qcu2,
+            },
+          ],
         },
       ],
     });
@@ -48,7 +53,7 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -50,13 +50,18 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
       ],
     };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      components: [
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
         {
-          type: 'element',
-          element: qrocm1,
+          id: 'grainId',
+          title: 'title',
+          components: [
+            {
+              type: 'element',
+              element: qrocm1,
+            },
+          ],
         },
       ],
     });
@@ -65,7 +70,7 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      sections: [section],
     });
 
     server.create('correction-response', {

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -66,8 +66,14 @@ module('Acceptance | Module | Routes | details', function (hooks) {
   });
   test('should redirect /modules/:slug to /modules/:slug/details', async function (assert) {
     // given
-    const grain = server.create('grain', {
-      id: 'grain1',
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
+        {
+          id: 'grain1',
+          components: [],
+        },
+      ],
     });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
@@ -81,7 +87,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
         level: 'Débutant',
         objectives: ['Écrire une adresse mail correctement, en évitant les erreurs courantes'],
       },
-      grains: [grain],
+      sections: [section],
     });
 
     // when

--- a/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
@@ -10,14 +10,20 @@ module('Acceptance | Module | Routes | get', function (hooks) {
 
   test('can visit /modules/:slug/passage', async function (assert) {
     // given
-    const grain = server.create('grain', {
-      id: 'grain1',
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
+        {
+          id: 'grain1',
+          components: [],
+        },
+      ],
     });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      sections: [section],
     });
 
     // when
@@ -32,15 +38,21 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     const module = {
       title: 'Bien écrire son adresse mail',
     };
-    const grain = server.create('grain', {
-      id: 'grain1',
+    const section = server.create('section', {
+      id: 'sectionId-1',
+      grains: [
+        {
+          id: 'grain1',
+          components: [],
+        },
+      ],
     });
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: module.title,
-      grains: [grain],
+      sections: [section],
     });
 
     // when

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -13,8 +13,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
   test('should display given grain with its current step', async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
-    const grain = store.createRecord('grain', { id: '12345-abcdef' });
+    const grain = { id: '12345-abcdef', components: [] };
     const currentStep = 1;
     const totalSteps = 10;
 
@@ -32,7 +31,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when element is a custom element', function () {
       test('should display a "CustomElement" element', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const customElement = {
           type: 'custom',
           tagName: 'qcu-image',
@@ -84,9 +82,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           },
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: customElement }],
-        });
+        };
 
         // when
         await render(<template><ModuleGrain @grain={{grain}} /></template>);
@@ -100,15 +98,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when element is a text', function () {
       test('should display text element', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const textElement = {
           content: 'element content',
           type: 'text',
           isAnswerable: false,
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: textElement }],
-        });
+        };
         this.set('grain', grain);
 
         // when
@@ -130,9 +127,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           type: 'qcu',
           isAnswerable: true,
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qcuElement }],
-        });
+        };
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -156,9 +153,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           type: 'qcu-declarative',
           isAnswerable: true,
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qcuDeclarativeElement }],
-        });
+        };
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -195,9 +192,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ],
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qabElement }],
-        });
+        };
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -254,9 +251,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           type: 'qrocm',
           isAnswerable: true,
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qrocmElement }],
-        });
+        };
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -274,7 +271,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when element is an image', function () {
       test('should display image element', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const url =
           'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
         const imageElement = {
@@ -283,9 +279,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           alternativeText: 'alternative instruction',
           type: 'image',
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: imageElement }],
-        });
+        };
         this.set('grain', grain);
 
         // when
@@ -300,7 +296,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when element is of type flashcards', function () {
       test('should display a flashcards element', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const flashCardsElement = {
           id: '71de6394-ff88-4de3-8834-a40057a50ff4',
           type: 'flashcards',
@@ -324,9 +319,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ],
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: flashCardsElement }],
-        });
+        };
         this.set('grain', grain);
 
         // when
@@ -341,16 +336,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
     module('when element is an expand', function () {
       test('should display an "Expand" element', async function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const title = 'An Expand title';
         const expandElement = {
           title,
           content: '<p>My Content</p>',
           type: 'expand',
         };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: expandElement }],
-        });
+        };
         this.set('grain', grain);
 
         // when
@@ -368,9 +362,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element }],
-        });
+        };
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -425,12 +419,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           };
 
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [
               { type: 'element', element },
               { type: 'element', element: qcuDeclarativeElement },
             ],
-          });
+          };
           store.createRecord('module', { grains: [grain] });
           this.set('grain', grain);
           const passage = store.createRecord('passage');
@@ -453,9 +447,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [{ type: 'element', element }],
-          });
+          };
           store.createRecord('module', { grains: [grain] });
           this.set('grain', grain);
           const passage = store.createRecord('passage');
@@ -477,10 +471,10 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu-declarative', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             title: 'Grain title',
             components: [{ type: 'element', element }],
-          });
+          };
           this.set('grain', grain);
           const passage = store.createRecord('passage');
           this.set('passage', passage);
@@ -499,9 +493,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [{ type: 'element', element }],
-          });
+          };
           this.set('grain', grain);
           const passage = store.createRecord('passage');
           this.set('passage', passage);
@@ -518,9 +512,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [{ type: 'element', element }],
-          });
+          };
           store.createRecord('module', { grains: [grain] });
           this.set('grain', grain);
           const passage = store.createRecord('passage');
@@ -540,9 +534,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [{ type: 'element', element }],
-          });
+          };
           this.set('grain', grain);
           const passage = store.createRecord('passage');
           this.set('passage', passage);
@@ -559,9 +553,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [{ type: 'element', element }],
-          });
+          };
           store.createRecord('module', { grains: [grain] });
           this.set('grain', grain);
           const passage = store.createRecord('passage');
@@ -585,9 +579,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', {
+      const grain = {
         components: [{ type: 'element', element }],
-      });
+      };
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
 
@@ -613,7 +607,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { components: [{ type: 'element', element }] });
+      const grain = { components: [{ type: 'element', element }] };
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
       const passage = store.createRecord('passage');
@@ -644,7 +638,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { components: [{ type: 'element', element }] });
+      const grain = { components: [{ type: 'element', element }] };
       this.set('grain', grain);
       const passage = store.createRecord('passage');
       this.set('passage', passage);
@@ -670,15 +664,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
   module('when grain contains a stepper', function () {
     test('should display the stepper', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
       const textElement = {
         content: 'element content',
         type: 'text',
         isAnswerable: false,
       };
-      const grain = store.createRecord('grain', {
+      const grain = {
         components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
-      });
+      };
 
       // when
       const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
@@ -721,14 +714,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const passageEventService = this.owner.lookup('service:passage-events');
         sinon.stub(passageEventService, 'record');
         const store = this.owner.lookup('service:store');
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [
             {
               type: 'stepper',
               steps,
             },
           ],
-        });
+        };
         const passage = store.createRecord('passage');
         passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
         this.set('grain', grain);
@@ -778,14 +771,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         ];
         const onElementRetryStub = sinon.stub();
         const store = this.owner.lookup('service:store');
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [
             {
               type: 'stepper',
               steps,
             },
           ],
-        });
+        };
         const passage = store.createRecord('passage');
         const correctionResponse = store.createRecord('correction-response', {
           feedback: { state: 'Too bad!' },
@@ -841,14 +834,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
           ];
 
           const store = this.owner.lookup('service:store');
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [
               {
                 type: 'stepper',
                 steps,
               },
             ],
-          });
+          };
 
           const passage = store.createRecord('passage');
           const onElementRetryStub = sinon.stub();
@@ -890,14 +883,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
           ];
 
           const store = this.owner.lookup('service:store');
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [
               {
                 type: 'stepper',
                 steps,
               },
             ],
-          });
+          };
 
           const passage = store.createRecord('passage');
           const onElementRetryStub = sinon.stub();
@@ -953,14 +946,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ];
 
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [
               {
                 type: 'stepper',
                 steps,
               },
             ],
-          });
+          };
 
           this.set('grain', grain);
           this.set('passage', passage);
@@ -1001,14 +994,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ];
 
-          const grain = store.createRecord('grain', {
+          const grain = {
             components: [
               {
                 type: 'stepper',
                 steps,
               },
             ],
-          });
+          };
 
           this.set('grain', grain);
           this.set('passage', passage);
@@ -1069,14 +1062,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
               },
             ];
 
-            const grain = store.createRecord('grain', {
+            const grain = {
               components: [
                 {
                   type: 'stepper',
                   steps,
                 },
               ],
-            });
+            };
 
             this.set('grain', grain);
             this.set('passage', passage);
@@ -1119,14 +1112,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
               },
             ];
 
-            const grain = store.createRecord('grain', {
+            const grain = {
               components: [
                 {
                   type: 'stepper',
                   steps,
                 },
               ],
-            });
+            };
 
             this.set('grain', grain);
             this.set('passage', passage);
@@ -1172,14 +1165,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 },
               ];
 
-              const grain = store.createRecord('grain', {
+              const grain = {
                 components: [
                   {
                     type: 'stepper',
                     steps,
                   },
                 ],
-              });
+              };
 
               this.set('grain', grain);
               this.set('passage', passage);
@@ -1221,14 +1214,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 },
               ];
 
-              const grain = store.createRecord('grain', {
+              const grain = {
                 components: [
                   {
                     type: 'stepper',
                     steps,
                   },
                 ],
-              });
+              };
 
               this.set('grain', grain);
               this.set('passage', passage);
@@ -1281,14 +1274,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ];
 
             const store = this.owner.lookup('service:store');
-            const grain = store.createRecord('grain', {
+            const grain = {
               components: [
                 {
                   type: 'stepper',
                   steps,
                 },
               ],
-            });
+            };
 
             const passage = store.createRecord('passage');
             const correction = store.createRecord('correction-response', {
@@ -1343,14 +1336,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ];
 
             const store = this.owner.lookup('service:store');
-            const grain = store.createRecord('grain', {
+            const grain = {
               components: [
                 {
                   type: 'stepper',
                   steps,
                 },
               ],
-            });
+            };
 
             const passage = store.createRecord('passage');
             const correction = store.createRecord('correction-response', {
@@ -1422,14 +1415,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
               ];
 
               const store = this.owner.lookup('service:store');
-              const grain = store.createRecord('grain', {
+              const grain = {
                 components: [
                   {
                     type: 'stepper',
                     steps,
                   },
                 ],
-              });
+              };
 
               const correction = store.createRecord('correction-response', {
                 status: 'ok',
@@ -1486,14 +1479,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
               ];
 
               const store = this.owner.lookup('service:store');
-              const grain = store.createRecord('grain', {
+              const grain = {
                 components: [
                   {
                     type: 'stepper',
                     steps,
                   },
                 ],
-              });
+              };
 
               const correction = store.createRecord('correction-response', {
                 status: 'ok',

--- a/mon-pix/tests/integration/components/module/navbar_test.gjs
+++ b/mon-pix/tests/integration/components/module/navbar_test.gjs
@@ -86,12 +86,18 @@ module('Integration | Component | Module | Navbar', function (hooks) {
 
 function createModule(owner) {
   const store = owner.lookup('service:store');
-  const grain1 = store.createRecord('grain', { title: 'Grain title', type: 'discovery', id: '123-abc' });
-  const grain2 = store.createRecord('grain', { title: 'Grain title', type: 'activity', id: '234-abc' });
-  const grain3 = store.createRecord('grain', { title: 'Grain title', type: 'lesson', id: '345-abc' });
-  const grain4 = store.createRecord('grain', { title: 'Grain title', type: 'summary', id: '456-abc' });
+  const section = store.createRecord('section', {
+    id: 'section1',
+    type: 'blank',
+    grains: [
+      { title: 'Grain title', type: 'discovery', id: '123-abc' },
+      { title: 'Grain title', type: 'activity', id: '234-abc' },
+      { title: 'Grain title', type: 'lesson', id: '345-abc' },
+      { title: 'Grain title', type: 'summary', id: '456-abc' },
+    ],
+  });
   return store.createRecord('module', {
     title: 'Didacticiel',
-    grains: [grain1, grain2, grain3, grain4],
+    sections: [section],
   });
 }

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -43,9 +43,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
           element: qcuElement,
         },
       ];
-      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ id: 'grainId1', components }],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -78,9 +82,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
           element: qcuElement,
         },
       ];
-      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ id: 'grainId1', components }],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -109,9 +117,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
           steps: [{ elements: [nonExistingElement2] }],
         },
       ];
-      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ id: 'grainId1', components }],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -143,9 +155,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
           element: existingElement,
         },
       ];
-      const grain = store.createRecord('grain', { id: 'grainId1', components });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ id: 'grainId1', components }],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
 
       const passage = store.createRecord('passage');
 
@@ -162,11 +178,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const textElement = { content: 'content', type: 'text' };
-      const grain = store.createRecord('grain', {
-        id: 'grainId1',
-        components: [{ type: 'element', element: textElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            id: 'grainId1',
+            components: [{ type: 'element', element: textElement }],
+          },
+        ],
       });
-      const module = store.createRecord('module', { title: 'Module title', isBeta: true, grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', isBeta: true, sections: [section] });
 
       const passage = store.createRecord('passage');
 
@@ -183,11 +205,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const textElement = { content: 'content', type: 'text' };
-      const grain = store.createRecord('grain', {
-        id: 'grainId1',
-        components: [{ type: 'element', element: textElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            id: 'grainId1',
+            components: [{ type: 'element', element: textElement }],
+          },
+        ],
       });
-      const module = store.createRecord('module', { title: 'Module title', isBeta: false, grains: [grain] });
+      const module = store.createRecord('module', { title: 'Module title', isBeta: false, sections: [section] });
 
       const passage = store.createRecord('passage');
 
@@ -209,10 +237,16 @@ module('Integration | Component | Module | Passage', function (hooks) {
         proposals: ['radio1', 'radio2'],
         type: 'qcu',
       };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: textElement }] },
+          { components: [{ type: 'element', element: qcuElement }] },
+        ],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -235,10 +269,16 @@ module('Integration | Component | Module | Passage', function (hooks) {
         proposals: ['radio1', 'radio2'],
         type: 'qcu',
       };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: textElement }] },
+          { components: [{ type: 'element', element: qcuElement }] },
+        ],
+      });
 
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      const module = store.createRecord('module', { title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -260,13 +300,19 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: qcuElement }] },
+          { components: [{ type: 'element', element: textElement }] },
+        ],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -291,13 +337,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      const grain1 = { components: [{ type: 'element', element: qcuElement }] };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [grain1, { components: [{ type: 'element', element: textElement }] }],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -331,13 +381,19 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: text1Element }] },
+          { components: [{ type: 'element', element: text2Element }] },
+        ],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -359,13 +415,19 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: text1Element }] },
+          { components: [{ type: 'element', element: text2Element }] },
+        ],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -384,14 +446,20 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
       const text3Element = { content: 'content 3', type: 'text' };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
-      const grain3 = store.createRecord('grain', { components: [{ type: 'element', element: text3Element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          { components: [{ type: 'element', element: text1Element }] },
+          { components: [{ type: 'element', element: text2Element }] },
+          { components: [{ type: 'element', element: text3Element }] },
+        ],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2, grain3],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -425,13 +493,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+      const grain1 = { components: [{ type: 'element', element: text1Element }] };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [grain1, { components: [{ type: 'element', element: text2Element }] }],
+      });
 
       const module = store.createRecord('module', {
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1, grain2],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -467,13 +539,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ components: [{ type: 'element', element: qcuElement }] }],
+      });
 
       const module = store.createRecord('module', {
         id: 'module-id',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain1],
+        sections: [section],
       });
       const passage = store.createRecord('passage', { id: 'passage-id' });
 
@@ -503,12 +579,16 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
       const module = store.createRecord('module', {
         id: 'module-id',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -544,12 +624,16 @@ module('Integration | Component | Module | Passage', function (hooks) {
         alt: "Dessin détaillé dans l'alternative textuelle",
         alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
       const module = store.createRecord('module', {
         id: 'module-id',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -582,15 +666,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
           alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
         };
         const step = { elements: [imageElement] };
-        const grain = store.createRecord('grain', {
-          id: '123',
-          components: [{ type: 'stepper', steps: [step] }],
+        const section = store.createRecord('section', {
+          id: 'section1',
+          type: 'blank',
+          grains: [
+            {
+              id: '123',
+              components: [{ type: 'stepper', steps: [step] }],
+            },
+          ],
         });
         const module = store.createRecord('module', {
           id: 'module-id',
           slug: 'module-slug',
           title: 'Module title',
-          grains: [grain],
+          sections: [section],
         });
         const passage = store.createRecord('passage');
 
@@ -629,12 +719,16 @@ module('Integration | Component | Module | Passage', function (hooks) {
         subtitles: '',
         transcription: '<p>transcription</p>',
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
       const module = store.createRecord('module', {
         id: 'module-id',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -668,15 +762,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
           transcription: '<p>transcription</p>',
         };
         const step = { elements: [videoElement] };
-        const grain = store.createRecord('grain', {
-          id: '123',
-          components: [{ type: 'stepper', steps: [step] }],
+        const section = store.createRecord('section', {
+          id: 'section1',
+          type: 'blank',
+          grains: [
+            {
+              id: '123',
+              components: [{ type: 'stepper', steps: [step] }],
+            },
+          ],
         });
         const module = store.createRecord('module', {
           id: 'module-id',
           slug: 'module-slug',
           title: 'Module title',
-          grains: [grain],
+          sections: [section],
         });
         const passage = store.createRecord('passage');
 
@@ -703,16 +803,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const text2Element = { content: 'content 2', type: 'text' };
       const step1 = { elements: [text1Element] };
       const step2 = { elements: [text2Element] };
-      const grain = store.createRecord('grain', {
+      const grain = {
         id: '123',
         components: [{ type: 'stepper', steps: [step1, step2] }],
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [grain],
       });
 
       const module = store.createRecord('module', {
         id: '1',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
       const onStepperNextStepButtonName = t('pages.modulix.buttons.stepper.next.ariaLabel');
@@ -747,16 +852,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const step1 = { elements: [text1Element] };
       const step2 = { elements: [text2Element] };
       const step3 = { elements: [text3Element] };
-      const grain = store.createRecord('grain', {
+      const grain = {
         id: '123',
         components: [{ type: 'stepper', steps: [step1, step2, step3] }],
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [grain],
       });
 
       const module = store.createRecord('module', {
         id: '1',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
       const onStepperNextStepButtonName = t('pages.modulix.buttons.stepper.next.ariaLabel');
@@ -787,9 +897,13 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
 
-      const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
+      const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', sections: [section] });
       const passage = store.createRecord('passage');
 
       // when
@@ -809,12 +923,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
             proposals: ['radio1', 'radio2'],
             type: 'qcu',
           };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element: qcuElement }],
+          const section = store.createRecord('section', {
+            id: 'section1',
+            type: 'blank',
+            grains: [
+              {
+                title: 'Grain title',
+                components: [{ type: 'element', element: qcuElement }],
+              },
+            ],
           });
 
-          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            sections: [section],
+          });
           const passage = store.createRecord('passage');
 
           // when
@@ -834,12 +958,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
             proposals: ['radio1', 'radio2'],
             type: 'qcu',
           };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element: qcuElement }],
+          const section = store.createRecord('section', {
+            id: 'section1',
+            type: 'blank',
+            grains: [
+              {
+                title: 'Grain title',
+                components: [{ type: 'element', element: qcuElement }],
+              },
+            ],
           });
 
-          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            sections: [section],
+          });
           const passage = store.createRecord('passage');
 
           // when
@@ -862,12 +996,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
             proposals: ['radio1', 'radio2'],
             type: 'qcu',
           };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'stepper', steps: [{ elements: [textElement] }, { elements: [qcuElement] }] }],
+          const section = store.createRecord('section', {
+            id: 'section1',
+            type: 'blank',
+            grains: [
+              {
+                title: 'Grain title',
+                components: [{ type: 'stepper', steps: [{ elements: [textElement] }, { elements: [qcuElement] }] }],
+              },
+            ],
           });
 
-          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            sections: [section],
+          });
           const passage = store.createRecord('passage');
 
           // when
@@ -884,12 +1028,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
           const store = this.owner.lookup('service:store');
           const text1Element = { type: 'text', isAnswerable: false };
           const text2Element = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'stepper', steps: [{ elements: [text1Element] }, { elements: [text2Element] }] }],
+          const section = store.createRecord('section', {
+            id: 'section1',
+            type: 'blank',
+            grains: [
+              {
+                title: 'Grain title',
+                components: [{ type: 'stepper', steps: [{ elements: [text1Element] }, { elements: [text2Element] }] }],
+              },
+            ],
           });
 
-          const module = store.createRecord('module', { slug: 'module-slug', title: 'Module title', grains: [grain] });
+          const module = store.createRecord('module', {
+            slug: 'module-slug',
+            title: 'Module title',
+            sections: [section],
+          });
           const passage = store.createRecord('passage');
 
           // when
@@ -918,16 +1072,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'video',
         transcription: '',
       };
-      const grain = store.createRecord('grain', {
-        id: '123',
-        components: [{ type: 'element', element: videoElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            id: '123',
+            components: [{ type: 'element', element: videoElement }],
+          },
+        ],
       });
 
       const module = store.createRecord('module', {
         id: '1',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -964,15 +1124,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
           subtitles: '',
           transcription: '<p>transcription</p>',
         };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: videoElement }],
+        const section = store.createRecord('section', {
+          id: 'section1',
+          type: 'blank',
+          grains: [
+            {
+              title: 'Grain title',
+              components: [{ type: 'element', element: videoElement }],
+            },
+          ],
         });
         const module = store.createRecord('module', {
           id: 'module-id',
           slug: 'module-slug',
           title: 'Module title',
-          grains: [grain],
+          sections: [section],
         });
         const passage = store.createRecord('passage');
         await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1008,16 +1174,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'download',
         files: [{ format: downloadedFormat, url: 'https://example.org/modulix/placeholder-doc.pdf' }],
       };
-      const grain = store.createRecord('grain', {
-        id: '123',
-        components: [{ type: 'element', element: downloadElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            id: '123',
+            components: [{ type: 'element', element: downloadElement }],
+          },
+        ],
       });
 
       const module = store.createRecord('module', {
         id: '1',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
 
@@ -1060,15 +1232,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
           type: 'download',
           files: [{ format: downloadedFormat, url: 'https://example.org/modulix/placeholder-doc.pdf' }],
         };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: downloadElement }],
+        const section = store.createRecord('section', {
+          id: 'section1',
+          type: 'blank',
+          grains: [
+            {
+              title: 'Grain title',
+              components: [{ type: 'element', element: downloadElement }],
+            },
+          ],
         });
         const module = store.createRecord('module', {
           id: 'module-id',
           slug: 'module-slug',
           title: 'Module title',
-          grains: [grain],
+          sections: [section],
         });
         const passage = store.createRecord('passage');
         const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
@@ -1118,17 +1296,22 @@ module('Integration | Component | Module | Passage', function (hooks) {
         proposals: ['radio1', 'radio2'],
         type: 'qcu',
       };
-      const grain = store.createRecord('grain', {
+      const grain = {
         id: '123',
         title: 'Grain title',
         components: [{ type: 'element', element: qcuElement }],
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [grain],
       });
 
       const module = store.createRecord('module', {
         id: 'module-title',
         slug: 'module-slug',
         title: 'Module title',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
       passage.terminate = sinon.stub();
@@ -1162,17 +1345,23 @@ module('Integration | Component | Module | Passage', function (hooks) {
         title: 'Mon Expand',
         content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
       };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        type: 'discovery',
-        id: '123-abc',
-        components: [{ type: 'element', element: expandElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            title: 'Grain title',
+            type: 'discovery',
+            id: '123-abc',
+            components: [{ type: 'element', element: expandElement }],
+          },
+        ],
       });
 
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         slug: 'module-slug',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:pix-metrics');
@@ -1207,17 +1396,23 @@ module('Integration | Component | Module | Passage', function (hooks) {
         };
 
         const step = { elements: [expandElement] };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          type: 'discovery',
-          id: '123-abc',
-          components: [{ type: 'stepper', steps: [step] }],
+        const section = store.createRecord('section', {
+          id: 'section1',
+          type: 'blank',
+          grains: [
+            {
+              title: 'Grain title',
+              type: 'discovery',
+              id: '123-abc',
+              components: [{ type: 'stepper', steps: [step] }],
+            },
+          ],
         });
 
         const module = store.createRecord('module', {
           title: 'Didacticiel',
           slug: 'module-slug',
-          grains: [grain],
+          sections: [section],
         });
         const passage = store.createRecord('passage');
         const metrics = this.owner.lookup('service:pix-metrics');
@@ -1252,17 +1447,23 @@ module('Integration | Component | Module | Passage', function (hooks) {
         title: 'Mon Expand',
         content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
       };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        type: 'discovery',
-        id: '123-abc',
-        components: [{ type: 'element', element: expandElement }],
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            title: 'Grain title',
+            type: 'discovery',
+            id: '123-abc',
+            components: [{ type: 'element', element: expandElement }],
+          },
+        ],
       });
 
       const module = store.createRecord('module', {
         title: 'Didacticiel',
         slug: 'module-slug',
-        grains: [grain],
+        sections: [section],
       });
       const passage = store.createRecord('passage');
       const metrics = this.owner.lookup('service:pix-metrics');

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -286,7 +286,6 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     elementId: qcmElement.id,
   });
-  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qcmElement }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcmElement.id,

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -272,7 +272,6 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     elementId: qcuElement.id,
   });
-  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qcuElement }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcuElement.id,

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -530,7 +530,6 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       correction: correctionResponse,
       elementId: qrocm.id,
     });
-    store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qrocm }] });
     store.createRecord('element-answer', {
       correction: correctionResponse,
       elementId: qrocm.id,
@@ -629,7 +628,6 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     elementId: qrocm.id,
   });
-  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qrocm }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qrocm.id,

--- a/mon-pix/tests/unit/components/module/grain-test.gjs
+++ b/mon-pix/tests/unit/components/module/grain-test.gjs
@@ -10,19 +10,18 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when there are answerable elements in grain', function () {
       test('should return true', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const qcu = { type: 'qcu', isAnswerable: true };
         const qcm = { type: 'qcm', isAnswerable: true };
         const qrocm = { type: 'qrocm', isAnswerable: true };
         const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [
             { type: 'element', element: qcu },
             { type: 'element', element: qcm },
             { type: 'element', element: qrocm },
             { type: 'element', element: text },
           ],
-        });
+        };
         const component = createGlimmerComponent('module/grain/grain', { grain });
 
         // when
@@ -36,11 +35,10 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when there are no answerable element in grain', function () {
       test('should return false', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: text }],
-        });
+        };
         const component = createGlimmerComponent('module/grain/grain', { grain });
 
         // when
@@ -56,19 +54,18 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when there are answerable elements in elements', function () {
       test('should return only answerable elements', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const qcu = { type: 'qcu', isAnswerable: true };
         const qcm = { type: 'qcm', isAnswerable: true };
         const qrocm = { type: 'qrocm', isAnswerable: true };
         const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [
             { type: 'element', element: qcu },
             { type: 'element', element: qcm },
             { type: 'element', element: qrocm },
             { type: 'element', element: text },
           ],
-        });
+        };
         const component = createGlimmerComponent('module/grain/grain', { grain });
 
         // when
@@ -83,11 +80,10 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when there are no answerable elements in elements', function () {
       test('should return an empty array', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const text = { type: 'text' };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: text }],
-        });
+        };
         const component = createGlimmerComponent('module/grain/grain', { grain });
 
         // when
@@ -111,9 +107,9 @@ module('Unit | Component | Module | Grain', function (hooks) {
         const passage = store.createRecord('passage', {
           elementAnswers: [elementAnswer],
         });
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qcu }],
-        });
+        };
 
         const component = createGlimmerComponent('module/grain/grain', { grain, passage });
 
@@ -130,9 +126,9 @@ module('Unit | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const qcu = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qcu }],
-        });
+        };
         const passage = store.createRecord('passage');
         const component = createGlimmerComponent('module/grain/grain', { grain, passage });
 
@@ -149,11 +145,10 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when component.type is supported', function () {
       test('should return the displayable element', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const qcu = { id: 'qcu-id-1', type: 'qcu' };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'element', element: qcu }],
-        });
+        };
 
         const component = createGlimmerComponent('module/grain/grain', { grain });
 
@@ -169,11 +164,10 @@ module('Unit | Component | Module | Grain', function (hooks) {
     module('when component.type is not supported', function () {
       test('should return an empty array', function (assert) {
         // given
-        const store = this.owner.lookup('service:store');
         const qcu = { id: 'qcu-id-1', type: 'qcu' };
-        const grain = store.createRecord('grain', {
+        const grain = {
           components: [{ type: 'toto', element: qcu }],
-        });
+        };
 
         const component = createGlimmerComponent('module/grain/grain', { grain });
 

--- a/mon-pix/tests/unit/models/modules/module-test.js
+++ b/mon-pix/tests/unit/models/modules/module-test.js
@@ -11,10 +11,10 @@ module('Unit | Model | Module | Module', function (hooks) {
     const store = this.owner.lookup('service:store');
     const version = Symbol('version');
     const isBeta = Symbol('isBeta');
-    const grain = store.createRecord('grain', {});
+    const section = store.createRecord('section', {});
 
     // when
-    const module = store.createRecord('module', { title, isBeta, details, version, grains: [grain] });
+    const module = store.createRecord('module', { title, isBeta, details, version, sections: [section] });
 
     // then
     assert.ok(module);
@@ -22,6 +22,6 @@ module('Unit | Model | Module | Module', function (hooks) {
     assert.strictEqual(module.isBeta, isBeta);
     assert.strictEqual(module.details, details);
     assert.strictEqual(module.version, version);
-    assert.strictEqual(module.grains[0], grain);
+    assert.strictEqual(module.sections[0], section);
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Depuis #13180 les modules disposent de sections qui permettent de chapitrer. Ces sections ne sont pour le moment pas utilisées.

## ⛱️ Proposition

Remplacer l'envoi des grains directs par l'envoi des sections (qui contiennent les grains) côté API.

Côté Pix App, s'attendre maintenant à consommer une liste de sections plutôt qu'une liste de grains. Comme précédemment, pas nécessaire pour Ember Data de connnaître le model `grain` car il n'est qu'en lecture seule, ça simplifie pas mal les choses ! (cf. #8129)

Au moment du déploiement, il y aura un petit timing où le front et l'API seront désynchronisées et donc inutilisables. Sachant qu'il n'y a quasiment pas d'usage aujourd'hui, on se permet de faire ce gros refacto ainsi.

## 🌊 Remarques

Manque de bol, le modèle grain mettait une valeur par défaut au champ `components` (`[]`), il a fallu l'ajouter partout.

## 🏄 Pour tester

Vérifier que [l'API](https://api-pr13196.review.pix.fr/api/modules/bac-a-sable) renvoie bien les sections du module dans l'onglet Network des devtools.

Vérifier qu'on accède et peut utiliser [un module](https://app-pr13196.review.pix.fr/modules/bac-a-sable).

Vérifier que [la prévisualisation de module existant](https://app-pr13196.review.pix.fr/modules/preview/bac-a-sable) refonctionne.
