### PR TITLE
[TECH] Mettre à jour les versions de postgresql et redis des review apps

### DIFF
--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -33,13 +33,13 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "16.6"
+        "version": "16.9"
       }
     },
     {
       "plan": "redis:redis-sandbox",
       "options": {
-        "version": "7.2.5"
+        "version": "7.2.9"
       }
     }
   ],

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -33,7 +33,7 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "16.6"
+        "version": "16.9"
       }
     }
   ],


### PR DESCRIPTION
## 🔆 Problème
Actuellement, les RA sont créées avec des versions d'addon postgresql et redis antérieures à celles de production. 

## ⛱️ Proposition
Mettre à jour les versions de postgresql et redis des review apps

## 🌊 Remarques
Renovate se chargeait de mettre à jour ces versions mais suite à un déplacement des fichiers scalingo.json cela ne fonctionnait plus. Une PR a été mergée sur 1024pix/renovate-config afin de corriger ce problème.

## 🏄 Pour tester
Vérifier que les RA pix-api et pix-audit-logger sont bien créées.