### PR TITLE
[FEATURE] Écrire la locale dans users.locale, à la connexion d'un utilisateur (PIX-19079)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -17,6 +17,7 @@ async function authenticateOidcUser(request, h) {
   const { code, state, iss, identityProvider: identityProviderCode } = request.deserializedPayload;
   const origin = getForwardedOrigin(request.headers);
   const requestedApplication = RequestedApplication.fromOrigin(origin);
+  const locale = getUserLocale(request);
 
   const sessionState = request.yar.get('state', true);
   const nonce = request.yar.get('nonce', true);
@@ -30,6 +31,7 @@ async function authenticateOidcUser(request, h) {
     code,
     state,
     iss,
+    locale,
     identityProviderCode,
     nonce,
     sessionState,

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -33,17 +33,17 @@ const createToken = async function (request, h) {
   const requestedApplication = RequestedApplication.fromOrigin(origin);
 
   const grantType = request.payload.grant_type;
+  const locale = getUserLocale(request);
 
   if (grantType === 'password') {
     const { username, password } = request.payload;
-    const localeFromCookie = request.state?.locale;
     const source = 'pix';
 
     const tokensInfo = await usecases.authenticateUser({
       username,
       password,
       source,
-      locale: localeFromCookie,
+      locale,
       audience: origin,
       requestedApplication,
     });
@@ -54,7 +54,7 @@ const createToken = async function (request, h) {
   } else if (grantType === 'refresh_token') {
     refreshToken = request.payload.refresh_token;
 
-    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken, audience: origin });
+    const tokensInfo = await usecases.createAccessTokenFromRefreshToken({ refreshToken, audience: origin, locale });
 
     accessToken = tokensInfo.accessToken;
     expirationDelaySeconds = tokensInfo.expirationDelaySeconds;

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -103,12 +103,17 @@ class User {
     return dayjs(parsedDate).isBefore(dayjs(config.dataProtectionPolicy.updateDate)) && isNotOrganizationLearner;
   }
 
-  setLocaleIfNotAlreadySet(newLocale, dependencies = { localeService }) {
-    this.hasBeenModified = false;
-    if (newLocale && !this.locale) {
-      this.locale = dependencies.localeService.getNearestSupportedLocale(newLocale);
-      this.hasBeenModified = true;
+  changeLocale(newLocale, dependencies = { localeService }) {
+    if (!newLocale) {
+      this.locale = dependencies.localeService.getDefaultLocale();
+      return true;
     }
+    if (!this.locale || this.locale !== newLocale) {
+      this.locale = dependencies.localeService.getNearestSupportedLocale(newLocale);
+      return true;
+    }
+
+    return false;
   }
 
   isLinkedToOrganizations() {

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.js
@@ -77,7 +77,7 @@ const authenticateUser = async function ({
       audience,
     });
 
-    user.setLocaleIfNotAlreadySet(locale);
+    user.changeLocale(locale);
     if (user.hasBeenModified) {
       await userRepository.update({ id: user.id, locale: user.locale });
     }

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
@@ -77,10 +77,7 @@ const authenticateUser = async function ({
       audience,
     });
 
-    user.changeLocale(locale);
-    if (user.hasBeenModified) {
-      await userRepository.update({ id: user.id, locale: user.locale });
-    }
+    await _updateUserLocaleIfNeeded({ user, locale, userRepository });
 
     const userLogin = await userLoginRepository.findByUserId(user.id);
     if (user.email && userLogin?.shouldSendConnectionWarning()) {
@@ -116,6 +113,13 @@ const authenticateUser = async function ({
     }
   }
 };
+
+async function _updateUserLocaleIfNeeded({ user, locale, userRepository }) {
+  const localeChanged = user.changeLocale(locale);
+  if (localeChanged) {
+    await userRepository.update({ id: user.id, locale: user.locale });
+  }
+}
 
 async function _assertUserHasAccessToApplication({ requestedApplication, user, adminMemberRepository }) {
   if (requestedApplication.isPixOrga && !user.isLinkedToOrganizations()) {

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -118,7 +118,7 @@ import { authenticateAnonymousUser } from './authenticate-anonymous-user.usecase
 import { authenticateApplication } from './authenticate-application.js';
 import { authenticateForSaml } from './authenticate-for-saml.usecase.js';
 import { authenticateOidcUser } from './authenticate-oidc-user.usecase.js';
-import { authenticateUser } from './authenticate-user.js';
+import { authenticateUser } from './authenticate-user.usecase.js';
 import { changeUserLocale } from './change-user-locale.usecase.js';
 import { checkScoAccountRecovery } from './check-sco-account-recovery.usecase.js';
 import { createAccessTokenFromRefreshToken } from './create-access-token-from-refresh-token.usecase.js';

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -1,4 +1,4 @@
-import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 
@@ -11,14 +11,14 @@ import { certificationCenterInvitationSerializer } from '../../infrastructure/se
 const acceptCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.id;
   const { code, email: rawEmail } = request.deserializedPayload;
-  const localeFromCookie = request.state?.locale;
+  const locale = getUserLocale(request);
   const email = rawEmail.trim().toLowerCase();
 
   await usecases.acceptCertificationCenterInvitation({
     certificationCenterInvitationId,
     code,
     email,
-    locale: localeFromCookie,
+    locale,
   });
   return h.response({}).code(204);
 };

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { MissingQueryParamError } from '../../../shared/application/http-errors.js';
-import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getChallengeLocale, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
 import { serializer as scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
@@ -9,14 +9,14 @@ import { serializer as scoOrganizationInvitationSerializer } from '../../infrast
 const acceptOrganizationInvitation = async function (request) {
   const organizationInvitationId = request.params.id;
   const { code, email: rawEmail } = request.payload.data.attributes;
-  const localeFromCookie = request.state?.locale;
+  const locale = getUserLocale(request);
   const email = rawEmail?.trim().toLowerCase();
 
   const membership = await usecases.acceptOrganizationInvitation({
     organizationInvitationId,
     code,
     email,
-    locale: localeFromCookie,
+    locale,
   });
   await usecases.createCertificationCenterMembershipForScoOrganizationAdminMember({ membership });
   return null;

--- a/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
@@ -35,13 +35,7 @@ const acceptCertificationCenterInvitation = async function ({
     );
   }
 
-  if (locale) {
-    const user = await userRepository.get(userId);
-    user.setLocaleIfNotAlreadySet(locale);
-    if (user.hasBeenModified) {
-      await userRepository.update({ id: user.id, locale: user.locale });
-    }
-  }
+  await _updateUserLocaleIfNeeded({ locale, userRepository, userId });
 
   certificationCenterInvitedUser.acceptInvitation(code);
 
@@ -49,3 +43,13 @@ const acceptCertificationCenterInvitation = async function ({
 };
 
 export { acceptCertificationCenterInvitation };
+
+async function _updateUserLocaleIfNeeded({ locale, userRepository, userId }) {
+  if (locale) {
+    const user = await userRepository.get(userId);
+    const localeChanged = user.changeLocale(locale);
+    if (localeChanged) {
+      await userRepository.update({ id: user.id, locale: user.locale });
+    }
+  }
+}

--- a/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js
@@ -1,5 +1,17 @@
 import { AlreadyExistingMembershipError } from '../../../shared/domain/errors.js';
 
+/**
+ * @typedef {function} acceptCertificationCenterInvitation
+ * @param {Object} params
+ * @param {string} params.certificationCenterInvitationId
+ * @param {string} params.code
+ * @param {string} params.email
+ * @param {string} [params.locale]
+ * @param {CertificationCenterInvitedUserRepository} params.certificationCenterInvitedUserRepository
+ * @param {CertificationCenterMembershipRepository} params.certificationCenterMembershipRepository
+ * @param {UserRepository} params.userRepository
+ * @returns {Promise<void>}
+ */
 const acceptCertificationCenterInvitation = async function ({
   certificationCenterInvitationId,
   code,

--- a/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
@@ -1,5 +1,17 @@
 import { AlreadyExistingMembershipError } from '../../../shared/domain/errors.js';
 
+/**
+ * @typedef {function} acceptOrganizationInvitation
+ * @param {Object} params
+ * @param {string} params.organizationInvitationId
+ * @param {string} params.code
+ * @param {string} params.email
+ * @param {string} [params.locale]
+ * @param {OrganizationInvitationRepository} params.organizationInvitationRepository
+ * @param {OrganizationInvitedUserRepository} params.organizationInvitedUserRepository
+ * @param {UserRepository} params.userRepository
+ * @returns {Promise<{id: string, isAdmin: boolean}>}
+ */
 const acceptOrganizationInvitation = async function ({
   organizationInvitationId,
   code,

--- a/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
+++ b/api/src/team/domain/usecases/accept-organization-invitation.usecase.js
@@ -20,16 +20,20 @@ const acceptOrganizationInvitation = async function ({
     throw error;
   }
 
-  if (locale) {
-    const user = await userRepository.get(organizationInvitedUser.userId);
-    user.setLocaleIfNotAlreadySet(locale);
-    if (user.hasBeenModified) {
-      await userRepository.update({ id: user.id, locale: user.locale });
-    }
-  }
+  await _updateUserLocaleIfNeeded({ locale, userRepository, organizationInvitedUser });
 
   await organizationInvitedUserRepository.save({ organizationInvitedUser });
   return { id: organizationInvitedUser.currentMembershipId, isAdmin: organizationInvitedUser.currentRole === 'ADMIN' };
 };
 
 export { acceptOrganizationInvitation };
+
+async function _updateUserLocaleIfNeeded({ locale, userRepository, organizationInvitedUser }) {
+  if (locale) {
+    const user = await userRepository.get(organizationInvitedUser.userId);
+    const localeChanged = user.changeLocale(locale);
+    if (localeChanged) {
+      await userRepository.update({ id: user.id, locale: user.locale });
+    }
+  }
+}

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -307,12 +307,15 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         it('does not update the user locale', async function () {
           // given
           const locale = 'fr-BE';
-          const userLocale = 'fr';
+          const userLocale = 'fr-BE';
           const email = 'user-with-locale@example.net';
+          const creationDate = new Date('2020-01-01');
           const userWithLocale = databaseBuilder.factory.buildUser.withRawPassword({
             email,
             rawPassword: userPassword,
             locale: userLocale,
+            createdAt: creationDate,
+            updatedAt: creationDate,
           });
           await databaseBuilder.commit();
 
@@ -333,8 +336,8 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           // then
           expect(response.statusCode).to.equal(200);
           const user = await knex('users').where({ id: userWithLocale.id }).first();
-          expect(user.locale).to.not.equal(locale);
           expect(user.locale).to.equal(userLocale);
+          expect(user.updatedAt).to.deep.equal(creationDate);
         });
       });
     });

--- a/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-access-token-from-refresh-token.usecase.test.js
@@ -3,13 +3,14 @@ import { usecases } from '../../../../../src/identity-access-management/domain/u
 import { refreshTokenRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/refresh-token.repository.js';
 import { UnauthorizedError } from '../../../../../src/shared/application/http-errors.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCases | create-access-token-from-refresh-token', function () {
   let userId;
+  const locale = 'fr-FR';
 
   beforeEach(async function () {
-    userId = databaseBuilder.factory.buildUser().id;
+    userId = databaseBuilder.factory.buildUser({ locale }).id;
     databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
     await databaseBuilder.commit();
     await temporaryStorage.flushAll();
@@ -28,6 +29,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const { accessToken, expirationDelaySeconds } = await usecases.createAccessTokenFromRefreshToken({
         refreshToken: refreshToken.value,
         audience,
+        locale,
       });
 
       // then
@@ -46,6 +48,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const error = await catchErr(usecases.createAccessTokenFromRefreshToken)({
         refreshToken: unknownRefreshToken,
         audience,
+        locale,
       });
 
       // then
@@ -69,12 +72,59 @@ describe('Integration | Identity Access Management | Domain | UseCases | create-
       const error = await catchErr(usecases.createAccessTokenFromRefreshToken)({
         refreshToken: refreshToken.value,
         audience: badAudience,
+        locale,
       });
 
       // then
       expect(error).to.instanceOf(UnauthorizedError);
       expect(error.message).to.equal('Refresh token is invalid');
       expect(error.code).to.equal('INVALID_REFRESH_TOKEN');
+    });
+  });
+
+  context('when the user locale is different from the given locale', function () {
+    it('updates the user locale with the formatted value', async function () {
+      // given
+      const source = 'pix';
+      const audience = 'https://app.pix.fr';
+      const newLocale = 'fr-BE';
+
+      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      await refreshTokenRepository.save({ refreshToken });
+
+      // when
+      await usecases.createAccessTokenFromRefreshToken({
+        refreshToken: refreshToken.value,
+        audience,
+        locale: newLocale,
+      });
+
+      // then
+      const user = await knex('users').where({ id: userId }).first();
+      expect(user.locale).to.equal(newLocale);
+    });
+  });
+
+  context('when the user locale is the same as the given locale', function () {
+    it("doesn't update the user locale", async function () {
+      // given
+      const source = 'pix';
+      const audience = 'https://app.pix.fr';
+      const initialLocale = 'fr-FR';
+
+      const refreshToken = RefreshToken.generate({ userId, source, audience });
+      await refreshTokenRepository.save({ refreshToken });
+
+      // when
+      await usecases.createAccessTokenFromRefreshToken({
+        refreshToken: refreshToken.value,
+        audience,
+        locale: initialLocale,
+      });
+
+      // then
+      const user = await knex('users').where({ id: userId }).first();
+      expect(user.locale).to.equal(initialLocale);
     });
   });
 });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -16,6 +16,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     const pixAccessToken = 'pixAccessToken';
     const audience = 'https://app.pix.fr';
     const requestedApplication = new RequestedApplication('app');
+    const locale = 'fr-FR';
 
     let request;
 
@@ -32,6 +33,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           state: identityProviderState,
           iss,
         },
+        state: { locale },
         yar: { get: sinon.stub(), commit: sinon.stub() },
       };
 
@@ -60,6 +62,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         sessionState: state,
         state: identityProviderState,
         iss,
+        locale,
         audience,
         requestedApplication,
       });

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -106,6 +106,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
         // given
         const expirationDelaySeconds = 6666;
         const refreshToken = 'refresh.token';
+        const locale = 'fr-FR';
         const request = {
           headers: {
             'content-type': 'application/x-www-form-urlencoded',
@@ -113,11 +114,14 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
             'x-forwarded-host': 'app.pix.fr',
           },
           payload: { grant_type: 'refresh_token', refresh_token: refreshToken },
+          state: {
+            locale,
+          },
         };
 
         sinon
           .stub(usecases, 'createAccessTokenFromRefreshToken')
-          .withArgs({ refreshToken, audience })
+          .withArgs({ refreshToken, audience, locale })
           .resolves({ accessToken, expirationDelaySeconds });
 
         sinon.stub(UserAccessToken, 'decode').withArgs(accessToken).returns({ userId });

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -103,17 +103,16 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     });
   });
 
-  describe('setLocaleIfNotAlreadySet', function () {
+  describe('changeLocale', function () {
     it('deals with empty locale', function () {
       // given
       const user = new User(undefined);
 
       // when
-      user.setLocaleIfNotAlreadySet(null, { localeService });
+      user.changeLocale(null, { localeService });
 
       // then
-      expect(user.locale).to.be.undefined;
-      expect(user.hasBeenModified).to.be.false;
+      expect(user.locale).to.equal(localeService.getDefaultLocale());
     });
 
     context('when user has no locale', function () {
@@ -127,31 +126,40 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
         const locale3 = 'fr-BE';
 
         // when
-        user1.setLocaleIfNotAlreadySet(locale1, { localeService });
-        user2.setLocaleIfNotAlreadySet(locale2, { localeService });
-        user3.setLocaleIfNotAlreadySet(locale3, { localeService });
+        user1.changeLocale(locale1, { localeService });
+        user2.changeLocale(locale2, { localeService });
+        user3.changeLocale(locale3, { localeService });
 
         // then
         expect(user1.locale).to.equal('fr');
-        expect(user1.hasBeenModified).to.be.true;
         expect(user2.locale).to.equal('fr-FR');
-        expect(user2.hasBeenModified).to.be.true;
         expect(user3.locale).to.equal('fr-BE');
-        expect(user3.hasBeenModified).to.be.true;
       });
     });
 
-    context('when user has a locale', function () {
+    context('when user has already the same locale', function () {
       it('does not set a new locale', function () {
         // given
-        const user = new User({ locale: 'en' });
+        const user = new User({ locale: 'fr-FR' });
 
         // when
-        user.setLocaleIfNotAlreadySet('fr-FR');
+        user.changeLocale('fr-FR');
 
         // then
-        expect(user.locale).to.equal('en');
-        expect(user.hasBeenModified).to.be.false;
+        expect(user.locale).to.equal('fr-FR');
+      });
+    });
+
+    context('when user has a different locale', function () {
+      it('validates and sets the new locale', function () {
+        // given
+        const user = new User({ locale: 'nl-BE' });
+
+        // when
+        user.changeLocale('fr-FR', { localeService });
+
+        // then
+        expect(user.locale).to.equal('fr-FR');
       });
     });
   });

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
@@ -10,12 +10,14 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
       const code = 'ABCDEFGH01';
       const notValidEmail = '   RANDOM@email.com   ';
       const certificationCenterInvitationId = '1234';
+      const locale = 'fr-FR';
       const request = {
         params: { id: certificationCenterInvitationId },
         deserializedPayload: {
           code,
           email: notValidEmail,
         },
+        state: { locale },
       };
 
       sinon.stub(usecases, 'acceptCertificationCenterInvitation').resolves();
@@ -31,7 +33,7 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
         certificationCenterInvitationId,
         code,
         email: notValidEmail.trim().toLowerCase(),
-        locale: undefined,
+        locale,
       });
       expect(response.statusCode).to.equal(204);
     });

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
@@ -11,6 +11,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
       // given
       const code = 'ABCDEFGH01';
       const email = 'random@email.com';
+      const locale = 'fr-FR';
       const organizationInvitation = domainBuilder.buildOrganizationInvitation({ code, email });
       const request = {
         params: { id: organizationInvitation.id },
@@ -20,6 +21,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
             attributes: { code, email: email.toUpperCase() },
           },
         },
+        state: { locale },
       };
 
       sinon.stub(usecases, 'acceptOrganizationInvitation').resolves();
@@ -33,7 +35,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
         organizationInvitationId: organizationInvitation.id,
         code,
         email,
-        locale: undefined,
+        locale,
       });
     });
 

--- a/api/tests/team/unit/domain/usecases/accept-organization-invitation.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/accept-organization-invitation.usecase.test.js
@@ -102,7 +102,7 @@ describe('Unit | Domain | UseCases | accept-organization-invitation', function (
           const { organizationInvitationId, code, email, locale } = createContext({
             organizationInvitedUserRepository,
             userRepository,
-            userLocale: 'fr-FR',
+            userLocale: 'fr-BE',
           });
 
           // when


### PR DESCRIPTION
## 🔆 Problème

À la connexion d'un utilisateur, sauvegarder la locale (du cookie) dans "users.locale"

## ⛱️ Proposition

Récupérer la locale depuis le cookie getUserLocale(request)

- Si la locale est la même que l’actuelle dans users.locale, ne rien faire.

- Si la locale est différente de l’actuelle, sauvegarder la locale du cookie dans users.locale

Dans tous les cas de connexion utilisateur 

- /api/token, 

- /api/token/oidc,

- Également, voir dans le code où on utilise setLocaleIfNotAlreadySet :

  - api/src/identity-access-management/domain/usecases/authenticate-user.js

  - api/src/team/domain/usecases/accept-certification-center-invitation.usecase.js

  - api/src/team/domain/usecases/accept-organization-invitation.usecase.js



## 🏄 Pour tester

- Pour chaque cas, tester sur .fr ('fr-FR') et .org ('en')

1. Vérifier lors de l'obtention d'un `access token` avec un couple  `identifiant / mot de passe` que la locale est sauvegardée en base. :heavy_check_mark: 

2. Vérifier lors de l'utiilisation d'un `refresh token` que la locale est sauvegardée en base. :heavy_check_mark: 

3. Vérifier lors de l'obtention d'un `access token` via SSO que la locale est sauvegardée en base. :heavy_check_mark: 

4. Vérifier que lorsqu'un utilisateur accepte une invitation à un centre de certification, locale est sauvegardée en base. :heavy_check_mark: 

4. Vérifier que lorsqu'un utilisateur accepte une invitation à une organisation, locale est sauvegardée en base. :heavy_check_mark: 
