### PR TITLE
[BUGFIX] Ne pas afficher les boutons d'action lors de la prévisualisation de module existant (PIX-19127)

### DIFF
--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -91,12 +91,16 @@ export default class ModulixPreview extends Component {
     }
   }
 
+  get previewingExistingModule() {
+    return this.args.module !== undefined;
+  }
+
   get passage() {
     return this.store.createRecord('passage');
   }
 
   get formattedModule() {
-    if (this.args.module) {
+    if (this.previewingExistingModule) {
       return this.args.module;
     }
 
@@ -137,21 +141,23 @@ export default class ModulixPreview extends Component {
   <template>
     {{pageTitle this.formattedModule.title}}
 
-    <div class="module-preview__buttons">
-      <PixButton @triggerAction={{this.toggleModuleCodeEditor}}>
-        {{t "pages.modulix.preview.showJson"}}
-      </PixButton>
+    {{#unless this.previewingExistingModule}}
+      <div class="module-preview__buttons">
+        <PixButton @triggerAction={{this.toggleModuleCodeEditor}}>
+          {{t "pages.modulix.preview.showJson"}}
+        </PixButton>
 
-      <PixButtonLink
-        @variant="secondary"
-        @href="https://1024pix.github.io/modulix-editor/"
-        @size="small"
-        target="_blank"
-      >
-        {{! template-lint-disable "no-bare-strings" }}
-        Modulix Editor
-      </PixButtonLink>
-    </div>
+        <PixButtonLink
+          @variant="secondary"
+          @href="https://1024pix.github.io/modulix-editor/"
+          @size="small"
+          target="_blank"
+        >
+          {{! template-lint-disable "no-bare-strings" }}
+          Modulix Editor
+        </PixButtonLink>
+      </div>
+    {{/unless}}
 
     <div class="module-preview {{if this.moduleCodeDisplayed 'module-preview--with-editor'}}">
       <aside class="module-preview__passage">

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -51,5 +51,17 @@ module('Integration | Component | Module | Preview', function (hooks) {
       // then
       assert.dom(screen.getByRole('heading', { name: 'Existing module' })).exists();
     });
+
+    test('should not display the navbar', async function (assert) {
+      // given
+      const moduleData = { title: 'Existing module' };
+      const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+      // then
+      const linkToModulixEditor = screen.queryByRole('link', { name: 'Modulix Editor' });
+      assert.dom(linkToModulixEditor).doesNotExist();
+      const displayJsonButton = screen.queryByRole('button', { name: 'Afficher le JSON' });
+      assert.dom(displayJsonButton).doesNotExist();
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Lors de la prévisualisation de module existant, on affiche des boutons d'action permettant théoriquement de visualiser le JSON du module et retourner sur Modulix Editor. Ces actions ne fonctionnent pas comme attendu car on ne prend pas en compte le JSON en cours de modification.

## ⛱️ Proposition

Cacher les boutons lors de la prévisualisation de module existant.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Vérifier que les boutons d'action existent toujours sur [la preview "de base"](https://app-pr13198.review.pix.fr/modules/preview) en haut de la page.
- Vérifier que les boutons d'action ont bien disparu lors de [la preview de module existant](https://app-pr13198.review.pix.fr/modules/preview/bac-a-sable).
