### PR TITLE
[FEATURE] Permettre la création de plusieurs campagne via la campaignAPI du contexte Prescription (PIX-19158).

### DIFF
--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -34,21 +34,29 @@ import { SavedCampaign } from './models/SavedCampaign.js';
  * @function
  * @name save
  *
- * @param {CampaignPayload} campaign
- * @returns {Promise<SavedCampaign>}
+ * @param {CampaignPayload|Array<CampaignPayload>} campaigns
+ * @returns {Promise<SavedCampaign|Array<CampaignPayload>>}
  * @throws {UserNotAuthorizedToCreateCampaignError} to be improved to handle different error types
  */
-export const save = async (campaign) => {
-  const savedCampaign = await usecases.createCampaign({
-    campaign: {
-      ...campaign,
-      type: 'ASSESSMENT',
-      ownerId: campaign.creatorId,
-      multipleSendings: false,
-    },
-  });
+export const save = async (campaigns) => {
+  if (Array.isArray(campaigns)) {
+    const savedCampaign = await usecases.createCampaigns({
+      campaignsToCreate: campaigns,
+    });
 
-  return new SavedCampaign(savedCampaign);
+    return savedCampaign.map((campaign) => new SavedCampaign(campaign));
+  } else {
+    const savedCampaign = await usecases.createCampaign({
+      campaign: {
+        ...campaigns,
+        type: 'ASSESSMENT',
+        ownerId: campaigns.creatorId,
+        multipleSendings: false,
+      },
+    });
+
+    return new SavedCampaign(savedCampaign);
+  }
 };
 
 /**

--- a/api/src/prescription/campaign/application/api/models/SavedCampaign.js
+++ b/api/src/prescription/campaign/application/api/models/SavedCampaign.js
@@ -1,6 +1,7 @@
 export class SavedCampaign {
-  constructor({ id, code }) {
+  constructor({ id, code, targetProfileId }) {
     this.id = id;
     this.code = code;
+    this.targetProfileId = targetProfileId;
   }
 }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -97,7 +97,7 @@ const _update = async function (campaign, attributes) {
 const save = async function (campaigns, dependencies = { skillRepository }) {
   const trx = await knex.transaction();
   const campaignsToCreate = _.isArray(campaigns) ? campaigns : [campaigns];
-
+  const createdCampaigns = [];
   try {
     let latestCreatedCampaign;
     for (const campaign of campaignsToCreate) {
@@ -132,9 +132,11 @@ const save = async function (campaigns, dependencies = { skillRepository }) {
         }
         await knex.batchInsert('campaign_skills', skillData).transacting(trx);
       }
+
+      createdCampaigns.push(latestCreatedCampaign);
     }
     await trx.commit();
-    return latestCreatedCampaign;
+    return createdCampaigns.length > 1 ? createdCampaigns : createdCampaigns[0];
   } catch (err) {
     await trx.rollback();
     throw err;

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -8,42 +8,6 @@ import { domainBuilder } from '../../../../../tooling/domain-builder/domain-buil
 
 describe('Unit | API | Campaigns', function () {
   describe('#save', function () {
-    it('should return code', async function () {
-      const createdCampaign = domainBuilder.buildCampaign({ code: 'SOMETHING' });
-
-      const createCampaignStub = sinon.stub(usecases, 'createCampaign');
-      createCampaignStub
-        .withArgs({
-          campaign: {
-            name: 'ABCDiag',
-            title: 'Mon diagnostic Pix',
-            customLandingPageText: 'Bienvenue',
-            type: 'ASSESSMENT',
-            targetProfileId: 1,
-            creatorId: 2,
-            ownerId: 2,
-            organizationId: 1,
-            multipleSendings: false,
-          },
-        })
-        .resolves(createdCampaign);
-
-      // when
-      const result = await campaignApi.save({
-        name: 'ABCDiag',
-        title: 'Mon diagnostic Pix',
-        targetProfileId: 1,
-        organizationId: 1,
-        creatorId: 2,
-        customLandingPageText: 'Bienvenue',
-      });
-
-      // then
-      expect(result.id).to.equal(createdCampaign.id);
-      expect(result.code).to.equal(createdCampaign.code);
-      expect(result).not.to.be.instanceOf(Campaign);
-    });
-
     describe('When creator is not in organization or has no right to use target profile', function () {
       it('should throw an error', async function () {
         const createCampaignStub = sinon.stub(usecases, 'createCampaign');


### PR DESCRIPTION
## 🔆 Problème

Combinix à le besoin de pouvoir créer des campagnes tout en outrepassant le droit de propriété de la campagne.

## ⛱️ Proposition

Exposer au campaignApi.save dans le cas ou l'on passe un array de campagne. d'utiliser la création de campagne en masse `createCampaigns`

## 🌊 Remarques

RAS

## 🏄 Pour tester

Amusez-vous
