### PR TITLE
[BUGFIX] Afficher correctement la liste des participants (PIX-19165).

### DIFF
--- a/orga/app/components/organization-participant/list.gjs
+++ b/orga/app/components/organization-participant/list.gjs
@@ -92,17 +92,7 @@ export default class List extends Component {
   }
 
   get hasActionColumn() {
-    return Boolean(this.actionsForParticipant().length);
-  }
-
-  get extraColumnRowInfo() {
-    if (!this.args.participant.extraColumns) {
-      return [];
-    }
-
-    return Object.keys(this.args.participant.extraColumns).map((extraColumnName) =>
-      this.getExtraColumnRowValue(extraColumnName, this.args.participant),
-    );
+    return Boolean(this.actionsForParticipant(this.args.participants[0]).length);
   }
 
   get onClickLearner() {
@@ -153,19 +143,17 @@ export default class List extends Component {
 
     if (this.currentUser.canActivateOralizationLearner) {
       const oralizationActivated = participant.extraColumns['ORALIZATION'];
-      actions.push([
-        {
-          label: oralizationActivated
-            ? this.intl.t('pages.organization-participants.table.actions.disable-oralization')
-            : this.intl.t('pages.organization-participants.table.actions.enable-oralization'),
-          onClick: () =>
-            this.args.toggleOralizationFeatureForParticipant(
-              participant.id,
-              this.currentUser.organization.id,
-              !oralizationActivated,
-            ),
-        },
-      ]);
+      actions.push({
+        label: oralizationActivated
+          ? this.intl.t('pages.organization-participants.table.actions.disable-oralization')
+          : this.intl.t('pages.organization-participants.table.actions.enable-oralization'),
+        onClick: () =>
+          this.args.toggleOralizationFeatureForParticipant(
+            participant.id,
+            this.currentUser.organization.id,
+            !oralizationActivated,
+          ),
+      });
     }
 
     if (this.currentUser.canEditLearnerName) {

--- a/orga/tests/acceptance/organization-participant-list-test.js
+++ b/orga/tests/acceptance/organization-participant-list-test.js
@@ -96,5 +96,34 @@ module('Acceptance | Organization Participant List', function (hooks) {
         assert.notOk(screen.queryByText('Charles'));
       });
     });
+
+    module('when organization has oralization management feature', function (hooks) {
+      let user;
+
+      hooks.beforeEach(async function () {
+        user = createUserWithMembershipAndTermsOfServiceAccepted();
+        createPrescriberByUser({ user, features: { ORALIZATION: { active: true } } });
+        await authenticateSession(user.id);
+      });
+
+      test('should allow to deactivate oralization when feature is active', async function (assert) {
+        // given
+        const organizationId = user.memberships.models[0].organizationId;
+        server.create('organization-participant', {
+          organizationId,
+          firstName: 'Xavier',
+          lastName: 'Charles',
+          extraColumns: { ORALIZATION: true },
+        });
+
+        const screen = await visit('/participants');
+
+        // when
+        await clickByName(t('pages.sup-organization-participants.actions.show-actions'));
+
+        // then
+        assert.ok(screen.getByText(t('pages.organization-participants.table.actions.disable-oralization')));
+      });
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Actuellement, lorsque la feature de gestion de l'oralisation est activé, la liste des élèves ne fonctionne pas.

## ⛱️ Proposition

Corriger la liste en poussant uniquement un objet au lieu d'un tableau. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Se rendre sur une orga Junior, et aller dans la liste des élèves et constater le bon fonctionnement 
Puis tester le comportement sans la feature dans une orga SCO par exemple