### PR TITLE
[TECH] Quitter le redis uniquement quand il existe

### DIFF
--- a/api/src/shared/infrastructure/utils/redis-monitor.js
+++ b/api/src/shared/infrastructure/utils/redis-monitor.js
@@ -16,7 +16,7 @@ class RedisMonitor {
   }
 
   async quit() {
-    await this._client.quit();
+    await this._client?.quit();
   }
 }
 


### PR DESCRIPTION
## 🔆 Problème
Les captaines, très occupés en ce moment, ont gentiment remonté un problème : 

<img width="1664" height="450" alt="Screenshot 2025-08-25 at 15 19 22" src="https://github.com/user-attachments/assets/2d8264e9-5ff4-43ea-888f-0522f1589bd8" />


## ⛱️ Proposition

Je propose de vérifier si le client est présent avant de le quitter

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
