### PR TITLE
[BUGFIX] Permettre de retourner un masteryPercentage sans arrondi pour des calculs complexe (PIX-17143).

### DIFF
--- a/api/src/evaluation/domain/services/get-mastery-percentage-service.js
+++ b/api/src/evaluation/domain/services/get-mastery-percentage-service.js
@@ -4,10 +4,11 @@
  *
  * @param {KnowledgeElement[]} knowledgeElements
  * @param {string[]} skillIds
+ * @param {boolean} round
  *
  * @returns {number}
  */
-export const getMasteryPercentage = (knowledgeElements, skillIds) => {
+export const getMasteryPercentage = (knowledgeElements, skillIds, round = true) => {
   if (!skillIds.length) return 0;
 
   const validatedKnowledgeElements = knowledgeElements.filter(({ isValidated }) => isValidated);
@@ -16,5 +17,9 @@ export const getMasteryPercentage = (knowledgeElements, skillIds) => {
     skillIds.some((id) => String(id) === String(knowledgeElement.skillId)),
   );
 
-  return Math.round((knowledgeElementsInSkills.length * 100) / skillIds.length);
+  if (round) {
+    return Math.round((knowledgeElementsInSkills.length * 100) / skillIds.length);
+  } else {
+    return (knowledgeElementsInSkills.length * 100) / skillIds.length;
+  }
 };

--- a/api/src/shared/domain/models/BadgeCriterionForCalculation.js
+++ b/api/src/shared/domain/models/BadgeCriterionForCalculation.js
@@ -7,7 +7,7 @@ export class BadgeCriterionForCalculation {
   }
 
   getAcquisitionPercentage(knowledgeElements) {
-    const masteryPercentage = getMasteryPercentage(knowledgeElements, this.skillIds);
+    const masteryPercentage = getMasteryPercentage(knowledgeElements, this.skillIds, false);
     const acquisitionPercentage = Math.round((masteryPercentage / this.threshold) * 100);
     return acquisitionPercentage > 100 ? 100 : acquisitionPercentage;
   }

--- a/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
+++ b/api/tests/unit/domain/models/BadgeCriterionForCalculation_test.js
@@ -39,7 +39,7 @@ describe('Unit | Domain | Models | BadgeCriterionForCalculation', function () {
         const acquisitionPercentage = badgeCriterion.getAcquisitionPercentage(knowledgeElements);
 
         // then
-        expect(acquisitionPercentage).to.equal(84);
+        expect(acquisitionPercentage).to.equal(83);
       });
     });
 

--- a/api/tests/unit/domain/services/get-mastery-percentage-service_test.js
+++ b/api/tests/unit/domain/services/get-mastery-percentage-service_test.js
@@ -16,6 +16,7 @@ describe('Unit | Service | Compute mastery percentage', function () {
         ].map(domainBuilder.buildKnowledgeElement),
         skillIds: [1, 2, 3],
         expected: 100,
+        expectedWithoutRound: 100,
       },
       {
         knowledgeElements: [
@@ -24,6 +25,7 @@ describe('Unit | Service | Compute mastery percentage', function () {
         ].map(domainBuilder.buildKnowledgeElement),
         skillIds: [1, 2, 3],
         expected: 67,
+        expectedWithoutRound: (2 * 100) / 3,
       },
       {
         knowledgeElements: [
@@ -32,6 +34,7 @@ describe('Unit | Service | Compute mastery percentage', function () {
         ].map(domainBuilder.buildKnowledgeElement),
         skillIds: [1, 2, 3, 4],
         expected: 25,
+        expectedWithoutRound: 25,
       },
       {
         knowledgeElements: [
@@ -40,6 +43,7 @@ describe('Unit | Service | Compute mastery percentage', function () {
         ].map(domainBuilder.buildKnowledgeElement),
         skillIds: [],
         expected: 0,
+        expectedWithoutRound: 0,
       },
       {
         knowledgeElements: [{ id: 1, skillId: 1, status: KnowledgeElement.StatusType.VALIDATED }].map(
@@ -47,6 +51,7 @@ describe('Unit | Service | Compute mastery percentage', function () {
         ),
         skillIds: [4],
         expected: 0,
+        expectedWithoutRound: 0,
       },
     ];
   });
@@ -55,6 +60,9 @@ describe('Unit | Service | Compute mastery percentage', function () {
     it('should return the correct mastery percentage', function () {
       dataSets.forEach((dataSet) => {
         expect(getMasteryPercentage(dataSet.knowledgeElements, dataSet.skillIds)).to.deep.equal(dataSet.expected);
+        expect(getMasteryPercentage(dataSet.knowledgeElements, dataSet.skillIds, false)).to.deep.equal(
+          dataSet.expectedWithoutRound,
+        );
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème

A certains endroit nous faisons des doubles arrondi, ce qui peut entrainer une baisse ou une hausse du pourcentage et deregler un arrondi futur. 

## ⛱️ Proposition

Autoriser le service getMasteryPercentage a retourner la valeur sans arrondi pour des calculs complexe

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI au vert