### PR TITLE
[FEATURE] Permettre de créer des parcours combinés depuis PixAdmin (PIX-18162)

### DIFF
--- a/admin/app/components/administration/common/create-combined-courses.gjs
+++ b/admin/app/components/administration/common/create-combined-courses.gjs
@@ -1,0 +1,99 @@
+import PixButtonUpload from '@1024pix/pix-ui/components/pix-button-upload';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import ENV from 'pix-admin/config/environment';
+import { scrollToElement } from 'pix-admin/modifiers/scroll-to';
+
+import AdministrationBlockLayout from '../block-layout';
+
+export default class CreateCombinedCourses extends Component {
+  @service intl;
+  @service pixToast;
+  @service session;
+  @service fileSaver;
+  @service errorResponseHandler;
+
+  @tracked errors = null;
+
+  @action
+  async createCombinedCourses(files) {
+    let response;
+    this.errors = null;
+    try {
+      const fileContent = files[0];
+
+      const token = this.session.data.authenticated.access_token;
+      response = await window.fetch(`${ENV.APP.API_HOST}/api/admin/combined-courses`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/csv',
+          Accept: 'application/json',
+        },
+        method: 'POST',
+        body: fileContent,
+      });
+      if (response.ok) {
+        this.pixToast.sendSuccessNotification({
+          message: this.intl.t('components.administration.create-combined-courses.notifications.success'),
+        });
+        return;
+      } else {
+        const responseJson = await response.json();
+        const { errors: responseErrors } = responseJson;
+        if (isJSONAPIError(responseErrors)) {
+          this.errors = responseErrors;
+        } else {
+          this.errorResponseHandler.notify(responseJson, undefined, true);
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  <template>
+    <AdministrationBlockLayout
+      @title={{t "components.administration.create-combined-courses.title"}}
+      @description={{t "components.administration.create-combined-courses.description"}}
+      @actionsClass="create-combined-courses__actions"
+      class="create-combined-courses"
+    >
+      <div class="create-combined-courses__buttons">
+        <PixButtonUpload
+          @id="combined-courses-file-upload"
+          @onChange={{this.createCombinedCourses}}
+          @variant="primary"
+          accept=".csv"
+        >
+          {{t "components.administration.create-combined-courses.upload-button"}}
+        </PixButtonUpload>
+      </div>
+      {{#if this.errors}}
+        <PixNotificationAlert @withIcon={{true}} @type="error" class="create-combined-courses__errors">
+          <ul>
+            {{#each this.errors as |error|}}
+              <li class="create-combined-courses__error" {{scrollToElement}}>
+                <span>{{error.detail}}</span>
+              </li>
+            {{/each}}
+          </ul>
+        </PixNotificationAlert>
+      {{/if}}
+    </AdministrationBlockLayout>
+  </template>
+}
+
+function isEmpty(value) {
+  return Array.isArray(value) && value.length === 0;
+}
+
+function isJSONAPIError(errors) {
+  return !isEmpty(errors) && errors.every((error) => error.title);
+}

--- a/admin/app/components/administration/common/index.gjs
+++ b/admin/app/components/administration/common/index.gjs
@@ -1,4 +1,5 @@
 import AddOrganizationFeaturesInBatch from './add-organization-features-in-batch';
+import CreateCombinedCourses from './create-combined-courses';
 import LearningContent from './learning-content';
 import UpsertQuestsInBatch from './upsert-quests-in-batch';
 import UserQuestChecker from './user-quest-checker';
@@ -8,4 +9,5 @@ import UserQuestChecker from './user-quest-checker';
   <AddOrganizationFeaturesInBatch />
   <UpsertQuestsInBatch />
   <UserQuestChecker />
+  <CreateCombinedCourses />
 </template>

--- a/admin/app/styles/components/administration/create-combined-courses.scss
+++ b/admin/app/styles/components/administration/create-combined-courses.scss
@@ -1,0 +1,25 @@
+.create-combined-courses {
+  &__actions {
+    display: block;
+  }
+
+  &__buttons {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+  }
+
+  &__errors {
+    margin-top: var(--pix-spacing-4x);
+
+    & > span {
+      width: 100%;
+    }
+  }
+
+  &__error {
+    & > span {
+      font-weight: var(--pix-font-bold);
+    }
+  }
+
+}

--- a/admin/app/styles/components/administration/index.scss
+++ b/admin/app/styles/components/administration/index.scss
@@ -4,3 +4,4 @@
 @use 'block-layout';
 @use 'upsert-quests-in-batch';
 @use 'user-quest-checker';
+@use 'create-combined-courses';

--- a/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
@@ -1,0 +1,133 @@
+import { render } from '@1024pix/ember-testing-library';
+import PixToastContainer from '@1024pix/pix-ui/components/pix-toast-container';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CreateCombinedCourses from 'pix-admin/components/administration/common/create-combined-courses';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+const accessToken = 'An access token';
+const fileContent = 'foo';
+const file = new Blob([fileContent], { type: `valid-file` });
+
+module('Integration | Component | administration/create-combined-courses', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let fetchStub;
+
+  hooks.beforeEach(function () {
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+
+    fetchStub = sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    window.fetch.restore();
+  });
+
+  module('when import succeeds', function (hooks) {
+    hooks.beforeEach(function () {
+      fetchStub
+        .withArgs(`${ENV.APP.API_HOST}/api/admin/combined-courses`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'text/csv',
+            Accept: 'application/json',
+          },
+          method: 'POST',
+          body: file,
+        })
+        .resolves(fetchResponse({ status: 204 }));
+    });
+
+    test('it displays a success notification', async function (assert) {
+      // when
+      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const input = await screen.getByLabelText(t('components.administration.create-combined-courses.upload-button'));
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(await screen.findByText(t('components.administration.create-combined-courses.notifications.success')));
+    });
+  });
+
+  module('when import fails', function () {
+    test('it displays an error block', async function (assert) {
+      // given
+      fetchStub
+        .withArgs(`${ENV.APP.API_HOST}/api/admin/combined-courses`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'text/csv',
+            Accept: 'application/json',
+          },
+          method: 'POST',
+          body: file,
+        })
+        .resolves(
+          fetchResponse({
+            body: {
+              errors: [
+                {
+                  status: '412',
+                  title: "Un soucis avec l'import",
+                  code: '412',
+                  detail: "Erreur d'import",
+                  meta: { data: { something: 1 } },
+                },
+              ],
+            },
+            status: 412,
+          }),
+        );
+
+      // when
+      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(t('components.administration.create-combined-courses.upload-button'));
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(await screen.findByText("Erreur d'import", { exact: false }));
+    });
+
+    test('it displays an error notification', async function (assert) {
+      // given
+      fetchStub
+        .withArgs(`${ENV.APP.API_HOST}/api/admin/combined-courses`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'text/csv',
+            Accept: 'application/json',
+          },
+          method: 'POST',
+          body: file,
+        })
+        .rejects();
+      // when
+      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const input = await screen.findByLabelText(t('components.administration.create-combined-courses.upload-button'));
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(await screen.findByText(t('common.notifications.generic-error')));
+    });
+  });
+});
+
+function fetchResponse({ body, status }) {
+  const mockResponse = new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+
+  return mockResponse;
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -141,6 +141,14 @@
         "title": "Archiving of certification centers in batch",
         "upload-button": "Import a CSV file"
       },
+      "create-combined-courses": {
+        "description": "Ask for expert help if needed",
+        "notifications": {
+          "success": "Combined courses have been created, and campaign as well if included in courses."
+        },
+        "title": "Create combined courses",
+        "upload-button": "Import CSV file"
+      },
       "oidc-providers-import": {
         "description": "Note: Trying to import already existing OIDC Providers would produce an error.",
         "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -141,6 +141,14 @@
         "title": "Archivage des centres de certification en masse",
         "upload-button": "Importer un fichier CSV"
       },
+      "create-combined-courses": {
+        "description": "Sollicitez un spécialiste des parcours combinés",
+        "notifications": {
+          "success": "Les parcours combinés ont été créés, ainsi que les campagnes si les parcours en contiennent."
+        },
+        "title": "Création de parcours combinés",
+        "upload-button": "Importer un fichier CSV"
+      },
       "oidc-providers-import": {
         "description": "Note: Chercher à importer à nouveau des OIDC Providers déjà existants renverrait une erreur.",
         "notifications": {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -136,7 +136,7 @@ const save = async function (campaigns, dependencies = { skillRepository }) {
       createdCampaigns.push(latestCreatedCampaign);
     }
     await trx.commit();
-    return createdCampaigns.length > 1 ? createdCampaigns : createdCampaigns[0];
+    return Array.isArray(campaigns) ? createdCampaigns : createdCampaigns[0];
   } catch (err) {
     await trx.rollback();
     throw err;

--- a/api/src/prescription/target-profile/application/api/TargetProfile.js
+++ b/api/src/prescription/target-profile/application/api/TargetProfile.js
@@ -1,7 +1,8 @@
 export class TargetProfile {
-  constructor({ id, name, category, isSimplifiedAccess }) {
+  constructor({ id, name, internalName, category, isSimplifiedAccess }) {
     this.id = id;
     this.name = name;
+    this.internalName = internalName;
     this.category = category;
     this.isSimplifiedAccess = isSimplifiedAccess;
   }

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,3 +1,6 @@
+import { createReadStream } from 'node:fs';
+
+import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { requestResponseUtils } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
@@ -33,10 +36,19 @@ const reassessStatus = async function (request, h, dependencies = { requestRespo
   return h.response().code(204);
 };
 
+const createCombinedCourses = async function (request, h) {
+  const filePath = request.payload.path;
+  const stream = createReadStream(filePath);
+  const payload = await getDataBuffer(stream);
+  await usecases.createCombinedCourses({ payload });
+  return h.response(null).code(204);
+};
+
 const combinedCourseController = {
   getByCode,
   start,
   reassessStatus,
+  createCombinedCourses,
 };
 
 export { combinedCourseController };

--- a/api/src/quest/domain/constants.js
+++ b/api/src/quest/domain/constants.js
@@ -21,3 +21,22 @@ export const QUEST_HEADER = {
     }),
   ],
 };
+export const COMBINED_COURSE_HEADER = {
+  columns: [
+    new CsvColumn({
+      property: 'organizationIds',
+      name: 'Identifiant des organisations*',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'content',
+      name: 'Json configuration for quest*',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'creatorId',
+      name: 'Identifiant du createur des campagnes*',
+      isRequired: false,
+    }),
+  ],
+};

--- a/api/src/quest/domain/models/Campaign.js
+++ b/api/src/quest/domain/models/Campaign.js
@@ -1,8 +1,29 @@
 export class Campaign {
-  constructor({ id, name, code, targetProfileId }) {
+  constructor({
+    id,
+    name,
+    code,
+    targetProfileId,
+    organizationId,
+    creatorId,
+    ownerId,
+    type,
+    title,
+    multipleSendings,
+    customResultPageButtonUrl,
+    customResultPageButtonText,
+  }) {
     this.id = id;
     this.name = name;
     this.code = code;
     this.targetProfileId = targetProfileId;
+    this.organizationId = organizationId;
+    this.creatorId = creatorId;
+    this.ownerId = ownerId;
+    this.type = type;
+    this.multipleSendings = multipleSendings;
+    this.title = title;
+    this.customResultPageButtonUrl = customResultPageButtonUrl;
+    this.customResultPageButtonText = customResultPageButtonText;
   }
 }

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -7,21 +7,26 @@ import { Quest } from './Quest.js';
 import { TYPES } from './Requirement.js';
 
 export class CombinedCourse {
-  constructor({ id, code, organizationId, name } = {}) {
+  #quest;
+
+  constructor({ id, code, organizationId, name } = {}, quest) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
+    this.#quest = quest;
+  }
+
+  get quest() {
+    return this.#quest;
   }
 }
 
 export class CombinedCourseDetails extends CombinedCourse {
-  #quest;
   items = null;
 
   constructor({ id, code, organizationId, name }, quest, participation) {
-    super({ id, code, organizationId, name });
-    this.#quest = quest;
+    super({ id, code, organizationId, name }, quest);
     if (!participation) {
       this.status = CombinedCourseStatuses.NOT_STARTED;
     } else {
@@ -33,19 +38,19 @@ export class CombinedCourseDetails extends CombinedCourse {
   }
 
   get campaignIds() {
-    return this.#quest.successRequirements
+    return this.quest.successRequirements
       .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)
       .map(({ data }) => data.campaignId.data);
   }
 
   get moduleIds() {
-    return this.#quest.successRequirements
+    return this.quest.successRequirements
       .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.PASSAGES)
       .map(({ data }) => data.moduleId.data);
   }
 
   isCompleted(dataForQuest, recommendableModuleIds = [], recommendedModuleIdsForUser = []) {
-    const successRequirements = this.#quest.successRequirements.filter((req) => {
+    const successRequirements = this.quest.successRequirements.filter((req) => {
       if (req.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         return true;
       } else if (req.requirement_type === TYPES.OBJECT.PASSAGES) {
@@ -69,8 +74,8 @@ export class CombinedCourseDetails extends CombinedCourse {
     });
 
     const questForUser = new Quest({
-      ...this.#quest,
-      eligibilityRequirements: this.#quest.eligibilityRequirements,
+      ...this.quest,
+      eligibilityRequirements: this.quest.eligibilityRequirements,
       successRequirements,
     });
 
@@ -79,7 +84,7 @@ export class CombinedCourseDetails extends CombinedCourse {
 
   generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = [], encryptedCombinedCourseUrl) {
     this.items = [];
-    for (const requirement of this.#quest.successRequirements) {
+    for (const requirement of this.quest.successRequirements) {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
         this.items.push(

--- a/api/src/quest/domain/models/CombinedCourseTemplate.js
+++ b/api/src/quest/domain/models/CombinedCourseTemplate.js
@@ -1,0 +1,66 @@
+import { CombinedCourse } from './CombinedCourse.js';
+import { COMPARISONS as CITERION_PROPERTY_COMPARISONS } from './CriterionProperty.js';
+import { Quest } from './Quest.js';
+import { buildRequirement, COMPARISONS, TYPES } from './Requirement.js';
+
+export class CombinedCourseTemplate {
+  #quest;
+  #name;
+
+  constructor({ name, successRequirements }) {
+    const now = new Date();
+    this.#name = name;
+    this.#quest = new Quest({
+      createdAt: now,
+      updatedAt: now,
+      rewardType: null,
+      rewardId: null,
+      eligibilityRequirements: [],
+      successRequirements,
+    });
+  }
+
+  get targetProfileIds() {
+    return this.#quest.successRequirements
+      .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)
+      .map(({ data }) => data.targetProfileId.data);
+  }
+
+  toCombinedCourse(code, organizationId, campaigns) {
+    const quest = this.#toCombinedCourseQuestFormat(campaigns);
+    return new CombinedCourse({ name: this.#name, code, organizationId }, quest);
+  }
+
+  #toCombinedCourseQuestFormat(campaigns) {
+    const successRequirements = this.#quest.successRequirements.map((requirement) => {
+      if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
+        const requirementTargetProfileId = requirement.data.targetProfileId.data;
+        const campaignId = campaigns.find(({ targetProfileId }) => targetProfileId === requirementTargetProfileId).id;
+        return buildRequirement({
+          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: COMPARISONS.ALL,
+          data: {
+            campaignId: { data: campaignId, comparison: CITERION_PROPERTY_COMPARISONS.EQUAL },
+            status: { data: 'SHARED', comparison: CITERION_PROPERTY_COMPARISONS.EQUAL },
+          },
+        });
+      } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
+        return buildRequirement({
+          requirement_type: TYPES.OBJECT.PASSAGES,
+          comparison: COMPARISONS.ALL,
+          data: {
+            ...requirement.data,
+            isTerminated: { data: true, comparison: CITERION_PROPERTY_COMPARISONS.EQUAL },
+          },
+        });
+      } else {
+        return requirement;
+      }
+    });
+    return new Quest({
+      ...this.#quest,
+      successRequirements,
+      eligibilityRequirements: [],
+    });
+  }
+}

--- a/api/src/quest/domain/models/TargetProfile.js
+++ b/api/src/quest/domain/models/TargetProfile.js
@@ -1,0 +1,7 @@
+export class TargetProfile {
+  constructor({ id, name, internalName }) {
+    this.id = id;
+    this.name = name;
+    this.internalName = internalName;
+  }
+}

--- a/api/src/quest/domain/usecases/create-combined-courses.js
+++ b/api/src/quest/domain/usecases/create-combined-courses.js
@@ -1,0 +1,58 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
+import { COMBINED_COURSE_HEADER } from '../constants.js';
+import { Campaign } from '../models/Campaign.js';
+import { CombinedCourseTemplate } from '../models/CombinedCourseTemplate.js';
+
+export const createCombinedCourses = withTransaction(
+  async ({
+    payload,
+    campaignRepository,
+    targetProfileRepository,
+    codeGenerator,
+    accessCodeRepository,
+    combinedCourseRepository,
+  }) => {
+    const csvParser = new CsvParser(payload, COMBINED_COURSE_HEADER);
+    const csvData = csvParser.parse();
+
+    const combinedCourses = [];
+    const pendingCodes = [];
+    for (const row of csvData) {
+      const { organizationIds: organizationIdsSeparatedByComma, creatorId, content } = row;
+      const organizationIds = organizationIdsSeparatedByComma.split(',');
+      const combinedCourseInformation = JSON.parse(content);
+      const combinedCourseTemplate = new CombinedCourseTemplate(combinedCourseInformation);
+      const targetProfileIds = combinedCourseTemplate.targetProfileIds;
+      const targetProfiles = await targetProfileRepository.findByIds({ ids: targetProfileIds });
+
+      for (const organizationId of organizationIds) {
+        const code = await codeGenerator.generate(accessCodeRepository, pendingCodes);
+        pendingCodes.push(code);
+        // TODO: Plus tard avoir une url relative -> Futur ticket PIX-19131
+        const combinedCourseUrl = 'http://localhost:4200' + '/parcours/' + code;
+        const campaigns = targetProfiles.map((targetProfile) => {
+          return new Campaign({
+            organizationId: parseInt(organizationId),
+            targetProfileId: targetProfile.id,
+            creatorId: parseInt(creatorId),
+            ownerId: parseInt(creatorId),
+            type: 'ASSESSMENT',
+            multipleSendings: false,
+            name: targetProfile.internalName,
+            title: targetProfile.name,
+            customResultPageButtonUrl: combinedCourseUrl,
+            customResultPageButtonText: 'Continuer',
+          });
+        });
+
+        const createdCampaigns = await campaignRepository.save({ campaigns });
+
+        const combinedCourse = combinedCourseTemplate.toCombinedCourse(code, organizationId, createdCampaigns);
+        combinedCourses.push(combinedCourse);
+      }
+    }
+
+    await combinedCourseRepository.saveInBatch({ combinedCourses });
+  },
+);

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -1,8 +1,10 @@
+import * as codeGenerator from '../../../shared/domain/services/code-generator.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
 
 const dependencies = {
+  accessCodeRepository: repositories.accessCodeRepository,
   eligibilityRepository: repositories.eligibilityRepository,
   rewardRepository: repositories.rewardRepository,
   successRepository: repositories.successRepository,
@@ -14,10 +16,13 @@ const dependencies = {
   recommendedModulesRepository: repositories.recommendedModulesRepository,
   campaignRepository: repositories.campaignRepository,
   userRepository: repositories.userRepository,
+  targetProfileRepository: repositories.targetProfileRepository,
+  codeGenerator,
   logger,
 };
 
 import { checkUserQuest } from './check-user-quest-success.js';
+import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
@@ -35,6 +40,7 @@ const usecasesWithoutInjectedDependencies = {
   rewardUser,
   startCombinedCourse,
   updateCombinedCourse,
+  createCombinedCourses,
 };
 
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -9,3 +9,8 @@ export const get = async function ({ id, campaignsApi }) {
   const campaign = await campaignsApi.get(id);
   return new Campaign(campaign);
 };
+
+export const save = async function ({ campaigns, campaignsApi }) {
+  const createdCampaigns = await campaignsApi.save(campaigns);
+  return createdCampaigns.map((campaign) => new Campaign(campaign));
+};

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -13,4 +13,23 @@ const getByCode = async ({ code }) => {
   return new CombinedCourse(quest);
 };
 
-export { getByCode };
+const saveInBatch = async ({ combinedCourses }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const combinedCoursesToSave = combinedCourses.map(_toDTO);
+  await knexConn('quests').insert(combinedCoursesToSave);
+};
+
+const _toDTO = (combinedCourse) => {
+  const questDTO = combinedCourse.quest.toDTO();
+  return {
+    ...questDTO,
+    id: combinedCourse.id,
+    organizationId: combinedCourse.organizationId,
+    code: combinedCourse.code,
+    name: combinedCourse.name,
+    eligibilityRequirements: JSON.stringify([]),
+    successRequirements: JSON.stringify(questDTO.successRequirements),
+  };
+};
+
+export { getByCode, saveInBatch };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -20,6 +20,7 @@ import * as questRepository from './quest-repository.js';
 import * as recommendedModulesRepository from './recommended-module-repository.js';
 import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
+import * as targetProfileRepository from './target-profile-repository.js';
 import * as userRepository from './user-repository.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
@@ -36,6 +37,7 @@ const repositoriesWithoutInjectedDependencies = {
   combinedCourseParticipationRepository,
   userRepository,
   recommendedModulesRepository,
+  targetProfileRepository,
 };
 
 const dependencies = {

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -9,6 +9,7 @@ import * as targetProfilesApi from '../../../prescription/target-profile/applica
 import * as profileRewardApi from '../../../profile/application/api/profile-reward-api.js';
 import * as rewardApi from '../../../profile/application/api/reward-api.js';
 import { temporaryStorage } from '../../../shared/infrastructure/key-value-storages/index.js';
+import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
@@ -26,6 +27,7 @@ import * as userRepository from './user-repository.js';
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
 const repositoriesWithoutInjectedDependencies = {
+  accessCodeRepository,
   eligibilityRepository,
   moduleRepository,
   successRepository,

--- a/api/src/quest/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/quest/infrastructure/repositories/target-profile-repository.js
@@ -1,0 +1,12 @@
+import { TargetProfile } from '../../domain/models/TargetProfile.js';
+
+export const findByIds = async function ({ ids, targetProfilesApi }) {
+  const targetProfiles = [];
+  for (const targetProfileId of ids) {
+    const targetProfile = await targetProfilesApi.getById(targetProfileId);
+    targetProfiles.push(targetProfile);
+  }
+  return targetProfiles.map(toDomain);
+};
+
+const toDomain = (targetProfile) => new TargetProfile(targetProfile);

--- a/api/src/shared/infrastructure/repositories/access-code-repository.js
+++ b/api/src/shared/infrastructure/repositories/access-code-repository.js
@@ -1,0 +1,10 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+
+export const isCodeAvailable = async function (code) {
+  const isCodeExistsInCampaigns = await knex('campaigns').first('id').where({ code });
+  if (isCodeExistsInCampaigns) {
+    return false;
+  }
+  const isCodeExistsInCombinedCourse = await knex('quests').first('id').where({ code });
+  return !isCodeExistsInCombinedCourse;
+};

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -669,6 +669,32 @@ describe('Integration | Repository | Campaign Administration', function () {
           ]),
         );
       });
+
+      it('should returns an array even if the length is 1', async function () {
+        const campaignsToSave = [
+          {
+            name: 'Evaluation niveau 1 recherche internet',
+            code: 'ACTERD153',
+            customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+            creatorId: userId,
+            ownerId,
+            organizationId,
+            multipleSendings: true,
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId,
+            title: 'Parcours recherche internet',
+            customResultPageText: null,
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          },
+        ];
+
+        // when
+        const savedCampaigns = await campaignAdministrationRepository.save(campaignsToSave);
+
+        // then
+        expect(savedCampaigns).to.be.an('array');
+      });
     });
 
     context('when the campaign have an externalIdLabel', function () {

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -1,0 +1,179 @@
+import iconv from 'iconv-lite';
+
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Combined course | Domain | UseCases | create-combined-courses', function () {
+  it('should create combined course for given payload', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser().id;
+    const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({
+      ownerOrganizationId: firstOrganizationId,
+    });
+
+    databaseBuilder.factory.buildTargetProfileShare({
+      organizationId: secondOrganizationId,
+      targetProfileId: targetProfile.id,
+    });
+
+    await databaseBuilder.commit();
+
+    const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
+${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
+`;
+
+    const payload = iconv.encode(input, 'UTF-8');
+
+    // when
+    await usecases.createCombinedCourses({ payload });
+
+    const [firstCreatedCampaignForFirstOrganization, secondCreatedCampaignForFirstOrganization] = await knex(
+      'campaigns',
+    )
+      .where({ targetProfileId: targetProfile.id, organizationId: firstOrganizationId })
+      .orderBy('id');
+    const createdCampaignForSecondOrganization = await knex('campaigns')
+      .where({ targetProfileId: targetProfile.id, organizationId: secondOrganizationId })
+      .first();
+
+    const expectedModules = [
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: 'f32a2238-4f65-4698-b486-15d51935d335',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+    ];
+
+    const expectedFirstQuestForFirstOrganization = {
+      name: 'Combinix',
+      rewardType: null,
+      rewardId: null,
+      organizationId: firstOrganizationId,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: firstCreatedCampaignForFirstOrganization.id,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+        ...expectedModules,
+      ],
+    };
+    const expectedSecondQuestForFirstOrganization = {
+      name: 'Combinix',
+      rewardType: null,
+      rewardId: null,
+      organizationId: firstOrganizationId,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: secondCreatedCampaignForFirstOrganization.id,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+        ...expectedModules,
+      ],
+    };
+    const expectedQuestForSecondOrganization = {
+      name: 'Combinix',
+      rewardType: null,
+      rewardId: null,
+      organizationId: secondOrganizationId,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: createdCampaignForSecondOrganization.id,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+        ...expectedModules,
+      ],
+    };
+
+    // then
+    const [firstCreatedQuestForFirstOrganization, secondCreatedQuestForFirstOrganization] = await knex('quests')
+      .where('organizationId', firstOrganizationId)
+      .orderBy('id');
+    const createdQuestForSecondOrganization = await knex('quests')
+      .where('organizationId', secondOrganizationId)
+      .first();
+
+    expect(firstCreatedQuestForFirstOrganization.code).not.to.be.null;
+    expect(firstCreatedQuestForFirstOrganization.name).to.equal(expectedFirstQuestForFirstOrganization.name);
+    expect(firstCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
+      expectedFirstQuestForFirstOrganization.successRequirements,
+    );
+    expect(firstCreatedCampaignForFirstOrganization.name).to.equal(targetProfile.internalName);
+    expect(firstCreatedCampaignForFirstOrganization.title).to.equal(targetProfile.name);
+
+    expect(secondCreatedQuestForFirstOrganization.code).not.to.be.null;
+    expect(secondCreatedQuestForFirstOrganization.name).to.equal(expectedSecondQuestForFirstOrganization.name);
+    expect(secondCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
+      secondCreatedQuestForFirstOrganization.successRequirements,
+    );
+    expect(secondCreatedCampaignForFirstOrganization.name).to.equal(targetProfile.internalName);
+    expect(secondCreatedCampaignForFirstOrganization.title).to.equal(targetProfile.name);
+
+    expect(createdQuestForSecondOrganization.code).not.to.be.null;
+    expect(createdQuestForSecondOrganization.name).to.equal(expectedQuestForSecondOrganization.name);
+    expect(createdQuestForSecondOrganization.successRequirements).to.deep.equal(
+      expectedQuestForSecondOrganization.successRequirements,
+    );
+    expect(createdCampaignForSecondOrganization.name).to.equal(targetProfile.internalName);
+    expect(createdCampaignForSecondOrganization.title).to.equal(targetProfile.name);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -1,7 +1,8 @@
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Repository | combined-course', function () {
   describe('#getByCode', function () {
@@ -30,6 +31,61 @@ describe('Quest | Integration | Repository | combined-course', function () {
       // then
       expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal(`Le parcours combiné portant le code ${code} n'existe pas`);
+    });
+  });
+
+  describe('#saveInBatch', function () {
+    it('should save given combined course', async function () {
+      // given
+      const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const successRequirements = [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: 'equal',
+            },
+          },
+        },
+      ];
+      await databaseBuilder.commit();
+
+      const quest = new Quest({
+        successRequirements,
+        eligibilityRequirements: [],
+      });
+      const firstCombinedCourse = new CombinedCourse(
+        {
+          name: 'firstCombinedCourse',
+          code: 'firstCode',
+          organizationId: firstOrganizationId,
+        },
+        quest,
+      );
+      const secondCombinedCourse = new CombinedCourse(
+        {
+          name: 'secondCombinedCourse',
+          code: 'secondCode',
+          organizationId: secondOrganizationId,
+        },
+        quest,
+      );
+
+      // when
+      await combinedCourseRepository.saveInBatch({ combinedCourses: [firstCombinedCourse, secondCombinedCourse] });
+
+      // then
+      const firstSavedCombinedCourse = await knex('quests').where('organizationId', firstOrganizationId).first();
+      const secondSavedCombinedCourse = await knex('quests').where('organizationId', secondOrganizationId).first();
+
+      expect(firstSavedCombinedCourse.name).to.equal('firstCombinedCourse');
+      expect(firstSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
+
+      expect(secondSavedCombinedCourse.name).to.equal('secondCombinedCourse');
+      expect(secondSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
@@ -1,0 +1,173 @@
+import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { CombinedCourseTemplate } from '../../../../../src/quest/domain/models/CombinedCourseTemplate.js';
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () {
+  describe('#getTargetProfileIds', function () {
+    it('should return target profile ids from campaignParticipations success requirements', async function () {
+      const successRequirements = [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: 8,
+              comparison: 'equal',
+            },
+          },
+        },
+      ];
+      const combinedCourseTemplate = new CombinedCourseTemplate({
+        successRequirements,
+      });
+      expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([1, 8]);
+    });
+    it('should return empty list of ids if template has not any campaignParticipations success requirements', async function () {
+      const successRequirements = [
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+              comparison: 'equal',
+            },
+          },
+        },
+      ];
+      const combinedCourseTemplate = new CombinedCourseTemplate({
+        successRequirements,
+      });
+      expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([]);
+    });
+  });
+  describe('#toCombinedCourse', function () {
+    it('should create combined course from template and given organization data ', async function () {
+      // given
+      const organizationId = 1;
+      const firstCampaignId = 1001;
+      const secondCampaignId = 1002;
+      const firstTargetProfileId = 1;
+      const secondTargetProfileId = 2;
+      const name = 'Combinix';
+      const code = 'COMBINIX1';
+      const campaigns = [
+        {
+          id: firstCampaignId,
+          targetProfileId: firstTargetProfileId,
+        },
+        {
+          id: secondCampaignId,
+          targetProfileId: secondTargetProfileId,
+        },
+      ];
+      const successRequirements = [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: firstTargetProfileId,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: secondTargetProfileId,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+              comparison: 'equal',
+            },
+          },
+        },
+      ];
+
+      // when
+      const combinedCourseTemplate = new CombinedCourseTemplate({
+        name,
+        successRequirements,
+      });
+      const combinedCourse = combinedCourseTemplate.toCombinedCourse(code, organizationId, campaigns);
+
+      // then
+      const quest = new Quest({
+        eligibilityRequirements: [],
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: firstCampaignId,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: secondCampaignId,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      const questDTO = quest.toDTO();
+
+      expect(combinedCourse).to.be.instanceOf(CombinedCourse);
+
+      expect(combinedCourse.quest.toDTO().successRequirements).to.deep.equal(questDTO.successRequirements);
+      expect(combinedCourse.name).to.equal(name);
+      expect(combinedCourse.code).to.equal(code);
+      expect(combinedCourse.organizationId).to.equal(organizationId);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -13,9 +13,17 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign', function () 
     code = Symbol('code');
     expectedResult = {
       id: 1,
+      organizationId: 1,
       name: 'campagne',
       code: 'abc',
       targetProfileId: 123,
+      creatorId: 1,
+      type: 'type',
+      multipleSendings: true,
+      ownerId: 1,
+      title: 'titre campagne',
+      customResultPageButtonUrl: '/results',
+      customResultPageButtonText: 'Continuer',
     };
     campaignsApiStub = {
       get: sinon.stub(),

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -54,4 +54,50 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign', function () 
       expect(result).to.deep.equal(expectedResult);
     });
   });
+
+  describe('#save', function () {
+    it('should call save method from campaignsApi', async function () {
+      // given
+      const campaigns = [
+        {
+          creatorId: 2,
+          customResultPageButtonText: 'customResultPageButtonText',
+          customResultPageButtonUrl: 'customResultPageButtonUrl',
+          name: 'campagne',
+          organizationId: 3,
+          targetProfileId: 123,
+          title: 'title',
+        },
+        {
+          creatorId: 2,
+          customResultPageButtonText: 'customResultPageButtonText',
+          customResultPageButtonUrl: 'customResultPageButtonUrl',
+          name: 'campagne',
+          organizationId: 3,
+          targetProfileId: 123,
+          title: 'title',
+        },
+      ];
+
+      const campaignsApiStub = {
+        save: sinon.stub(),
+      };
+
+      const expectedCreatedCampaigns = campaigns.map((campaign, index) => ({
+        ...campaign,
+        id: index,
+        code: `code${index}`,
+      }));
+      campaignsApiStub.save.withArgs(campaigns).resolves(expectedCreatedCampaigns);
+
+      // when
+      const result = await campaignRepository.save({ campaigns, campaignsApi: campaignsApiStub });
+
+      // then
+      expect(result).to.deep.equal([
+        new Campaign({ ...expectedCreatedCampaigns[0], id: 0, code: 'code0' }),
+        new Campaign({ ...expectedCreatedCampaigns[1], id: 1, code: 'code1' }),
+      ]);
+    });
+  });
 });

--- a/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/target-profile-repository_test.js
@@ -1,0 +1,36 @@
+import { TargetProfile } from '../../../../../src/quest/domain/models/TargetProfile.js';
+import * as targetProfileRepository from '../../../../../src/quest/infrastructure/repositories/target-profile-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Repositories | target-profile', function () {
+  describe('#findByIds', function () {
+    it('should call getById method from targetProfileApi', async function () {
+      // given
+      const firstTargetProfileId = 1;
+      const secondTargetProfileId = 2;
+      const expectedFirstTargetProfile = new TargetProfile({
+        id: firstTargetProfileId,
+        name: 'targetProfileName',
+        internalName: 'targetProfileInternalName',
+      });
+      const expectedSecondTargetProfile = new TargetProfile({
+        id: secondTargetProfileId,
+        name: 'targetProfileName2',
+        internalName: 'targetProfileInternalName2',
+      });
+      const targetProfilesApiStub = {
+        getById: sinon.stub(),
+      };
+      targetProfilesApiStub.getById.withArgs(firstTargetProfileId).resolves(expectedFirstTargetProfile);
+      targetProfilesApiStub.getById.withArgs(secondTargetProfileId).resolves(expectedSecondTargetProfile);
+      // when
+      const result = await targetProfileRepository.findByIds({
+        ids: [firstTargetProfileId, secondTargetProfileId],
+        targetProfilesApi: targetProfilesApiStub,
+      });
+
+      // then
+      expect(result).to.deep.equal([expectedFirstTargetProfile, expectedSecondTargetProfile]);
+    });
+  });
+});

--- a/api/tests/shared/integration/infrastructure/repositories/access-code-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/access-code-repository_test.js
@@ -1,0 +1,27 @@
+import * as accessCodeRepository from '../../../../../src/shared/infrastructure/repositories/access-code-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('#isCodeAvailable', function () {
+  it('should return true if code does not already exist for campaign or combinedCourse', async function () {
+    const isCodeAvailable = await accessCodeRepository.isCodeAvailable('LONELYCODE');
+    expect(isCodeAvailable).to.be.true;
+  });
+
+  it('should return false if code is already used in a campaign', async function () {
+    databaseBuilder.factory.buildCampaign({ code: 'USEDCODE1' });
+    await databaseBuilder.commit();
+
+    const isCodeAvailable = await accessCodeRepository.isCodeAvailable('USEDCODE1');
+
+    expect(isCodeAvailable).to.be.false;
+  });
+
+  it('should return false if code is already used in a combined course', async function () {
+    databaseBuilder.factory.buildQuestForCombinedCourse({ code: 'USEDCODE1' });
+    await databaseBuilder.commit();
+
+    const isCodeAvailable = await accessCodeRepository.isCodeAvailable('USEDCODE1');
+
+    expect(isCodeAvailable).to.be.false;
+  });
+});


### PR DESCRIPTION
## 🔆 Problème
Maintenant que les parcours combinés sont dans un état fonctionnel dans les applis, nous voudrions pouvoir les créer directement depuis PixAdmin

## ⛱️ Proposition
Ajouter une entrée en dessous de la création des quêtes dans PixAdmin pour pouvoir créer des Parcours Combinés depuis un fichier csv

## 🌊 Remarques
Vu avec @1024pix/team-prescription on fait un petit fix dans un de leurs repo pour pouvoir utiliser campaignsApi avec un seul element dans le tableau de campagne à créer

## 🏄 Pour tester
Se connecter à PixAdmin,
Aller dans Administration
Aller créer un profil cible rattaché a l'organisation "Attestation"
Noter son id + l'id de l'orga attestation
Télécharger le template de création.
Faire une création de parcours combiné en ajoutant dans le fichier csv téléchargé : 
```csv
ID_ORGANIZATION_ATTESTATION;{"name":"Combinix trop beau","successRequirements":[{"requirement_type":"campaignParticipations","comparison":"all","data":{"targetProfileId":{"comparison":"equal","data":ID_TARGET_PROFILE}}}, {"requirement_type":"passages","comparison":"all","data":{"moduleId":{"data":"eeeb4951-6f38-4467-a4ba-0c85ed71321a","comparison":"equal"}}},{"requirement_type":"passages","comparison":"all","data":{"moduleId":{"data":"f32a2238-4f65-4698-b486-15d51935d335","comparison":"equal"}}}]};90000
```
Récupérer le code du parcours combiné crée via scalingo
Essayer de le jouer sur PixApp
