### PR TITLE
[BUGFIX] Réparer la validation de mot de passe lors de création de compte sco (PIX-19209)

### DIFF
--- a/mon-pix/app/components/routes/register-form.gjs
+++ b/mon-pix/app/components/routes/register-form.gjs
@@ -192,7 +192,7 @@ export default class RegisterForm extends Component {
           @id="password"
           @value={{this.password}}
           @subLabel={{t "pages.login-or-register.register-form.fields.password.help"}}
-          {{on "focusout" (fn this.triggerInputPasswordValidation "password" this.email)}}
+          {{on "focusout" (fn this.triggerInputPasswordValidation "password" this.password)}}
           {{on "input" this.handlePasswordInput}}
           @validationStatus={{this.validation.password.status}}
           @errorMessage={{this.validation.password.message}}

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -244,6 +244,24 @@ module('Integration | Component | routes/register-form', function (hooks) {
           assert.dom(screen.getByText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE)).exists();
         });
       });
+
+      module('when the password is correctly filled', function () {
+        test('should not display an error message on password field', async function (assert) {
+          // given
+          const screen = await render(hbs`<Routes::RegisterForm />`);
+          const correctPassword = '12345678Ab!';
+
+          await fillInputReconciliationForm({ screen, t });
+          await click(screen.getByRole('button', { name: t('pages.login-or-register.register-form.button-form') }));
+
+          // when
+          await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL, { exact: false }), correctPassword);
+          await triggerEvent(screen.getByLabelText(PASSWORD_INPUT_LABEL, { exact: false }), 'focusout');
+
+          // then
+          assert.dom(screen.queryByText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE)).doesNotExist();
+        });
+      });
     });
 
     test('should not call api when email is invalid', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème

Parcours SCO sans GAR. Les élèves ont été importées et lancent la campagne. Les élèves renseignent leur prénom, nom et on génère un identifiant et on demande la saisie d’un mot de passe. 

Après la saisie du mot de passe par l'élève et même si ce dernier respecte les critères, le message d’erreur s’affiche. 

Pour autant, même si message d’erreur s’affiche, l’utilisateur peut cliquer sur “Je m’inscris” et le compte est crée.

## ⛱️ Proposition

Réparer la validation de mot de passe


## 🏄 Pour tester

- Depuis [pix-app](https://app-pr13257.review.pix.fr/campagnes/SCOBADGE1)
  - cliquer sur commencer le parcours puis je m'inscris
  - Remplir "harry potter 12/12/2012"
  - entrer un mot de passe valide dans le formulaire
  - constater au focus out qu'aucun message d'erreur n'apparait
