### PR TITLE
[FEATURE] Créer un helper pour les tests de rôles sur les endpoints (PIX-19205)

### DIFF
--- a/api/tests/tooling/security-pre-handlers-helpers.js
+++ b/api/tests/tooling/security-pre-handlers-helpers.js
@@ -1,0 +1,36 @@
+import sinon from 'sinon';
+
+import { PIX_ADMIN } from '../../src/authorization/domain/constants.js';
+import { securityPreHandlers } from '../../src/shared/application/security-pre-handlers.js';
+
+const getAdminRoleStub = (role) => {
+  const pixAdminRole = PIX_ADMIN.ROLES[role];
+
+  if (pixAdminRole === undefined) {
+    throw new Error('Role is not supported');
+  }
+
+  let stub;
+
+  switch (role) {
+    case PIX_ADMIN.ROLES.CERTIF:
+      stub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif');
+      break;
+    case PIX_ADMIN.ROLES.METIER:
+      stub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier');
+      break;
+    case PIX_ADMIN.ROLES.SUPPORT:
+      stub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport');
+      break;
+    case PIX_ADMIN.ROLES.SUPER_ADMIN:
+      stub = sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+      break;
+  }
+
+  stub.callsFake((_, h) => {
+    return h.response(true);
+  });
+  return stub;
+};
+
+export { getAdminRoleStub };

--- a/api/tests/unit/tooling/security-pre-handlers-helpers_test.js
+++ b/api/tests/unit/tooling/security-pre-handlers-helpers_test.js
@@ -1,0 +1,58 @@
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
+import { catchErrSync, expect, hFake, sinon } from '../../test-helper.js';
+import { getAdminRoleStub } from '../../tooling/security-pre-handlers-helpers.js';
+
+describe('Unit | Tooling | SecurityPreHandlersHelpers', function () {
+  describe('#getAdminRoleStub', function () {
+    it('should throw if role does not exist', function () {
+      const error = catchErrSync(getAdminRoleStub)('WRONG_ROLE');
+
+      expect(error).to.exist;
+      expect(error.message).to.equal('Role is not supported');
+    });
+
+    it('should return checkAdminMemberHasRoleCertif stub if role CERTIF is provided', function () {
+      // when
+      const stub = getAdminRoleStub('CERTIF');
+      const hResponseSpy = sinon.spy(hFake, 'response');
+      securityPreHandlers.checkAdminMemberHasRoleCertif(null, hFake);
+
+      // then
+      expect(stub).to.have.been.calledOnce;
+      expect(hResponseSpy).to.have.been.calledOnceWith(true);
+    });
+
+    it('should return checkAdminMemberHasRoleCertif stub if role METIER is provided', function () {
+      // when
+      const stub = getAdminRoleStub('METIER');
+      const hResponseSpy = sinon.spy(hFake, 'response');
+      securityPreHandlers.checkAdminMemberHasRoleMetier(null, hFake);
+
+      // then
+      expect(stub).to.have.been.calledOnce;
+      expect(hResponseSpy).to.have.been.calledOnceWith(true);
+    });
+
+    it('should return checkAdminMemberHasRoleCertif stub if role SUPPORT is provided', function () {
+      // when
+      const stub = getAdminRoleStub('SUPPORT');
+      const hResponseSpy = sinon.spy(hFake, 'response');
+      securityPreHandlers.checkAdminMemberHasRoleSupport(null, hFake);
+
+      // then
+      expect(stub).to.have.been.calledOnce;
+      expect(hResponseSpy).to.have.been.calledOnceWith(true);
+    });
+
+    it('should return checkAdminMemberHasRoleCertif stub if role SUPER_ADMIN is provided', function () {
+      // when
+      const stub = getAdminRoleStub('SUPER_ADMIN');
+      const hResponseSpy = sinon.spy(hFake, 'response');
+      securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(null, hFake);
+
+      // then
+      expect(stub).to.have.been.calledOnce;
+      expect(hResponseSpy).to.have.been.calledOnceWith(true);
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Les tests sur les rôles de Pix Admin pour accéder à l’API ne sont pas fiables : ils ne retournent pas les erreurs que l’on souhaite quand ils échouent.

## ⛱️ Proposition

Créer un helper qui pour vérifier le comportement de l'API pour le rôle passé en paramètre.
On a créé une fonction getAdminRolesStub() pour stubber les fonctions du securityPrehandlers utilisé pour les routes.

## 🌊 Remarques

RAS

## 🏄 Pour tester

CI au vert ✅ 
