### PR TITLE
[TECH] Revoir les tests d'intégration du locale-switcher (PIX-19152)

### DIFF
--- a/certif/tests/integration/components/locale-switcher-test.gjs
+++ b/certif/tests/integration/components/locale-switcher-test.gjs
@@ -8,6 +8,7 @@ import LocaleSwitcher from 'pix-certif/components/locale-switcher';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { setCurrentLocale } from '../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | LocaleSwitcher', function (hooks) {
@@ -30,11 +31,11 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
   module('when component renders', function () {
     test('displays current locale', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setCurrentLocale('en');
 
       // when
       const screen = await render(<template><LocaleSwitcher /></template>);
-      await click(screen.getByRole('button', { name: 'Sélectionnez une langue' }));
+      await click(screen.getByRole('button', { name: 'Select a language' }));
       await screen.findByRole('listbox');
 
       // then
@@ -44,7 +45,7 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
 
     test('displays a defaultValue', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('fr');
+      setCurrentLocale('fr');
 
       // when
       const screen = await render(<template><LocaleSwitcher @defaultValue='en' /></template>);

--- a/mon-pix/tests/integration/components/locale-switcher-test.gjs
+++ b/mon-pix/tests/integration/components/locale-switcher-test.gjs
@@ -8,6 +8,7 @@ import LocaleSwitcher from 'mon-pix/components/locale-switcher';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { setCurrentLocale } from '../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | LocaleSwitcher', function (hooks) {
@@ -30,11 +31,11 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
   module('when component renders', function () {
     test('displays current locale', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setCurrentLocale('en');
 
       // when
       const screen = await render(<template><LocaleSwitcher /></template>);
-      await click(screen.getByRole('button', { name: 'Sélectionnez une langue' }));
+      await click(screen.getByRole('button', { name: 'Select a language' }));
       await screen.findByRole('listbox');
 
       // then
@@ -44,7 +45,7 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
 
     test('displays a defaultValue', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('fr');
+      setCurrentLocale('fr');
 
       // when
       const screen = await render(<template><LocaleSwitcher @defaultValue="en" /></template>);

--- a/orga/tests/integration/components/locale-switcher-test.gjs
+++ b/orga/tests/integration/components/locale-switcher-test.gjs
@@ -8,6 +8,7 @@ import LocaleSwitcher from 'pix-orga/components/locale-switcher';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { setCurrentLocale } from '../../helpers/setup-intl';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | LocaleSwitcher', function (hooks) {
@@ -30,11 +31,11 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
   module('when component renders', function () {
     test('displays current locale', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('en');
+      setCurrentLocale('en');
 
       // when
       const screen = await render(<template><LocaleSwitcher /></template>);
-      await click(screen.getByRole('button', { name: 'Sélectionnez une langue' }));
+      await click(screen.getByRole('button', { name: 'Select a language' }));
       await screen.findByRole('listbox');
 
       // then
@@ -44,7 +45,7 @@ module('Integration | Component | LocaleSwitcher', function (hooks) {
 
     test('displays a defaultValue', async function (assert) {
       // given
-      sinon.stub(localeService, 'currentLocale').value('fr');
+      setCurrentLocale('fr');
 
       // when
       const screen = await render(<template><LocaleSwitcher @defaultValue="en" /></template>);


### PR DESCRIPTION
## 🔆 Problème

Les tests d’intégration du locale-switcher doivent utiliser setCurrentLocale pour définir la locale courante.

## ⛱️ Proposition

setCurrentLocale est importé de import { setCurrentLocale } from '../../helpers/setup-intl';

À faire sur tous les fronts, s’assurer que les autres aient le même fichier sur sur mon-pix.


## 🏄 Pour tester

- S'assurer que les tests passent au vert