### PR TITLE
[FEATURE] Affichage du statut terminé sur les éléments d'un parcours combiné (PIX-19077)

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -82,17 +82,17 @@ export class CombinedCourseDetails extends CombinedCourse {
     return questForUser.isSuccessful(dataForQuest);
   }
 
-  generateItems(
-    data,
+  generateItems({
+    itemDetails,
     recommendableModuleIds = [],
     recommendedModuleIdsForUser = [],
     encryptedCombinedCourseUrl,
     dataForQuest,
-  ) {
+  }) {
     this.items = [];
     for (const requirement of this.quest.successRequirements) {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
-        const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
+        const campaign = itemDetails.find(({ id }) => id === requirement.data.campaignId.data);
         const isCompleted = requirement.isFulfilled(dataForQuest);
         this.items.push(
           new CombinedCourseItem({
@@ -104,7 +104,7 @@ export class CombinedCourseDetails extends CombinedCourse {
           }),
         );
       } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
-        const module = data.find(({ id }) => id === requirement.data.moduleId.data);
+        const module = itemDetails.find(({ id }) => id === requirement.data.moduleId.data);
 
         const isRecommandable = recommendableModuleIds.find(
           (potentiallyRecommendedModule) => potentiallyRecommendedModule.moduleId === module.id,

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -82,17 +82,25 @@ export class CombinedCourseDetails extends CombinedCourse {
     return questForUser.isSuccessful(dataForQuest);
   }
 
-  generateItems(data, recommendableModuleIds = [], recommendedModuleIdsForUser = [], encryptedCombinedCourseUrl) {
+  generateItems(
+    data,
+    recommendableModuleIds = [],
+    recommendedModuleIdsForUser = [],
+    encryptedCombinedCourseUrl,
+    dataForQuest,
+  ) {
     this.items = [];
     for (const requirement of this.quest.successRequirements) {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         const campaign = data.find(({ id }) => id === requirement.data.campaignId.data);
+        const isCompleted = requirement.isFulfilled(dataForQuest);
         this.items.push(
           new CombinedCourseItem({
             id: campaign.id,
             reference: campaign.code,
             title: campaign.name,
             type: ITEM_TYPE.CAMPAIGN,
+            isCompleted,
           }),
         );
       } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
@@ -111,6 +119,7 @@ export class CombinedCourseDetails extends CombinedCourse {
           }
         }
 
+        const isCompleted = requirement.isFulfilled(dataForQuest);
         this.items.push(
           new CombinedCourseItem({
             id: module.id,
@@ -118,6 +127,7 @@ export class CombinedCourseDetails extends CombinedCourse {
             title: module.title,
             type: ITEM_TYPE.MODULE,
             redirection: encryptedCombinedCourseUrl,
+            isCompleted,
           }),
         );
       }

--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -4,11 +4,12 @@ export const ITEM_TYPE = {
 };
 
 export class CombinedCourseItem {
-  constructor({ id, title, reference, type, redirection }) {
+  constructor({ id, title, reference, type, redirection, isCompleted }) {
     this.id = id;
     this.title = title;
     this.reference = reference;
     this.redirection = redirection;
     this.type = type;
+    this.isCompleted = isCompleted;
   }
 }

--- a/api/src/quest/domain/models/CombinedCourseTemplate.js
+++ b/api/src/quest/domain/models/CombinedCourseTemplate.js
@@ -27,11 +27,11 @@ export class CombinedCourseTemplate {
   }
 
   toCombinedCourse(code, organizationId, campaigns) {
-    const quest = this.#toCombinedCourseQuestFormat(campaigns);
+    const quest = this.toCombinedCourseQuestFormat(campaigns);
     return new CombinedCourse({ name: this.#name, code, organizationId }, quest);
   }
 
-  #toCombinedCourseQuestFormat(campaigns) {
+  toCombinedCourseQuestFormat(campaigns) {
     const successRequirements = this.#quest.successRequirements.map((requirement) => {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         const requirementTargetProfileId = requirement.data.targetProfileId.data;

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -68,13 +68,13 @@ export async function getCombinedCourseByCode({
 
   const combinedCourseUrl = '/parcours/' + combinedCourseDetails.code;
   const encryptedCombinedCourseUrl = await cryptoService.encrypt(combinedCourseUrl, config.module.secret);
-  combinedCourseDetails.generateItems(
-    [...campaigns, ...modules],
+  combinedCourseDetails.generateItems({
+    itemDetails: [...campaigns, ...modules],
     recommendableModuleIds,
     recommendedModuleIdsForUser,
     encryptedCombinedCourseUrl,
     dataForQuest,
-  );
+  });
 
   return combinedCourseDetails;
 }

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (combinedCourse) {
     items: {
       ref: 'id',
       included: true,
-      attributes: ['title', 'reference', 'type', 'redirection'],
+      attributes: ['title', 'reference', 'type', 'redirection', 'isCompleted'],
     },
     typeForAttribute: (attribute) => {
       if (attribute === 'items') return 'combined-course-items';

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -44,6 +44,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
               data: campaign.id,
               comparison: 'equal',
             },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
           },
         },
         {
@@ -54,6 +58,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
               data: moduleId1,
               comparison: 'equal',
             },
+            isTerminated: {
+              data: true,
+              comparison: 'equal',
+            },
           },
         },
         {
@@ -62,6 +70,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
           data: {
             moduleId: {
               data: moduleId2,
+              comparison: 'equal',
+            },
+            isTerminated: {
+              data: true,
               comparison: 'equal',
             },
           },
@@ -80,6 +92,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         reference: campaign.code,
         title: campaign.name,
         type: ITEM_TYPE.CAMPAIGN,
+        isCompleted: false,
       }),
       new CombinedCourseItem({
         id: moduleId1,
@@ -87,6 +100,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: 'Bac à sable',
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
+        isCompleted: false,
       }),
       new CombinedCourseItem({
         id: moduleId2,
@@ -94,6 +108,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: 'Les bases du clavier sur ordinateur 1/2',
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
+        isCompleted: false,
       }),
     ]);
     expect(result.id).to.equal(questId);
@@ -126,6 +141,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
       trainingId: training1.id,
       campaignParticipationId: campaignParticipation.id,
     });
+    databaseBuilder.factory.buildPassage({ moduleId: moduleId1, userId, terminatedAt: new Date() });
 
     const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
       code,
@@ -139,6 +155,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
               data: campaign.id,
               comparison: 'equal',
             },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
           },
         },
         {
@@ -147,6 +167,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
           data: {
             moduleId: {
               data: moduleId1,
+              comparison: 'equal',
+            },
+            isTerminated: {
+              data: true,
               comparison: 'equal',
             },
           },
@@ -159,6 +183,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
               data: moduleId2,
               comparison: 'equal',
             },
+            isTerminated: {
+              data: true,
+              comparison: 'equal',
+            },
           },
         },
         {
@@ -167,6 +195,10 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
           data: {
             moduleId: {
               data: moduleId3,
+              comparison: 'equal',
+            },
+            isTerminated: {
+              data: true,
               comparison: 'equal',
             },
           },
@@ -186,6 +218,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         reference: campaign.code,
         title: campaign.name,
         type: ITEM_TYPE.CAMPAIGN,
+        isCompleted: true,
       }),
       new CombinedCourseItem({
         id: moduleId1,
@@ -193,6 +226,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: 'Bac à sable',
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
+        isCompleted: true,
       }),
       new CombinedCourseItem({
         id: moduleId3,
@@ -200,6 +234,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: 'Bien écrire une adresse mail',
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
+        isCompleted: false,
       }),
     ]);
     expect(result).to.be.instanceOf(CombinedCourse);

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -5,6 +5,7 @@ import {
 import { Campaign } from '../../../../../src/quest/domain/models/Campaign.js';
 import { CombinedCourse, CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
 import { CombinedCourseItem, ITEM_TYPE } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
+import { CombinedCourseTemplate } from '../../../../../src/quest/domain/models/CombinedCourseTemplate.js';
 import { DataForQuest } from '../../../../../src/quest/domain/models/DataForQuest.js';
 import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
 import { Module } from '../../../../../src/quest/domain/models/Module.js';
@@ -665,30 +666,30 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
     describe('#generateItems', function () {
       it('returns a combined course item for provided campaign', function () {
         // given
-        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique', targetProfileId: 7 });
 
-        const quest = new Quest({
-          id: 1,
-          rewardId: null,
-          rewardType: null,
-          eligibilityRequirements: [],
+        const combinedCourseTemplate = new CombinedCourseTemplate({
           successRequirements: [
             {
               requirement_type: 'campaignParticipations',
               comparison: 'all',
               data: {
-                campaignId: {
-                  data: campaign.id,
+                targetProfileId: {
+                  data: campaign.targetProfileId,
                   comparison: 'equal',
                 },
               },
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
 
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
+        });
         // when
-        combinedCourse.generateItems([campaign]);
+        combinedCourse.generateItems([campaign], null, null, null, dataForQuest);
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -697,35 +698,35 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             reference: campaign.code,
             title: campaign.name,
             type: ITEM_TYPE.CAMPAIGN,
+            isCompleted: true,
           }),
         ]);
       });
       it('should not take encryptedCombinedCourseUrl if item type is campaign', function () {
         // given
         const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
-        const quest = new Quest({
-          id: 1,
-          rewardId: null,
-          rewardType: null,
-          eligibilityRequirements: [],
+        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique', targetProfileId: 7 });
+        const combinedCourseTemplate = new CombinedCourseTemplate({
           successRequirements: [
             {
               requirement_type: 'campaignParticipations',
               comparison: 'all',
               data: {
-                campaignId: {
-                  data: campaign.id,
+                targetProfileId: {
+                  data: campaign.targetProfileId,
                   comparison: 'equal',
                 },
               },
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
-
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
+        });
         // when
-        combinedCourse.generateItems([campaign], [], [], encryptedCombinedCourseUrl);
+        combinedCourse.generateItems([campaign], [], [], encryptedCombinedCourseUrl, dataForQuest);
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -735,6 +736,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             title: campaign.name,
             type: ITEM_TYPE.CAMPAIGN,
             redirection: undefined,
+            isCompleted: true,
           }),
         ]);
       });
@@ -745,11 +747,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           const recommendableModuleIds = [];
           const recommendedModuleIdsForUser = [];
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-          const quest = new Quest({
-            id: 1,
-            rewardId: null,
-            rewardType: null,
-            eligibilityRequirements: [],
+          const combinedCourseTemplate = new CombinedCourseTemplate({
             successRequirements: [
               {
                 requirement_type: 'passages',
@@ -763,15 +761,26 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               },
             ],
           });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([]);
+          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
           const module = new Module({ id: 7, title: 'module' });
-
+          const dataForQuest = new DataForQuest({
+            eligibility: new Eligibility({
+              passages: [
+                {
+                  id: 7,
+                  status: 'NOT_STARTED',
+                },
+              ],
+            }),
+          });
           // when
           combinedCourse.generateItems(
             [module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
             encryptedCombinedCourseUrl,
+            dataForQuest,
           );
 
           // then
@@ -782,27 +791,24 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               title: module.title,
               type: ITEM_TYPE.MODULE,
               redirection: encryptedCombinedCourseUrl,
+              isCompleted: false,
             }),
           ]);
         });
         it('should not return module if it is recommandable, but not recommended for user', function () {
           // given
-          const module = new Module({ id: 1, title: 'module' });
+          const module = new Module({ id: 'module-id', title: 'module' });
           const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
           const recommendableModuleIds = [{ moduleId: module.id, targetProfileIds: [campaign.targetProfileId] }];
           const recommendedModuleIdsForUser = [];
-          const quest = new Quest({
-            id: 1,
-            rewardId: null,
-            rewardType: null,
-            eligibilityRequirements: [],
+          const combinedCourseTemplate = new CombinedCourseTemplate({
             successRequirements: [
               {
                 requirement_type: 'campaignParticipations',
                 comparison: 'all',
                 data: {
-                  campaignId: {
-                    data: campaign.id,
+                  targetProfileId: {
+                    data: campaign.targetProfileId,
                     comparison: 'equal',
                   },
                 },
@@ -819,10 +825,29 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               },
             ],
           });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+
+          const dataForQuest = new DataForQuest({
+            eligibility: new Eligibility({
+              campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }],
+              passages: [
+                {
+                  id: module.id,
+                  status: 'NOT_STARTED',
+                },
+              ],
+            }),
+          });
 
           // when
-          combinedCourse.generateItems([campaign, module], recommendableModuleIds, recommendedModuleIdsForUser);
+          combinedCourse.generateItems(
+            [campaign, module],
+            recommendableModuleIds,
+            recommendedModuleIdsForUser,
+            null,
+            dataForQuest,
+          );
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -831,6 +856,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: campaign.code,
               title: campaign.name,
               type: ITEM_TYPE.CAMPAIGN,
+              isCompleted: true,
             }),
           ]);
         });
@@ -842,18 +868,14 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
 
           const recommendableModuleIds = [{ moduleId: module.id }];
           const recommendedModuleIdsForUser = [{ moduleId: module.id }];
-          const quest = new Quest({
-            id: 1,
-            rewardId: null,
-            rewardType: null,
-            eligibilityRequirements: [],
+          const combinedCourseTemplate = new CombinedCourseTemplate({
             successRequirements: [
               {
                 requirement_type: 'campaignParticipations',
                 comparison: 'all',
                 data: {
-                  campaignId: {
-                    data: campaign.id,
+                  targetProfileId: {
+                    data: campaign.targetProfileId,
                     comparison: 'equal',
                   },
                 },
@@ -870,7 +892,19 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               },
             ],
           });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+          const dataForQuest = new DataForQuest({
+            eligibility: new Eligibility({
+              campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }],
+              passages: [
+                {
+                  id: module.id,
+                  status: 'NOT_STARTED',
+                },
+              ],
+            }),
+          });
 
           // when
           combinedCourse.generateItems(
@@ -878,6 +912,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             recommendableModuleIds,
             recommendedModuleIdsForUser,
             encryptedCombinedCourseUrl,
+            dataForQuest,
           );
 
           // then
@@ -887,6 +922,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               reference: campaign.code,
               title: campaign.name,
               type: ITEM_TYPE.CAMPAIGN,
+              isCompleted: true,
             }),
             new CombinedCourseItem({
               id: module.id,
@@ -894,6 +930,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               title: module.title,
               type: ITEM_TYPE.MODULE,
               redirection: encryptedCombinedCourseUrl,
+              isCompleted: false,
             }),
           ]);
         });
@@ -901,31 +938,33 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
 
       it('should not take into account data that are not related to the quest', function () {
         // given
-        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
+        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique', targetProfileId: 888 });
         const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', name: 'diagnostique2' });
 
-        const quest = new Quest({
-          id: 1,
-          rewardId: null,
-          rewardType: null,
-          eligibilityRequirements: [],
+        const combinedCourseTemplate = new CombinedCourseTemplate({
           successRequirements: [
             {
               requirement_type: 'campaignParticipations',
               comparison: 'all',
               data: {
-                campaignId: {
-                  data: campaign1.id,
+                targetProfileId: {
+                  data: campaign1.targetProfileId,
                   comparison: 'equal',
                 },
               },
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign1, campaign2]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({
+            campaignParticipations: [{ campaignId: campaign1.id, status: 'STARTED' }],
+          }),
+        });
 
         // when
-        combinedCourse.generateItems([campaign1, campaign2]);
+        combinedCourse.generateItems([campaign1, campaign2], null, null, null, dataForQuest);
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -934,28 +973,25 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             reference: campaign1.code,
             title: campaign1.name,
             type: ITEM_TYPE.CAMPAIGN,
+            isCompleted: false,
           }),
         ]);
       });
 
       it('should keep success requirements order', function () {
         // given
-        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique' });
-        const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', name: 'diagnostique2' });
+        const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique', targetProfileId: 888 });
+        const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', name: 'diagnostique2', targetProfileId: 999 });
         const module = new Module({ id: 7, title: 'title', slug: 'abcdef' });
 
-        const quest = new Quest({
-          id: 1,
-          rewardId: null,
-          rewardType: null,
-          eligibilityRequirements: [],
+        const combinedCourseTemplate = new CombinedCourseTemplate({
           successRequirements: [
             {
               requirement_type: 'campaignParticipations',
               comparison: 'all',
               data: {
-                campaignId: {
-                  data: campaign2.id,
+                targetProfileId: {
+                  data: campaign2.targetProfileId,
                   comparison: 'equal',
                 },
               },
@@ -964,8 +1000,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               requirement_type: 'campaignParticipations',
               comparison: 'all',
               data: {
-                campaignId: {
-                  data: campaign1.id,
+                targetProfileId: {
+                  data: campaign1.targetProfileId,
                   comparison: 'equal',
                 },
               },
@@ -975,17 +1011,25 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               comparison: 'all',
               data: {
                 moduleId: {
-                  data: 7,
+                  data: module.id,
                   comparison: 'equal',
                 },
               },
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign1, campaign2]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({
+            campaignParticipations: [{ campaignId: campaign1.id, status: 'STARTED' }],
+            passages: [],
+          }),
+        });
+        const redirectionUrl = 'redirectionUrl';
 
         // when
-        combinedCourse.generateItems([campaign1, campaign2, module]);
+        combinedCourse.generateItems([campaign1, campaign2, module], [], null, redirectionUrl, dataForQuest);
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -994,20 +1038,90 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             reference: campaign2.code,
             title: campaign2.name,
             type: ITEM_TYPE.CAMPAIGN,
+            isCompleted: false,
           }),
           new CombinedCourseItem({
             id: campaign1.id,
             reference: campaign1.code,
             title: campaign1.name,
             type: ITEM_TYPE.CAMPAIGN,
+            isCompleted: false,
           }),
           new CombinedCourseItem({
             id: module.id,
             reference: module.slug,
             title: module.title,
             type: ITEM_TYPE.MODULE,
+            redirection: redirectionUrl,
+            isCompleted: false,
           }),
         ]);
+      });
+      it('should evaluates if module is completed', function () {
+        // given
+        const module = new Module({ id: 7, title: 'title', slug: 'abcdef' });
+
+        const combinedCourseTemplate = new CombinedCourseTemplate({
+          successRequirements: [
+            {
+              requirement_type: 'passages',
+              comparison: 'all',
+              data: {
+                moduleId: {
+                  data: module.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({
+            passages: [{ id: module.id, status: 'COMPLETED' }],
+          }),
+        });
+
+        // when
+        combinedCourse.generateItems([module], [], null, 'redirectionUrl', dataForQuest);
+        const [moduleItem] = combinedCourse.items;
+
+        // then
+        expect(moduleItem.isCompleted).to.be.true;
+      });
+      it('should evaluates if campaign is completed', function () {
+        // given
+        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', name: 'diagnostique', targetProfileId: 888 });
+
+        const combinedCourseTemplate = new CombinedCourseTemplate({
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                targetProfileId: {
+                  data: campaign.targetProfileId,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({
+            campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }],
+          }),
+        });
+
+        // when
+        combinedCourse.generateItems([campaign], [], null, 'redirectionUrl', dataForQuest);
+        const [campaignItem] = combinedCourse.items;
+
+        // then
+        expect(campaignItem.isCompleted).to.be.true;
       });
     });
 

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -689,7 +689,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
         });
         // when
-        combinedCourse.generateItems([campaign], null, null, null, dataForQuest);
+        combinedCourse.generateItems({ itemDetails: [campaign], dataForQuest });
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -726,7 +726,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
         });
         // when
-        combinedCourse.generateItems([campaign], [], [], encryptedCombinedCourseUrl, dataForQuest);
+        combinedCourse.generateItems({ itemDetails: [campaign], encryptedCombinedCourseUrl, dataForQuest });
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -775,13 +775,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             }),
           });
           // when
-          combinedCourse.generateItems(
-            [module],
+          combinedCourse.generateItems({
+            itemDetails: [module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
             encryptedCombinedCourseUrl,
             dataForQuest,
-          );
+          });
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -841,13 +841,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           });
 
           // when
-          combinedCourse.generateItems(
-            [campaign, module],
+          combinedCourse.generateItems({
+            itemDetails: [campaign, module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
-            null,
             dataForQuest,
-          );
+          });
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -907,13 +906,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           });
 
           // when
-          combinedCourse.generateItems(
-            [campaign, module],
+          combinedCourse.generateItems({
+            itemDetails: [campaign, module],
             recommendableModuleIds,
             recommendedModuleIdsForUser,
             encryptedCombinedCourseUrl,
             dataForQuest,
-          );
+          });
 
           // then
           expect(combinedCourse.items).to.deep.equal([
@@ -964,7 +963,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         });
 
         // when
-        combinedCourse.generateItems([campaign1, campaign2], null, null, null, dataForQuest);
+        combinedCourse.generateItems({ itemDetails: [campaign1, campaign2], dataForQuest });
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -1029,7 +1028,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         const redirectionUrl = 'redirectionUrl';
 
         // when
-        combinedCourse.generateItems([campaign1, campaign2, module], [], null, redirectionUrl, dataForQuest);
+        combinedCourse.generateItems({
+          itemDetails: [campaign1, campaign2, module],
+          encryptedCombinedCourseUrl: redirectionUrl,
+          dataForQuest,
+        });
 
         // then
         expect(combinedCourse.items).to.deep.equal([
@@ -1084,7 +1087,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         });
 
         // when
-        combinedCourse.generateItems([module], [], null, 'redirectionUrl', dataForQuest);
+        combinedCourse.generateItems({
+          itemDetails: [module],
+          encryptedCombinedCourseUrl: 'redirectionUrl',
+          dataForQuest,
+        });
         const [moduleItem] = combinedCourse.items;
 
         // then
@@ -1117,7 +1124,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         });
 
         // when
-        combinedCourse.generateItems([campaign], [], null, 'redirectionUrl', dataForQuest);
+        combinedCourse.generateItems({
+          itemDetails: [campaign],
+          encryptedCombinedCourseUrl: 'redirectionUrl',
+          dataForQuest,
+        });
         const [campaignItem] = combinedCourse.items;
 
         // then

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -40,6 +40,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             reference: 'ABCDIAG1',
             type: ITEM_TYPE.CAMPAIGN,
             redirection: undefined,
+            'is-completed': false,
           },
         },
         {
@@ -50,6 +51,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             reference: 'slug',
             type: ITEM_TYPE.MODULE,
             redirection: 'encryptedCombinedCourseUrl',
+            'is-completed': false,
           },
         },
       ],

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -58,7 +58,11 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
       passages: [],
     }),
   });
-  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], encryptedCombinedCourseUrl, dataForQuest);
+  combinedCourseDetails.generateItems({
+    itemDetails: items ?? [campaign, module],
+    encryptedCombinedCourseUrl,
+    dataForQuest,
+  });
 
   return combinedCourseDetails;
 }

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -1,5 +1,7 @@
 import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import { CombinedCourse, CombinedCourseDetails } from '../../../../src/quest/domain/models/CombinedCourse.js';
+import { DataForQuest } from '../../../../src/quest/domain/models/DataForQuest.js';
+import { Eligibility } from '../../../../src/quest/domain/models/Eligibility.js';
 import { Quest } from '../../../../src/quest/domain/models/Quest.js';
 import { domainBuilder } from '../domain-builder.js';
 
@@ -50,7 +52,13 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
 
   const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest);
-  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], encryptedCombinedCourseUrl);
+  const dataForQuest = new DataForQuest({
+    eligibility: new Eligibility({
+      campaignParticipations: [],
+      passages: [],
+    }),
+  });
+  combinedCourseDetails.generateItems(items ?? [campaign, module], [], [], encryptedCombinedCourseUrl, dataForQuest);
 
   return combinedCourseDetails;
 }

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -1,12 +1,20 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
+import { t } from 'ember-intl';
 
 const Content = <template>
   <div class="combined-course-item">
     <div class="combined-course-item__title">{{@title}}</div>
     {{#if @isLocked}}
       <PixIcon @name="lock" @plainIcon={{true}} />
+    {{/if}}
+    {{#if @isCompleted}}
+      <div class="combined-course-item__indicator--completed">
+        <span>{{t "pages.combined-courses.items.completed"}}</span>
+        <PixIcon @name="checkCircle" @plainIcon={{true}} class="combined-course-item__icon" />
+      </div>
+
     {{/if}}
   </div>
 </template>;
@@ -16,7 +24,7 @@ const Content = <template>
     <Content @title={{@item.title}} @isLocked={{true}} />
   {{else}}
     <LinkTo @route={{@item.route}} @model={{@item.reference}} @query={{hash redirection=@item.redirection}} disabled>
-      <Content @title={{@item.title}} />
+      <Content @title={{@item.title}} @isCompleted={{@item.isCompleted}} />
     </LinkTo>
   {{/if}}
 </template>

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -5,6 +5,7 @@ export default class CombinedCourseItem extends Model {
   @attr('string') reference;
   @attr('string') type;
   @attr('string') redirection;
+  @attr('boolean') isCompleted;
 
   get route() {
     return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -4,14 +4,14 @@
   padding: var(--pix-spacing-12x) 80px;
 
   &-completed {
-      display: flex;
-      gap: var(--pix-spacing-4x);
-      align-items: center;
-      padding: var(--pix-spacing-6x);
-      background: var(--pix-secondary-100);
-      border: 1px solid var(--pix-secondary-500);
-      border-radius: 16px;
-      box-shadow: 2px 6px 0 1px var(--pix-secondary-700);
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    padding: var(--pix-spacing-6x);
+    background: var(--pix-secondary-100);
+    border: 1px solid var(--pix-secondary-500);
+    border-radius: 16px;
+    box-shadow: 2px 6px 0 1px var(--pix-secondary-700);
 
     .completed-text {
       display: flex;
@@ -51,5 +51,23 @@
 
   &__title {
     @extend %pix-title-xxs;
+  }
+
+
+  &__indicator {
+    &--completed {
+      @extend %pix-body-m;
+
+      display: flex;
+      gap: var(--pix-spacing-2x);
+      align-items: center;
+      color: var(--pix-primary-300);
+      font-weight: var(--pix-font-bold);
+
+      .combined-course-item__icon {
+        width: var(--pix-spacing-8x);
+        height: var(--pix-spacing-8x);
+      }
+    }
   }
 }

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -140,7 +140,6 @@ module('Integration | Component | combined course', function (hooks) {
         router.urlFor('campaigns', { code: combinedCourseItem.reference }),
       );
     });
-
     test('should display modules with with related link', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -184,6 +183,33 @@ module('Integration | Component | combined course', function (hooks) {
           },
         ),
       );
+    });
+    test('should display completed status for finished items', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+        isCompleted: true,
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'STARTED',
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+    <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByText(t('pages.combined-courses.items.completed')));
     });
   });
   module('when participation is completed', function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1196,6 +1196,9 @@
       },
       "content": {
         "start-button": "Start course"
+      },
+      "items": {
+        "completed": "Completed!"
       }
     },
     "comparison-window": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1188,9 +1188,12 @@
       "content": {
         "start-button": "Iniciar el curso"
       },
-      "completed" : {
+      "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",
         "description": "¡Bien hecho! Ha dado un paso importante para navegar con seguridad por el mundo digital."
+      },
+      "items": {
+        "completed": "¡Completado!"
       }
     },
     "comparison-window": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1196,6 +1196,9 @@
       },
       "content": {
         "start-button": "Commencer mon parcours"
+      },
+      "items": {
+        "completed": "Complété !"
       }
     },
     "comparison-window": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1192,9 +1192,12 @@
       "content": {
         "start-button": "Cursus starten"
       },
-      "completed" : {
+      "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",
         "description": "Goed gedaan! Je hebt een belangrijke stap gezet om veilig door de digitale wereld te navigeren."
+      },
+      "items": {
+        "completed": "Voltooid!"
       }
     },
     "comparison-window": {


### PR DESCRIPTION
## 🔆 Problème

Lorsque les campagnes ou modules d'un parcours combiné sont terminé, rien ne l'indique sur l'écran du parcours.

## ⛱️ Proposition

Ajouter une indication visuelle (coche + message) sur les éléments terminés.

## 🏄 Pour tester

Se connecter avec attestation-blank@example.net (déjà réconcilié).
Passer un parcours combiné (code : COMBINIX1).
-> A chaque fois qu'un élément est terminé (campagne/module), l'indication visuelle est présente.
