### PR TITLE
[TECH] :truck: Déplace le modèle en lecture seule `SharedProfileForCampaign` vers un contexte de la prescription

### DIFF
--- a/api/src/prescription/campaign-participation/domain/read-models/SharedProfileForCampaign.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/SharedProfileForCampaign.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 const { map, isEmpty } = lodash;
 
-import { Scorecard } from '../../../evaluation/domain/models/Scorecard.js';
+import { Scorecard } from '../../../../evaluation/domain/models/Scorecard.js';
 
 class SharedProfileForCampaign {
   constructor({

--- a/api/src/prescription/campaign-participation/domain/usecases/get-shared-campaign-participation-profile.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-shared-campaign-participation-profile.js
@@ -1,6 +1,6 @@
 import { constants } from '../../../../shared/domain/constants.js';
 import { NoCampaignParticipationForUserAndCampaign } from '../../../../shared/domain/errors.js';
-import { SharedProfileForCampaign } from '../../../../shared/domain/read-models/SharedProfileForCampaign.js';
+import { SharedProfileForCampaign } from '../read-models/SharedProfileForCampaign.js';
 
 const getSharedCampaignParticipationProfile = async function ({
   userId,

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/SharedProfileForCampaign_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/SharedProfileForCampaign_test.js
@@ -1,6 +1,6 @@
-import { Scorecard } from '../../../../src/evaluation/domain/models/Scorecard.js';
-import { SharedProfileForCampaign } from '../../../../src/shared/domain/read-models/SharedProfileForCampaign.js';
-import { domainBuilder, expect } from '../../../test-helper.js';
+import { Scorecard } from '../../../../../../src/evaluation/domain/models/Scorecard.js';
+import { SharedProfileForCampaign } from '../../../../../../src/prescription/campaign-participation/domain/read-models/SharedProfileForCampaign.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | SharedProfileForCampaign', function () {
   describe('#scorecards', function () {

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer_test.js
@@ -1,5 +1,5 @@
+import { SharedProfileForCampaign } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/SharedProfileForCampaign.js';
 import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js';
-import { SharedProfileForCampaign } from '../../../../../../../src/shared/domain/read-models/SharedProfileForCampaign.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | shared-profile-for-campaign-serializer', function () {


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seule `SharedProfileForCampaign` est dans un contexte partagé. Il n'est utilisé que dans un contexte de la prescription

## ⛱️ Proposition

Déplacer le modèle en lecture seule `SharedProfileForCampaign` vers un contexte de la prescription

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Sur PixApp, participer à une campagne de collecte de profile.

