### PR TITLE
[FEATURE] Récupérer la locale depuis le cookie sous FT (PIX-18980)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -64,12 +64,14 @@ export default {
     type: 'boolean',
     description: 'Enable usage of cookie locale in Frontend apps keeping retro-compatibility with the backend.',
     defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-acces'],
   },
   useCookieLocaleInApi: {
     type: 'boolean',
     description: 'Enable usage of cookie locale in the API to get the user or challenge locales.',
     defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
     tags: ['team-acces'],
   },
 };

--- a/api/src/certification/enrolment/application/attendance-sheet-controller.js
+++ b/api/src/certification/enrolment/application/attendance-sheet-controller.js
@@ -5,7 +5,7 @@ const getAttendanceSheet = async function (request, h) {
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
 
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const { attendanceSheet, fileName } = await usecases.getAttendanceSheet({ sessionId, userId, i18n });
   return h

--- a/api/src/certification/enrolment/application/enrolment-controller.js
+++ b/api/src/certification/enrolment/application/enrolment-controller.js
@@ -14,7 +14,7 @@ const enrolStudentsToSession = async function (request, h, dependencies = { enro
 };
 
 const getCandidatesImportSheet = async function (request, h, dependencies = { fillCandidatesImportSheet }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
@@ -40,7 +40,7 @@ const getCandidatesImportSheet = async function (request, h, dependencies = { fi
 };
 
 const importCertificationCandidatesFromCandidatesImportSheet = async function (request) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const odsBuffer = request.payload;

--- a/api/src/certification/enrolment/application/session-mass-import-controller.js
+++ b/api/src/certification/enrolment/application/session-mass-import-controller.js
@@ -17,7 +17,7 @@ const createSessions = async function (request, h) {
 };
 
 const validateSessions = async function (request, h, dependencies = { csvHelpers, csvSerializer }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const certificationCenterId = request.params.certificationCenterId;
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/certification/evaluation/application/certification-course-controller.js
+++ b/api/src/certification/evaluation/application/certification-course-controller.js
@@ -7,7 +7,7 @@ const save = async function (request, h, dependencies = { certificationCourseSer
   const userId = request.auth.credentials.userId;
   const accessCode = request.payload.data.attributes['access-code'];
   const sessionId = request.payload.data.attributes['session-id'];
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const { created, certificationCourse } = await usecases.retrieveLastOrCreateCertificationCourse({
     sessionId,

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -12,8 +12,8 @@ import * as v3CertificationAttestationPdf from '../infrastructure/utils/pdf/gene
 import * as v2CertificationAttestationPdf from '../infrastructure/utils/pdf/generate-v2-pdf-certificate.js';
 
 const getCertificateByVerificationCode = async function (request, h, dependencies = { certificateSerializer }) {
-  const locale = getChallengeLocale(request);
-  const i18n = getI18nFromRequest(request);
+  const locale = await getChallengeLocale(request);
+  const i18n = await getI18nFromRequest(request);
 
   let certificate;
   const verificationCode = request.payload.verificationCode;
@@ -39,8 +39,8 @@ const getCertificate = async function (
   h,
   dependencies = { certificateSerializer, privateCertificateSerializer },
 ) {
-  const locale = getChallengeLocale(request);
-  const i18n = getI18nFromRequest(request);
+  const locale = await getChallengeLocale(request);
+  const i18n = await getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;
 
@@ -63,7 +63,7 @@ const getCertificate = async function (
 };
 
 const findUserCertificates = async function (request) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const userId = request.auth.credentials.userId;
 
@@ -78,7 +78,7 @@ const getPDFCertificate = async function (
 ) {
   const certificationCourseId = request.params.certificationCourseId;
   const { isFrenchDomainExtension } = request.query;
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const certificate = await usecases.getCertificate({ certificationCourseId, locale: i18n.getLocale() });
 
@@ -117,7 +117,7 @@ const getSessionCertificates = async function (
   h,
   dependencies = { v2CertificationAttestationPdf, v3CertificationAttestationPdf },
 ) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const isFrenchDomainExtension = request.query.isFrenchDomainExtension;
@@ -159,7 +159,7 @@ const downloadDivisionCertificates = async function (
   h,
   dependencies = { v2CertificationAttestationPdf, v3CertificationAttestationPdf },
 ) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const { division, isFrenchDomainExtension } = request.query;

--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -32,7 +32,7 @@ const getSessionResultsByRecipientEmail = async function (
   h,
   dependencies = { tokenService, getSessionCertificationResultsCsv },
 ) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const token = request.params.token;
 
@@ -59,7 +59,7 @@ const postSessionResultsToDownload = async function (
   h,
   dependencies = { tokenService, getSessionCertificationResultsCsv },
 ) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const { sessionId } = dependencies.tokenService.extractCertificationResultsLink(request.payload.token);
   const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
@@ -88,7 +88,7 @@ const getCertifiedProfile = async function (
 };
 
 const generateSessionResultsDownloadLink = async function (request, h, dependencies = { sessionResultsLinkService }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const sessionResultsLink = dependencies.sessionResultsLinkService.generateResultsLink({ sessionId, i18n });

--- a/api/src/certification/results/application/organization-controller.js
+++ b/api/src/certification/results/application/organization-controller.js
@@ -7,7 +7,7 @@ const downloadCertificationResults = async function (
   h,
   dependencies = { getDivisionCertificationResultsCsv },
 ) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const { division } = request.query;

--- a/api/src/certification/session-management/application/invigilator-kit-controller.js
+++ b/api/src/certification/session-management/application/invigilator-kit-controller.js
@@ -6,7 +6,7 @@ const getInvigilatorKitPdf = async function (request, h, dependencies = { invigi
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
 
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionForInvigilatorKit = await usecases.getInvigilatorKitSessionInfo({ sessionId, userId });
 

--- a/api/src/certification/session-management/application/jury-certification-controller.js
+++ b/api/src/certification/session-management/application/jury-certification-controller.js
@@ -3,7 +3,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as juryCertificationSerializer from '../infrastructure/serializers/jury-certification-serializer.js';
 
 const getJuryCertification = async function (request, h, dependencies = { juryCertificationSerializer }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;
   const juryCertification = await usecases.getJuryCertification({ certificationCourseId });

--- a/api/src/certification/session-management/application/session-publication-controller.js
+++ b/api/src/certification/session-management/application/session-publication-controller.js
@@ -5,7 +5,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as sessionManagementSerializer from '../infrastructure/serializers/session-serializer.js';
 
 const publish = async function (request, h, dependencies = { sessionManagementSerializer }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionId = request.params.id;
 
@@ -23,7 +23,7 @@ const unpublish = async function (request, h, dependencies = { sessionManagement
 };
 
 const publishInBatch = async function (request, h) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const sessionIds = request.payload.data.attributes.ids;
 

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -5,7 +5,7 @@ import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/tr
 const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
   const { userId } = request.auth.credentials;
   const { id: campaignParticipationId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const trainings = await devcompUsecases.findCampaignParticipationTrainings({
     userId,

--- a/api/src/devcomp/application/user-trainings/user-trainings-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-controller.js
@@ -10,7 +10,7 @@ const findPaginatedUserRecommendedTrainings = async function (
     devcompUsecases,
   },
 ) {
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const { page } = request.query;
   const { userRecommendedTrainings, meta } = await dependencies.devcompUsecases.findPaginatedUserRecommendedTrainings({
     userId: request.auth.credentials.userId,

--- a/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
+++ b/api/src/devcomp/application/user-tutorials/user-tutorials-controller.js
@@ -17,7 +17,7 @@ const add = async function (request, h, dependencies = { userSavedTutorialSerial
 const find = async function (request, h, dependencies = { tutorialSerializer }) {
   const { userId } = request.auth.credentials;
   const { page, filter: filters } = request.query;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const { tutorials, meta } = await usecases.findPaginatedFilteredTutorials({
     userId,
     filters,

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -12,7 +12,7 @@ import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/
 const save = async function (request, h, dependencies = { answerSerializer, assessmentRepository }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);
   const userId = extractUserIdFromRequest(request);
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const assessment = await dependencies.assessmentRepository.getWithAnswers(answer.assessmentId);
   let correctedAnswer;
   if (assessment.isCompetenceEvaluation()) {
@@ -83,7 +83,7 @@ const find = async function (request) {
 
 const getCorrection = async function (request, _h, dependencies = { correctionSerializer }) {
   const userId = extractUserIdFromRequest(request);
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const answerId = request.params.id;
 
   const correction = await evaluationUsecases.getCorrectionForAnswer({

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -8,7 +8,7 @@ import { evaluationUsecases } from '../../domain/usecases/index.js';
 
 const completeAssessment = async function (request) {
   const assessmentId = request.params.id;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   await DomainTransaction.execute(async () => {
     const assessment = await evaluationUsecases.completeAssessment({ assessmentId, locale });

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -8,8 +8,8 @@ import { Scorecard } from '../../domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as scorecardSerializer from '../../infrastructure/serializers/jsonapi/scorecard-serializer.js';
 
-const getScorecard = function (request, h, dependencies = { scorecardSerializer }) {
-  const locale = getChallengeLocale(request);
+const getScorecard = async function (request, h, dependencies = { scorecardSerializer }) {
+  const locale = await getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -23,7 +23,7 @@ const getScorecard = function (request, h, dependencies = { scorecardSerializer 
 };
 
 const findTutorials = async function (request, h, dependencies = { tutorialSerializer }) {
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -39,10 +39,10 @@ const findTutorials = async function (request, h, dependencies = { tutorialSeria
   return dependencies.tutorialSerializer.serialize(tutorials);
 };
 
-const resetScorecard = function (request, h, dependencies = { scorecardSerializer }) {
+const resetScorecard = async function (request, h, dependencies = { scorecardSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const competenceId = request.params.competenceId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   return evaluationUsecases
     .resetScorecard({ userId: authenticatedUserId, competenceId, locale })

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -58,7 +58,7 @@ async function createUser(request, h, dependencies = { localeService }) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
   const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
 
-  const localeFromHeader = getChallengeLocale(request);
+  const localeFromHeader = await getChallengeLocale(request);
   const language = localeService.getBaseLocale(localeFromHeader);
 
   const origin = getForwardedOrigin(request.headers);

--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -9,7 +9,7 @@ const checkResetDemand = async function (request, h, dependencies = { userSerial
 };
 const createResetPasswordDemand = async function (request, h) {
   const email = request.payload.email;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   await usecases.createResetPasswordDemand({ email, locale });
 

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -133,8 +133,8 @@ const getUserAuthenticationMethods = async function (request, h, dependencies = 
  */
 const createUser = async function (request, h, dependencies = { userSerializer, localeService }) {
   const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
-  const localeFromHeader = getChallengeLocale(request);
-  const i18n = getI18nFromRequest(request);
+  const localeFromHeader = await getChallengeLocale(request);
+  const i18n = await getI18nFromRequest(request);
 
   const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
   const user = { ...dependencies.userSerializer.deserialize(request.payload), locale: localeFromCookie };
@@ -205,7 +205,7 @@ const rememberUserHasSeenLastDataProtectionPolicyInformation = async function (
 
 const selfDeleteUserAccount = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   await usecases.selfDeleteUserAccount({ userId: authenticatedUserId, locale });
 
@@ -213,8 +213,8 @@ const selfDeleteUserAccount = async function (request, h) {
 };
 
 const sendVerificationCode = async function (request, h, dependencies = { emailVerificationSerializer }) {
-  const locale = getChallengeLocale(request);
-  const i18n = getI18nFromRequest(request);
+  const locale = await getChallengeLocale(request);
+  const i18n = await getI18nFromRequest(request);
 
   const userId = request.params.id;
   const { newEmail, password } = await dependencies.emailVerificationSerializer.deserialize(request.payload);
@@ -261,7 +261,7 @@ const upgradeToRealUser = async function (request, h, dependencies = { userSeria
 
   const localeFromCookie = dependencies.localeService.getNearestSupportedLocale(request.state?.locale);
 
-  const language = getChallengeLocale(request);
+  const language = await getChallengeLocale(request);
 
   const userAttributes = {
     firstName: request.payload.data.attributes['first-name'],

--- a/api/src/learning-content/application/frameworks-controller.js
+++ b/api/src/learning-content/application/frameworks-controller.js
@@ -15,7 +15,7 @@ const getFrameworkAreas = async function (request, h, dependencies = { framework
 };
 
 const getPixFrameworkAreasWithoutThematics = async function (request, h, dependencies = { frameworkAreasSerializer }) {
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const areas = await usecases.getFrameworkAreas({ frameworkName: 'Pix', locale });
   return dependencies.frameworkAreasSerializer.serialize(areas, { withoutThematics: true });
 };

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -8,7 +8,7 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
   const { page } = request.query;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -38,7 +38,7 @@ const findPaginatedParticipationsForCampaignManagement = async function (request
 const getAnalysis = async function (request, h, dependencies = { campaignAnalysisSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignParticipationId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignAnalysis = await usecases.computeCampaignParticipationAnalysis({
     userId,
@@ -51,7 +51,7 @@ const getAnalysis = async function (request, h, dependencies = { campaignAnalysi
 const getCampaignProfile = async function (request, h, dependencies = { campaignProfileSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignProfile = await usecases.getCampaignProfile({ userId, campaignId, campaignParticipationId, locale });
   return dependencies.campaignProfileSerializer.serialize(campaignProfile);
@@ -102,7 +102,7 @@ const getCampaignAssessmentParticipationResult = async function (
 ) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignAssessmentParticipationResult = await usecases.getCampaignAssessmentParticipationResult({
     userId,
@@ -180,7 +180,7 @@ const getUserCampaignAssessmentResult = async function (
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignAssessmentResult = await usecases.getUserCampaignAssessmentResult({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -68,7 +68,7 @@ const getSharedCampaignParticipationProfile = async function (
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const sharedProfileForCampaign = await usecases.getSharedCampaignParticipationProfile({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -24,7 +24,7 @@ const getGroups = async function (request) {
 const getPresentationSteps = async function (request, _, dependencies = { presentationStepsSerializer }) {
   const { userId } = request.auth.credentials;
   const campaignCode = request.params.campaignCode;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const presentationSteps = await usecases.getPresentationSteps({ userId, campaignCode, locale });
   return dependencies.presentationStepsSerializer.serialize(presentationSteps);
@@ -36,7 +36,7 @@ const getLevelPerTubesAndCompetences = async function (
   dependencies = { campaignResultLevelsPerTubesAndCompetencesSerializer },
 ) {
   const { campaignId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const campaignAnalysis = await usecases.getResultLevelsPerTubesAndCompetences({
     campaignId,
     locale,

--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -20,7 +20,7 @@ const getByCode = async function (
   },
 ) {
   const { code } = request.query.filter;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignToJoin = await usecases.getCampaignByCode({ code, locale });
   return dependencies.campaignToJoinSerializer.serialize(campaignToJoin);
@@ -71,7 +71,7 @@ const findPaginatedFilteredCampaigns = async function (request, _, dependencies 
 };
 
 const getCsvAssessmentResults = async function (request, h) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const { campaignId } = request.params;
 
@@ -96,7 +96,7 @@ const getCsvAssessmentResults = async function (request, h) {
 };
 
 const getCsvProfilesCollectionResults = async function (request, h) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const { campaignId } = request.params;
 

--- a/api/src/prescription/campaign/application/campaign-results-controller.js
+++ b/api/src/prescription/campaign/application/campaign-results-controller.js
@@ -44,7 +44,7 @@ const findProfilesCollectionParticipations = async function (request) {
 const getCollectiveResult = async function (request, h, dependencies = { campaignCollectiveResultSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId } = request.params;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId, locale });
   return dependencies.campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -10,7 +10,7 @@ import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers
 const INVALID_FILE_EXTENSION_ERROR = 'INVALID_FILE_EXTENSION';
 
 const importOrganizationLearnersFromSIECLE = async function (request, h, dependencies = { logger }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const authenticatedUserId = request.auth.credentials.userId;
   const organizationId = request.params.id;

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -7,7 +7,7 @@ import { usecases } from '../domain/usecases/index.js';
 import { SupOrganizationLearnerParser } from '../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 
 const importSupOrganizationLearners = async function (request, h, dependencies = { logger, unlink: fs.unlink }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const userId = request.auth.credentials.userId;
@@ -37,7 +37,7 @@ const importSupOrganizationLearners = async function (request, h, dependencies =
 };
 
 const replaceSupOrganizationLearners = async function (request, h, dependencies = { logger, unlink: fs.unlink }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const userId = request.auth.credentials.userId;
   const organizationId = request.params.organizationId;
@@ -69,7 +69,7 @@ const replaceSupOrganizationLearners = async function (request, h, dependencies 
 };
 
 const getOrganizationLearnersCsvTemplate = async function (request, h, dependencies = { tokenService }) {
-  const i18n = getI18nFromRequest(request);
+  const i18n = await getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const token = request.query.accessToken;

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -39,8 +39,8 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 };
 
 const createAndReconcileUserToOrganizationLearner = async function (request, h) {
-  const locale = getChallengeLocale(request);
-  const i18n = getI18nFromRequest(request);
+  const locale = await getChallengeLocale(request);
+  const i18n = await getI18nFromRequest(request);
 
   const payload = request.payload.data.attributes;
   const userAttributes = {

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -14,7 +14,7 @@ const getFrameworksForTargetProfileSubmission = async function (
   _,
   dependencies = { frameworkwithoutskillserializer },
 ) {
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const learningContent = await usecases.getLearningContentForTargetProfileSubmission({ locale });
   return dependencies.frameworkwithoutskillserializer.serialize(learningContent.frameworks);
 };

--- a/api/src/profile/application/profile-controller.js
+++ b/api/src/profile/application/profile-controller.js
@@ -2,18 +2,18 @@ import { getChallengeLocale } from '../../shared/infrastructure/utils/request-re
 import { usecases } from '../domain/usecases/index.js';
 import * as profileSerializer from '../infrastructure/serializers/jsonapi/profile-serializer.js';
 
-const getProfile = function (request, h, dependencies = { profileSerializer }) {
+const getProfile = async function (request, h, dependencies = { profileSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   return usecases
     .getUserProfile({ userId: authenticatedUserId, locale })
     .then(dependencies.profileSerializer.serialize);
 };
 
-const getProfileForAdmin = function (request, h, dependencies = { profileSerializer }) {
+const getProfileForAdmin = async function (request, h, dependencies = { profileSerializer }) {
   const userId = request.params.id;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   return usecases.getUserProfile({ userId, locale }).then(dependencies.profileSerializer.serialize);
 };

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -22,7 +22,7 @@ const save = async function (request, h, dependencies = { assessmentRepository }
 
 const getAssessmentWithNextChallenge = async function (request) {
   const assessmentId = request.params.id;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const userId = extractUserIdFromRequest(request);
 
   const assessment = await DomainTransaction.execute(async () => {
@@ -59,7 +59,7 @@ const findCompetenceEvaluations = async function (request) {
 
 const autoValidateNextChallenge = async function (request, h) {
   const assessmentId = request.params.id;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
   const assessment = await sharedUsecases.getAssessment({ assessmentId, locale });
   const userId = assessment.userId;
   const fakeAnswer = new Answer({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -21,6 +21,7 @@ import {
   UserNotMemberOfOrganizationError,
 } from '../../team/domain/errors.js';
 import * as SharedDomainErrors from '../domain/errors.js';
+import { getBaseLocale } from '../domain/services/locale-service.js';
 import { getChallengeLocale } from '../infrastructure/utils/request-response-utils.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
 import { HttpErrors } from './http-errors.js';
@@ -514,12 +515,13 @@ function _mapToHttpError(error) {
   return new HttpErrors.BaseHttpError(error.message);
 }
 
-function handle(request, h, error) {
+async function handle(request, h, error) {
   if (error instanceof SharedDomainErrors.EntityValidationError) {
-    const locale = getChallengeLocale(request).split('-')[0];
+    const locale = await getChallengeLocale(request);
+    const language = getBaseLocale(locale);
 
     const jsonApiError =
-      error.invalidAttributes?.map(_formatInvalidAttribute.bind(_formatInvalidAttribute, locale, error.meta)) ||
+      error.invalidAttributes?.map(_formatInvalidAttribute.bind(_formatInvalidAttribute, language, error.meta)) ||
       new HttpErrors.InvalidEntityError();
     return HttpErrors.sendJsonApiError(jsonApiError, h);
   }

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -8,8 +8,8 @@ import { getBaseLocale } from '../../domain/services/locale-service.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
 import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
-const get = function (request) {
-  const locale = getChallengeLocale(request);
+const get = async function (request) {
+  const locale = await getChallengeLocale(request);
 
   return {
     name: packageJSON.name,

--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -100,6 +100,35 @@ function isFranceLocale(locale) {
   return supportedLocale === FRENCH_FRANCE_LOCALE;
 }
 
+/**
+ * @param {string} locale
+ * @returns {string} - returns the nearest challenge locale according to the given locale
+ */
+function getNearestChallengeLocale(locale) {
+  if (!locale) {
+    return getDefaultChallengeLocale();
+  }
+
+  try {
+    const intlLocale = new Intl.Locale(locale);
+
+    if (intlLocale.toString() === FRENCH_FRANCE_LOCALE) {
+      return FRENCH_FRANCE;
+    }
+
+    if (CHALLENGE_LOCALES.includes(intlLocale.toString())) {
+      return intlLocale.toString();
+    }
+
+    const localeMatch = CHALLENGE_LOCALES.find((l) => new Intl.Locale(l).language === intlLocale.language);
+    if (localeMatch) return localeMatch;
+
+    return DEFAULT_CHALLENGE_LOCALE;
+  } catch {
+    return DEFAULT_CHALLENGE_LOCALE;
+  }
+}
+
 export {
   coerceLanguage,
   DUTCH_SPOKEN,
@@ -110,6 +139,7 @@ export {
   getChallengeLocales,
   getDefaultChallengeLocale,
   getDefaultLocale,
+  getNearestChallengeLocale,
   getNearestSupportedLocale,
   getSupportedLanguages,
   getSupportedLocales,

--- a/api/src/shared/infrastructure/i18n/i18n.js
+++ b/api/src/shared/infrastructure/i18n/i18n.js
@@ -56,7 +56,7 @@ export function getI18n(locale) {
  * @param {*} request HAPI request
  * @returns the i18n instance according the locale extracted from the request
  */
-export function getI18nFromRequest(request) {
-  const locale = request.query?.lang || getChallengeLocale(request);
+export async function getI18nFromRequest(request) {
+  const locale = request.query?.lang || (await getChallengeLocale(request));
   return getI18n(locale);
 }

--- a/api/src/shared/infrastructure/monitoring-tools.js
+++ b/api/src/shared/infrastructure/monitoring-tools.js
@@ -3,8 +3,8 @@ import lodash from 'lodash';
 import { config } from '../config.js';
 
 const { get, update } = lodash;
+import { tokenService } from '../domain/services/token-service.js';
 import { asyncLocalStorage, getContext, getInContext, setInContext } from './async-local-storage.js';
-import * as requestResponseUtils from './utils/request-response-utils.js';
 
 function getRequestId() {
   if (!config.hapi.enableRequestMonitoring) {
@@ -33,7 +33,12 @@ function getCorrelationContext() {
 
 function extractUserIdFromRequest(request) {
   let userId = get(request, 'auth.credentials.userId');
-  if (!userId && get(request, 'headers.authorization')) userId = requestResponseUtils.extractUserIdFromRequest(request);
+
+  if (!userId && get(request, 'headers.authorization')) {
+    const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
+    userId = tokenService.extractUserId(token);
+  }
+
   return userId || '-';
 }
 

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -4,9 +4,11 @@ import {
   getChallengeLocales,
   getDefaultChallengeLocale,
   getDefaultLocale,
+  getNearestChallengeLocale,
   getNearestSupportedLocale,
 } from '../../../shared/domain/services/locale-service.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
+import { featureToggles } from '../feature-toggles/index.js';
 
 const acceptedLanguages = getChallengeLocales();
 const defaultChallengeLocale = getDefaultChallengeLocale();
@@ -28,6 +30,9 @@ function escapeFileName(fileName) {
     .replace(/ /g, '_');
 }
 
+/**
+ * @deprecated Instead, for authenticated routes, use `const { userId } = request.auth.credentials.userId`
+ */
 function extractUserIdFromRequest(request) {
   if (request.headers && request.headers.authorization) {
     const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
@@ -36,6 +41,14 @@ function extractUserIdFromRequest(request) {
   return null;
 }
 
+/**
+ * Returns the locale for the user request. (ie. fr-FR, fr-BE, nl...)
+ * Determined from the query params locale or lang, from the `locale` cookie.
+ * When no locale found, return the default one.
+ *
+ * @param {*} request - http request
+ * @returns {string} - supported locale (ie. fr-FR, fr-BE, nl...)
+ */
 function getUserLocale(request = {}) {
   const locale = request.query?.locale || request.query?.lang || request.state?.locale;
   if (locale) {
@@ -45,7 +58,25 @@ function getUserLocale(request = {}) {
   return getDefaultLocale();
 }
 
-function getChallengeLocale(request) {
+/**
+ * Returns a challenge locale for the user request. (ie. fr-fr, fr, nl...)
+ * Determined from the query params locale or lang, from the `locale` cookie.
+ * When no locale found, return the default challenge locale.
+ *
+ * @param {*} request - http request
+ * @returns {string} - locale of a challenge (ie. fr-fr, fr, nl...)
+ */
+async function getChallengeLocale(request) {
+  const useCookieLocaleInApi = await featureToggles.get('useCookieLocaleInApi');
+
+  if (!useCookieLocaleInApi) return _getLegacyChallengeLocale(request);
+
+  const locale = request.query?.locale || request.query?.lang || request.state?.locale;
+
+  return getNearestChallengeLocale(locale);
+}
+
+function _getLegacyChallengeLocale(request) {
   const languageHeader = request.headers && request.headers['accept-language'];
   if (!languageHeader) {
     return defaultChallengeLocale;

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -1,6 +1,11 @@
 import accept from '@hapi/accept';
 
-import { getChallengeLocales, getDefaultChallengeLocale } from '../../../shared/domain/services/locale-service.js';
+import {
+  getChallengeLocales,
+  getDefaultChallengeLocale,
+  getDefaultLocale,
+  getNearestSupportedLocale,
+} from '../../../shared/domain/services/locale-service.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 
 const acceptedLanguages = getChallengeLocales();
@@ -31,6 +36,15 @@ function extractUserIdFromRequest(request) {
   return null;
 }
 
+function getUserLocale(request = {}) {
+  const locale = request.query?.locale || request.query?.lang || request.state?.locale;
+  if (locale) {
+    return getNearestSupportedLocale(locale, acceptedLanguages);
+  }
+
+  return getDefaultLocale();
+}
+
 function getChallengeLocale(request) {
   const languageHeader = request.headers && request.headers['accept-language'];
   if (!languageHeader) {
@@ -50,4 +64,5 @@ export {
   extractTLDFromRequest,
   extractUserIdFromRequest,
   getChallengeLocale,
+  getUserLocale,
 };

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -43,7 +43,7 @@ const getCertificationCenterInvitation = async function (request) {
 const sendInvitations = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
   const emails = request.payload.data.attributes.emails;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   await usecases.createOrUpdateCertificationCenterInvitation({ certificationCenterId, emails, locale });
 
@@ -52,7 +52,7 @@ const sendInvitations = async function (request, h) {
 
 const resendCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const certificationCenterInvitation = await usecases.resendCertificationCenterInvitation({
     certificationCenterInvitationId,

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -80,7 +80,7 @@ const getOrganizationInvitation = async function (request, h, dependencies = { o
 const sendScoInvitation = async function (request, h, dependencies = { scoOrganizationInvitationSerializer }) {
   const { uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
 
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const organizationScoInvitation = await usecases.sendScoInvitation({
     uai,
@@ -95,7 +95,7 @@ const sendScoInvitation = async function (request, h, dependencies = { scoOrgani
 const sendInvitations = async function (request, h) {
   const organizationId = request.params.id;
   const emails = request.payload.data.attributes.email.split(',');
-  const locale = getChallengeLocale(request);
+  const locale = await getChallengeLocale(request);
 
   const organizationInvitations = await usecases.createOrganizationInvitations({ organizationId, emails, locale });
   return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();

--- a/api/tests/shared/unit/domain/services/locale-service.test.js
+++ b/api/tests/shared/unit/domain/services/locale-service.test.js
@@ -136,4 +136,39 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       });
     });
   });
+
+  describe('getNearestChallengeLocale', function () {
+    context('when no locale is provided', function () {
+      it('returns the default locale', function () {
+        // given
+        const locale = null;
+
+        // when
+        const challengeLocale = localeService.getNearestChallengeLocale(locale);
+
+        // then
+        expect(challengeLocale).to.equal(localeService.getDefaultChallengeLocale());
+      });
+    });
+
+    context('when locale is supported', function () {
+      [
+        { locale: 'fr-FR', expectedChallengeLocale: 'fr-fr' },
+        { locale: 'fr-BE', expectedChallengeLocale: 'fr' },
+        { locale: 'en', expectedChallengeLocale: 'en' },
+        { locale: 'nl', expectedChallengeLocale: 'nl' },
+        { locale: 'nl-BE', expectedChallengeLocale: 'nl' },
+        { locale: 'es', expectedChallengeLocale: 'es' },
+        { locale: 'tlh', expectedChallengeLocale: 'fr-fr' },
+      ].forEach(({ locale, expectedChallengeLocale }) => {
+        it(`returns the challenge locale: ${expectedChallengeLocale} for locale: ${locale}`, function () {
+          // when
+          const challengeLocale = localeService.getNearestChallengeLocale(locale);
+
+          // then
+          expect(challengeLocale).to.equal(expectedChallengeLocale);
+        });
+      });
+    });
+  });
 });

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -2,6 +2,7 @@ import {
   ENGLISH_SPOKEN,
   FRENCH_FRANCE,
   FRENCH_SPOKEN,
+  getDefaultLocale,
 } from '../../../../../src/shared/domain/services/locale-service.js';
 import {
   escapeFileName,
@@ -9,6 +10,7 @@ import {
   extractTLDFromRequest,
   extractUserIdFromRequest,
   getChallengeLocale,
+  getUserLocale,
 } from '../../../../../src/shared/infrastructure/utils/request-response-utils.js';
 import { expect, generateAuthenticatedUserRequestHeaders } from '../../../../test-helper.js';
 
@@ -84,6 +86,92 @@ describe('Unit | Utils | Request Utils', function () {
 
       // then
       expect(escapedFileName).to.equal('file-name_with_e_invalid_chars_.csv');
+    });
+  });
+
+  describe('getUserLocale', function () {
+    context('when the request has no cookie locale and no query param', function () {
+      it('should return the default locale', function () {
+        // when
+        const locale = getUserLocale();
+
+        // then
+        expect(locale).to.equal(getDefaultLocale());
+      });
+    });
+
+    context('when the request has a cookie locale', function () {
+      it('should return the locale from the cookie', function () {
+        // given
+        const request = { state: { locale: 'fr-FR' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal('fr-FR');
+      });
+    });
+
+    context('when the request has a query param locale', function () {
+      it('should return the locale from the query param', function () {
+        // given
+        const request = { query: { locale: 'fr-BE' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal('fr-BE');
+      });
+    });
+
+    context('when the request has a query param lang', function () {
+      it('should return the lang from the query param', function () {
+        // given
+        const request = { query: { lang: 'fr-BE' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal('fr-BE');
+      });
+    });
+
+    context('when the locale is not supported', function () {
+      it('should return the default locale for invalid locale', function () {
+        // given
+        const request = { query: { lang: 'unsupported-locale' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal(getDefaultLocale());
+      });
+
+      it('should return the default locale for empty locale', function () {
+        // given
+        const request = { query: { lang: '' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal(getDefaultLocale());
+      });
+
+      it('should return the nearest supported locale for invalid locale', function () {
+        // given
+        const request = { query: { lang: 'fr-CA' } };
+
+        // when
+        const locale = getUserLocale(request);
+
+        // then
+        expect(locale).to.equal('fr');
+      });
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

Maintenant que la locale d'un utilisateur est présente dans le cookie `locale`, on souhaite se baser dessus pour toutes les opérations sur les locales.

## ⛱️ Proposition

1. Créer une fonction `getUserLocale(request)` qui permet de récupérer la locale de la requête utilisateur en s'assurant qu'il s'agit d'une locale supportée par le serveur et standardisée (ex: `fr-FR`, `nl-BE`, `fr`...). Cette fonction sera utilisée dans le futur pour remplacer `getChallengeLocale` dans les controlleurs quand c'est nécessaire.

2. Sous le feature toggle `useCookieLocaleInApi`, modifier la fonction `getChallengeLocale(request)` pour utiliser récupérer la locale des challenges depuis le cookie en s'assurant qu'il s'agit d'une locale supportée par les épreuves (ex: `fr-fr`, `nl`, `fr`...)

## 🌊 Remarques

- L'ajout du feature toggle a nécessité de rendre la fonction `getChallengeLocale` asynchrone.

- Activation des FT par défaut en review app.
```js
{
  useLocale: {
    ...
    defaultValue: false,
    devDefaultValues: { test: false, reviewApp: true }
  },
  useCookieLocaleInApi: {
    ...
    defaultValue: false,
    devDefaultValues: { test: false, reviewApp: true },
  },
}
```

## 🏄 Pour tester

**À tester en navigation privée !**

**Avec FT `useLocale=true` et `useCookieLocaleInApi=false`:**

1. Sur [app.pix.fr](https://app-pr13247.review.pix.fr/), passer les épreuves et s'assurer quelles correspondent à la locale `fr-fr`
2. Sur [app.pix.org](https://app-pr13247.review.pix.org/), en `fr-BE`, passer les épreuves et s'assurer quelles correspondent à la locale `fr`
3. Sur [app.pix.org](https://app-pr13247.review.pix.org/), en `en`, passer les épreuves et s'assurer quelles correspondent à la locale `fr`


**Avec FT `useLocale=true` et `useCookieLocaleInApi=true`:**

1. Sur [app.pix.fr](https://app-pr13247.review.pix.fr/), passer les épreuves et s'assurer quelles correspondent à la locale `fr-fr`
2. Sur [app.pix.org](https://app-pr13247.review.pix.org/), en `fr-BE`, passer les épreuves et s'assurer quelles correspondent à la locale `fr`
3. Sur [app.pix.org](https://app-pr13247.review.pix.org/), en `en`, passer les épreuves et s'assurer quelles correspondent à la locale `fr`
