### PR TITLE
[FEATURE] Ajouter le nouveau POI complete-phrase à modulix (relatif à pix-18766 | pix epreuves)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -17,6 +17,122 @@
       "type": "blank",
       "grains": [
         {
+          "id": "208deb8a-4580-4a33-8ca5-32205f5f07dd",
+          "type": "lesson",
+          "title": "complete-phrase",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5a7f67f1-dd86-4cdb-a2b6-b5e4b51cb3dc",
+                "type": "text",
+                "content": "<p>complete-phrase</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "9fb9c98c-50e1-4338-9128-521e48060ad7",
+                "type": "custom",
+                "tagName": "complete-phrase",
+                "props": {
+                  "titleLevel": 2,
+                  "listOfProbabilityBarsLists": [
+                    [
+                      {
+                        "name": "chocolat",
+                        "percent": 100
+                      },
+                      {
+                        "name": "beurre",
+                        "percent": 80
+                      },
+                      {
+                        "name": "sucre",
+                        "percent": 80
+                      },
+                      {
+                        "name": "sirop",
+                        "percent": 60
+                      },
+                      {
+                        "name": "caramel",
+                        "percent": 43
+                      },
+                      {
+                        "name": "miel",
+                        "percent": 25
+                      },
+                      {
+                        "name": "fromage",
+                        "percent": 20
+                      }
+                    ],
+                    [
+                      {
+                        "name": "et",
+                        "percent": 100
+                      },
+                      {
+                        "name": "avec",
+                        "percent": 80
+                      },
+                      {
+                        "name": "fondu",
+                        "percent": 80
+                      },
+                      {
+                        "name": "avec",
+                        "percent": 60
+                      },
+                      {
+                        "name": "dedans",
+                        "percent": 43
+                      }
+                    ],
+                    [
+                      {
+                        "name": "du",
+                        "percent": 100
+                      },
+                      {
+                        "name": "puis",
+                        "percent": 80
+                      }
+                    ],
+                    [
+                      {
+                        "name": "sucre",
+                        "percent": 100
+                      },
+                      {
+                        "name": "miel",
+                        "percent": 80
+                      },
+                      {
+                        "name": "caramel",
+                        "percent": 60
+                      },
+                      {
+                        "name": "chocolat",
+                        "percent": 20
+                      }
+                    ]
+                  ],
+                  "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
+                  "llmMessage": "On peut mettre du ",
+                  "wordsToAdd": [
+                    "beurre",
+                    "et",
+                    "du",
+                    "sucre"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "d31c9fb7-ebaf-4d60-be31-a5c1aafa5ecf",
           "type": "lesson",
           "title": "message-conversation",

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -158,11 +158,29 @@ const pixCursorPropsSchema = Joi.object({
   options: Joi.array().items(pixCursorOptions.required()).required(),
 });
 
+const completePhrasePropsSchema = Joi.object({
+  titleLevel: Joi.number().required(),
+  listOfProbabilityBarsLists: Joi.array()
+    .items(
+      Joi.array().items(
+        Joi.object({
+          name: Joi.string().required(),
+          percent: Joi.number().integer().required(),
+        }),
+      ),
+    )
+    .required(),
+  userMessage: Joi.string().required(),
+  llmMessage: Joi.string().required(),
+  wordsToAdd: Joi.array().items(Joi.string()).required(),
+});
+
 const customElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
   tagName: Joi.string()
     .valid(
+      'complete-phrase',
       'image-quiz',
       'image-quizzes',
       'llm-compare-messages',
@@ -177,6 +195,7 @@ const customElementSchema = Joi.object({
   props: Joi.alternatives()
     .conditional('tagName', {
       switch: [
+        { is: 'complete-phrase', then: completePhrasePropsSchema },
         { is: 'image-quiz', then: imageQuizPropsSchema },
         { is: 'image-quizzes', then: imageQuizzesPropsSchema },
         { is: 'llm-compare-messages', then: llmCompareMessagesPropsSchema },

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.9.6",
+        "@1024pix/epreuves-components": "^0.10.0",
         "@1024pix/eslint-plugin": "^2.1.8",
         "@1024pix/pix-ui": "^55.25.2",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -98,11 +98,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.6.tgz",
-      "integrity": "sha512-qu3PR1CgzBKfmzivfdugLLD2ougnh2f4IqEJc9zDyJcbncGUSm8S7gegmHYvjhOkHCAsQ9WfN8sOXEpVU4Z0vQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.10.0.tgz",
+      "integrity": "sha512-GdApwIGphYvmwHN2e7FsEJRJsV30WibTzFVCeIFqrHlnl+dUez14M4ds/N1nsLa+vGbNx1YEIBlOasiSs9njhw==",
+      "dev": true
     },
     "node_modules/@1024pix/eslint-plugin": {
       "version": "2.1.8",

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.9.6",
+    "@1024pix/epreuves-components": "^0.10.0",
     "@1024pix/eslint-plugin": "^2.1.8",
     "@1024pix/pix-ui": "^55.25.2",
     "@1024pix/stylelint-config": "^5.1.34",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^0.9.6",
+        "@1024pix/epreuves-components": "^0.10.0",
         "@1024pix/eslint-plugin": "^2.1.8",
         "@1024pix/pix-ui": "^55.25.2",
         "@1024pix/stylelint-config": "^5.1.34",
@@ -805,11 +805,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.9.6.tgz",
-      "integrity": "sha512-qu3PR1CgzBKfmzivfdugLLD2ougnh2f4IqEJc9zDyJcbncGUSm8S7gegmHYvjhOkHCAsQ9WfN8sOXEpVU4Z0vQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-0.10.0.tgz",
+      "integrity": "sha512-GdApwIGphYvmwHN2e7FsEJRJsV30WibTzFVCeIFqrHlnl+dUez14M4ds/N1nsLa+vGbNx1YEIBlOasiSs9njhw==",
+      "dev": true
     },
     "node_modules/@1024pix/eslint-plugin": {
       "version": "2.1.8",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^0.9.6",
+    "@1024pix/epreuves-components": "^0.10.0",
     "@1024pix/eslint-plugin": "^2.1.8",
     "@1024pix/pix-ui": "^55.25.2",
     "@1024pix/stylelint-config": "^5.1.34",


### PR DESCRIPTION
## 🔆 Problème
Il manquait le POI complete-phrase

## ⛱️ Proposition
mettre à jour le package correspondant qui ajoute ledit POI

## 🌊 Remarques
RAS

## 🏄 Pour tester
Aller sur la démo de module et constater que `complete-phrase` apparaît comme première leçon.
