### PR TITLE
[TECH] Renommer extractLocaleFromRequest en getChallengeLocale

### DIFF
--- a/api/src/certification/enrolment/application/enrolment-controller.js
+++ b/api/src/certification/enrolment/application/enrolment-controller.js
@@ -1,14 +1,9 @@
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import { fillCandidatesImportSheet } from '../infrastructure/files/candidates-import/fill-candidates-import-sheet.js';
 import * as enrolledCandidateSerializer from '../infrastructure/serializers/enrolled-candidate-serializer.js';
 
-const enrolStudentsToSession = async function (
-  request,
-  h,
-  dependencies = { enrolledCandidateSerializer, requestResponseUtils },
-) {
+const enrolStudentsToSession = async function (request, h, dependencies = { enrolledCandidateSerializer }) {
   const sessionId = request.params.sessionId;
   const studentIds = request.deserializedPayload.organizationLearnerIds;
 

--- a/api/src/certification/evaluation/application/certification-course-controller.js
+++ b/api/src/certification/evaluation/application/certification-course-controller.js
@@ -1,13 +1,13 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases as certificationSharedUsecases } from '../../shared/domain/usecases/index.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certificationCourseSerializer from '../infrastructure/serializers/certification-course-serializer.js';
 
-const save = async function (request, h, dependencies = { extractLocaleFromRequest, certificationCourseSerializer }) {
+const save = async function (request, h, dependencies = { certificationCourseSerializer }) {
   const userId = request.auth.credentials.userId;
   const accessCode = request.payload.data.attributes['access-code'];
   const sessionId = request.payload.data.attributes['session-id'];
-  const locale = dependencies.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const { created, certificationCourse } = await usecases.retrieveLastOrCreateCertificationCourse({
     sessionId,

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { usecases as certificationSharedUsecases } from '../../../../src/certification/shared/domain/usecases/index.js';
-import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { normalizeAndRemoveAccents } from '../../../shared/infrastructure/utils/string-utils.js';
 import { Certificate } from '../domain/models/v3/Certificate.js';
@@ -11,12 +11,8 @@ import * as privateCertificateSerializer from '../infrastructure/serializers/pri
 import * as v3CertificationAttestationPdf from '../infrastructure/utils/pdf/generate-pdf-certificate.js';
 import * as v2CertificationAttestationPdf from '../infrastructure/utils/pdf/generate-v2-pdf-certificate.js';
 
-const getCertificateByVerificationCode = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, certificateSerializer },
-) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+const getCertificateByVerificationCode = async function (request, h, dependencies = { certificateSerializer }) {
+  const locale = getChallengeLocale(request);
   const i18n = getI18nFromRequest(request);
 
   let certificate;
@@ -41,9 +37,9 @@ const getCertificateByVerificationCode = async function (
 const getCertificate = async function (
   request,
   h,
-  dependencies = { requestResponseUtils, certificateSerializer, privateCertificateSerializer },
+  dependencies = { certificateSerializer, privateCertificateSerializer },
 ) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const i18n = getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;

--- a/api/src/certification/session-management/application/pre-handlers/authorization.js
+++ b/api/src/certification/session-management/application/pre-handlers/authorization.js
@@ -1,9 +1,10 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
 import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
-import * as requestResponseUtils from '../../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../../shared/infrastructure/utils/request-response-utils.js';
 import * as sessionRepository from '../../../session-management/infrastructure/repositories/session-repository.js';
 import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
+
 const { Error: JSONAPIError } = jsonapiSerializer;
 
 const FORBIDDEN_ERROR_MESSAGE = 'User is not allowed to access to this resource.';
@@ -40,12 +41,8 @@ async function checkUserHaveCertificationCenterMembershipForSession(request, h, 
   }
 }
 
-async function checkUserHaveInvigilatorAccessForSession(
-  request,
-  h,
-  dependencies = { supervisorAccessRepository, requestResponseUtils },
-) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+async function checkUserHaveInvigilatorAccessForSession(request, h, dependencies = { supervisorAccessRepository }) {
+  const userId = extractUserIdFromRequest(request);
   const sessionId = request.params.sessionId;
 
   try {

--- a/api/src/certification/shared/application/pre-handlers/session-supervisor-authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/session-supervisor-authorization.js
@@ -1,12 +1,8 @@
-import * as requestResponseUtils from '../../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../../shared/infrastructure/utils/request-response-utils.js';
 import * as supervisorAccessRepository from '../../../session-management/infrastructure/repositories/supervisor-access-repository.js';
 
-const verifyByCertificationCandidateId = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, supervisorAccessRepository },
-) {
-  const supervisorUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const verifyByCertificationCandidateId = async function (request, h, dependencies = { supervisorAccessRepository }) {
+  const supervisorUserId = extractUserIdFromRequest(request);
   const certificationCandidateId = request.params.certificationCandidateId;
   const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSessionCandidate({
     supervisorId: supervisorUserId,
@@ -20,12 +16,8 @@ const verifyByCertificationCandidateId = async function (
   return true;
 };
 
-const verifyBySessionId = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, supervisorAccessRepository },
-) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const verifyBySessionId = async function (request, h, dependencies = { supervisorAccessRepository }) {
+  const userId = extractUserIdFromRequest(request);
   const sessionId = request.params.sessionId;
 
   const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSession({

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -1,11 +1,11 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
 import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
 const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
   const { userId } = request.auth.credentials;
   const { id: campaignParticipationId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const trainings = await devcompUsecases.findCampaignParticipationTrainings({
     userId,

--- a/api/src/devcomp/application/passage-events/passage-event-controller.js
+++ b/api/src/devcomp/application/passage-events/passage-event-controller.js
@@ -1,13 +1,13 @@
 import { BadRequestError } from '../../../shared/application/http-errors.js';
 import { DomainError } from '../../../shared/domain/errors.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const create = async function (request, h, { usecases, passageEventSerializer }) {
   try {
     const passageEvents = await passageEventSerializer.deserialize(request.payload);
     await usecases.recordPassageEvents({
       events: passageEvents,
-      userId: requestResponseUtils.extractUserIdFromRequest(request),
+      userId: extractUserIdFromRequest(request),
     });
 
     return h.response().code(204);

--- a/api/src/devcomp/application/passages/passage-controller.js
+++ b/api/src/devcomp/application/passages/passage-controller.js
@@ -1,5 +1,5 @@
 import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
 const create = async function (request, h, { usecases, passageSerializer }) {
   const {
@@ -8,7 +8,7 @@ const create = async function (request, h, { usecases, passageSerializer }) {
     'occurred-at': occurredAt,
     'sequence-number': sequenceNumber,
   } = request.payload.data.attributes;
-  const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
   const passage = await usecases.createPassage({
     moduleId,
     userId,

--- a/api/src/devcomp/application/user-trainings/user-trainings-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-controller.js
@@ -1,4 +1,4 @@
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases as devcompUsecases } from '../../domain/usecases/index.js';
 import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/training-serializer.js';
 
@@ -7,11 +7,10 @@ const findPaginatedUserRecommendedTrainings = async function (
   h,
   dependencies = {
     trainingSerializer,
-    requestResponseUtils,
     devcompUsecases,
   },
 ) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const { page } = request.query;
   const { userRecommendedTrainings, meta } = await dependencies.devcompUsecases.findPaginatedUserRecommendedTrainings({
     userId: request.auth.credentials.userId,

--- a/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
+++ b/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
@@ -1,4 +1,4 @@
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as userSavedTutorialRepository from '../../infrastructure/repositories/user-saved-tutorial-repository.js';
 import * as tutorialSerializer from '../../infrastructure/serializers/jsonapi/tutorial-serializer.js';
@@ -14,10 +14,10 @@ const add = async function (request, h, dependencies = { userSavedTutorialSerial
   return h.response(dependencies.userSavedTutorialSerializer.serialize(createdUserSavedTutorial)).created();
 };
 
-const find = async function (request, h, dependencies = { requestResponseUtils, tutorialSerializer }) {
+const find = async function (request, h, dependencies = { tutorialSerializer }) {
   const { userId } = request.auth.credentials;
   const { page, filter: filters } = request.query;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const { tutorials, meta } = await usecases.findPaginatedFilteredTutorials({
     userId,
     filters,

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -1,4 +1,3 @@
-import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
 import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
@@ -11,7 +10,6 @@ const dependencies = {
   moduleSerializer,
   passageEventSerializer,
   passageSerializer,
-  extractUserIdFromRequest,
 };
 
 const handlerWithDependencies = (handler) => {

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,19 +1,18 @@
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import {
+  extractUserIdFromRequest,
+  getChallengeLocale,
+} from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
 import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
 
-const save = async function (
-  request,
-  h,
-  dependencies = { answerSerializer, assessmentRepository, requestResponseUtils },
-) {
+const save = async function (request, h, dependencies = { answerSerializer, assessmentRepository }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
+  const locale = getChallengeLocale(request);
   const assessment = await dependencies.assessmentRepository.getWithAnswers(answer.assessmentId);
   let correctedAnswer;
   if (assessment.isCompetenceEvaluation()) {
@@ -51,24 +50,24 @@ const save = async function (
   return h.response(dependencies.answerSerializer.serialize(correctedAnswer)).created();
 };
 
-const get = async function (request, _h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const get = async function (request) {
+  const userId = extractUserIdFromRequest(request);
   const answerId = request.params.id;
   const answer = await evaluationUsecases.getAnswer({ answerId, userId });
 
   return answerSerializer.serialize(answer);
 };
 
-const update = async function (request, _h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const update = async function (request) {
+  const userId = extractUserIdFromRequest(request);
   const answerId = request.params.id;
   const answer = await evaluationUsecases.getAnswer({ answerId, userId });
 
   return answerSerializer.serialize(answer);
 };
 
-const find = async function (request, _h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const find = async function (request) {
+  const userId = extractUserIdFromRequest(request);
   const challengeId = request.query.challengeId;
   const assessmentId = request.query.assessmentId;
   let answers = [];
@@ -82,9 +81,9 @@ const find = async function (request, _h, dependencies = { requestResponseUtils 
   return answerSerializer.serialize(answers);
 };
 
-const getCorrection = async function (request, _h, dependencies = { correctionSerializer, requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+const getCorrection = async function (request, _h, dependencies = { correctionSerializer }) {
+  const userId = extractUserIdFromRequest(request);
+  const locale = getChallengeLocale(request);
   const answerId = request.params.id;
 
   const correction = await evaluationUsecases.getCorrectionForAnswer({

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -3,12 +3,12 @@ import { usecases as questUsecases } from '../../../quest/domain/usecases/index.
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import * as llmChatSerializer from '../../../shared/infrastructure/serializers/llm-chat-serializer.js';
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 
 const completeAssessment = async function (request) {
   const assessmentId = request.params.id;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   await DomainTransaction.execute(async () => {
     const assessment = await evaluationUsecases.completeAssessment({ assessmentId, locale });

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
@@ -1,10 +1,10 @@
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
 import * as autonomousCoursePaginatedListSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
 import * as autonomousCourseSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
 
-const save = async (request, h, dependencies = { requestResponseUtils, usecases, autonomousCourseSerializer }) => {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const save = async (request, h, dependencies = { usecases, autonomousCourseSerializer }) => {
+  const userId = extractUserIdFromRequest(request);
 
   const deserializedPayload = await dependencies.autonomousCourseSerializer.deserialize(request.payload);
 

--- a/api/src/evaluation/application/pre-handlers/assessment-authorization.js
+++ b/api/src/evaluation/application/pre-handlers/assessment-authorization.js
@@ -1,13 +1,9 @@
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as validationErrorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 
-const verify = function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, assessmentRepository, validationErrorSerializer },
-) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const verify = function (request, h, dependencies = { assessmentRepository, validationErrorSerializer }) {
+  const userId = extractUserIdFromRequest(request);
 
   const assessmentId = parseInt(request.params.id) || parseInt(request.params.assessmentId);
 

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -3,13 +3,13 @@ import { usecases as devCompUsecases } from '../../../devcomp/domain/usecases/in
 // TODO Bounded context violation
 import * as tutorialSerializer from '../../../devcomp/infrastructure/serializers/jsonapi/tutorial-serializer.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { Scorecard } from '../../domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as scorecardSerializer from '../../infrastructure/serializers/jsonapi/scorecard-serializer.js';
 
-const getScorecard = function (request, h, dependencies = { requestResponseUtils, scorecardSerializer }) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+const getScorecard = function (request, h, dependencies = { scorecardSerializer }) {
+  const locale = getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -22,8 +22,8 @@ const getScorecard = function (request, h, dependencies = { requestResponseUtils
     .then(dependencies.scorecardSerializer.serialize);
 };
 
-const findTutorials = async function (request, h, dependencies = { requestResponseUtils, tutorialSerializer }) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+const findTutorials = async function (request, h, dependencies = { tutorialSerializer }) {
+  const locale = getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -39,10 +39,10 @@ const findTutorials = async function (request, h, dependencies = { requestRespon
   return dependencies.tutorialSerializer.serialize(tutorials);
 };
 
-const resetScorecard = function (request, h, dependencies = { scorecardSerializer, requestResponseUtils }) {
+const resetScorecard = function (request, h, dependencies = { scorecardSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const competenceId = request.params.competenceId;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   return evaluationUsecases
     .resetScorecard({ userId: authenticatedUserId, competenceId, locale })

--- a/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
+++ b/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
@@ -1,13 +1,8 @@
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { clearLog, startLogging } from '../../domain/services/smart-random-log-service.js';
 import * as algorithmSimulatorSerializer from '../../infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
 
-const getNextChallenge = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, algorithmSimulatorSerializer },
-) {
+const getNextChallenge = async function (request, h, dependencies = { algorithmSimulatorSerializer }) {
   const deserializedPayload = await dependencies.algorithmSimulatorSerializer.deserialize(request.payload);
 
   try {

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -1,7 +1,7 @@
 import { BadRequestError, UnauthorizedError } from '../../../shared/application/http-errors.js';
 import * as localeService from '../../../shared/domain/services/locale-service.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import * as oidcSerializer from '../../infrastructure/serializers/jsonapi/oidc-serializer.js';
@@ -54,11 +54,11 @@ async function authenticateOidcUser(request, h) {
  * @param h
  * @return {Promise<{access_token: string, logout_url_uuid: string}>}
  */
-async function createUser(request, h, dependencies = { requestResponseUtils, localeService }) {
+async function createUser(request, h, dependencies = { localeService }) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
   const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
 
-  const localeFromHeader = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const localeFromHeader = getChallengeLocale(request);
   const language = localeService.getBaseLocale(localeFromHeader);
 
   const origin = getForwardedOrigin(request.headers);

--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -1,5 +1,5 @@
 import * as userSerializer from '../../../shared/infrastructure/serializers/jsonapi/user-serializer.js';
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const checkResetDemand = async function (request, h, dependencies = { userSerializer }) {
@@ -9,7 +9,7 @@ const checkResetDemand = async function (request, h, dependencies = { userSerial
 };
 const createResetPasswordDemand = async function (request, h) {
   const email = request.payload.email;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   await usecases.createResetPasswordDemand({ email, locale });
 

--- a/api/src/learning-content/application/frameworks-controller.js
+++ b/api/src/learning-content/application/frameworks-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as frameworkAreasSerializer from '../infrastructure/serializers/framework-areas-serializer.js';
 import * as frameworkSerializer from '../infrastructure/serializers/framework-serializer.js';
@@ -14,12 +14,8 @@ const getFrameworkAreas = async function (request, h, dependencies = { framework
   return dependencies.frameworkAreasSerializer.serialize(areas);
 };
 
-const getPixFrameworkAreasWithoutThematics = async function (
-  request,
-  h,
-  dependencies = { extractLocaleFromRequest, frameworkAreasSerializer },
-) {
-  const locale = dependencies.extractLocaleFromRequest(request);
+const getPixFrameworkAreasWithoutThematics = async function (request, h, dependencies = { frameworkAreasSerializer }) {
+  const locale = getChallengeLocale(request);
   const areas = await usecases.getFrameworkAreas({ frameworkName: 'Pix', locale });
   return dependencies.frameworkAreasSerializer.serialize(areas, { withoutThematics: true });
 };

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 
 export async function getOrganizations(request, h, dependencies = { findOrganizations: usecases.findOrganizations }) {
@@ -8,7 +8,7 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
   const { page } = request.query;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as anonymisedCampaignAssessmentSerializer from '../infrastructure/serializers/jsonapi/anonymised-campaign-assessment-serializer.js';
 import * as availableCampaignParticipationsSerializer from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
@@ -38,7 +38,7 @@ const findPaginatedParticipationsForCampaignManagement = async function (request
 const getAnalysis = async function (request, h, dependencies = { campaignAnalysisSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignParticipationId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAnalysis = await usecases.computeCampaignParticipationAnalysis({
     userId,
@@ -51,7 +51,7 @@ const getAnalysis = async function (request, h, dependencies = { campaignAnalysi
 const getCampaignProfile = async function (request, h, dependencies = { campaignProfileSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignProfile = await usecases.getCampaignProfile({ userId, campaignId, campaignParticipationId, locale });
   return dependencies.campaignProfileSerializer.serialize(campaignProfile);
@@ -102,7 +102,7 @@ const getCampaignAssessmentParticipationResult = async function (
 ) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAssessmentParticipationResult = await usecases.getCampaignAssessmentParticipationResult({
     userId,
@@ -176,12 +176,11 @@ const getUserCampaignAssessmentResult = async function (
   _,
   dependencies = {
     participantResultSerializer,
-    extractLocaleFromRequest,
   },
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = dependencies.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAssessmentResult = await usecases.getUserCampaignAssessmentResult({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -1,7 +1,7 @@
 import { usecases as profileUsecases } from '../../../profile/domain/usecases/index.js';
 import { usecases as questUsecases } from '../../../quest/domain/usecases/index.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
 import * as sharedProfileForCampaignSerializer from '../infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
@@ -64,12 +64,11 @@ const getSharedCampaignParticipationProfile = async function (
   h,
   dependencies = {
     sharedProfileForCampaignSerializer,
-    requestResponseUtils,
   },
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const sharedProfileForCampaign = await usecases.getSharedCampaignParticipationProfile({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign/application/campaign-administration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-administration-controller.js
@@ -4,7 +4,6 @@ import * as checkAdminMemberHasRoleSuperAdminUseCase from '../../../shared/appli
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as csvCampaignsIdsParser from '../infrastructure/serializers/csv/csv-campaigns-ids-parser.js';
@@ -28,8 +27,8 @@ const createCampaigns = async function (request, h, dependencies = { csvSerializ
   return h.response(null).code(204);
 };
 
-const save = async function (request, h, dependencies = { requestResponseUtils, campaignReportSerializer }) {
-  const creatorId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const save = async function (request, h, dependencies = { campaignReportSerializer }) {
+  const creatorId = extractUserIdFromRequest(request);
   const {
     name,
     type,

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignResultLevelsPerTubesAndCompetencesSerializer from '../infrastructure/serializers/jsonapi/campaign-result-levels-per-tubes-and-competences-serializer.js';
 import * as divisionSerializer from '../infrastructure/serializers/jsonapi/division-serializer.js';
@@ -21,14 +21,10 @@ const getGroups = async function (request) {
   return groupSerializer.serialize(groups);
 };
 
-const getPresentationSteps = async function (
-  request,
-  _,
-  dependencies = { presentationStepsSerializer, extractLocaleFromRequest },
-) {
+const getPresentationSteps = async function (request, _, dependencies = { presentationStepsSerializer }) {
   const { userId } = request.auth.credentials;
   const campaignCode = request.params.campaignCode;
-  const locale = dependencies.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const presentationSteps = await usecases.getPresentationSteps({ userId, campaignCode, locale });
   return dependencies.presentationStepsSerializer.serialize(presentationSteps);
@@ -40,7 +36,7 @@ const getLevelPerTubesAndCompetences = async function (
   dependencies = { campaignResultLevelsPerTubesAndCompetencesSerializer },
 ) {
   const { campaignId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const campaignAnalysis = await usecases.getResultLevelsPerTubesAndCompetences({
     campaignId,
     locale,

--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,7 +1,7 @@
 import stream from 'node:stream';
 
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { escapeFileName } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignDetailsManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
@@ -16,12 +16,11 @@ const getByCode = async function (
   request,
   _,
   dependencies = {
-    extractLocaleFromRequest,
     campaignToJoinSerializer,
   },
 ) {
   const { code } = request.query.filter;
-  const locale = dependencies.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignToJoin = await usecases.getCampaignByCode({ code, locale });
   return dependencies.campaignToJoinSerializer.serialize(campaignToJoin);

--- a/api/src/prescription/campaign/application/campaign-results-controller.js
+++ b/api/src/prescription/campaign/application/campaign-results-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { certificabilityByLabel } from '../../shared/application/helpers.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignAssessmentResultMinimalSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js';
@@ -44,7 +44,7 @@ const findProfilesCollectionParticipations = async function (request) {
 const getCollectiveResult = async function (request, h, dependencies = { campaignCollectiveResultSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId } = request.params;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId, locale });
   return dependencies.campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -6,7 +6,7 @@ import {
 } from '../../../identity-access-management/infrastructure/utils/network.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as scoOrganizationLearnerSerializer from '../../learner-management/infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 
@@ -38,15 +38,8 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   return h.response(dependencies.scoOrganizationLearnerSerializer.serializeExternal(scoOrganizationLearner)).code(200);
 };
 
-const createAndReconcileUserToOrganizationLearner = async function (
-  request,
-  h,
-  dependencies = {
-    scoOrganizationLearnerSerializer,
-    requestResponseUtils,
-  },
-) {
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+const createAndReconcileUserToOrganizationLearner = async function (request, h) {
+  const locale = getChallengeLocale(request);
   const i18n = getI18nFromRequest(request);
 
   const payload = request.payload.data.attributes;

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -1,4 +1,4 @@
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as frameworkwithoutskillserializer from '../infrastructure/serializers/jsonapi/framework-without-skills-serializer.js';
 import * as targetProfileForSpecifierSerializer from '../infrastructure/serializers/jsonapi/target-profile-for-specifier-serializer.js';
@@ -12,9 +12,9 @@ const findTargetProfiles = async function (request, h, dependencies = { targetPr
 const getFrameworksForTargetProfileSubmission = async function (
   request,
   _,
-  dependencies = { extractLocaleFromRequest, frameworkwithoutskillserializer },
+  dependencies = { frameworkwithoutskillserializer },
 ) {
-  const locale = dependencies.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const learningContent = await usecases.getLearningContentForTargetProfileSubmission({ locale });
   return dependencies.frameworkwithoutskillserializer.serialize(learningContent.frameworks);
 };

--- a/api/src/profile/application/attestation-controller.js
+++ b/api/src/profile/application/attestation-controller.js
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
 import * as url from 'node:url';
 
-import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { FRENCH_FRANCE } from '../../shared/domain/services/locale-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as attestationSerializer from '../infrastructure/serializers/jsonapi/attestation-detail-serializer.js';
@@ -9,7 +8,7 @@ import * as pdfWithFormSerializer from '../infrastructure/serializers/pdf/pdf-wi
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-const getUserAttestation = async function (request, h, dependencies = { pdfWithFormSerializer, requestResponseUtils }) {
+const getUserAttestation = async function (request, h, dependencies = { pdfWithFormSerializer }) {
   const userId = request.params.userId;
   const attestationKey = request.params.attestationKey;
 

--- a/api/src/profile/application/profile-controller.js
+++ b/api/src/profile/application/profile-controller.js
@@ -1,19 +1,19 @@
-import * as requestResponseUtils from '../../../src/shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as profileSerializer from '../infrastructure/serializers/jsonapi/profile-serializer.js';
 
-const getProfile = function (request, h, dependencies = { profileSerializer, requestResponseUtils }) {
+const getProfile = function (request, h, dependencies = { profileSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   return usecases
     .getUserProfile({ userId: authenticatedUserId, locale })
     .then(dependencies.profileSerializer.serialize);
 };
 
-const getProfileForAdmin = function (request, h, dependencies = { profileSerializer, requestResponseUtils }) {
+const getProfileForAdmin = function (request, h, dependencies = { profileSerializer }) {
   const userId = request.params.id;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   return usecases.getUserProfile({ userId, locale }).then(dependencies.profileSerializer.serialize);
 };

--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -1,19 +1,19 @@
 import { createReadStream } from 'node:fs';
 
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
-import { requestResponseUtils } from '../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 
-const getByCode = async function (request, _, dependencies = { requestResponseUtils, combinedCourseSerializer }) {
+const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
   const { code } = request.query.filter;
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
   const combinedCourse = await usecases.getCombinedCourseByCode({ userId, code });
   return dependencies.combinedCourseSerializer.serialize(combinedCourse);
 };
 
-const start = async function (request, h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const start = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
   const code = request.params.code;
 
   await usecases.startCombinedCourse({
@@ -24,8 +24,8 @@ const start = async function (request, h, dependencies = { requestResponseUtils 
   return h.response().code(204);
 };
 
-const reassessStatus = async function (request, h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const reassessStatus = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
   const code = request.params.code;
 
   await usecases.updateCombinedCourse({

--- a/api/src/quest/application/quest-controller.js
+++ b/api/src/quest/application/quest-controller.js
@@ -1,12 +1,12 @@
 import { generateCSVTemplate } from '../../shared/infrastructure/serializers/csv/csv-template.js';
-import * as requestResponseUtils from '../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { QUEST_HEADER } from '../domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as questResultSerializer from '../infrastructure/serializers/quest-result-serializer.js';
 
-const getQuestResults = async function (request, h, dependencies = { questResultSerializer, requestResponseUtils }) {
+const getQuestResults = async function (request, h, dependencies = { questResultSerializer }) {
   const { campaignParticipationId } = request.params;
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
 
   const questResults = await usecases.getQuestResultsForCampaignParticipation({ userId, campaignParticipationId });
 

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -10,10 +10,7 @@ import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { sharedUsecases } from '../../domain/usecases/index.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
-import {
-  extractLocaleFromRequest,
-  extractUserIdFromRequest,
-} from '../../infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest, getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
 const save = async function (request, h, dependencies = { assessmentRepository }) {
   const assessment = assessmentSerializer.deserialize(request.payload);
@@ -25,7 +22,7 @@ const save = async function (request, h, dependencies = { assessmentRepository }
 
 const getAssessmentWithNextChallenge = async function (request) {
   const assessmentId = request.params.id;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const userId = extractUserIdFromRequest(request);
 
   const assessment = await DomainTransaction.execute(async () => {
@@ -62,7 +59,7 @@ const findCompetenceEvaluations = async function (request) {
 
 const autoValidateNextChallenge = async function (request, h) {
   const assessmentId = request.params.id;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
   const assessment = await sharedUsecases.getAssessment({ assessmentId, locale });
   const userId = assessment.userId;
   const fakeAnswer = new Answer({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -21,7 +21,7 @@ import {
   UserNotMemberOfOrganizationError,
 } from '../../team/domain/errors.js';
 import * as SharedDomainErrors from '../domain/errors.js';
-import { extractLocaleFromRequest } from '../infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../infrastructure/utils/request-response-utils.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
 import { HttpErrors } from './http-errors.js';
 
@@ -516,7 +516,7 @@ function _mapToHttpError(error) {
 
 function handle(request, h, error) {
   if (error instanceof SharedDomainErrors.EntityValidationError) {
-    const locale = extractLocaleFromRequest(request).split('-')[0];
+    const locale = getChallengeLocale(request).split('-')[0];
 
     const jsonApiError =
       error.invalidAttributes?.map(_formatInvalidAttribute.bind(_formatInvalidAttribute, locale, error.meta)) ||

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -6,10 +6,10 @@ import * as network from '../../../identity-access-management/infrastructure/uti
 import { config } from '../../config.js';
 import { getBaseLocale } from '../../domain/services/locale-service.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
-import { extractLocaleFromRequest } from '../../infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
 const get = function (request) {
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   return {
     name: packageJSON.name,

--- a/api/src/shared/infrastructure/i18n/i18n.js
+++ b/api/src/shared/infrastructure/i18n/i18n.js
@@ -8,7 +8,7 @@ import {
   getNearestSupportedLocale,
 } from '../../../shared/domain/services/locale-service.js';
 import { logger } from '../utils/logger.js';
-import { extractLocaleFromRequest } from '../utils/request-response-utils.js';
+import { getChallengeLocale } from '../utils/request-response-utils.js';
 
 const __dirname = import.meta.dirname;
 const translationsFolder = path.resolve(path.join(__dirname, '../../../../translations'));
@@ -57,6 +57,6 @@ export function getI18n(locale) {
  * @returns the i18n instance according the locale extracted from the request
  */
 export function getI18nFromRequest(request) {
-  const locale = request.query?.lang || extractLocaleFromRequest(request);
+  const locale = request.query?.lang || getChallengeLocale(request);
   return getI18n(locale);
 }

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -6,14 +6,6 @@ import { tokenService } from '../../../shared/domain/services/token-service.js';
 const acceptedLanguages = getChallengeLocales();
 const defaultChallengeLocale = getDefaultChallengeLocale();
 
-const requestResponseUtils = {
-  escapeFileName,
-  extractUserIdFromRequest,
-  extractLocaleFromRequest,
-  extractTimestampFromRequest,
-  extractTLDFromRequest,
-};
-
 function extractTLDFromRequest(request) {
   const forwardedHost = request.headers['x-forwarded-host'];
   if (forwardedHost.includes('.fr')) return 'fr';
@@ -39,7 +31,7 @@ function extractUserIdFromRequest(request) {
   return null;
 }
 
-function extractLocaleFromRequest(request) {
+function getChallengeLocale(request) {
   const languageHeader = request.headers && request.headers['accept-language'];
   if (!languageHeader) {
     return defaultChallengeLocale;
@@ -54,9 +46,8 @@ function extractTimestampFromRequest(request) {
 
 export {
   escapeFileName,
-  extractLocaleFromRequest,
   extractTimestampFromRequest,
   extractTLDFromRequest,
   extractUserIdFromRequest,
-  requestResponseUtils,
+  getChallengeLocale,
 };

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -1,7 +1,4 @@
-import {
-  extractLocaleFromRequest,
-  requestResponseUtils,
-} from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 
@@ -46,7 +43,7 @@ const getCertificationCenterInvitation = async function (request) {
 const sendInvitations = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
   const emails = request.payload.data.attributes.emails;
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   await usecases.createOrUpdateCertificationCenterInvitation({ certificationCenterId, emails, locale });
 
@@ -55,7 +52,7 @@ const sendInvitations = async function (request, h) {
 
 const resendCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
-  const locale = requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const certificationCenterInvitation = await usecases.resendCertificationCenterInvitation({
     certificationCenterInvitationId,

--- a/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.admin.controller.js
@@ -1,5 +1,5 @@
 import { BadRequestError } from '../../../shared/application/http-errors.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 
@@ -16,16 +16,12 @@ const findCertificationCenterMembershipsByCertificationCenter = async function (
   return dependencies.certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
 };
 
-const updateRole = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, certificationCenterMembershipSerializer },
-) {
+const updateRole = async function (request, h, dependencies = { certificationCenterMembershipSerializer }) {
   const certificationCenterMembershipId = request.params.id;
   const certificationCenterMembership = dependencies.certificationCenterMembershipSerializer.deserialize(
     request.payload,
   );
-  const pixAgentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const pixAgentUserId = extractUserIdFromRequest(request);
 
   if (certificationCenterMembershipId !== certificationCenterMembership.id) {
     throw new BadRequestError();
@@ -42,9 +38,9 @@ const updateRole = async function (
   );
 };
 
-const disableFromPixAdmin = async function (request, h, dependencies = { requestResponseUtils }) {
+const disableFromPixAdmin = async function (request, h) {
   const certificationCenterMembershipId = request.params.id;
-  const pixAgentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const pixAgentUserId = extractUserIdFromRequest(request);
 
   await usecases.disableCertificationCenterMembershipFromPixAdmin({
     certificationCenterMembershipId,

--- a/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
+++ b/api/src/team/application/certification-center-membership/certification-center-membership.controller.js
@@ -1,12 +1,12 @@
 import { ForbiddenError } from '../../../shared/application/http-errors.js';
-import { requestResponseUtils } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import * as certificationCenterMembershipSerializer from '../../../team/infrastructure/serializers/jsonapi/certification-center-membership.serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterMembershipRepository } from '../../infrastructure/repositories/certification-center-membership.repository.js';
 
-const disableFromPixCertif = async function (request, h, dependencies = { requestResponseUtils }) {
+const disableFromPixCertif = async function (request, h) {
   const certificationCenterMembershipId = request.params.certificationCenterMembershipId;
-  const currentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const currentUserId = extractUserIdFromRequest(request);
 
   await usecases.disableCertificationCenterMembershipFromPixCertif({
     certificationCenterMembershipId,
@@ -28,17 +28,13 @@ const findCertificationCenterMemberships = async function (
   return dependencies.certificationCenterMembershipSerializer.serializeMembers(certificationCenterMemberships);
 };
 
-const updateFromPixCertif = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, certificationCenterMembershipSerializer },
-) {
+const updateFromPixCertif = async function (request, h, dependencies = { certificationCenterMembershipSerializer }) {
   const certificationCenterId = request.params.certificationCenterId;
   const certificationCenterMembershipId = request.params.id;
   const certificationCenterMembership = dependencies.certificationCenterMembershipSerializer.deserialize(
     request.payload,
   );
-  const currentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const currentUserId = extractUserIdFromRequest(request);
 
   const foundCertificationCenterId = await certificationCenterMembershipRepository.getCertificationCenterId(
     certificationCenterMembershipId,
@@ -70,8 +66,8 @@ const updateReferer = async function (request, h) {
   return h.response().code(204);
 };
 
-const updateLastAccessedAt = async function (request, h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+const updateLastAccessedAt = async function (request, h) {
+  const userId = extractUserIdFromRequest(request);
   const certificationCenterMembershipId = request.params.certificationCenterMembershipId;
 
   await usecases.updateCertificationCenterMembershipLastAccessedAt({

--- a/api/src/team/application/membership/membership.controller.js
+++ b/api/src/team/application/membership/membership.controller.js
@@ -1,6 +1,6 @@
 import { BadRequestError } from '../../../shared/application/http-errors.js';
 import * as membershipSerializer from '../../../shared/infrastructure/serializers/jsonapi/membership.serializer.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const create = async function (request, h, dependencies = { membershipSerializer }) {
@@ -15,7 +15,7 @@ const create = async function (request, h, dependencies = { membershipSerializer
 
 const disable = async function (request, h) {
   const membershipId = request.params.id;
-  const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
 
   await usecases.disableMembership({ membershipId, userId });
   return h.response().code(204);
@@ -23,16 +23,16 @@ const disable = async function (request, h) {
 
 const disableOwnOrganizationMembership = async function (request, h) {
   const organizationId = request.payload.organizationId;
-  const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
 
   await usecases.disableOwnOrganizationMembership({ organizationId, userId });
 
   return h.response().code(204);
 };
 
-const update = async function (request, h, dependencies = { requestResponseUtils, membershipSerializer }) {
+const update = async function (request, h, dependencies = { membershipSerializer }) {
   const membershipId = request.params.id;
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = extractUserIdFromRequest(request);
   const membership = dependencies.membershipSerializer.deserialize(request.payload);
 
   const membershipIdFromPayload = parseInt(membership.id);
@@ -59,8 +59,8 @@ const findPaginatedFilteredMemberships = async function (request) {
   return membershipSerializer.serialize(memberships, pagination);
 };
 
-async function updateLastAccessedAt(request, h, dependencies = { requestResponseUtils }) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+async function updateLastAccessedAt(request, h) {
+  const userId = extractUserIdFromRequest(request);
   const membershipId = request.params.membershipId;
 
   await usecases.updateMembershipLastAccessedAt({

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -1,8 +1,7 @@
 import _ from 'lodash';
 
 import { MissingQueryParamError } from '../../../shared/application/http-errors.js';
-import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
-import { extractLocaleFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
 import { serializer as scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
@@ -78,14 +77,10 @@ const getOrganizationInvitation = async function (request, h, dependencies = { o
  * @param dependencies
  * @returns {Promise<void>}
  */
-const sendScoInvitation = async function (
-  request,
-  h,
-  dependencies = { requestResponseUtils, scoOrganizationInvitationSerializer },
-) {
+const sendScoInvitation = async function (request, h, dependencies = { scoOrganizationInvitationSerializer }) {
   const { uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
 
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const organizationScoInvitation = await usecases.sendScoInvitation({
     uai,
@@ -100,7 +95,7 @@ const sendScoInvitation = async function (
 const sendInvitations = async function (request, h) {
   const organizationId = request.params.id;
   const emails = request.payload.data.attributes.email.split(',');
-  const locale = extractLocaleFromRequest(request);
+  const locale = getChallengeLocale(request);
 
   const organizationInvitations = await usecases.createOrganizationInvitations({ organizationId, emails, locale });
   return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();

--- a/api/tests/devcomp/unit/application/passage-events/passage-event-controller_test.js
+++ b/api/tests/devcomp/unit/application/passage-events/passage-event-controller_test.js
@@ -1,8 +1,7 @@
 import { passageEventsController } from '../../../../../src/devcomp/application/passage-events/passage-event-controller.js';
 import { BadRequestError } from '../../../../../src/shared/application/http-errors.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
-import { expect, sinon } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Passage-Events | Controller', function () {
   describe('#create', function () {
@@ -19,13 +18,17 @@ describe('Unit | Devcomp | Application | Passage-Events | Controller', function 
       usecases.recordPassageEvents.resolves();
       const code = sinon.stub();
       const userId = 123;
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userId);
       const hStub = {
         response: () => ({ code }),
       };
 
+      const request = {
+        payload: serializedPayload,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+
       // when
-      await passageEventsController.create({ payload: serializedPayload }, hStub, {
+      await passageEventsController.create(request, hStub, {
         usecases,
         passageEventSerializer,
       });

--- a/api/tests/devcomp/unit/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/passage-controller_test.js
@@ -1,6 +1,5 @@
 import { passageController } from '../../../../../src/devcomp/application/passages/passage-controller.js';
-import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
-import { expect, sinon } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Passages | Controller', function () {
   describe('#create', function () {
@@ -15,7 +14,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const passage = {
         id: Symbol('passageId'),
       };
-      const userId = Symbol('user-id');
+      const userId = 123;
       const passageSerializer = {
         serialize: sinon.stub(),
       };
@@ -27,6 +26,7 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       hStub.response.withArgs(serializedPassage).returns({ created });
 
       const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
         payload: {
           data: {
             attributes: {
@@ -38,9 +38,6 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
           },
         },
       };
-
-      const extractUserIdFromRequestStub = sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
-      extractUserIdFromRequestStub.withArgs(request).returns(userId);
 
       const passageStartedEvent = {
         occurredAt: occurredAtDate,

--- a/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
@@ -9,32 +9,24 @@ describe('Unit | Controller | user-trainings-controller', function () {
       const page = Symbol('page');
       const locale = 'fr';
       const request = {
-        auth: {
-          credentials: {
-            userId: 1,
-          },
-        },
+        auth: { credentials: { userId: 1 } },
         query: { page },
         headers: { 'accept-language': locale },
       };
       const expectedResult = Symbol('serialized-trainings');
       const userRecommendedTrainings = Symbol('userRecommendedTrainings');
       const meta = Symbol('meta');
-      const requestResponseUtils = { extractLocaleFromRequest: sinon.stub() };
-      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
       sinon.stub(devcompUsecases, 'findPaginatedUserRecommendedTrainings').resolves({ userRecommendedTrainings, meta });
       const trainingSerializer = { serialize: sinon.stub() };
       trainingSerializer.serialize.returns(expectedResult);
 
       // when
       const response = await userTrainingsController.findPaginatedUserRecommendedTrainings(request, hFake, {
-        requestResponseUtils,
         devcompUsecases,
         trainingSerializer,
       });
 
       // then
-      expect(requestResponseUtils.extractLocaleFromRequest).to.have.been.calledOnce;
       expect(devcompUsecases.findPaginatedUserRecommendedTrainings).to.have.been.calledOnce;
       expect(devcompUsecases.findPaginatedUserRecommendedTrainings).to.have.been.calledWithExactly({
         userId: 1,

--- a/api/tests/devcomp/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -81,15 +81,12 @@ describe('Unit | Controller | User-tutorials', function () {
             size: '200',
           },
         },
+        headers: { 'accept-language': 'fr' },
       };
 
-      const expectedLocale = Symbol('locale');
       const expectedFilters = request.query.filter;
       const expectedPage = request.query.page;
       const expectedTutorials = Symbol('tutorials');
-
-      const requestResponseUtils = { extractLocaleFromRequest: sinon.stub() };
-      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(expectedLocale);
 
       const returnedTutorials = Symbol('returned-tutorials');
       const returnedMeta = Symbol('returned-meta');
@@ -104,10 +101,7 @@ describe('Unit | Controller | User-tutorials', function () {
       tutorialSerializer.serialize.returns(expectedTutorials);
 
       // when
-      const result = await userTutorialsController.find(request, hFake, {
-        tutorialSerializer,
-        requestResponseUtils,
-      });
+      const result = await userTutorialsController.find(request, hFake, { tutorialSerializer });
 
       // then
       expect(tutorialSerializer.serialize).to.have.been.calledWithExactly(returnedTutorials, returnedMeta);
@@ -115,7 +109,7 @@ describe('Unit | Controller | User-tutorials', function () {
         userId,
         filters: expectedFilters,
         page: expectedPage,
-        locale: expectedLocale,
+        locale: 'fr',
       });
       expect(result).to.equal(expectedTutorials);
     });

--- a/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
@@ -1,11 +1,12 @@
 import { autonomousCourseController } from '../../../../../src/evaluation/application/autonomous-courses/autonomous-course-controller.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
-import { expect, hFake, sinon } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | autonomous-course-controller', function () {
   describe('#save', function () {
     it('should return autonomous course created Id', async function () {
       // given
+      const userId = '123';
       const autonomousCourseAttributes = {
         'internal-title': 'Titre pour usage interne',
         'public-title': 'Titre pour usage public',
@@ -19,17 +20,14 @@ describe('Unit | Controller | autonomous-course-controller', function () {
         },
       };
       const request = {
-        headers: { 'user-agent': 'Mozilla' },
+        headers: {
+          ...generateAuthenticatedUserRequestHeaders({ userId }),
+          'user-agent': 'Mozilla',
+        },
         payload: payload,
       };
       const h = {
         ...hFake,
-      };
-
-      const userId = '123';
-
-      const requestResponseUtils = {
-        extractUserIdFromRequest: sinon.stub().returns(userId),
       };
 
       const expectedAutonomousCourseId = 123;
@@ -51,17 +49,12 @@ describe('Unit | Controller | autonomous-course-controller', function () {
         serializeId: sinon.stub().returns(serializedAutonomousCourseId),
         deserialize: sinon.stub().returns(expectedDeserializedPayloadAttributes),
       };
-      const dependencies = {
-        requestResponseUtils,
-        usecases,
-        autonomousCourseSerializer,
-      };
+      const dependencies = { usecases, autonomousCourseSerializer };
 
       // when
       await autonomousCourseController.save(request, h, dependencies);
 
       // then
-      expect(requestResponseUtils.extractUserIdFromRequest).to.have.been.called;
       expect(usecases.saveAutonomousCourse).to.have.been.calledWithExactly({
         autonomousCourse: { ...expectedDeserializedPayloadAttributes, ownerId: userId },
       });

--- a/api/tests/evaluation/unit/application/pre-handlers/assessment-authorization_test.js
+++ b/api/tests/evaluation/unit/application/pre-handlers/assessment-authorization_test.js
@@ -1,19 +1,15 @@
 import { assessmentAuthorization } from '../../../../../src/evaluation/application/pre-handlers/assessment-authorization.js';
-import { expect, hFake, sinon } from '../../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Pre-handler | Assessment Authorization', function () {
   let assessmentRepository;
-  let requestResponseUtils;
   let validationErrorSerializer;
 
   beforeEach(function () {
     assessmentRepository = {
       getByAssessmentIdAndUserId: sinon.stub(),
     };
-    requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
-    validationErrorSerializer = {
-      serialize: sinon.stub(),
-    };
+    validationErrorSerializer = { serialize: sinon.stub() };
   });
 
   describe('#verify', function () {
@@ -21,19 +17,16 @@ describe('Unit | Pre-handler | Assessment Authorization', function () {
       it('should return the assessment', async function () {
         // given
         const request = {
-          headers: { authorization: 'VALID_TOKEN' },
+          headers: generateAuthenticatedUserRequestHeaders({ userId: 100 }),
           params: {
             id: 8,
           },
         };
         const fetchedAssessment = {};
-        const extractedUserId = 100;
-        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
         assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
 
         // when
         const response = await assessmentAuthorization.verify(request, hFake, {
-          requestResponseUtils,
           assessmentRepository,
           validationErrorSerializer,
         });
@@ -48,19 +41,15 @@ describe('Unit | Pre-handler | Assessment Authorization', function () {
       it('should return the assessment', async function () {
         // given
         const request = {
-          headers: { authorization: 'VALID_TOKEN' },
           params: {
             id: 8,
           },
         };
         const fetchedAssessment = {};
-        const extractedUserId = null;
-        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
         assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
 
         // when
         const response = await assessmentAuthorization.verify(request, hFake, {
-          requestResponseUtils,
           assessmentRepository,
           validationErrorSerializer,
         });
@@ -75,17 +64,15 @@ describe('Unit | Pre-handler | Assessment Authorization', function () {
       it('should return a status 401', async function () {
         // given
         const request = {
+          headers: generateAuthenticatedUserRequestHeaders({ userId: 101 }),
           params: {
             id: 8,
           },
         };
-        const extractedUserId = 101;
-        requestResponseUtils.extractUserIdFromRequest.returns(extractedUserId);
         assessmentRepository.getByAssessmentIdAndUserId.rejects();
 
         // when
         const response = await assessmentAuthorization.verify(request, hFake, {
-          requestResponseUtils,
           assessmentRepository,
           validationErrorSerializer,
         });

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -2,7 +2,6 @@ import { usecases as devCompUsecases } from '../../../../../src/devcomp/domain/u
 import { scorecardController } from '../../../../../src/evaluation/application/scorecards/scorecard-controller.js';
 import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
-import * as requestResponseUtils from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | scorecard-controller', function () {
@@ -43,10 +42,7 @@ describe('Unit | Controller | scorecard-controller', function () {
       };
 
       // when
-      const result = await scorecardController.getScorecard(request, hFake, {
-        scorecardSerializer,
-        requestResponseUtils,
-      });
+      const result = await scorecardController.getScorecard(request, hFake, { scorecardSerializer });
 
       // then
       expect(result).to.be.equal(scorecard);
@@ -82,10 +78,7 @@ describe('Unit | Controller | scorecard-controller', function () {
       };
 
       // when
-      const result = await scorecardController.findTutorials(request, hFake, {
-        tutorialSerializer,
-        requestResponseUtils,
-      });
+      const result = await scorecardController.findTutorials(request, hFake, { tutorialSerializer });
 
       // then
       expect(result).to.be.equal(tutorials);
@@ -120,7 +113,7 @@ describe('Unit | Controller | scorecard-controller', function () {
       };
 
       // when
-      await scorecardController.resetScorecard(request, hFake, { scorecardSerializer, requestResponseUtils });
+      await scorecardController.resetScorecard(request, hFake, { scorecardSerializer });
 
       // then
       expect(evaluationUsecases.resetScorecard).to.have.been.calledWithExactly({ userId, competenceId, locale });

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -3,7 +3,6 @@ import { User } from '../../../../../src/identity-access-management/domain/model
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import * as localeService from '../../../../../src/shared/domain/services/locale-service.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
-import * as requestResponseUtils from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Application | Controller | User', function () {
@@ -210,12 +209,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
         hashPassword: sinon.stub(),
       };
 
-      dependencies = {
-        userSerializer,
-        cryptoService,
-        localeService,
-        requestResponseUtils,
-      };
+      dependencies = { userSerializer, cryptoService, localeService };
 
       sinon.stub(usecases, 'createUser').returns(savedUser);
     });
@@ -325,11 +319,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
         serialize: sinon.stub().returns(expectedSerializedUser),
       };
 
-      const requestResponseUtils = {
-        extractLocaleFromRequest: sinon.stub().returns(language),
-      };
-
-      dependencies = { userSerializer, requestResponseUtils, localeService };
+      dependencies = { userSerializer, localeService };
     });
 
     afterEach(function () {
@@ -354,13 +344,13 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
               },
             },
           },
+          headers: { 'accept-language': language },
         },
         hFake,
         dependencies,
       );
 
       // then
-      expect(dependencies.requestResponseUtils.extractLocaleFromRequest).to.have.been.called;
       expect(usecases.upgradeToRealUser).to.have.been.calledWithExactly({
         userId,
         userAttributes: {

--- a/api/tests/learning-content/unit/application/frameworks-controller_test.js
+++ b/api/tests/learning-content/unit/application/frameworks-controller_test.js
@@ -8,7 +8,6 @@ describe('Unit | Controller | frameworks-controller', function () {
   let serializedAreas;
   let frameworkAreasSerializer;
   let frameworkSerializer;
-  let requestResponseUtils;
   let serializedFrameworks;
 
   beforeEach(function () {
@@ -23,7 +22,6 @@ describe('Unit | Controller | frameworks-controller', function () {
     frameworkSerializer = {
       serialize: sinon.stub().returns(serializedFrameworks),
     };
-    requestResponseUtils = { extractLocaleFromRequest: sinon.stub().returns('en') };
   });
 
   describe('#getFrameworks', function () {
@@ -69,7 +67,6 @@ describe('Unit | Controller | frameworks-controller', function () {
 
       // when
       const result = await frameworksController.getPixFrameworkAreasWithoutThematics(request, hFake, {
-        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
         frameworkAreasSerializer,
       });
 

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -344,7 +344,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
 
     it('should call usecase and serializer with expected parameters', async function () {
       //given
-      const locale = Symbol('locale');
+      const locale = 'fr';
       const userId = Symbol('userId');
       const campaignId = Symbol('campaignId');
 
@@ -354,13 +354,12 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { campaignId },
+        headers: { 'accept-language': locale },
       };
       const dependencies = {
-        extractLocaleFromRequest: sinon.stub(),
         participantResultSerializer: { serialize: sinon.stub() },
       };
       usecases.getUserCampaignAssessmentResult.withArgs({ locale, userId, campaignId }).returns(expectedResult);
-      dependencies.extractLocaleFromRequest.withArgs(request).returns(locale);
       dependencies.participantResultSerializer.serialize.withArgs(expectedResult).returns(serializedResult);
 
       // when

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -220,39 +220,30 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
   });
 
   describe('#getSharedCampaignParticipationProfile', function () {
-    let campaignId,
-      dependencies,
-      locale,
-      request,
-      requestResponseUtilsStub,
-      sharedProfileForCampaignSerializerStub,
-      userId;
+    let campaignId, dependencies, locale, request, sharedProfileForCampaignSerializerStub, userId;
 
     beforeEach(function () {
       sinon.stub(usecases, 'getSharedCampaignParticipationProfile');
       campaignId = Symbol('campaignId');
       userId = Symbol('userId');
-      locale = Symbol('locale');
+      locale = 'fr';
 
       sharedProfileForCampaignSerializerStub = {
         serialize: sinon.stub(),
       };
-      requestResponseUtilsStub = { extractUserIdFromRequest: sinon.stub(), extractLocaleFromRequest: sinon.stub() };
       dependencies = {
         sharedProfileForCampaignSerializer: sharedProfileForCampaignSerializerStub,
-        requestResponseUtils: requestResponseUtilsStub,
       };
 
       request = {
         params: { campaignId },
         auth: { credentials: { userId } },
+        headers: { 'accept-language': locale },
       };
     });
 
     it('should call the usecase to get learner shared profile', async function () {
       // given
-      requestResponseUtilsStub.extractUserIdFromRequest.returns(100);
-      requestResponseUtilsStub.extractLocaleFromRequest.returns(locale);
       usecases.getSharedCampaignParticipationProfile.resolves({});
       const serializedCampaignProfileShared = Symbol('campaignProfileShared');
       dependencies.sharedProfileForCampaignSerializer.serialize.resolves(serializedCampaignProfileShared);

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
@@ -1,21 +1,22 @@
 import { campaignAdministrationController } from '../../../../../src/prescription/campaign/application/campaign-administration-controller.js';
 import { usecases } from '../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignExternalIdTypes } from '../../../../../src/prescription/shared/domain/constants.js';
-import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+import {
+  domainBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  hFake,
+  sinon,
+} from '../../../../test-helper.js';
 
 describe('Unit | Application | Controller | Campaign administration', function () {
   describe('#save', function () {
     let campaignReportSerializerStub;
-    let requestResponseUtils;
 
     beforeEach(function () {
       sinon.stub(usecases, 'createCampaign');
       campaignReportSerializerStub = {
         serialize: sinon.stub(),
-      };
-
-      requestResponseUtils = {
-        extractUserIdFromRequest: sinon.stub(),
       };
     });
 
@@ -24,7 +25,7 @@ describe('Unit | Application | Controller | Campaign administration', function (
       const connectedUserId = 1;
       const ownerId = 4;
       const request = {
-        auth: { credentials: { userId: connectedUserId } },
+        headers: generateAuthenticatedUserRequestHeaders({ userId: connectedUserId }),
         payload: {
           data: {
             attributes: {
@@ -43,9 +44,6 @@ describe('Unit | Application | Controller | Campaign administration', function (
             },
           },
         },
-        i18n: {
-          __: sinon.stub(),
-        },
       };
       const campaign = {
         name: 'name',
@@ -60,12 +58,11 @@ describe('Unit | Application | Controller | Campaign administration', function (
         ownerId: 4,
         multipleSendings: true,
       };
-      requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(connectedUserId);
       const expectedResult = Symbol('result');
       const createdCampaign = Symbol('created campaign');
       usecases.createCampaign.withArgs({ campaign }).resolves(createdCampaign);
       campaignReportSerializerStub.serialize.withArgs(createdCampaign).returns(expectedResult);
-      const dependencies = { requestResponseUtils, campaignReportSerializer: campaignReportSerializerStub };
+      const dependencies = { campaignReportSerializer: campaignReportSerializerStub };
 
       // when
       const response = await campaignAdministrationController.save(request, hFake, dependencies);
@@ -79,7 +76,7 @@ describe('Unit | Application | Controller | Campaign administration', function (
       // given
       const connectedUserId = 1;
       const request = {
-        auth: { credentials: { userId: connectedUserId } },
+        headers: generateAuthenticatedUserRequestHeaders({ userId: connectedUserId }),
         payload: {
           data: {
             attributes: {
@@ -97,9 +94,6 @@ describe('Unit | Application | Controller | Campaign administration', function (
             },
           },
         },
-        i18n: {
-          __: sinon.stub(),
-        },
       };
       const campaign = {
         name: 'name',
@@ -115,12 +109,11 @@ describe('Unit | Application | Controller | Campaign administration', function (
         multipleSendings: true,
       };
 
-      requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(connectedUserId);
       const expectedResult = Symbol('result');
       const createdCampaign = Symbol('created campaign');
       usecases.createCampaign.withArgs({ campaign }).resolves(createdCampaign);
       campaignReportSerializerStub.serialize.withArgs(createdCampaign).returns(expectedResult);
-      const dependencies = { requestResponseUtils, campaignReportSerializer: campaignReportSerializerStub };
+      const dependencies = { campaignReportSerializer: campaignReportSerializerStub };
 
       // when
       const response = await campaignAdministrationController.save(request, hFake, dependencies);

--- a/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
@@ -14,7 +14,6 @@ describe('Unit | Application | Controller | Campaign', function () {
       sinon.stub(usecases, 'getPresentationSteps');
 
       const dependencies = {
-        extractLocaleFromRequestStub: sinon.stub().returns(locale),
         presentationStepsSerializerStub: {
           serialize: sinon.stub(),
         },
@@ -34,7 +33,6 @@ describe('Unit | Application | Controller | Campaign', function () {
 
       // when
       const response = await campaignController.getPresentationSteps(request, hFake, {
-        extractLocaleFromRequest: dependencies.extractLocaleFromRequestStub,
         presentationStepsSerializer: dependencies.presentationStepsSerializerStub,
       });
 

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -15,9 +15,9 @@ describe('Unit | Application | Controller | Campaign detail', function () {
       const locale = FRENCH_SPOKEN;
       const request = {
         query: { filter: { code } },
+        headers: { 'accept-language': locale },
       };
       dependencies = {
-        extractLocaleFromRequest: sinon.stub().returns(locale),
         campaignToJoinSerializer: { serialize: sinon.stub() },
       };
       sinon.stub(usecases, 'getCampaignByCode').withArgs({ code, locale }).resolves(campaignToJoin);

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
@@ -287,9 +287,6 @@ describe('Unit | Controller | admin-target-profile-controller', function () {
         deserializedPayload: { organizationIds },
         params: { targetProfileId: 1 },
         payload,
-        i18n: {
-          __: sinon.stub(),
-        },
       };
 
       sinon.stub(usecases, 'detachOrganizationsFromTargetProfile');

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -38,7 +38,6 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
   describe('#getFrameworksForTargetProfileSubmission', function () {
     let frameworks;
     let frameworkwithoutskillserializer;
-    let requestResponseUtils;
     let serializedFrameworks;
 
     beforeEach(function () {
@@ -49,20 +48,16 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
       frameworkwithoutskillserializer = {
         serialize: sinon.stub().returns(serializedFrameworks),
       };
-      requestResponseUtils = { extractLocaleFromRequest: sinon.stub().returns('en') };
     });
 
     it('should fetch and return frameworks, serialized as JSONAPI', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        headers: { 'accept-language': 'en' },
       };
 
       // when
       const result = await targetProfileController.getFrameworksForTargetProfileSubmission(request, hFake, {
-        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
         frameworkwithoutskillserializer,
       });
 

--- a/api/tests/profile/unit/application/attestation-controller_test.js
+++ b/api/tests/profile/unit/application/attestation-controller_test.js
@@ -1,7 +1,6 @@
 import { attestationController } from '../../../../src/profile/application/attestation-controller.js';
 import { usecases } from '../../../../src/profile/domain/usecases/index.js';
 import { FRENCH_FRANCE } from '../../../../src/shared/domain/services/locale-service.js';
-import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Profile | Unit | Controller | attestation-controller', function () {
@@ -37,7 +36,6 @@ describe('Profile | Unit | Controller | attestation-controller', function () {
       // when
       await attestationController.getUserAttestation(request, hFake, {
         pdfWithFormSerializer: pdfWithFormSerializerStub,
-        requestResponseUtils,
       });
 
       // then

--- a/api/tests/profile/unit/application/profile-controller_test.js
+++ b/api/tests/profile/unit/application/profile-controller_test.js
@@ -1,6 +1,5 @@
 import { profileController } from '../../../../src/profile/application/profile-controller.js';
 import { usecases } from '../../../../src/profile/domain/usecases/index.js';
-import * as requestResponseUtils from '../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Profile | Unit | Controller | profile-controller', function () {
@@ -32,7 +31,7 @@ describe('Profile | Unit | Controller | profile-controller', function () {
       };
 
       // when
-      await profileController.getProfile(request, hFake, { profileSerializer, requestResponseUtils });
+      await profileController.getProfile(request, hFake, { profileSerializer });
 
       // then
       expect(usecases.getUserProfile).to.have.been.calledWithExactly({ userId, locale });

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -5,10 +5,10 @@ import {
 } from '../../../../../src/shared/domain/services/locale-service.js';
 import {
   escapeFileName,
-  extractLocaleFromRequest,
   extractTimestampFromRequest,
   extractTLDFromRequest,
   extractUserIdFromRequest,
+  getChallengeLocale,
 } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
@@ -87,13 +87,13 @@ describe('Unit | Utils | Request Utils', function () {
     });
   });
 
-  describe('#extractLocaleFromRequest', function () {
+  describe('#getChallengeLocale', function () {
     it('should return fr-fr locale when there is no header (to ensure retro-compat)', function () {
       // given
       const request = {};
 
       // when
-      const locale = extractLocaleFromRequest(request);
+      const locale = getChallengeLocale(request);
 
       // then
       expect(locale).to.equal(FRENCH_FRANCE);
@@ -113,7 +113,7 @@ describe('Unit | Utils | Request Utils', function () {
         };
 
         // when
-        const locale = extractLocaleFromRequest(request);
+        const locale = getChallengeLocale(request);
 
         // then
         expect(locale).to.equal(data.expectedLocale);

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
@@ -1,4 +1,3 @@
-import { requestResponseUtils } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { certificationCenterInvitationController } from '../../../../../src/team/application/certification-center-invitation/certification-center-invitation.controller.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../../../../src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
@@ -45,7 +44,7 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
       const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
         id: certificationCenterInvitationId,
       });
-      const locale = 'nl-BE';
+      const locale = 'nl';
       const serializerResult = {
         type: 'certification-center-invitation',
         id: certificationCenterInvitation.id,
@@ -56,14 +55,9 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
         },
       };
 
-      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest').returns(locale);
-
       sinon.stub(usecases, 'resendCertificationCenterInvitation');
       usecases.resendCertificationCenterInvitation
-        .withArgs({
-          certificationCenterInvitationId,
-          locale,
-        })
+        .withArgs({ certificationCenterInvitationId, locale })
         .resolves(certificationCenterInvitation);
 
       sinon.stub(certificationCenterInvitationSerializer, 'serializeForAdmin');
@@ -76,12 +70,12 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
         {
           auth: { credentials: { userId: 1 } },
           params: { certificationCenterInvitationId },
+          headers: { 'accept-language': locale },
         },
         hFake,
       );
 
       // then
-      expect(requestResponseUtils.extractLocaleFromRequest).to.have.been.called;
       expect(usecases.resendCertificationCenterInvitation).to.have.been.called;
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal(serializerResult);

--- a/api/tests/team/unit/application/certification-center-membership/certification-center-membership.admin.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-membership/certification-center-membership.admin.controller.test.js
@@ -1,6 +1,12 @@
 import { certificationCenterMembershipAdminController } from '../../../../../src/team/application/certification-center-membership/certification-center-membership.admin.controller.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
-import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+import {
+  domainBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  hFake,
+  sinon,
+} from '../../../../test-helper.js';
 
 describe('Unit | Team | Application | Controller | CertificationCenterMembershipAdminController', function () {
   describe('#findCertificationCenterMembershipsByCertificationCenter', function () {
@@ -79,35 +85,29 @@ describe('Unit | Team | Application | Controller | CertificationCenterMembership
   });
 
   describe('#updateRole', function () {
-    const id = 1;
-    let certificationCenterMembership;
+    it('should call usecase and serializer and return 201 HTTP code', async function () {
+      // given
+      const id = 1;
 
-    const request = {
-      params: { id },
-      payload: {},
-    };
+      const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ userId: 1234 }),
+        params: { id },
+        payload: {},
+      };
 
-    let certificationCenterMembershipSerializerStub;
-    let requestResponseUtilsStub;
-
-    beforeEach(function () {
-      sinon.stub(usecases, 'updateCertificationCenterMembership');
-      certificationCenterMembership = domainBuilder.buildCertificationCenterMembership();
-      certificationCenterMembershipSerializerStub = {
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership();
+      const certificationCenterMembershipSerializerStub = {
         deserialize: sinon.stub().returns(certificationCenterMembership),
         serializeForAdmin: sinon.stub(),
       };
-      requestResponseUtilsStub = {
-        extractUserIdFromRequest: sinon.stub().returns(1234),
-      };
-      usecases.updateCertificationCenterMembership.resolves();
-    });
 
-    it('should call usecase and serializer and return 201 HTTP code', async function () {
+      sinon.stub(usecases, 'updateCertificationCenterMembership');
+
+      usecases.updateCertificationCenterMembership.resolves();
+
       // when
       const response = await certificationCenterMembershipAdminController.updateRole(request, hFake, {
         certificationCenterMembershipSerializer: certificationCenterMembershipSerializerStub,
-        requestResponseUtils: requestResponseUtilsStub,
       });
 
       // then
@@ -122,29 +122,20 @@ describe('Unit | Team | Application | Controller | CertificationCenterMembership
   });
 
   describe('#disableFromPixAdmin', function () {
-    const id = 1;
-
-    const request = {
-      params: { id },
-      payload: {},
-    };
-
-    let requestResponseUtilsStub;
-
-    beforeEach(function () {
-      sinon.stub(usecases, 'disableCertificationCenterMembershipFromPixAdmin');
-
-      requestResponseUtilsStub = {
-        extractUserIdFromRequest: sinon.stub().returns(1234),
-      };
-      usecases.disableCertificationCenterMembershipFromPixAdmin.resolves();
-    });
-
     it('should call usecase and serializer and return 201 HTTP code', async function () {
+      // given
+      const id = 1;
+
+      const request = {
+        headers: generateAuthenticatedUserRequestHeaders({ userId: 1234 }),
+        params: { id },
+        payload: {},
+      };
+
+      sinon.stub(usecases, 'disableCertificationCenterMembershipFromPixAdmin').resolves();
+
       // when
-      const response = await certificationCenterMembershipAdminController.disableFromPixAdmin(request, hFake, {
-        requestResponseUtils: requestResponseUtilsStub,
-      });
+      const response = await certificationCenterMembershipAdminController.disableFromPixAdmin(request, hFake);
 
       // then
       expect(usecases.disableCertificationCenterMembershipFromPixAdmin).calledWith({

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -6,7 +6,6 @@ import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '.
 
 describe('Unit | Controller | certification-course-controller', function () {
   let certificationCourseSerializer;
-  let requestResponseUtils;
 
   beforeEach(function () {
     certificationCourseSerializer = {
@@ -14,7 +13,6 @@ describe('Unit | Controller | certification-course-controller', function () {
       serializeFromCertificationCourse: sinon.stub(),
       deserializeCertificationCandidateModificationCommand: sinon.stub(),
     };
-    requestResponseUtils = { extractLocaleFromRequest: sinon.stub() };
   });
 
   describe('#save', function () {
@@ -32,9 +30,9 @@ describe('Unit | Controller | certification-course-controller', function () {
             },
           },
         },
+        headers: { 'accept-language': 'fr' },
       };
       sinon.stub(usecases, 'retrieveLastOrCreateCertificationCourse');
-      requestResponseUtils.extractLocaleFromRequest.returns('fr');
       certificationCourseSerializer.serialize.returns('ok');
     });
 
@@ -48,10 +46,7 @@ describe('Unit | Controller | certification-course-controller', function () {
         .resolves({ created: true, certificationCourse: retrievedCertificationCourse });
 
       // when
-      await certificationCourseController.save(request, hFake, {
-        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
-        certificationCourseSerializer,
-      });
+      await certificationCourseController.save(request, hFake, { certificationCourseSerializer });
 
       // then
       expect(usecases.retrieveLastOrCreateCertificationCourse).to.have.been.calledOnce;
@@ -67,10 +62,7 @@ describe('Unit | Controller | certification-course-controller', function () {
       certificationCourseSerializer.serialize.resolves(serializedCertificationCourse);
 
       // when
-      const response = await certificationCourseController.save(request, hFake, {
-        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
-        certificationCourseSerializer,
-      });
+      const response = await certificationCourseController.save(request, hFake, { certificationCourseSerializer });
 
       // then
       expect(response.source).to.equal(serializedCertificationCourse);

--- a/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
@@ -1,9 +1,8 @@
 import { assessmentSupervisorAuthorization as sessionSupervisorAuthorization } from '../../../../src/certification/shared/application/pre-handlers/session-supervisor-authorization.js';
-import { expect, hFake, sinon } from '../../../test-helper.js';
+import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Pre-handler | Supervisor Authorization', function () {
   let supervisorAccessRepository;
-  let requestResponseUtils;
   let dependencies;
 
   beforeEach(function () {
@@ -11,12 +10,12 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       isUserSupervisorForSessionCandidate: sinon.stub(),
       isUserSupervisorForSession: sinon.stub(),
     };
-    requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
-    dependencies = { supervisorAccessRepository, requestResponseUtils };
+    dependencies = { supervisorAccessRepository };
   });
 
   describe('#verifyByCertificationCandidateId', function () {
     const request = {
+      headers: generateAuthenticatedUserRequestHeaders({ userId: 100 }),
       params: {
         certificationCandidateId: 8,
       },
@@ -25,7 +24,6 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
     describe('When user is the supervisor of the assessment session', function () {
       it('should return true', async function () {
         // given
-        requestResponseUtils.extractUserIdFromRequest.returns(100);
         supervisorAccessRepository.isUserSupervisorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
@@ -48,7 +46,6 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
     describe('When user is not the supervisor of the assessment session', function () {
       it('should return 401', async function () {
         // given
-        requestResponseUtils.extractUserIdFromRequest.returns(100);
         supervisorAccessRepository.isUserSupervisorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
@@ -71,6 +68,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
 
   describe('#verifyBySessionId', function () {
     const request = {
+      headers: generateAuthenticatedUserRequestHeaders({ userId: 100 }),
       params: {
         sessionId: 201,
       },
@@ -79,8 +77,6 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
     describe('When user is the supervisor of the assessment session', function () {
       it('should return true', async function () {
         // given
-        requestResponseUtils.extractUserIdFromRequest.returns(100);
-
         supervisorAccessRepository.isUserSupervisorForSession.resolves(true);
 
         // when
@@ -98,8 +94,8 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
     describe('When user is not the supervisor of the session', function () {
       it('should return status code 401', async function () {
         // given
-        requestResponseUtils.extractUserIdFromRequest.returns(101);
         supervisorAccessRepository.isUserSupervisorForSession.resolves(false);
+        request.headers = generateAuthenticatedUserRequestHeaders({ userId: 101 });
 
         // when
         const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake, dependencies);


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre de l'unification de la gestion des locales, nous allons renommer les fonctions de récupération des locales pour qu'elles indiquent explicitement quel type de locale est récupéré.

## ⛱️ Proposition

Actuellement, dans les controlleurs, on récupère la locale via `extractLocaleFromRequest(request)`. Or cette locale, **ne correspond pas réellement à la locale utilisateur mais à la locale des épreuves** (challenge locale) déterminée par rapport à celle de l'utilisateur (côté front).

Dans un premier temps, nous renommons cette fonction en `getChallengeLocale(request)`, comme ça on sait explicitement que l'on récupère la locale des épreuves.

**Ensuite dans de futures PRs**, nous allons créer une fonction `getUserLocale(request)`, qui va récupérer la locale de l'utilisateur, et nous remplacerons `getChallengeLocale` par `getUserLocale` quand c'est nécessaire.

## 🌊 Remarques

De plus, comme `getChallengeLocale(request)` est une fonction pure basée sur l'argument `request` passé en paramètre, nous l'avons enlevé de l'injection des dépendances. Il n'y a plus besoin de stubber cette fonction, il suffit de donner la bonne `request` aux controlleurs.

## 🏄 Pour tester

Il ne s'agit que renommage et d'injection de dépendance.
Tous les tests doivent être au vert.
