### PR TITLE
[BUGFIX] Réparer la pagination de la page attestation (PIX-19193).

### DIFF
--- a/api/src/prescription/organization-learner/domain/usecases/find-paginated-filtered-attestation-participants-status.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-paginated-filtered-attestation-participants-status.js
@@ -6,33 +6,17 @@ export const findPaginatedFilteredAttestationParticipantsStatus = async ({
   organizationLearnerRepository,
 }) => {
   const { search: name, divisions, statuses } = filter;
-  const { learners, pagination } = await organizationLearnerRepository.findPaginatedLearners({
-    organizationId,
-    filter: { name, divisions },
-    page,
-  });
 
-  let attestationParticipantsStatus =
-    await organizationLearnerRepository.getAttestationStatusForOrganizationLearnersAndKey({
+  const { attestationParticipantsStatus, pagination } =
+    await organizationLearnerRepository.findPaginatedAttestationStatusForOrganizationLearnersAndKey({
       attestationKey,
-      organizationLearners: learners,
+      filter: { name, divisions, statuses },
+      page,
       organizationId,
     });
-
-  if (statuses?.length > 0) {
-    attestationParticipantsStatus = attestationParticipantsStatus.filter((attestationParticipantStatus) =>
-      _filterByStatuses(attestationParticipantStatus, statuses),
-    );
-  }
 
   return {
     attestationParticipantsStatus,
     pagination,
   };
 };
-
-function _filterByStatuses(attestationParticipantStatus, filterStatuses) {
-  const isFilteredByObtained = filterStatuses.includes('OBTAINED') && Boolean(attestationParticipantStatus.obtainedAt);
-  const isFilteredByNotObtained = filterStatuses.includes('NOT_OBTAINED') && !attestationParticipantStatus.obtainedAt;
-  return isFilteredByObtained || isFilteredByNotObtained;
-}

--- a/api/src/profile/application/api/attestations-api.js
+++ b/api/src/profile/application/api/attestations-api.js
@@ -26,11 +26,10 @@ export const generateAttestations = async function ({
   return dependencies.pdfWithFormSerializer.serialize(templatePath, data);
 };
 
-export const getAttestationsUserDetail = async function ({ attestationKey, userIds, organizationId }) {
+export const getAttestationsUserDetail = async function ({ attestationKey, organizationId }) {
   const locale = FRENCH_FRANCE;
-  const attestations = await usecases.getSharedAttestationsUserDetailForOrganizationByUserIds({
+  const attestations = await usecases.getSharedAttestationsUserDetailByOrganizationId({
     attestationKey,
-    userIds,
     organizationId,
     locale,
   });

--- a/api/src/profile/domain/usecases/get-shared-attestations-user-detail-by-organization-id.js
+++ b/api/src/profile/domain/usecases/get-shared-attestations-user-detail-by-organization-id.js
@@ -1,11 +1,9 @@
 import { AttestationNotFoundError } from '../errors.js';
 import { AttestationUserDetail } from '../models/AttestationUserDetail.js';
 
-export async function getSharedAttestationsUserDetailForOrganizationByUserIds({
+export async function getSharedAttestationsUserDetailByOrganizationId({
   attestationKey,
-  userIds,
   organizationId,
-  userRepository,
   profileRewardRepository,
   attestationRepository,
   organizationProfileRewardRepository,
@@ -16,8 +14,6 @@ export async function getSharedAttestationsUserDetailForOrganizationByUserIds({
     throw new AttestationNotFoundError();
   }
 
-  const users = await userRepository.getByIds({ userIds });
-
   const sharedProfileRewards = await organizationProfileRewardRepository.getByOrganizationId({
     attestationKey,
     organizationId,
@@ -26,19 +22,11 @@ export async function getSharedAttestationsUserDetailForOrganizationByUserIds({
 
   const profileRewards = await profileRewardRepository.getByIds({ profileRewardIds });
 
-  const filteredUsers = users.filter((user) => !user.isAnonymous && !user.hasBeenAnonymised);
-
-  return profileRewards
-    .filter((profileReward) => _hasActiveUser(profileReward, filteredUsers))
-    .map((profileReward) => {
-      return new AttestationUserDetail({
-        attestationKey,
-        obtainedAt: profileReward.createdAt,
-        userId: profileReward.userId,
-      });
+  return profileRewards.map((profileReward) => {
+    return new AttestationUserDetail({
+      attestationKey,
+      obtainedAt: profileReward.createdAt,
+      userId: profileReward.userId,
     });
-}
-
-function _hasActiveUser(profileReward, activeUsers) {
-  return activeUsers.some(({ id }) => id === profileReward.userId);
+  });
 }

--- a/api/src/profile/domain/usecases/index.js
+++ b/api/src/profile/domain/usecases/index.js
@@ -32,7 +32,7 @@ import { getAttestationDetails } from './get-attestation-details.js';
 import { getProfileRewardsByUserId } from './get-profile-rewards-by-user-id.js';
 import { getRewardByIdAndType } from './get-reward-by-id-and-type.js';
 import { getSharedAttestationsForOrganizationByUserIds } from './get-shared-attestations-for-organization-by-user-ids.js';
-import { getSharedAttestationsUserDetailForOrganizationByUserIds } from './get-shared-attestations-user-detail-for-organization-by-user-ids.js';
+import { getSharedAttestationsUserDetailByOrganizationId } from './get-shared-attestations-user-detail-by-organization-id.js';
 import { getUserProfile } from './get-user-profile.js';
 import { rewardUser } from './reward-user.js';
 import { shareProfileReward } from './share-profile-reward.js';
@@ -43,7 +43,7 @@ const usecasesWithoutInjectedDependencies = {
   getProfileRewardsByUserId,
   getRewardByIdAndType,
   getSharedAttestationsForOrganizationByUserIds,
-  getSharedAttestationsUserDetailForOrganizationByUserIds,
+  getSharedAttestationsUserDetailByOrganizationId,
   getUserProfile,
   rewardUser,
   shareProfileReward,

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -99,7 +99,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
 
       const request = {
         method: 'GET',
-        url: `/api/organizations/${organizationId}/attestations/${attestation.key}/statuses?filter[statuses][]=OBTAINED`,
+        url: `/api/organizations/${organizationId}/attestations/${attestation.key}/statuses?page[size]=1&filter[statuses][]=OBTAINED`,
         headers: generateAuthenticatedUserRequestHeaders({ userId }),
       };
 
@@ -127,7 +127,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
         meta: {
           page: 1,
           pageCount: 1,
-          pageSize: 10,
+          pageSize: 1,
           rowCount: 1,
         },
       };

--- a/api/tests/profile/unit/application/api/attestations-api_test.js
+++ b/api/tests/profile/unit/application/api/attestations-api_test.js
@@ -44,7 +44,6 @@ describe('Profile | Unit | Application | Api | attestations', function () {
   describe('#getAttestationsUserDetail', function () {
     it('should return users attestations', async function () {
       const attestationKey = Symbol('attestationKey');
-      const userIds = Symbol('userIds');
       const organizationId = Symbol('organizationId');
       const data = Symbol('data');
       const locale = FRENCH_FRANCE;
@@ -55,13 +54,13 @@ describe('Profile | Unit | Application | Api | attestations', function () {
         },
       };
 
-      sinon.stub(usecases, 'getSharedAttestationsUserDetailForOrganizationByUserIds');
+      sinon.stub(usecases, 'getSharedAttestationsUserDetailByOrganizationId');
 
-      usecases.getSharedAttestationsUserDetailForOrganizationByUserIds
-        .withArgs({ attestationKey, userIds, organizationId, locale })
+      usecases.getSharedAttestationsUserDetailByOrganizationId
+        .withArgs({ attestationKey, organizationId, locale })
         .resolves(data);
 
-      const result = await getAttestationsUserDetail({ attestationKey, userIds, organizationId, dependencies });
+      const result = await getAttestationsUserDetail({ attestationKey, organizationId, dependencies });
 
       expect(result).to.equal(data);
     });

--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -33,7 +33,7 @@ export default class AttestationList extends Component {
       @title={{t "common.filters.title"}}
       class="participant-filter-banner hide-on-mobile"
       aria-label={{t "pages.attestations.table.filter.legend"}}
-      @details={{t "pages.attestations.table.filter.results" total=@participantStatuses.length}}
+      @details={{t "pages.attestations.table.filter.results" total=@participantStatuses.meta.rowCount}}
       @clearFiltersLabel={{t "common.filters.actions.clear"}}
       @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
       @onClearFilters={{@clearFilters}}

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -34,23 +34,19 @@ export default class AuthenticatedAttestationsRoute extends Route {
   async model(params) {
     const attestationKey = this.currentUser.prescriber.availableAttestations[0];
     const organizationId = this.currentUser.organization.id;
-    const attestationParticipantStatuses = await this.store.query(
-      'attestation-participant-status',
-      {
-        organizationId,
-        attestationKey,
-        filter: {
-          statuses: params.statuses,
-          divisions: params.divisions,
-          search: params.search,
-        },
-        page: {
-          number: params.pageNumber,
-          size: params.pageSize,
-        },
+    const attestationParticipantStatuses = await this.store.query('attestation-participant-status', {
+      organizationId,
+      attestationKey,
+      filter: {
+        statuses: params.statuses,
+        divisions: params.divisions,
+        search: params.search,
       },
-      { reload: true },
-    );
+      page: {
+        number: params.pageNumber,
+        size: params.pageSize,
+      },
+    });
 
     if (this.currentUser.organization.isManagingStudents) {
       const divisions = await this.currentUser.organization.divisions;
@@ -74,5 +70,10 @@ export default class AuthenticatedAttestationsRoute extends Route {
   @action
   refreshModel() {
     this.refresh();
+  }
+
+  @action
+  loading() {
+    return false;
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -569,15 +569,15 @@
           "legend": "Filtres pour le tableau des attestations, des champs de saisie permettent de filtrer le tableau par le nom ou prénom d'un élève et par classes. Des boutons permettent de filtrer les attestations obtenues ou non.",
           "results": "{total, plural, =0 {0 résultat} =1 {1 résultat} other {{total, number} résultats}}",
           "status": {
-            "empty-option": "Obtenu / Non obtenu",
+            "empty-option": "Obtenue / Non obtenue",
             "label": "Obtention",
-            "not-obtained": "Non obtenu",
-            "obtained": "Obtenu"
+            "not-obtained": "Non obtenue",
+            "obtained": "Obtenue"
           }
         },
         "status": {
-          "not-obtained": "Non obtenu",
-          "obtained": "Obtenu le {date}"
+          "not-obtained": "Non obtenue",
+          "obtained": "Obtenue le {date}"
         }
       },
       "title": "Attestations"


### PR DESCRIPTION
## 🔆 Problème
Actuellement, la pagination de la page attestations sur Pix Orga, est cassée

<img width="3456" height="1988" alt="Screenshot 2025-08-22 at 11 12 01" src="https://github.com/user-attachments/assets/5a5914a5-15ae-4ea1-b6ff-9c712f841021" />

Plusieurs problèmes : 
- Le chiffre dans l'encadré bleu devrait correspondre au total après filtres  (donc correspondre au nombre dans l'encadré vert 17) 
- Puis, on demande une pageSize de 5, et nous avons 4 élements 

## ⛱️ Proposition

Les paginations étaient faites en amont des filtres, pour remédier à ça, nous avons déplacé la logique dans la méthode du repository et nous avons fait en sorte que l'API interne d'attestations nous ramène tous les users de l'organisation et non pas que ceux qu'on donne.  

## 🌊 Remarques

Au passage on a corrigé le soucis de reload à chaque selection sur le multiselect

Avant : 

https://github.com/user-attachments/assets/a5082919-3b8c-4b00-a408-61b8861bf35e

Après : 

https://github.com/user-attachments/assets/331fd0c5-03da-46c0-ab25-9f350cbed91a





## 🏄 Pour tester
- Se connecter sur Pix Orga
- Aller sur page attestations
- Filtrer et constater le bon fonctionnement 