### PR TITLE
[TECH] :truck: Déplace le modèle en lecture seul `CampaignParticipationOverview` vers un contexte de la prescription

### DIFF
--- a/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import _ from 'lodash';
 
-import { CampaignParticipationStatuses, CampaignTypes } from '../../../prescription/shared/domain/constants.js';
-import { MAX_MASTERY_RATE, MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../constants.js';
+import { MAX_MASTERY_RATE, MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING } from '../../../../shared/domain/constants.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,9 +1,9 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CampaignParticipationOverview } from '../../../../shared/domain/read-models/CampaignParticipationOverview.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
+import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 
 const findByUserIdWithFilters = async function ({ userId, states, page }) {
   const queryBuilder = _getQueryBuilder((qb) => {

--- a/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -1,8 +1,11 @@
 import dayjs from 'dayjs';
 
-import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
-import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { CampaignParticipationOverview } from '../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes,
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;
 

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,9 +1,9 @@
+import { CampaignParticipationOverview } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
 import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
 import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 import { expect } from '../../../../../../test-helper.js';
 
 const { SHARED, STARTED } = CampaignParticipationStatuses;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/find-organization-learners-with-participations_test.js
@@ -1,10 +1,10 @@
 import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
 import { tagRepository } from '../../../../../../src/organizational-entities/infrastructure/repositories/tag.repository.js';
+import { CampaignParticipationOverview } from '../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
 import * as campaignParticipationOverviewRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js';
 import { OrganizationLearner } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearner.js';
 import { findOrganizationLearnersWithParticipations } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-organization-learners-with-participations.js';
 import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
-import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 import * as organizationRepository from '../../../../../../src/shared/infrastructure/repositories/organization-repository.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner-with-participations_test.js
@@ -1,6 +1,6 @@
 import { Organization } from '../../../../../../src/organizational-entities/domain/models/Organization.js';
+import { CampaignParticipationOverview } from '../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
-import { CampaignParticipationOverview } from '../../../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCases | get-organization-learner-with-participations', function () {

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-overview.js
@@ -1,5 +1,5 @@
+import { CampaignParticipationOverview } from '../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { CampaignParticipationOverview } from '../../../../src/shared/domain/read-models/CampaignParticipationOverview.js';
 const { SHARED } = CampaignParticipationStatuses;
 
 const buildCampaignParticipationOverview = function ({


### PR DESCRIPTION
## 🔆 Problème

Le modèle en lecture seul `CampaignParticipationOverview` est placé dans le contexte partagé. Il n'est utilisé que dans le context `prescription`.

## ⛱️ Proposition

Déplacer le modèle en lecture seul `CampaignParticipationOverview` vers un contexte de la prescription

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Sur pixApp, participer à une campagne (PROASSMUL, PROASSSIMP) et afficher la pages Mes Parcours
