### PR TITLE
[BUGFIX] Réparer l'affichage du bandeau de langue non supportée  (PIX-19174)

### DIFF
--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -24,9 +24,11 @@ export default class CurrentSessionService extends SessionService {
     const queryParams = transition?.to?.queryParams;
     this.locale.setBestLocale({ user: this.currentUser.certificationPointOfContact, queryParams });
 
-    if (!this.featureToggles.featureToggles?.useLocale) {
+    if (!this.featureToggles.featureToggles?.useLocale && this.currentUser.certificationPointOfContact) {
       // should not happen with new locale system because we dont rely on user lang anymore.
       this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.certificationPointOfContact?.lang);
+    } else {
+      this.data.localeNotSupported = false;
     }
   }
 

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -22,9 +22,11 @@ export default class CurrentSessionService extends SessionService {
     const queryParams = transition?.to?.queryParams;
     this.locale.setBestLocale({ user: this.currentUser.prescriber, queryParams });
 
-    if (!this.featureToggles.featureToggles?.useLocale) {
+    if (!this.featureToggles.featureToggles?.useLocale && this.currentUser.prescriber) {
       // should not happen with new locale system because we dont rely on user lang anymore.
       this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.prescriber?.lang);
+    } else {
+      this.data.localeNotSupported = false;
     }
   }
 


### PR DESCRIPTION
## 🔆 Problème

Si une langue n’est pas supportée dans Pix Orga alors on affiche un bandeau à l’utilisateur pour l’informer que sa langue n’est pas supportée et que nous travaillons dessus.
Or, ce bandeau s’affiche aujourd’hui en recette sur le domaine .fr


## ⛱️ Proposition

Réparer le bandeau

## 🌊 Remarques

Même soucis sur pix-certif

## 🏄 Pour tester

- Sur pix-orga & pix-certif
  - Mettre le toggle useLocale à false
  - Se connecter en choisissant "Français" dans le local switcher
  - Mettre le toggle useLocale à true
  - Recharger la page
  - Constater que le bandeau qui indique que la langue n'est pas disponnible n'apparait pas
  
  
<img width="1561" height="154" alt="image" src="https://github.com/user-attachments/assets/552fa36c-1eba-4e81-aaaf-9d0f774acd08" />
