### PR TITLE
[BUGFIX] Utiliser les challenges des référentiels cadres en cas de simulation de complémentaire (PIX-19189).

### DIFF
--- a/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
@@ -3,6 +3,7 @@
  * @typedef {import('./index.js').SharedChallengeRepository} SharedChallengeRepository
  */
 
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { AssessmentSimulator } from '../models/AssessmentSimulator.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../models/AssessmentSimulatorSingleMeasureStrategy.js';
@@ -74,10 +75,13 @@ async function _simulateComplementaryCertificationScenario({
   sharedFlashAlgorithmConfigurationRepository,
   stopAtChallenge,
 }) {
+  const hasComplementaryReferential = complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA;
+
   const challenges = await _getChallenges({
     locale,
     challengeRepository,
     complementaryCertificationKey,
+    hasComplementaryReferential,
   });
 
   const mostRecentAlgorithmConfiguration = await sharedFlashAlgorithmConfigurationRepository.getMostRecent();
@@ -134,11 +138,18 @@ async function _simulateCoreCertificationScenario({
  * @param {Object} params
  * @param {SharedChallengeRepository} params.challengeRepository
  */
-function _getChallenges({ challengeRepository, locale, accessibilityAdjustmentNeeded, complementaryCertificationKey }) {
+function _getChallenges({
+  challengeRepository,
+  locale,
+  accessibilityAdjustmentNeeded,
+  complementaryCertificationKey,
+  hasComplementaryReferential,
+}) {
   return challengeRepository.findActiveFlashCompatible({
     locale,
     accessibilityAdjustmentNeeded,
     complementaryCertificationKey,
+    hasComplementaryReferential,
   });
 }
 

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -5,32 +5,61 @@ import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', function () {
   describe('#simulateFlashAssessmentScenario', function () {
-    describe('when a complementary certification scenario is required', function () {
-      it('should fetch the complementary framework challenges', async function () {
-        // given
-        const locale = FRENCH_FRANCE;
-        const accessibilityAdjustmentNeeded = false;
-        const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
-        const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+    describe('when simulating a complementary certification', function () {
+      describe('when the certification does not have a complementary referential', function () {
+        it('should fetch the core framework challenges', async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+          const accessibilityAdjustmentNeeded = false;
+          const complementaryCertificationKey = ComplementaryCertificationKeys.CLEA;
+          const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
 
-        // when
-        await catchErr(simulateFlashAssessmentScenario)({
-          locale,
-          accessibilityAdjustmentNeeded,
-          complementaryCertificationKey,
-          sharedChallengeRepository: challengeRepositoryStub,
+          // when
+          await catchErr(simulateFlashAssessmentScenario)({
+            locale,
+            accessibilityAdjustmentNeeded,
+            complementaryCertificationKey,
+            sharedChallengeRepository: challengeRepositoryStub,
+          });
+
+          // then
+          expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+            complementaryCertificationKey,
+            locale,
+            accessibilityAdjustmentNeeded: undefined,
+            hasComplementaryReferential: false,
+          });
         });
+      });
 
-        // then
-        expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-          complementaryCertificationKey,
-          locale,
-          accessibilityAdjustmentNeeded: undefined,
+      describe('when the certification has a complementary referential', function () {
+        it('should fetch the complementary framework challenges', async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+          const accessibilityAdjustmentNeeded = false;
+          const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+          const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+
+          // when
+          await catchErr(simulateFlashAssessmentScenario)({
+            locale,
+            accessibilityAdjustmentNeeded,
+            complementaryCertificationKey,
+            sharedChallengeRepository: challengeRepositoryStub,
+          });
+
+          // then
+          expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+            complementaryCertificationKey,
+            locale,
+            accessibilityAdjustmentNeeded: undefined,
+            hasComplementaryReferential: true,
+          });
         });
       });
     });
 
-    describe('when a complementary certification scenario is not required', function () {
+    describe('when simulating a core certification', function () {
       it('should fetch the core referential challenges', async function () {
         // given
         const locale = FRENCH_FRANCE;
@@ -50,6 +79,7 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
           locale,
           accessibilityAdjustmentNeeded,
           complementaryCertificationKey: undefined,
+          hasComplementaryReferential: undefined,
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Depuis la PR #13151 , nous vérifions la présence (ou l'absence) d'un référentiel complémentaire pour récupérer les challenges d'un référentiel cadre particulier (ou du référentiel coeur)

Cet ajout n'a pas été pris en compte dans le cadre des simulations de déroulés, qui peuvent également être utilisés pour des simulations de certifications complémentaires.

## ⛱️ Proposition

Utilisation de la propriété `hasComplementaryReferential` côté simulateur

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Simuler un déroulé de certification à l'aide de la commande suivante : 
- Vérifier que les challenges en sortie du simulateur fassent bien partie du référentiel cadre (ici DROIT dans les seeds)

Si vous le souhaitez, vous pouvez tester en créant vous-même votre référentiel cadre (⚠️ , les challenges doivent être calibrés pour que le simulateur fonctionne)

```
TOKEN=$(curl --insecure 'https://admin-pr13258.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13258.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "complementaryCertificationKey": "DROIT", "locale": "fr-fr", "stopAtChallenge": 3 }' | jq '.'