### PR TITLE
[TECH] Ajout de log de debug pour les erreurs d'api (PIX-18983)

### DIFF
--- a/api/src/shared/application/pre-response-utils.js
+++ b/api/src/shared/application/pre-response-utils.js
@@ -1,6 +1,9 @@
 import { DomainError } from '../domain/errors.js';
+import { child, SCOPES } from '../infrastructure/utils/logger.js';
 import * as errorManager from './error-manager.js';
 import { BaseHttpError } from './http-errors.js';
+
+const logger = child('iam:http', { event: SCOPES.IAM });
 
 function handleDomainAndHttpErrors(
   request,
@@ -12,10 +15,34 @@ function handleDomainAndHttpErrors(
   const response = request.response;
 
   if (response instanceof DomainError || response instanceof BaseHttpError) {
+    debugRequestErrors(request, [
+      { method: 'post', path: '/api/users' },
+      { method: 'post', path: '/api/oidc/token' },
+    ]);
+
     return dependencies.errorManager.handle(request, h, response);
   }
 
   return h.continue;
+}
+
+function debugRequestErrors(request, debugConfig = []) {
+  for (const config of debugConfig) {
+    const { method, path } = config;
+
+    if (request?.route?.method !== method) continue;
+    if (request?.route?.path !== path) continue;
+
+    logger.info(
+      {
+        method,
+        path,
+        stack: JSON.stringify(request?.response?.stack || ''),
+        detail: JSON.stringify(request?.response?.invalidAttributes || ''),
+      },
+      `Debug HTTP error for ${method} ${path}`,
+    );
+  }
 }
 
 export { handleDomainAndHttpErrors };


### PR DESCRIPTION
## 🔆 Problème

Nous avons des erreurs HTTP 422 sur les routes `POST /api/users` et `POST /api/oidc/token` que nous ne pouvons expliquer et analyser. 

## ⛱️ Proposition

Ajout de log en ciblant spécifiquement ces routes quand une erreur est levée. Nous avons loggé le message et la stack pour avoir plus d'information en question sur l'erreur.


