### PR TITLE
[BUGFIX] Corriger la gestion des tags d'orga dans PixAdmin (PIX-19161)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -149,7 +149,7 @@ class FeaturesSection extends Component {
   @service intl;
 
   attestationLabels = (attestations) => {
-    return attestations.map((name) =>
+    return attestations?.map((name) =>
       this.intl.t(`components.organizations.information-section-view.features.attestation-list.${name}`),
     );
   };


### PR DESCRIPTION
## 🔆 Problème

Sur certaines organisations, il est impossible d'éditer des tags.

## ⛱️ Proposition

Un partie de problème a été reproduit sur une orga avec des attestations qui délencheait un erreur javascript. Cette erreur a été corrigé.

## 🏄 Pour tester

1. Se connecter sur Pix Admin.
2. Aller sur l'organisation "Attestation".
  - https://admin-pr13210.review.pix.fr/organizations/107868/all-tags
3. Modifier les tags
> Tout se passe bien !
