### PR TITLE
[FEATURE] Cacher l'onglet Référentiel Cadre pour CléA sur Pix Admin (PIX-19144)

### DIFF
--- a/admin/app/components/complementary-certifications/list.gjs
+++ b/admin/app/components/complementary-certifications/list.gjs
@@ -30,7 +30,14 @@ export default class List extends Component {
             {{t "components.complementary-certifications.list.name"}}
           </:header>
           <:cell>
-            <LinkTo @route="authenticated.complementary-certifications.item.framework" @model={{row.id}}>
+            <LinkTo
+              @route={{if
+                row.hasComplementaryReferential
+                "authenticated.complementary-certifications.item.framework"
+                "authenticated.complementary-certifications.item.target-profile"
+              }}
+              @model={{row.id}}
+            >
               {{row.label}}
             </LinkTo>
           </:cell>

--- a/admin/app/models/complementary-certification.js
+++ b/admin/app/models/complementary-certification.js
@@ -5,6 +5,7 @@ export default class ComplementaryCertification extends Model {
   @attr() label;
   @attr() hasExternalJury;
   @attr() targetProfilesHistory;
+  @attr() hasComplementaryReferential;
 
   @hasMany('complementary-certification-badge', { async: false, inverse: 'complementaryCertification' })
   complementaryCertificationBadges;

--- a/admin/app/templates/authenticated/complementary-certifications/item.hbs
+++ b/admin/app/templates/authenticated/complementary-certifications/item.hbs
@@ -6,9 +6,11 @@
   class="complementary-certification__tabs"
   @ariaLabel={{t "components.complementary-certifications.item.navigation.aria-label"}}
 >
-  <LinkTo @route="authenticated.complementary-certifications.item.framework">
-    {{t "components.complementary-certifications.item.framework.tab"}}
-  </LinkTo>
+  {{#if @model.hasComplementaryReferential}}
+    <LinkTo @route="authenticated.complementary-certifications.item.framework">
+      {{t "components.complementary-certifications.item.framework.tab"}}
+    </LinkTo>
+  {{/if}}
   <LinkTo @route="authenticated.complementary-certifications.item.target-profile">
     {{t "components.complementary-certifications.item.target-profile"}}
   </LinkTo>

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
@@ -18,6 +18,7 @@ module('Acceptance | Complementary certifications | Complementary certification 
       id: 1,
       key: 'KEY',
       label: 'Pix+Droit',
+      hasComplementaryReferential: true,
     });
 
     server.create('certification-consolidated-framework', { id: 'KEY' });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
@@ -61,6 +61,7 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
         id: 1,
         key: 'AN',
         label: 'TOINE',
+        hasComplementaryReferential: true,
         targetProfilesHistory: [
           {
             id: 52,

--- a/api/src/certification/complementary-certification/domain/models/ComplementaryCertification.js
+++ b/api/src/certification/complementary-certification/domain/models/ComplementaryCertification.js
@@ -1,8 +1,9 @@
 class ComplementaryCertification {
-  constructor({ id, label, key }) {
+  constructor({ id, label, key, hasComplementaryReferential }) {
     this.id = id;
     this.label = label;
     this.key = key;
+    this.hasComplementaryReferential = hasComplementaryReferential;
   }
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
@@ -14,7 +14,10 @@ function _toDomain(row) {
 }
 
 const findAll = async function () {
-  const result = await knex.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
+  const result = await knex
+    .from('complementary-certifications')
+    .select('id', 'label', 'key', 'hasComplementaryReferential')
+    .orderBy('id', 'asc');
 
   return result.map(_toDomain);
 };

--- a/api/src/certification/configuration/infrastructure/serializers/complementary-certification-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/complementary-certification-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (complementaryCertifications) {
   return new Serializer('complementary-certification', {
-    attributes: ['label', 'key'],
+    attributes: ['label', 'key', 'hasComplementaryReferential'],
   }).serialize(complementaryCertifications);
 };
 

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
@@ -26,6 +26,7 @@ describe('Integration | Certification | Repository | complementary-certification
           id: 4,
           key: 'CLEA',
           label: 'CléA Numérique',
+          hasComplementaryReferential: false,
         });
 
         await databaseBuilder.commit();
@@ -54,6 +55,7 @@ describe('Integration | Certification | Repository | complementary-certification
             id: 4,
             key: 'CLEA',
             label: 'CléA Numérique',
+            hasComplementaryReferential: false,
           }),
         ];
 

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -38,6 +38,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
         id: 2,
         label: 'Cléa Numérique',
         key: ComplementaryCertificationKeys.CLEA,
+        hasComplementaryReferential: false,
       });
       await databaseBuilder.commit();
 
@@ -54,6 +55,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
             attributes: {
               label: 'Pix+ Edu 1er degré',
               key: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+              'has-complementary-referential': true,
             },
           },
           {
@@ -62,6 +64,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
             attributes: {
               label: 'Cléa Numérique',
               key: ComplementaryCertificationKeys.CLEA,
+              'has-complementary-referential': false,
             },
           },
         ],

--- a/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
@@ -5,11 +5,13 @@ const buildComplementaryCertification = function ({
   id = 1,
   label = 'Complementary certification name',
   key = ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+  hasComplementaryReferential = true,
 } = {}) {
   return new ComplementaryCertification({
     id,
     label,
     key,
+    hasComplementaryReferential,
   });
 };
 


### PR DESCRIPTION
## 🔆 Problème

CléA n'utilise pas de référentiel cadre donc on souhaite masquer l'onglet Référentiel Cadre pour CléA sur Pix Admin.

## ⛱️ Proposition

Utiliser l'information "hasComplementaryReferential" (false que pour CléA) pour conditionner l'affichage de l'onglet.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Aller sur Pix Admin, sous Certifications Complémentaires, vérifier que CléA n'a que l'onglet Profils Cibles et que les autres ont les deux onglets.
