### PR TITLE
[TECH] :truck: Déplace un modèle en lecture seul depuis le contexte partagé vers le contexte prescription

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,9 +1,9 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CampaignParticipationOverview } from '../../../../shared/domain/read-models/CampaignParticipationOverview.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
+import { CampaignParticipationOverview } from '../../../shared/domain/read-models/CampaignParticipationOverview.js';
 
 const findByUserIdWithFilters = async function ({ userId, states, page }) {
   const queryBuilder = _getQueryBuilder((qb) => {

--- a/api/src/prescription/shared/domain/read-models/CampaignParticipationOverview.js
+++ b/api/src/prescription/shared/domain/read-models/CampaignParticipationOverview.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
 
-import { CampaignParticipationStatuses, CampaignTypes } from '../../../prescription/shared/domain/constants.js';
-import { MAX_MASTERY_RATE, MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../constants.js';
+import { MAX_MASTERY_RATE, MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../../../../shared/domain/constants.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../constants.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -3,7 +3,7 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { CampaignParticipationOverview } from '../../../../../../../src/prescription/shared/domain/read-models/CampaignParticipationOverview.js';
 import { expect } from '../../../../../../test-helper.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
@@ -4,7 +4,7 @@ import * as campaignParticipationOverviewRepository from '../../../../../../src/
 import { OrganizationLearner } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
 import { findOrganizationLearnersWithParticipations } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
 import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
-import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { CampaignParticipationOverview } from '../../../../../../src/prescription/shared/domain/read-models/CampaignParticipationOverview.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
@@ -1,6 +1,6 @@
 import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
-import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { CampaignParticipationOverview } from '../../../../../../src/prescription/shared/domain/read-models/CampaignParticipationOverview.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | get-organization-learner-with-participations', function () {

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
@@ -1,5 +1,5 @@
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { CampaignParticipationOverview } from '../../../../src/prescription/shared/domain/read-models/CampaignParticipationOverview.js';
 const { SHARED } = CampaignParticipationStatuses;
 
 const buildCampaignParticipationOverview = function ({

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
+import { CampaignParticipationOverview } from '../../../../src/prescription/shared/domain/read-models/CampaignParticipationOverview.js';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seule `CampaignParticipationOverview` est placé dans le contexte partagé, mais n'est utilisé que dans le contexte de prescription. 

## ⛱️ Proposition

Déplacer le modèle en lecture seule vers le contexte partagé de prescription.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

C'est une campagne et faire les inscriptions (?)
