### PR TITLE
[FEATURE] Afficher le nombre d'organisations enfant dans le titre de l'onglet (PIX-17881)

### DIFF
--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -41,6 +41,7 @@
     {{/if}}
     <LinkTo @route="authenticated.organizations.get.children" @model={{@model}}>
       {{t "pages.organization.navbar.children"}}
+      ({{@model.children.length}})
     </LinkTo>
   </PixTabs>
 

--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -24,7 +24,19 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
     // then
     assert.strictEqual(currentURL(), `/organizations/${organizationId}/children`);
-    assert.dom(screen.getByRole('link', { name: 'Organisations filles' })).hasClass('active');
+    assert.dom(screen.getByRole('link', { name: 'Organisations filles (0)' })).hasClass('active');
+  });
+
+  test('Displays the number of child organisations in tab name', async function (assert) {
+    // given
+    const parentOrganizationId = this.server.create('organization', { id: 1, name: 'Orga name' }).id;
+    this.server.create('organization', { id: 2, parentOrganizationId: 1, name: 'Child' });
+
+    // when
+    const screen = await visit(`/organizations/${parentOrganizationId}/children`);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Organisations filles (1)' })).hasClass('active');
   });
 
   module('when there is no child organization', function () {


### PR DESCRIPTION
## 🔆 Problème & ⛱️ Proposition
Dans Pix Admin, sur la page de détail d’une organisation

Ajouter le nombre d’organisations rattachées, dans le nom de l’onglet, entre parenthèses

L'info doit être visible pour tous les rôles

## 🏄 Pour tester
- Se connecter à Pix Admin
- Aller sur l'organisation House of the dragon 
- Constater que l'onglet "Organisations filles (1)" apparait et qu'il y a bien une seule orga fille dedans.
- Cliquer sur cette orga pour constater qu'une orga sans enfants a comme titre d'onglet "Organisations filles (0)"