### PR TITLE
[BUGFIX] Corriger le toggle "Cacher les organisations archivées" sur PixAdmin dans les profils cible (PIX-19182).

### DIFF
--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -49,9 +49,15 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
   }
 
   @action
-  filter(value) {
+  filterType(value) {
     const event = { target: { value } };
     this.args.triggerFiltering('type', event);
+  }
+
+  @action
+  filterHideArchived(value) {
+    const event = { target: { value } };
+    this.args.triggerFiltering('hideArchived', event);
   }
 
   <template>
@@ -66,7 +72,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
         @id="type"
         @hideDefaultOption={{true}}
         @options={{this.optionType}}
-        @onChange={{this.filter}}
+        @onChange={{this.filterType}}
         @value={{@type}}
       >
         <:label>Type</:label>
@@ -74,7 +80,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
       <PixInput value={{this.searchedExternalId}} oninput={{fn @triggerFiltering "externalId"}}>
         <:label>Identifiant externe</:label>
       </PixInput>
-      <PixToggleButton @onChange={{@toggleArchived}} @toggled={{@hideArchived}}>
+      <PixToggleButton @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>
         <:label>Masquer les organisations archivées</:label>
         <:viewA>Oui</:viewA>
         <:viewB>Non</:viewB>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -191,6 +191,7 @@ export default class Organizations extends Component {
         @goToOrganizationPage={{@goToOrganizationPage}}
         @detachOrganizations={{@detachOrganizations}}
         @targetProfileName={{@targetProfile.internalName}}
+        @hideArchived={{@hideArchived}}
         @showDetachColumn={{this.isSuperAdminOrMetier}}
       />
     </section>

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -8,7 +8,7 @@ import config from 'pix-admin/config/environment';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class TargetProfileOrganizationsController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'hideArchived'];
   DEBOUNCE_MS = config.pagination.debounce;
   @service router;
   @service pixToast;
@@ -17,6 +17,7 @@ export default class TargetProfileOrganizationsController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
+  @tracked hideArchived = false;
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -12,6 +12,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
     name: { refreshModel: true },
     type: { refreshModel: true },
     externalId: { refreshModel: true },
+    hideArchived: { refreshModel: true },
   };
 
   beforeModel() {
@@ -32,6 +33,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
         name: params.name,
         type: params.type,
         externalId: params.externalId,
+        hideArchived: params.hideArchived,
       },
     };
     try {
@@ -54,6 +56,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
       controller.name = null;
       controller.type = null;
       controller.externalId = null;
+      controller.hideArchived = false;
     }
   }
 }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -7,6 +7,7 @@
   @name={{this.name}}
   @type={{this.type}}
   @externalId={{this.externalId}}
+  @hideArchived={{this.hideArchived}}
   @triggerFiltering={{this.triggerFiltering}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @detachOrganizations={{this.detachOrganizations}}

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -12,6 +12,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
   const triggerFiltering = () => {};
   const goToOrganizationPage = () => {};
   const detachOrganizations = () => {};
+  const queryParams = { hideArchived: false };
 
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:currentUser');
@@ -32,6 +33,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -55,6 +57,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -79,6 +82,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -98,6 +102,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -119,6 +124,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -142,6 +148,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -167,6 +174,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -192,6 +200,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -213,6 +222,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @organizations={{organizations}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
+          @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
         />
       </template>,
@@ -245,6 +255,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
+            @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
           />
         </template>,
@@ -272,6 +283,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
+            @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
           />
         </template>,
@@ -296,6 +308,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
+            @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
           />
         </template>,

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -394,6 +394,7 @@ const register = async function (server) {
               name: Joi.string().empty('').allow(null).optional(),
               type: Joi.string().empty('').allow(null).optional(),
               'external-id': Joi.string().empty('').allow(null).optional(),
+              hideArchived: Joi.boolean().optional(),
             }).default({}),
             page: {
               number: Joi.number().integer().empty('').allow(null).optional(),


### PR DESCRIPTION
## 🔆 Problème

Une erreur s'affiche lorsque l'on souhaite utiliser le toggle masquer les organisations archivé.

## ⛱️ Proposition

Ajouter le boolean qui fait le taff

## 🌊 Remarques

RAS

## 🏄 Pour tester

Aller sur PixAdmin => PC => Details d'un PC => organisations => Cliquer sur le toggle "masquer les organizations archivées" => ça marche