### PR TITLE
[TECH] :bug: Ne pas bloquer si un `recipientEmail` n'est pas associé au candidat

### DIFF
--- a/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
+++ b/api/src/certification/results/domain/usecases/get-session-results-by-result-recipient-email.js
@@ -8,7 +8,7 @@ const getSessionResultsByResultRecipientEmail = async function ({
 }) {
   const session = await sharedSessionRepository.getWithCertificationCandidates({ id: sessionId });
   const certificationCandidateIdsForResultRecipient = _(session.certificationCandidates)
-    .filter((candidate) => candidate.resultRecipientEmail.toLowerCase() === resultRecipientEmail.toLowerCase())
+    .filter((candidate) => candidate.resultRecipientEmail?.toLowerCase() === resultRecipientEmail.toLowerCase())
     .map('id')
     .value();
 

--- a/api/tests/certification/results/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
+++ b/api/tests/certification/results/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
@@ -49,8 +49,19 @@ describe('Certification | Results | Unit | Domain | Use Cases | get-session-resu
       resultRecipientEmail: 'MATCHING@example.net',
       subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
     });
+    const certificationCandidateWithoutRecipientEmail = domainBuilder.buildCertificationCandidate({
+      id: 988,
+      resultRecipientEmail: null,
+      subscriptions: [domainBuilder.certification.enrolment.buildCoreSubscription()],
+    });
+
     const expectedSession = domainBuilder.certification.sessionManagement.buildSession({
-      certificationCandidates: [certificationCandidate1, certificationCandidate2, certificationCandidate3],
+      certificationCandidates: [
+        certificationCandidate1,
+        certificationCandidate2,
+        certificationCandidate3,
+        certificationCandidateWithoutRecipientEmail,
+      ],
       date: '2019-06-06',
       time: '12:05:30',
     });


### PR DESCRIPTION
## 🔆 Problème

Il y a des candidats qui n'ont pas de  `recipientEmail`,  il ne faut pas pour autant lever une erreur.

## ⛱️ Proposition

Faire en sorte que ce ne soit pas un problème de ne pas avoir ce mail.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Inscrire une personne pour une session de certification, sans remplir le champ `email des destinataires de résultat`.
Publier la session une fois finalisé. Il ne devrait pas y avoir d'erreur.
