### PR TITLE
[BUGFIX] Utiliser les challenges des référentiels cadres en cas de simulation de complémentaire (PIX-19189).

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
@@ -3,6 +3,7 @@
  * @typedef {import('./index.js').SharedChallengeRepository} SharedChallengeRepository
  */
 
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { AssessmentSimulator } from '../models/AssessmentSimulator.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../models/AssessmentSimulatorSingleMeasureStrategy.js';
@@ -74,10 +75,14 @@ async function _simulateComplementaryCertificationScenario({
   sharedFlashAlgorithmConfigurationRepository,
   stopAtChallenge,
 }) {
+  const isCertificationWithComplementaryReferentialSimulation =
+    complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA;
+
   const challenges = await _getChallenges({
     locale,
     challengeRepository,
     complementaryCertificationKey,
+    isCertificationWithComplementaryReferentialSimulation,
   });
 
   const mostRecentAlgorithmConfiguration = await sharedFlashAlgorithmConfigurationRepository.getMostRecent();
@@ -134,11 +139,18 @@ async function _simulateCoreCertificationScenario({
  * @param {Object} params
  * @param {SharedChallengeRepository} params.challengeRepository
  */
-function _getChallenges({ challengeRepository, locale, accessibilityAdjustmentNeeded, complementaryCertificationKey }) {
+function _getChallenges({
+  challengeRepository,
+  locale,
+  accessibilityAdjustmentNeeded,
+  complementaryCertificationKey,
+  isCertificationWithComplementaryReferentialSimulation,
+}) {
   return challengeRepository.findActiveFlashCompatible({
     locale,
     accessibilityAdjustmentNeeded,
     complementaryCertificationKey,
+    isCertificationWithComplementaryReferentialSimulation,
   });
 }
 

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { httpAgent } from '../../../../src/shared/infrastructure/http-agent.js';
 import { getVersionNumber } from '../../../certification/configuration/domain/services/get-version-number.js';
+import { ComplementaryCertificationKeys } from '../../../certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import { config } from '../../config.js';
 import { NotFoundError } from '../../domain/errors.js';
@@ -111,12 +112,13 @@ export async function findActiveFlashCompatible({
   accessibilityAdjustmentNeeded = false,
   complementaryCertificationKey,
   hasComplementaryReferential,
+  isCertificationWithComplementaryReferentialSimulation,
 } = {}) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
   let challengeDtos;
 
-  if (hasComplementaryReferential) {
+  if (hasComplementaryReferential || isCertificationWithComplementaryReferentialSimulation) {
     const version = getVersionNumber(date);
 
     challengeDtos = await _findChallengesForComplementaryCertification({
@@ -131,6 +133,10 @@ export async function findActiveFlashCompatible({
   return challengesDtosWithSkills.map(([challengeDto, skill]) =>
     toDomain({ challengeDto, skill, successProbabilityThreshold }),
   );
+}
+
+function _isNotDoubleCertificationSimulation(complementaryCertificationKey) {
+  return complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA;
 }
 
 async function _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, version }) {

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -5,32 +5,61 @@ import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', function () {
   describe('#simulateFlashAssessmentScenario', function () {
-    describe('when a complementary certification scenario is required', function () {
-      it('should fetch the complementary framework challenges', async function () {
-        // given
-        const locale = FRENCH_FRANCE;
-        const accessibilityAdjustmentNeeded = false;
-        const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
-        const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+    describe('when simulating a complementary certification', function () {
+      describe('when the certification does not have a complementary referential', function () {
+        it('should fetch the core framework challenges', async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+          const accessibilityAdjustmentNeeded = false;
+          const complementaryCertificationKey = ComplementaryCertificationKeys.CLEA;
+          const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
 
-        // when
-        await catchErr(simulateFlashAssessmentScenario)({
-          locale,
-          accessibilityAdjustmentNeeded,
-          complementaryCertificationKey,
-          sharedChallengeRepository: challengeRepositoryStub,
+          // when
+          await catchErr(simulateFlashAssessmentScenario)({
+            locale,
+            accessibilityAdjustmentNeeded,
+            complementaryCertificationKey,
+            sharedChallengeRepository: challengeRepositoryStub,
+          });
+
+          // then
+          expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+            complementaryCertificationKey,
+            locale,
+            accessibilityAdjustmentNeeded: undefined,
+            isCertificationWithComplementaryReferentialSimulation: false,
+          });
         });
+      });
 
-        // then
-        expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-          complementaryCertificationKey,
-          locale,
-          accessibilityAdjustmentNeeded: undefined,
+      describe('when the certification has a complementary referential', function () {
+        it('should fetch the complementary framework challenges', async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+          const accessibilityAdjustmentNeeded = false;
+          const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+          const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+
+          // when
+          await catchErr(simulateFlashAssessmentScenario)({
+            locale,
+            accessibilityAdjustmentNeeded,
+            complementaryCertificationKey,
+            sharedChallengeRepository: challengeRepositoryStub,
+          });
+
+          // then
+          expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+            complementaryCertificationKey,
+            locale,
+            accessibilityAdjustmentNeeded: undefined,
+            isCertificationWithComplementaryReferentialSimulation: true,
+          });
         });
       });
     });
 
-    describe('when a complementary certification scenario is not required', function () {
+    describe('when simulating a core certification', function () {
       it('should fetch the core referential challenges', async function () {
         // given
         const locale = FRENCH_FRANCE;
@@ -50,6 +79,7 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
           locale,
           accessibilityAdjustmentNeeded,
           complementaryCertificationKey: undefined,
+          isCertificationWithComplementaryReferentialSimulation: undefined,
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Depuis la PR , nous vérifions la présence (ou l'absence) d'un référentiel complémentaire pour récupérer les challenges d'un référentiel cadre particulier (ou du référentiel coeur)

Cet ajout n'a pas été pris en compte dans le cadre des simulations de déroulés, qui peuvent également être utilisés pour des simulations de certifications complémentaires.

## ⛱️ Proposition

Ajout d'une propriété pour palier à ce problème

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Créer un référentiel cadre de certification complémentaire
- Simuler un déroulé de certification à l'aide de la commande suivante : 

```
TOKEN=$(curl --insecure 'https://admin-pr13256.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13256.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "complementaryCertificationKey": "<CLE_DE_VOTRE_COMPLEMENTAIRE>", "locale": "fr-fr" }' | jq '.'