### PR TITLE
[FEATURE] Envoyer la solution et les feedbacks des QCU à la récupération des données du module (PIX-19220)

### DIFF
--- a/api/src/devcomp/domain/models/QcuProposal.js
+++ b/api/src/devcomp/domain/models/QcuProposal.js
@@ -4,12 +4,11 @@ class QcuProposal {
   constructor({ id, content, feedback }) {
     assertNotNullOrUndefined(id, 'The id is required for a QCU proposal.');
     assertNotNullOrUndefined(content, 'The content is required for a QCU proposal.');
+    assertNotNullOrUndefined(feedback, 'The feedback is required for a QCU proposal.');
 
     this.id = id;
     this.content = content;
-    if (feedback) {
-      this.feedback = feedback;
-    }
+    this.feedback = feedback;
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCU-declarative.js
+++ b/api/src/devcomp/domain/models/element/QCU-declarative.js
@@ -1,8 +1,30 @@
-import { QCU } from './QCU.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ModuleInstantiationError } from '../../errors.js';
+import { Element } from './Element.js';
 
-class QCUDeclarative extends QCU {
+class QCUDeclarative extends Element {
   constructor({ id, instruction, proposals }) {
-    super({ id, instruction, proposals, type: 'qcu-declarative' });
+    super({ id, type: 'qcu-declarative' });
+
+    assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU declarative');
+    this.#assertProposalsIsAnArray(proposals);
+    this.#assertProposalsAreNotEmpty(proposals);
+
+    this.instruction = instruction;
+    this.proposals = proposals;
+    this.isAnswerable = true;
+  }
+
+  #assertProposalsAreNotEmpty(proposals) {
+    if (proposals.length === 0) {
+      throw new ModuleInstantiationError('The proposals are required for a QCU declarative');
+    }
+  }
+
+  #assertProposalsIsAnArray(proposals) {
+    if (!Array.isArray(proposals)) {
+      throw new ModuleInstantiationError('The QCU declarative proposals should be a list');
+    }
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCU-discovery.js
+++ b/api/src/devcomp/domain/models/element/QCU-discovery.js
@@ -2,7 +2,7 @@ import { QCU } from './QCU.js';
 
 class QCUDiscovery extends QCU {
   constructor({ id, instruction, proposals, solution }) {
-    super({ id, instruction, proposals, type: 'qcu-discovery' });
+    super({ id, instruction, proposals, solution, type: 'qcu-discovery' });
 
     this.solution = solution;
   }

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -10,12 +10,10 @@ import { QCU } from './QCU.js';
 class QCUForAnswerVerification extends QCU {
   userResponse;
   constructor({ id, instruction, locales, proposals, solution, validator }) {
-    super({ id, instruction, locales, proposals });
+    super({ id, instruction, locales, proposals, solution: { value: solution } });
 
     assertNotNullOrUndefined(solution, 'The solution is required for a verification QCU');
     this.#assertSolutionIsAnExistingProposal(solution, proposals);
-
-    this.solution = { value: solution };
 
     if (validator) {
       this.validator = validator;

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -3,16 +3,18 @@ import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
 class QCU extends Element {
-  constructor({ id, instruction, locales, proposals, type = 'qcu' }) {
+  constructor({ id, instruction, locales, proposals, solution, type = 'qcu' }) {
     super({ id, type });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU');
     this.#assertProposalsIsAnArray(proposals);
     this.#assertProposalsAreNotEmpty(proposals);
+    assertNotNullOrUndefined(solution, 'The solution is required for a QCU');
 
     this.instruction = instruction;
     this.locales = locales;
     this.proposals = proposals;
+    this.solution = solution;
     this.isAnswerable = true;
   }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -2,7 +2,7 @@
   "id": "235c680e-cbd2-4c56-bef6-80d3ed4d417a",
   "slug": "demo-epreuves-components",
   "title": "Démonstration des composants Pix Épreuves",
-  "isBeta": false,
+  "isBeta": true,
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement tous les composants Pix Épreuves.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -2,7 +2,7 @@
   "id": "1b33d6ab-ebfe-49fa-8568-8c40471b4baa",
   "slug": "galerie",
   "title": "Galerie Modulix",
-  "isBeta": false,
+  "isBeta": true,
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -2,7 +2,7 @@
   "id": "d03cef94-74af-463d-8901-c886b48d6e0b",
   "slug": "tmp-ia-int-mgo",
   "title": "Comment l'IA générative apprend-elle à discuter avec vous ?",
-  "isBeta": false,
+  "isBeta": true,
   "details": {
     "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les logiciels d'IA génératives&nbsp;de texte sont capables de tenir des conversations étonnamment naturelles. Mais comment en sont-ils arrivés là ? Ce module vous emmène dans les coulisses de leur apprentissage&nbsp;: des montagnes de textes analysés aux techniques d’entraînement sophistiquées qui leur ont permis de comprendre, prédire et générer le langage humain.</p>",

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -253,8 +253,10 @@ export class ModuleFactory {
         return new QcuProposal({
           id: proposal.id,
           content: proposal.content,
+          feedback: proposal.feedback,
         });
       }),
+      solution: element.solution,
     });
   }
 

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -211,17 +211,16 @@
                       "proposals": [
                         {
                           "id": "1",
-                          "content": "Vrai"
+                          "content": "Vrai",
+                          "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
                         },
                         {
                           "id": "2",
-                          "content": "Faux"
+                          "content": "Faux",
+                          "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
                         }
                       ],
-                      "feedbacks": {
-                        "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
-                        "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
-                      },
+
                       "solution": "1"
                     }
                   ]
@@ -235,17 +234,15 @@
                       "proposals": [
                         {
                           "id": "1",
-                          "content": "Vrai"
+                          "content": "Vrai",
+                          "feedback": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
                         },
                         {
                           "id": "2",
-                          "content": "Faux"
+                          "content": "Faux",
+                          "feedback": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>"
                         }
                       ],
-                      "feedbacks": {
-                        "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>",
-                        "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
-                      },
                       "solution": "2"
                     }
                   ]
@@ -259,11 +256,14 @@
                       "proposals": [
                         {
                           "id": "1",
-                          "content": "Vrai"
+                          "content": "Vrai",
+                          "feedback": { "diagnosis": "Bonne réponse !" }
                         },
                         {
                           "id": "2",
-                          "content": "Faux"
+                          "content": "Faux",
+                          "feedback": { "diagnosis": "Mauvaise réponse !" }
+
                         }
                       ]
                     }

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -13,24 +13,21 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
       const element = new QCUForAnswerVerification({
         id: elementId,
-        type: 'qcu',
         instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
         proposals: [
           {
             id: '1',
             content: 'Vrai',
+            feedback:
+              '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
           },
           {
             id: '2',
             content: 'Faux',
+            feedback:
+              '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
           },
         ],
-        feedbacks: {
-          valid:
-            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-          invalid:
-            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
-        },
         solution: '1',
       });
       const moduleDatasourceStub = {
@@ -69,18 +66,16 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                         {
                           id: '1',
                           content: 'Vrai',
+                          feedback:
+                            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                         },
                         {
                           id: '2',
                           content: 'Faux',
+                          feedback:
+                            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                         },
                       ],
-                      feedbacks: {
-                        valid:
-                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                        invalid:
-                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
-                      },
                       solution: '1',
                     },
                   },
@@ -109,24 +104,21 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
       const element = new QCUForAnswerVerification({
         id: elementId,
-        type: 'qcu',
         instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
         proposals: [
           {
             id: '1',
             content: 'Vrai',
+            feedback:
+              '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
           },
           {
             id: '2',
             content: 'Faux',
+            feedback:
+              '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
           },
         ],
-        feedbacks: {
-          valid:
-            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-          invalid:
-            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
-        },
         solution: '1',
       });
       const moduleDatasourceStub = {
@@ -168,18 +160,16 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                               {
                                 id: '1',
                                 content: 'Vrai',
+                                feedback:
+                                  '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                               },
                               {
                                 id: '2',
                                 content: 'Faux',
+                                feedback:
+                                  '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
                               },
                             ],
-                            feedbacks: {
-                              valid:
-                                '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                              invalid:
-                                '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
-                            },
                             solution: '1',
                           },
                         ],
@@ -196,18 +186,16 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                         {
                           id: '1',
                           content: 'Vrai',
+                          feedback:
+                            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                         },
                         {
                           id: '2',
                           content: 'Faux',
+                          feedback:
+                            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
                         },
                       ],
-                      feedbacks: {
-                        valid:
-                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                        invalid:
-                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
-                      },
                       solution: '1',
                     },
                   },
@@ -305,18 +293,16 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                         {
                           id: '1',
                           content: 'Vrai',
+                          feedback:
+                            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                         },
                         {
                           id: '2',
                           content: 'Faux',
+                          feedback:
+                            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                         },
                       ],
-                      feedbacks: {
-                        valid:
-                          '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-                        invalid:
-                          '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
-                      },
                       solution: '1',
                     },
                   },
@@ -337,18 +323,16 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
             {
               id: '1',
               content: 'Vrai',
+              feedback:
+                '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
             },
             {
               id: '2',
               content: 'Faux',
+              feedback:
+                '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
             },
           ],
-          feedbacks: {
-            valid:
-              '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
-            invalid:
-              '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
-          },
           solution: '1',
         },
       ]);

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -42,4 +42,18 @@ describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
       expect(error.message).to.equal('The content is required for a QCU proposal.');
     });
   });
+
+  describe('A QCU proposal without feedback', function () {
+    it('should throw an error', function () {
+      // given
+      const content = 'vrai';
+
+      // when
+      const error = catchErrSync(() => new QcuProposal({ id: '1', content }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedback is required for a QCU proposal.');
+    });
+  });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -13,6 +13,7 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
         instruction: 'instruction',
         locales: ['fr-FR'],
         proposals: [Symbol('proposal1'), Symbol('proposal2')],
+        solution: 'proposal1',
       });
 
       const qrocm = new QROCM({

--- a/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-discovery_test.js
@@ -1,5 +1,8 @@
+import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { QCUDeclarative } from '../../../../../../src/devcomp/domain/models/element/QCU-declarative.js';
 import { QCUDiscovery } from '../../../../../../src/devcomp/domain/models/element/QCU-discovery.js';
-import { expect } from '../../../../../test-helper.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | QCU-discovery', function () {
   describe('#constructor', function () {
@@ -22,6 +25,50 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU-discovery', function 
       expect(qcu.type).equal('qcu-discovery');
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
       expect(qcu.solution).equal('1');
+    });
+  });
+
+  describe('A QCUDeclarative without id', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCUDeclarative({}))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The id is required for an element');
+    });
+  });
+
+  describe('A QCUDeclarative without instruction', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCUDeclarative({ id: '123' }))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The instruction is required for a QCU declarative');
+    });
+  });
+
+  describe('A QCUDeclarative with an empty list of proposals', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCUDeclarative({ id: '123', instruction: 'toto', proposals: [] }))();
+
+      // then
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
+      expect(error.message).to.equal('The proposals are required for a QCU declarative');
+    });
+  });
+
+  describe('A QCUDeclarative does not have a list of proposals', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCUDeclarative({ id: '123', instruction: 'toto', proposals: 'toto' }))();
+
+      // then
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
+      expect(error.message).to.equal('The QCU declarative proposals should be a list');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -16,6 +16,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
         instruction: 'instruction',
         locales: ['fr-FR'],
         proposals: [proposal1, proposal2],
+        solution: 'proposal1',
       });
 
       // Then
@@ -24,6 +25,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
       expect(qcu.type).equal('qcu');
       expect(qcu.locales).deep.equal(['fr-FR']);
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcu.solution).deep.equal('proposal1');
       expect(qcu.feedbacks).to.be.undefined;
     });
   });
@@ -37,38 +39,61 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
       expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('The id is required for an element');
     });
+  });
 
-    describe('A QCU without instruction', function () {
-      it('should throw an error', function () {
-        // when
-        const error = catchErrSync(() => new QCU({ id: '123' }))();
+  describe('A QCU without instruction', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCU({ id: '123' }))();
 
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The instruction is required for a QCU');
-      });
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The instruction is required for a QCU');
     });
+  });
 
-    describe('A QCU with an empty list of proposals', function () {
-      it('should throw an error', function () {
-        // when
-        const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: [] }))();
+  describe('A QCU with an empty list of proposals', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: [] }))();
 
-        // then
-        expect(error).to.be.instanceOf(ModuleInstantiationError);
-        expect(error.message).to.equal('The proposals are required for a QCU');
-      });
+      // then
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
+      expect(error.message).to.equal('The proposals are required for a QCU');
     });
+  });
 
-    describe('A QCU does not have a list of proposals', function () {
-      it('should throw an error', function () {
-        // when
-        const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' }))();
+  describe('A QCU does not have a list of proposals', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' }))();
 
-        // then
-        expect(error).to.be.instanceOf(ModuleInstantiationError);
-        expect(error.message).to.equal('The QCU proposals should be a list');
-      });
+      // then
+      expect(error).to.be.instanceOf(ModuleInstantiationError);
+      expect(error.message).to.equal('The QCU proposals should be a list');
+    });
+  });
+
+  describe('A QCU without solution', function () {
+    it('should throw an error', function () {
+      // given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+
+      // when
+      const error = catchErrSync(
+        () =>
+          new QCU({
+            id: '123',
+            instruction: 'instruction',
+            locales: ['fr-FR'],
+            proposals: [proposal1, proposal2],
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solution is required for a QCU');
     });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/element-for-verification-factory_test.js
@@ -12,10 +12,9 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
     describe('when data is incorrect', function () {
       it('should throw an ElementInstantiationError', function () {
         // given
-        const feedbacks = { valid: 'valid', invalid: 'invalid' };
         const proposals = [
-          { id: '1', content: 'toto' },
-          { id: '2', content: 'foo' },
+          { id: '1', content: 'toto', feedback: 'ok' },
+          { id: '2', content: 'foo', feedback: 'ko' },
         ];
 
         const dataWithMissingSolutionForQCU = {
@@ -23,7 +22,6 @@ describe('Unit | Devcomp | Infrastructure | Factories | ElementForVerification',
           instruction: 'instruction',
           locales: ['fr-FR'],
           proposals,
-          feedbacks,
           type: 'qcu',
         };
 

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1775,7 +1775,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
         expect(module.sections[0].grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
-        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
+        expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCUDeclarative);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QCM Element', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -338,8 +338,9 @@ function getComponents() {
     new ComponentElement({
       element: new QCU({
         id: '2',
-        proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
+        proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto', feedback: 'Bonne réponse !' }],
         instruction: 'hello',
+        solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
       }),
     }),
     new ComponentElement({
@@ -518,9 +519,11 @@ function getAttributesComponents() {
           {
             content: 'toto',
             id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+            feedback: 'Bonne réponse !',
           },
         ],
         type: 'qcu',
+        solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
       },
     },
     {
@@ -529,7 +532,6 @@ function getAttributesComponents() {
         id: 'af447a7b-6790-4b3b-b83e-296e6618ca31',
         instruction: 'question declarative',
         isAnswerable: true,
-        locales: undefined,
         proposals: [
           {
             content: 'plop',


### PR DESCRIPTION
## 🔆 Problème

Actuellement, la validation des QCU se fait en appelant l'url /answers pour récupérer si les réponses saisies sont valides ou non. Cela peut entraîner, en cas de mauvaise connexion, des bugs.

## ⛱️ Proposition

Transmettre, lors de la récupération des données du module, ces 2 champs afin d'éviter de dépendre de l'API pour la validation.

## 🌊 Remarques

- On a redécouvert l'existence d'un champ locales sur les QCU, QCM, QROCM. A voir pour l'enlever ensuite car non utilisé.

## 🏄 Pour tester

- Ouvrir la console navigateur -> Onglet Network
- Aller sur le module [chatgpt-vraiment-neutre](https://app-pr13276.review.pix.fr/modules/chatgpt-vraiment-neutre)
- Vérifier, dans la réponse de la requête récupérant les données du module, que les feedbacks et la solution remontent bien pour chaque élément QCU (exemple de QCU dans  `included[0].attributes.grains[1].components[2]`) 🎉 
