### PR TITLE
[TECH] :card_file_box: Ajoute une structure de donnée  pour accueillir les anciennes calibrations

### DIFF
--- a/api/db/migrations/20250819085221_create-certification-data-calibrations-tables.js
+++ b/api/db/migrations/20250819085221_create-certification-data-calibrations-tables.js
@@ -1,0 +1,35 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable('certification-data-calibrations', function (table) {
+    table.increments('id').primary();
+    table.dateTime('calibrationDate').notNullable().comment('Date of calibration');
+    table.string('status').notNullable().comment('Validation status of the calibration');
+    table.string('scope').notNullable().comment('Calibration scope');
+
+    table.index(['calibrationDate', 'scope', 'status']);
+  });
+
+  await knex.schema.createTable('certification-data-active-calibrated-challenges', function (table) {
+    table.string('challengeId').notNullable().comment('Challenge id');
+    table.float('alpha').comment('Discriminant');
+    table.float('delta').comment('Difficulty');
+    table.integer('calibrationId').notNullable().comment('link to calibration');
+
+    table.primary(['calibrationId', 'challengeId']);
+    table.foreign('calibrationId').references('certification-data-calibrations.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable('certification-data-active-calibrated-challenges');
+  await knex.schema.dropTable('certification-data-calibrations');
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous devons pouvoir accéder aux anciennes calibrations.
Elles sont aujourd'hui placées dans le airtable, et dans le datawarehouse.
Nous allons  mettre la nouvelle calibration dans le airtable.

## ⛱️ Proposition

Créer une structure de donnée pour accueillir l'ancienne calibration.
Ajout d'un script pour copier les données de la structure du datawarehouse vers la base de données API-Pix.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Lancer la migration en RA, vérifier la structure des tables `certification-data-calibrations` et `certification-data-active-calibrated-challenges`
- Puis lancer `npm run db:rollback:latest` et vérifier que les tables ont bien été supprimées
