### PR TITLE
[TECH] Séparer les responsabilités du token service (partie 2) (PIX-19217)

### DIFF
--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -17,9 +17,9 @@ const createResetPasswordDemand = async function (request, h) {
 };
 
 const updateExpiredPassword = async function (request, h) {
-  const passwordResetToken = request.payload.data.attributes['password-reset-token'];
+  const passwordExpirationToken = request.payload.data.attributes['password-reset-token'];
   const newPassword = request.payload.data.attributes['new-password'];
-  const login = await usecases.updateExpiredPassword({ passwordResetToken, newPassword });
+  const login = await usecases.updateExpiredPassword({ passwordExpirationToken, newPassword });
 
   return h
     .response({

--- a/api/src/identity-access-management/domain/models/ApplicationAccessToken.js
+++ b/api/src/identity-access-management/domain/models/ApplicationAccessToken.js
@@ -1,0 +1,29 @@
+import { config } from '../../../shared/config.js';
+import { tokenService } from '../../../shared/domain/services/token-service.js';
+
+export class ApplicationAccessToken {
+  constructor({ clientId, source, scope }) {
+    this.clientId = clientId;
+    this.source = source;
+    this.scope = scope;
+  }
+
+  static decode(token, secret = config.authentication.secret) {
+    const decoded = tokenService.getDecodedToken(token, secret);
+    if (!decoded) return new ApplicationAccessToken({});
+
+    return new ApplicationAccessToken({ clientId: decoded.client_id, source: decoded.source, scope: decoded.scope });
+  }
+
+  static generate({ clientId, source, scope }) {
+    return tokenService.encodeToken(
+      {
+        client_id: clientId,
+        source,
+        scope: Array.isArray(scope) ? scope.join(' ') : scope,
+      },
+      config.authentication.secret,
+      { expiresIn: config.authentication.accessTokenLifespanMs },
+    );
+  }
+}

--- a/api/src/identity-access-management/domain/models/PasswordExpirationToken.js
+++ b/api/src/identity-access-management/domain/models/PasswordExpirationToken.js
@@ -1,0 +1,21 @@
+import { config } from '../../../shared/config.js';
+import { tokenService } from '../../../shared/domain/services/token-service.js';
+
+export class PasswordExpirationToken {
+  constructor({ userId }) {
+    this.userId = userId;
+  }
+
+  static decode(token) {
+    const decoded = tokenService.getDecodedToken(token, config.authentication.secret);
+    if (!decoded) return new PasswordExpirationToken({});
+
+    return new PasswordExpirationToken({ userId: decoded.user_id });
+  }
+
+  static generate({ userId }) {
+    return tokenService.encodeToken({ user_id: userId }, config.authentication.secret, {
+      expiresIn: config.authentication.passwordResetTokenLifespan,
+    });
+  }
+}

--- a/api/src/identity-access-management/domain/usecases/authenticate-application.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-application.js
@@ -1,18 +1,16 @@
-import { config } from '../../../shared/config.js';
 import {
   ApplicationScopeNotAllowedError,
   ApplicationWithInvalidCredentialsError,
 } from '../../../shared/domain/errors.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
+import { ApplicationAccessToken } from '../models/ApplicationAccessToken.js';
 
-const { authentication } = config;
 const logger = child('iam:applicationauth', { event: SCOPES.IAM });
 
 export async function authenticateApplication({
   clientId,
   clientSecret,
   scope,
-  tokenService,
   clientApplicationRepository,
   cryptoService,
 }) {
@@ -21,13 +19,7 @@ export async function authenticateApplication({
   await _checkClientSecret(application, clientSecret, cryptoService);
   _checkAppScope(application, scope);
 
-  return tokenService.createAccessTokenFromApplication(
-    clientId,
-    application.name,
-    scope,
-    authentication.secret,
-    authentication.accessTokenLifespanMs,
-  );
+  return ApplicationAccessToken.generate({ clientId, source: application.name, scope });
 }
 
 function _checkApplication(application, clientId) {

--- a/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
@@ -6,6 +6,7 @@ import {
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { MissingOrInvalidCredentialsError, PasswordNotMatching, UserShouldChangePasswordError } from '../errors.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
+import { PasswordExpirationToken } from '../models/PasswordExpirationToken.js';
 import { UserAccessToken } from '../models/UserAccessToken.js';
 
 /**
@@ -63,8 +64,8 @@ async function authenticateForSaml({
     });
 
     if (userFromCredentials.shouldChangePassword) {
-      const passwordResetToken = tokenService.createPasswordResetToken(userFromCredentials.id);
-      throw new UserShouldChangePasswordError(undefined, passwordResetToken);
+      const passwordExpirationToken = PasswordExpirationToken.generate({ userId: userFromCredentials.id });
+      throw new UserShouldChangePasswordError(undefined, passwordExpirationToken);
     }
 
     const { accessToken } = UserAccessToken.generateSamlUserToken({ userId: userFromCredentials.id, audience });

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -9,6 +9,7 @@ import {
   PixAdminLoginFromPasswordDisabledError,
   UserShouldChangePasswordError,
 } from '../errors.js';
+import { PasswordExpirationToken } from '../models/PasswordExpirationToken.js';
 import { RefreshToken } from '../models/RefreshToken.js';
 import { UserAccessToken } from '../models/UserAccessToken.js';
 
@@ -22,7 +23,6 @@ import { UserAccessToken } from '../models/UserAccessToken.js';
  * @param {string} params.locale
  * @param {RefreshTokenRepository} params.refreshTokenRepository
  * @param {PixAuthenticationService} params.pixAuthenticationService
- * @param {TokenService} params.tokenService
  * @param {UserRepository} params.userRepository
  * @param {UserLoginRepository} params.userLoginRepository
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
@@ -41,7 +41,6 @@ const authenticateUser = async function ({
   locale,
   refreshTokenRepository,
   pixAuthenticationService,
-  tokenService,
   userRepository,
   userLoginRepository,
   authenticationMethodRepository,
@@ -63,8 +62,8 @@ const authenticateUser = async function ({
     });
 
     if (user.shouldChangePassword) {
-      const passwordResetToken = tokenService.createPasswordResetToken(user.id);
-      throw new UserShouldChangePasswordError(undefined, passwordResetToken);
+      const passwordExpirationToken = PasswordExpirationToken.generate({ userId: user.id });
+      throw new UserShouldChangePasswordError(undefined, passwordExpirationToken);
     }
 
     await _assertUserHasAccessToApplication({ requestedApplication, user, adminMemberRepository });

--- a/api/src/identity-access-management/domain/usecases/update-expired-password.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-expired-password.usecase.js
@@ -5,16 +5,16 @@ const { get } = lodash;
 import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import { PasswordExpirationToken } from '../models/PasswordExpirationToken.js';
 
 const updateExpiredPassword = async function ({
-  passwordResetToken,
+  passwordExpirationToken,
   newPassword,
   cryptoService,
-  tokenService,
   authenticationMethodRepository,
   userRepository,
 }) {
-  const userId = await tokenService.extractUserId(passwordResetToken);
+  const { userId } = PasswordExpirationToken.decode(passwordExpirationToken);
 
   let foundUser;
   try {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -21,32 +21,6 @@ function encodeToken(payload, secret, options) {
   return jsonwebtoken.sign(payload, secret, options);
 }
 
-/**
- * @param {string} clientId
- * @param {string} source
- * @param {string | string[]} scope
- * @param {string} secret
- * @param {number | string} expiresIn
- * @returns {string}
- */
-function createAccessTokenFromApplication(
-  clientId,
-  source,
-  scope,
-  secret = config.authentication.secret,
-  expiresIn = config.authentication.accessTokenLifespanMs,
-) {
-  return jsonwebtoken.sign(
-    {
-      client_id: clientId,
-      source,
-      scope: Array.isArray(scope) ? scope.join(' ') : scope,
-    },
-    secret,
-    { expiresIn },
-  );
-}
-
 function createIdTokenForUserReconciliation(externalUser) {
   return jsonwebtoken.sign(
     {
@@ -167,11 +141,6 @@ function extractUserId(token) {
   return decoded.user_id || null;
 }
 
-function extractClientId(token, secret = config.authentication.secret) {
-  const decoded = getDecodedToken(token, secret);
-  return decoded.client_id || null;
-}
-
 async function extractExternalUserFromIdToken(token) {
   const externalUser = getDecodedToken(token);
 
@@ -188,7 +157,6 @@ async function extractExternalUserFromIdToken(token) {
   };
 }
 const tokenService = {
-  createAccessTokenFromApplication,
   createIdTokenForUserReconciliation,
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
@@ -202,7 +170,6 @@ const tokenService = {
   extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
-  extractClientId,
 };
 
 /**
@@ -210,7 +177,6 @@ const tokenService = {
  */
 
 export {
-  createAccessTokenFromApplication,
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
   createIdTokenForUserReconciliation,
@@ -218,7 +184,6 @@ export {
   decodeIfValid,
   extractCertificationResultsByRecipientEmailLink,
   extractCertificationResultsLink,
-  extractClientId,
   extractExternalUserFromIdToken,
   extractSamlId,
   extractTokenFromAuthChain,

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -64,16 +64,6 @@ function createCertificationResultsLinkToken({ sessionId }) {
   );
 }
 
-function createPasswordResetToken(userId) {
-  return jsonwebtoken.sign(
-    {
-      user_id: userId,
-    },
-    config.authentication.secret,
-    { expiresIn: config.authentication.passwordResetTokenLifespan },
-  );
-}
-
 function extractTokenFromAuthChain(authChain) {
   if (!authChain) {
     return authChain;
@@ -160,7 +150,6 @@ const tokenService = {
   createIdTokenForUserReconciliation,
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
-  createPasswordResetToken,
   decodeIfValid,
   getDecodedToken,
   encodeToken,
@@ -180,7 +169,6 @@ export {
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
   createIdTokenForUserReconciliation,
-  createPasswordResetToken,
   decodeIfValid,
   extractCertificationResultsByRecipientEmailLink,
   extractCertificationResultsLink,

--- a/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/password/password.route.test.js
@@ -1,6 +1,6 @@
+import { PasswordExpirationToken } from '../../../../../src/identity-access-management/domain/models/PasswordExpirationToken.js';
 import { resetPasswordService } from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
 import { config } from '../../../../../src/shared/config.js';
-import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
 import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | password', function () {
@@ -157,19 +157,17 @@ describe('Acceptance | Identity Access Management | Application | Route | passwo
     context('Success cases', function () {
       it('returns 201 HTTP status code', async function () {
         // given
-        const user = databaseBuilder.factory.buildUser.withRawPassword({
-          shouldChangePassword: true,
-        });
+        const user = databaseBuilder.factory.buildUser.withRawPassword({ shouldChangePassword: true });
         await databaseBuilder.commit();
-        const passwordResetToken = tokenService.createPasswordResetToken(user.id);
 
+        const passwordExpirationToken = PasswordExpirationToken.generate({ userId: user.id });
         const options = {
           method: 'POST',
           url: '/api/expired-password-updates',
           payload: {
             data: {
               attributes: {
-                'password-reset-token': passwordResetToken,
+                'password-reset-token': passwordExpirationToken,
                 'new-password': 'Password02',
               },
             },
@@ -188,19 +186,17 @@ describe('Acceptance | Identity Access Management | Application | Route | passwo
       context('when shouldChangePassword is false', function () {
         it('responds 403 HTTP status code', async function () {
           // given
-          const user = databaseBuilder.factory.buildUser.withRawPassword({
-            shouldChangePassword: false,
-          });
+          const user = databaseBuilder.factory.buildUser.withRawPassword({ shouldChangePassword: false });
           await databaseBuilder.commit();
-          const passwordResetToken = tokenService.createPasswordResetToken(user.id);
 
+          const passwordExpirationToken = PasswordExpirationToken.generate({ userId: user.id });
           const options = {
             method: 'POST',
             url: '/api/expired-password-updates',
             payload: {
               data: {
                 attributes: {
-                  'password-reset-token': passwordResetToken,
+                  'password-reset-token': passwordExpirationToken,
                   'new-password': 'Password02',
                 },
               },

--- a/api/tests/identity-access-management/unit/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/password/password.controller.test.js
@@ -76,7 +76,7 @@ describe('Unit | Identity Access Management | Application | Controller | passwor
         payload: {
           data: {
             attributes: {
-              'password-reset-token': 'PASSWORD_RESET_TOKEN',
+              'password-reset-token': 'PASSWORD_EXPIRATION_TOKEN',
               'new-password': 'Password123',
             },
           },
@@ -85,7 +85,7 @@ describe('Unit | Identity Access Management | Application | Controller | passwor
       sinon.stub(usecases, 'updateExpiredPassword');
       usecases.updateExpiredPassword
         .withArgs({
-          passwordResetToken: 'PASSWORD_RESET_TOKEN',
+          passwordExpirationToken: 'PASSWORD_EXPIRATION_TOKEN',
           newPassword: 'Password123',
         })
         .resolves('beth.rave1221');

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -204,10 +204,6 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
           scope,
         },
       };
-      const tokenServiceStub = { extractUserId: sinon.stub() };
-      tokenServiceStub.extractUserId.returns(client_id);
-
-      const dependencies = { tokenService: tokenServiceStub };
 
       sinon
         .stub(usecases, 'authenticateApplication')
@@ -215,7 +211,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
         .resolves(access_token);
 
       // when
-      const response = await tokenController.authenticateApplication(request, hFake, dependencies);
+      const response = await tokenController.authenticateApplication(request, hFake);
 
       // then
       const expectedResponseSource = {

--- a/api/tests/identity-access-management/unit/domain/models/ApplicationAccessToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/ApplicationAccessToken.test.js
@@ -1,0 +1,68 @@
+import { ApplicationAccessToken } from '../../../../../src/identity-access-management/domain/models/ApplicationAccessToken.js';
+import { config } from '../../../../../src/shared/config.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Model | ApplicationAccessToken', function () {
+  beforeEach(function () {
+    sinon.stub(config.authentication, 'secret').value('secret!');
+    sinon.stub(config.authentication, 'accessTokenLifespanMs').value(3600000);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('ApplicationAccessToken.decode', function () {
+    it('decodes a valid token', function () {
+      // given
+      const token = ApplicationAccessToken.generate({
+        clientId: 'clientId!',
+        source: 'source!',
+        scope: 'scope!',
+      });
+
+      // when
+      const decoded = ApplicationAccessToken.decode(token);
+
+      // then
+      expect(decoded).to.be.instanceOf(ApplicationAccessToken);
+      expect(decoded).to.deep.include({
+        clientId: 'clientId!',
+        source: 'source!',
+        scope: 'scope!',
+      });
+    });
+
+    it('returns empty object for invalid token', function () {
+      // given / when
+      const decoded = ApplicationAccessToken.decode('invalid.token');
+
+      // then
+      expect(decoded).to.be.instanceOf(ApplicationAccessToken);
+      expect(decoded.clientId).to.be.undefined;
+      expect(decoded.source).to.be.undefined;
+      expect(decoded.scope).to.be.undefined;
+    });
+  });
+
+  describe('ApplicationAccessToken.generate', function () {
+    it('builds an access token', function () {
+      // given / when
+      const token = ApplicationAccessToken.generate({
+        clientId: 'clientId!',
+        source: 'source!',
+        scope: ['read', 'write'],
+      });
+
+      // then
+      expect(token).to.be.a('string');
+
+      const decoded = ApplicationAccessToken.decode(token);
+      expect(decoded).to.deep.include({
+        clientId: 'clientId!',
+        source: 'source!',
+        scope: 'read write',
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/models/PasswordExpirationToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/PasswordExpirationToken.test.js
@@ -1,0 +1,52 @@
+import { PasswordExpirationToken } from '../../../../../src/identity-access-management/domain/models/PasswordExpirationToken.js';
+import { config } from '../../../../../src/shared/config.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Model | PasswordExpirationToken', function () {
+  beforeEach(function () {
+    sinon.stub(config.authentication, 'secret').value('secret!');
+    sinon.stub(config.authentication, 'passwordResetTokenLifespan').value(1000);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('PasswordExpirationToken.decode', function () {
+    it('decodes a valid token', function () {
+      // given
+      const token = PasswordExpirationToken.generate({ userId: 'userId!' });
+
+      // when
+      const decoded = PasswordExpirationToken.decode(token);
+
+      // then
+      expect(decoded).to.be.instanceOf(PasswordExpirationToken);
+      expect(decoded).to.deep.include({ userId: 'userId!' });
+    });
+
+    it('returns empty object for invalid token', function () {
+      // given / when
+      const decoded = PasswordExpirationToken.decode('invalid.token');
+
+      // then
+      expect(decoded).to.be.instanceOf(PasswordExpirationToken);
+      expect(decoded.clientId).to.be.undefined;
+      expect(decoded.source).to.be.undefined;
+      expect(decoded.scope).to.be.undefined;
+    });
+  });
+
+  describe('PasswordExpirationToken.generate', function () {
+    it('builds a password expiration token', function () {
+      // given / when
+      const token = PasswordExpirationToken.generate({ userId: 'userId!' });
+
+      // then
+      expect(token).to.be.a('string');
+
+      const decoded = PasswordExpirationToken.decode(token);
+      expect(decoded).to.deep.include({ userId: 'userId!' });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-application_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-application_test.js
@@ -1,6 +1,6 @@
 import { PasswordNotMatching } from '../../../../../src/identity-access-management/domain/errors.js';
+import { ApplicationAccessToken } from '../../../../../src/identity-access-management/domain/models/ApplicationAccessToken.js';
 import { authenticateApplication } from '../../../../../src/identity-access-management/domain/usecases/authenticate-application.js';
-import { config } from '../../../../../src/shared/config.js';
 import {
   ApplicationScopeNotAllowedError,
   ApplicationWithInvalidCredentialsError,
@@ -121,23 +121,18 @@ describe('Unit | Usecase | authenticate-application', function () {
             .withArgs({ password: payload.clientSecret, passwordHash: application.clientSecret })
             .resolves();
 
-          const tokenService = {
-            createAccessTokenFromApplication: sinon.stub(),
-          };
-          const expectedToken = Symbol('Mon Super token');
-          tokenService.createAccessTokenFromApplication
-            .withArgs(
-              application.clientId,
-              application.name,
-              payload.scope,
-              config.authentication.secret,
-              config.authentication.accessTokenLifespanMs,
-            )
-            .resolves(expectedToken);
+          const expectedToken = 'Mon Super token';
+          sinon
+            .stub(ApplicationAccessToken, 'generate')
+            .withArgs({
+              clientId: application.clientId,
+              source: application.name,
+              scope: payload.scope,
+            })
+            .returns(expectedToken);
 
           const token = await authenticateApplication({
             ...payload,
-            tokenService,
             clientApplicationRepository,
             cryptoService,
           });

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -5,6 +5,7 @@ import {
   UserShouldChangePasswordError,
 } from '../../../../../src/identity-access-management/domain/errors.js';
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
+import { PasswordExpirationToken } from '../../../../../src/identity-access-management/domain/models/PasswordExpirationToken.js';
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { authenticateForSaml } from '../../../../../src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
@@ -29,7 +30,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
   beforeEach(function () {
     tokenService = {
       extractExternalUserFromIdToken: sinon.stub(),
-      createPasswordResetToken: sinon.stub(),
     };
     pixAuthenticationService = {
       getUserByUsernameAndPassword: sinon.stub(),
@@ -347,7 +347,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
 
       it('creates and return password reset token', async function () {
         // given
-        tokenService.createPasswordResetToken.returns('token');
+        sinon.stub(PasswordExpirationToken, 'generate').returns('token');
+
         const oneTimePassword = 'Azerty123*';
         const user = createUserWithValidCredentialsWhoShouldChangePassword({
           oneTimePassword,

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -336,18 +336,4 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
     });
   });
-
-  describe('#createPasswordResetToken', function () {
-    it('should return a valid token with userId', function () {
-      // given
-      const userId = 1;
-
-      // when
-      const token = tokenService.createPasswordResetToken(userId);
-
-      // then
-      const decodedToken = jsonwebtoken.verify(token, settings.authentication.secret);
-      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal({ user_id: userId });
-    });
-  });
 });

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -10,73 +10,11 @@ import {
   InvalidTemporaryKeyError,
 } from '../../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
-import { catchErr, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, expect } from '../../../../test-helper.js';
 
 const { omit } = lodash;
 
 describe('Unit | Shared | Domain | Services | Token Service', function () {
-  describe('#createAccessTokenFromApplication', function () {
-    it('should create access token with client id, source and scope', function () {
-      // given
-      const clientId = 'client id';
-      const source = 'client application';
-      const scope = 'organizations';
-      const secret = 'a secret';
-      const accessTokenLifespanMs = 1000;
-
-      const payload = { client_id: clientId, source, scope };
-      const options = { expiresIn: accessTokenLifespanMs };
-
-      const expectedAccessToken = Symbol('expectedAccessToken');
-
-      sinon.stub(jsonwebtoken, 'sign').returns(expectedAccessToken);
-
-      // when
-      const result = tokenService.createAccessTokenFromApplication(
-        clientId,
-        source,
-        scope,
-        secret,
-        accessTokenLifespanMs,
-      );
-
-      // then
-      expect(result).to.be.equal(expectedAccessToken);
-      expect(jsonwebtoken.sign).to.have.been.calledWithExactly(payload, secret, options);
-    });
-
-    describe('when scope contains an array of several', function () {
-      it('should join scopes separated by spaces', function () {
-        // given
-        const clientId = 'client id';
-        const source = 'client application';
-        const scope = ['organizations', 'campaigns'];
-        const secret = 'a secret';
-        const accessTokenLifespanMs = 1000;
-
-        const payload = { client_id: clientId, source, scope: 'organizations campaigns' };
-        const options = { expiresIn: accessTokenLifespanMs };
-
-        const expectedAccessToken = Symbol('expectedAccessToken');
-
-        sinon.stub(jsonwebtoken, 'sign').returns(expectedAccessToken);
-
-        // when
-        const result = tokenService.createAccessTokenFromApplication(
-          clientId,
-          source,
-          scope,
-          secret,
-          accessTokenLifespanMs,
-        );
-
-        // then
-        expect(result).to.be.equal(expectedAccessToken);
-        expect(jsonwebtoken.sign).to.have.been.calledWithExactly(payload, secret, options);
-      });
-    });
-  });
-
   describe('#createIdTokenForUserReconciliation', function () {
     it('should return a valid idToken with firstName, lastName, samlId', function () {
       // given

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -25,9 +25,9 @@ import { createServer } from '../server.js';
 import { createMaddoServer } from '../server.maddo.js';
 import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
+import { ApplicationAccessToken } from '../src/identity-access-management/domain/models/ApplicationAccessToken.js';
 import { UserAccessToken } from '../src/identity-access-management/domain/models/UserAccessToken.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
-import { config } from '../src/shared/config.js';
 import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
 import { Membership } from '../src/shared/domain/models/Membership.js';
 import * as tokenService from '../src/shared/domain/services/token-service.js';
@@ -138,12 +138,7 @@ function generateAuthenticatedUserRequestHeaders({
 }
 
 function generateValidRequestAuthorizationHeaderForApplication(clientId = 'client-id-name', source, scope = '') {
-  const accessToken = tokenService.createAccessTokenFromApplication(
-    clientId,
-    source,
-    scope,
-    config.authentication.secret,
-  );
+  const accessToken = ApplicationAccessToken.generate({ clientId, source, scope });
   return `Bearer ${accessToken}`;
 }
 


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le `token-service` à beaucoup de dépendances et trop de responsabilités. On retrouve des cas d'usage spécifiques à des contextes différents et du code "métier" dans ce fichier. Exemples :
- Contexte IAM : `createAccessTokenFromUser`, `createAccessTokenForSaml`...
- Contexte Certif : `createCertificationResultsByRecipientEmailLinkToken`...
- Contexte Prescription : `createIdTokenForUserReconciliation`...

Ce couplage entraîne des **soucis de dépendances cycliques** quand on souhaite encoder / décoder des tokens.

## ⛱️ Proposition

**Isoler la génération des tokens par cas d'usage et par contexte** tout en conservant le `token-service` pour l'encodage et décodage de base avec `jsonwebtoken`. À la fin du refactoring, le `token-service` devrait avoir uniquement 2 fonctions: `encodeToken` et `decodeToken`. Et on aura plus les soucis de dépendances cyclique causées par ce fichier.

Cette isolation sera faite en plusieurs PR.

**Cette PR** isole: 
- la création **d'access token application** via la classe `ApplicationAccessToken`
- la création **de token de password expiré** via la classe `PasswordExpirationToken`

## 🌊 Remarques

> [!NOTE]
> `PasswordExpirationToken` a été nommé ainsi et pas `PasswordResetToken` car il s'agit du token utilisé pour la fonctionnalité `shouldChangePassword`. Or le reset de password (mot de passe oublié) génère aussi un token différemment dans `api/src/identity-access-management/domain/services/reset-password.service.js`

## 🏄 Pour tester

**Test du token des applications clientes :**

1. Démarrer MADDO `npm run start:maddo`
2. Demander un token
```
curl --no-progress-meter -H 'Accept: application/json' -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'grant_type=client_credentials' --data 'client_id=parcoursup' --data 'client_secret=parcoursup-secret-de-trente-deux-caracteres' --data 'scope=parcoursup' http://localhost:3000/api/application/token
```
3. Faire un appel avec le token (remplacer `METTRE_ACCESS_TOKEN_ICI` par l'access token)
```
curl --no-progress-meter --include -H "Authorization: Bearer METTRE_ACCESS_TOKEN_ICI" -H 'Accept: application/json' -H "Content-Type: application/json" -X POST --data "{\"ine\":\"123456789LR\"}" http://localhost:3000/api/application/parcoursup/certification/search
```
> On doit avoir une 404 avec le message: `No certifications found for given search parameters`, mais si on modifie le token pour qu'il soit invalide on a bien une erreur `401 Unauthorized`

**Test du token de mot de passe expiré :**

1. Marquer le mot de passe comme expiré en utilisant l'ID utilisateur :

```sql
UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", '{shouldChangePassword}', 'true') WHERE "userId" = 100000;
```

5. Aller sur Pix App et se connecter
> L'écran de changement de mot de passe apparaît

6. Changer le mot de passe
> L'utilisateur est connecté et peut se reconnecter avec le nouveau mot de passe.
