### PR TITLE
[FEATURE] Afficher dans PixOrga les organization-learners associés à des utilisateurs anonymisés (PIX-19192)

### DIFF
--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -98,7 +98,10 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         it('from participant with anonymous users linked', async function () {
           // given
           const anonymousUserId = databaseBuilder.factory.buildUser({ isAnonymous: true }).id;
-          buildLearnerWithParticipation({ organizationId, learnerAttributes: { userId: anonymousUserId } });
+          buildLearnerWithParticipation({
+            organizationId,
+            learnerAttributes: { userId: anonymousUserId },
+          });
 
           await databaseBuilder.commit();
 
@@ -110,6 +113,22 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
 
           // then
           expect(organizationParticipants).to.have.lengthOf(0);
+        });
+
+        it('from participant with anonymised users linked', async function () {
+          // given
+          buildLearnerWithParticipation({ organizationId, learnerAttributes: { userId: null } });
+
+          await databaseBuilder.commit();
+
+          // when
+          const { organizationParticipants } =
+            await organizationParticipantRepository.findPaginatedFilteredParticipants({
+              organizationId,
+            });
+
+          // then
+          expect(organizationParticipants).to.have.lengthOf(1);
         });
       });
 
@@ -232,6 +251,23 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
 
         // then
         expect(participantCount).to.equal(0);
+      });
+
+      it('should take into account anonymised users', async function () {
+        // given
+        buildLearnerWithParticipation({ userId: null, organizationId, learnerAttributes: { userId: null } });
+
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          meta: { participantCount },
+        } = await organizationParticipantRepository.findPaginatedFilteredParticipants({
+          organizationId,
+        });
+
+        // then
+        expect(participantCount).to.equal(1);
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

Si on ne les affiches pas, les prescripteurs ne peuvent pas les supprimer sur demande du pôle Support

## ⛱️ Proposition

Les afficher

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Aller dans PixApp
- Créer un compte utilisateur
- Participer à une campagne PRO
- Aller dans PixAdmin
- Anonymiser l'utilisateur
- Aller dans PixOrga
- se connecter à l'orga a qui appartient la campagne
- se rendre sur la page participants
- remarquer que l'organization-learner associé à l'utilisateur est bien présent
- tester le fait de le supprimer car maintenant c'est possible
- 🎉 