### PR TITLE
[BUGFIX] Récupérer les épreuves fr-FR à la création d'un référentiel cadre (PIX-19208).

### DIFF
--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -6,7 +6,7 @@
  * @typedef {import ('./index.js').ConsolidatedFrameworkRepository} ConsolidatedFrameworkRepository
  */
 
-import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
+import { FRENCH_FRANCE, FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
 import { getVersionNumber } from '../services/get-version-number.js';
 
 /**
@@ -31,7 +31,7 @@ export const createConsolidatedFramework = async ({
   const skillIds = tubes.flatMap((tube) => tube.skillIds);
   const skills = await skillRepository.findActiveByRecordIds(skillIds);
 
-  const challenges = await challengeRepository.findOperativeBySkills(skills, FRENCH_SPOKEN);
+  const challenges = await challengeRepository.findOperativeBySkills(skills, FRENCH_FRANCE);
 
   return consolidatedFrameworkRepository.create({
     complementaryCertificationKey,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -267,6 +267,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
         discriminant: 2.1,
         difficulty: 3.4,
         status: 'validé',
+        locales: ['fr-fr'],
       });
 
       await databaseBuilder.commit();

--- a/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
@@ -1,6 +1,6 @@
 import { createConsolidatedFramework } from '../../../../../../src/certification/configuration/domain/usecases/create-consolidated-framework.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
-import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
+import { FRENCH_FRANCE, FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Unit | UseCase | create-consolidated-framework', function () {
@@ -33,14 +33,17 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     const tubeIds = [tube1.id, tube2.id];
 
     const challenges = [
-      domainBuilder.buildChallenge({ id: 'challenge1' }),
-      domainBuilder.buildChallenge({ id: 'challenge2' }),
-      domainBuilder.buildChallenge({ id: 'challenge3' }),
+      domainBuilder.buildChallenge({ id: 'challenge1', locales: ['fr-fr'] }),
+      domainBuilder.buildChallenge({ id: 'challenge2', locales: ['fr-fr', 'fr-be'] }),
+      domainBuilder.buildChallenge({ id: 'challenge3', locales: ['fr', 'fr-fr'] }),
+      domainBuilder.buildChallenge({ id: 'challenge4', locales: ['fr'] }),
+      domainBuilder.buildChallenge({ id: 'challenge5', locales: ['fr-be'] }),
     ];
+    const frFrChallenges = challenges.filter((challenge) => challenge.locales.includes(FRENCH_FRANCE));
 
     tubeRepository.findActiveByRecordIds.resolves([tube1, tube2]);
     skillRepository.findActiveByRecordIds.resolves([...tube1.skills, ...tube2.skills]);
-    challengeRepository.findOperativeBySkills.resolves(challenges);
+    challengeRepository.findOperativeBySkills.resolves(frFrChallenges);
     consolidatedFrameworkRepository.create.resolves();
     sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
     const version = '20190101050607';
@@ -63,11 +66,11 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
     ]);
     expect(challengeRepository.findOperativeBySkills).to.have.been.calledOnceWithExactly(
       [...tube1.skills, ...tube2.skills],
-      FRENCH_SPOKEN,
+      FRENCH_FRANCE,
     );
     expect(consolidatedFrameworkRepository.create).to.have.been.calledOnceWithExactly({
       complementaryCertificationKey,
-      challenges,
+      challenges: frFrChallenges,
       version,
     });
   });

--- a/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
+++ b/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
@@ -14,7 +14,7 @@ describe('Integration | Scripts | Certification | target-profile-to-calibrated-f
     const learningContent = {
       tubes: [{ id: 'tube1', skillIds: ['skill1'] }],
       skills: [{ id: 'skill1', status: 'actif', tubeId: 'tube1' }],
-      challenges: [{ id: 'challenge1', skillId: 'skill1', locales: ['fr'] }],
+      challenges: [{ id: 'challenge1', skillId: 'skill1', locales: ['fr-fr'] }],
     };
     await mockLearningContent(learningContent);
 


### PR DESCRIPTION
## 🔆 Problème

Nous utilisions jusqu'à présent la locale "fr" lors de la création d'un référentiel cadre.

## ⛱️ Proposition

Utiliser la locale "fr-fr" à la place.

## 🏄 Pour tester

- Ajouter un référentiel cadre de complémentaire sur PixAdmin en RA.
- Vérifier en BDD que les challenges ajoutés ont bien la locale "fr-fr"
