### PR TITLE
[FEATURE] Ajouter des vérifications sur les routes des parcours combinés (PIX-19104)

### DIFF
--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -57,6 +57,11 @@ const register = async function (server) {
       method: 'PATCH',
       path: '/api/combined-courses/{code}/reassess-status',
       config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAuthorizationToAccessCombinedCourse,
+          },
+        ],
         validate: {
           params: Joi.object({
             code: Joi.string().regex(/^[a-zA-Z0-9]*$/),

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -38,6 +38,11 @@ const register = async function (server) {
       method: 'PUT',
       path: '/api/combined-courses/{code}/start',
       config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAuthorizationToAccessCombinedCourse,
+          },
+        ],
         validate: {
           params: Joi.object({
             code: Joi.string().regex(/^[a-zA-Z0-9]*$/),

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -15,6 +15,11 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/combined-courses',
       config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAuthorizationToAccessCombinedCourse,
+          },
+        ],
         handler: combinedCourseController.getByCode,
         validate: {
           query: Joi.object({

--- a/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
+++ b/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
@@ -1,0 +1,13 @@
+import * as combinedCourseParticipantRepository from '../../infrastructure/repositories/combined-course-participant-repository.js';
+import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
+
+const execute = async function ({ userId, code }) {
+  const { organizationId } = await combinedCourseRepository.getByCode({ code });
+  const organizationLearner = await combinedCourseParticipantRepository.findOrganizationLearner({
+    userId,
+    organizationId,
+  });
+  return Boolean(organizationLearner);
+};
+
+export { execute };

--- a/api/src/quest/domain/models/OrganizationLearner.js
+++ b/api/src/quest/domain/models/OrganizationLearner.js
@@ -1,0 +1,8 @@
+export class OrganizationLearner {
+  constructor({ id, firstName, lastName, isDisabled }) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.isDisabled = isDisabled;
+  }
+}

--- a/api/src/quest/domain/usecases/start-combined-course.js
+++ b/api/src/quest/domain/usecases/start-combined-course.js
@@ -9,7 +9,7 @@ export async function startCombinedCourse({
   const combinedCourse = await combinedCourseRepository.getByCode({ code });
   const user = await userRepository.findById({ userId });
 
-  const organizationLearnerId = await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
+  const { id: organizationLearnerId } = await combinedCourseParticipantRepository.getOrCreateNewOrganizationLearner({
     userId,
     organizationId: combinedCourse.organizationId,
     organizationLearner: { firstName: user.firstName, lastName: user.lastName },

--- a/api/src/quest/infrastructure/repositories/combined-course-participant-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participant-repository.js
@@ -3,14 +3,9 @@ import { OrganizationLearnersCouldNotBeSavedError } from '../../../shared/domain
 import * as knexUtils from '../../../shared/infrastructure/utils/knex-utils.js';
 
 export async function getOrCreateNewOrganizationLearner({ organizationLearner, userId, organizationId }) {
-  const knexConnection = DomainTransaction.getConnection();
+  const existingOrganizationLearner = await findOrganizationLearner({ userId, organizationId });
 
-  const existingOrganizationLearner = await knexConnection('view-active-organization-learners')
-    .where({
-      userId,
-      organizationId,
-    })
-    .first();
+  const knexConnection = DomainTransaction.getConnection();
 
   if (existingOrganizationLearner) {
     if (existingOrganizationLearner.isDisabled) {
@@ -43,4 +38,14 @@ export async function getOrCreateNewOrganizationLearner({ organizationLearner, u
       throw error;
     }
   }
+}
+
+export async function findOrganizationLearner({ userId, organizationId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  return knexConnection('view-active-organization-learners')
+    .where({
+      userId,
+      organizationId,
+    })
+    .first();
 }

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -674,7 +674,7 @@ async function checkAuthorizationToAccessCombinedCourse(
   dependencies = { checkAuthorizationToAccessCombinedCourseUsecase },
 ) {
   const userId = request.auth.credentials.userId;
-  const code = request.query.filter.code;
+  const code = request.query?.filter?.code || request.params.code;
 
   const belongsToOrganization = await dependencies.checkAuthorizationToAccessCombinedCourseUsecase.execute({
     userId,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -6,6 +6,7 @@ import * as checkUserIsCandidateUseCase from '../../certification/enrolment/appl
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
 import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js';
+import * as checkAuthorizationToAccessCombinedCourseUsecase from '../../quest/application/usecases/check-authorization-to-access-combined-course.js';
 import * as isSchoolSessionActive from '../../school/application/usecases/is-school-session-active.js';
 import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
@@ -38,6 +39,7 @@ import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/check
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkUserOwnsCertificationCourseUseCase from './usecases/checkUserOwnsCertificationCourse.js';
 import * as checkUserIsMemberOfAnOrganizationUseCase from './validator/checkUserIsMemberOfAnOrganization.js';
+
 const { Error: JSONAPIError } = jsonapiSerializer;
 const { has } = lodash;
 
@@ -666,6 +668,23 @@ async function checkAuthorizationToAccessCampaign(
   return _replyForbiddenError(h);
 }
 
+async function checkAuthorizationToAccessCombinedCourse(
+  request,
+  h,
+  dependencies = { checkAuthorizationToAccessCombinedCourseUsecase },
+) {
+  const userId = request.auth.credentials.userId;
+  const code = request.query.filter.code;
+
+  const belongsToOrganization = await dependencies.checkAuthorizationToAccessCombinedCourseUsecase.execute({
+    userId,
+    code,
+  });
+
+  if (belongsToOrganization) return h.response(true);
+  return _replyForbiddenError(h);
+}
+
 function hasAtLeastOneAccessOf(securityChecks) {
   return async (request, h) => {
     const responses = await PromiseUtils.map(securityChecks, (securityCheck) => securityCheck(request, h));
@@ -870,6 +889,7 @@ const securityPreHandlers = {
   checkAdminMemberHasRoleSupport,
   checkAuthorizationToManageCampaign,
   checkAuthorizationToAccessCampaign,
+  checkAuthorizationToAccessCombinedCourse,
   checkCertificationCenterIsNotScoManagingStudents,
   checkIfUserIsBlocked,
   checkOrganizationHasFeature,

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -137,6 +137,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[]}";${userId}
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId });
       databaseBuilder.factory.buildQuest({ name: 'MA QUETE', organizationId, code: 'COMBINIX2' });
 
       await databaseBuilder.commit();

--- a/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
@@ -1,0 +1,35 @@
+import * as checkAuthorizationToAccessCombinedCourse from '../../../../../src/quest/application/usecases/check-authorization-to-access-combined-course.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Unit | Application | Usecases | checkAuthorizationToAccessCombinedCourse', function () {
+  it('should return true if user belongs to combined course organization', async function () {
+    // given
+    const code = 'COMBINIX1';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+    databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
+    await databaseBuilder.commit();
+
+    // when
+    const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+
+    // then
+    expect(authorized).to.be.true;
+  });
+
+  it('should return false otherwise', async function () {
+    // given
+    const code = 'COMBINIX1';
+    const userId = databaseBuilder.factory.buildUser().id;
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+    await databaseBuilder.commit();
+
+    // when
+    const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+
+    // then
+    expect(authorized).to.be.false;
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
@@ -41,4 +41,34 @@ describe('Quest | Integration | Infrastructure | repositories | Combined Course 
       expect(learners[0].lastName).to.equal('Fonfek');
     });
   });
+  describe('#findOrganizationLearner', function () {
+    it('should return organization learner if exists', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await combinedCourseParticipantRepository.findOrganizationLearner({
+        userId: organizationLearner.userId,
+        organizationId,
+      });
+      expect(result).to.deep.equal(organizationLearner);
+    });
+    it('should return nothing otherwise', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      const result = await combinedCourseParticipantRepository.findOrganizationLearner({
+        userId,
+        organizationId,
+      });
+
+      //then
+      expect(result).to.be.undefined;
+    });
+  });
 });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participant-repository_test.js
@@ -1,3 +1,4 @@
+import { OrganizationLearner } from '../../../../../src/quest/domain/models/OrganizationLearner.js';
 import * as combinedCourseParticipantRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participant-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
@@ -17,7 +18,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined Course 
         userId: organizationLearner.userId,
         organizationId,
       });
-      expect(result).to.be.equal(organizationLearner.id);
+      expect(result.id).to.be.equal(organizationLearner.id);
     });
     it('should create a new organization learner if organization learner does not exist', async function () {
       const organizationLearner = { firstName: 'Sophie', lastName: 'Fonfek' };
@@ -55,7 +56,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined Course 
         userId: organizationLearner.userId,
         organizationId,
       });
-      expect(result).to.deep.equal(organizationLearner);
+      expect(result).to.deep.equal(new OrganizationLearner(organizationLearner));
     });
     it('should return nothing otherwise', async function () {
       const userId = databaseBuilder.factory.buildUser().id;
@@ -68,7 +69,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined Course 
       });
 
       //then
-      expect(result).to.be.undefined;
+      expect(result).to.be.null;
     });
   });
 });

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -37,4 +37,21 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
     });
   });
+
+  describe('PATCH /api/combined-course/{code}/reassess-status', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCombinedCourse').returns(() => true);
+      sinon.stub(combinedCourseController, 'reassessStatus').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('PATCH', '/api/combined-courses/ABC/reassess-status');
+
+      // then
+      expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
+    });
+  });
 });

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -1,0 +1,23 @@
+import { combinedCourseController } from '../../../../src/quest/application/combined-course-controller.js';
+import * as combinedCourseRoute from '../../../../src/quest/application/combined-course-route.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Quest | Unit | Routes | combined-course-route', function () {
+  describe('GET /api/combined-course', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCombinedCourse').returns(() => true);
+      sinon.stub(combinedCourseController, 'getByCode').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('GET', '/api/combined-courses?filter[code]=ABC');
+
+      // then
+      expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
+    });
+  });
+});

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -20,4 +20,21 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
       expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
     });
   });
+
+  describe('PUT /api/combined-course/{code}/start', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCombinedCourse').returns(() => true);
+      sinon.stub(combinedCourseController, 'start').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('PUT', '/api/combined-courses/ABC/start');
+
+      // then
+      expect(securityPreHandlers.checkAuthorizationToAccessCombinedCourse).to.have.been.called;
+    });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème
Nous n'avions absolument pas ajouté de pre-handler sur les routes concernant les parcours combinés. Il était alors possible d'appeler ses endpoints pour n'importe qui n'étant pas prescrit de l'organisation.

## ⛱️ Proposition
Creer un préhandler qui vérifie pour un code de parcours combiné donné et le userId connecté que celui ci est bien prescrit de l'organisation

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Euh
S'amuser a faire un curl avec un user non prescrit de l'organisation ayant le parcours COMBINIX1 ? 
Sinon faire confiance a nos tests 😎 
