### PR TITLE
[TECH] Séparer les responsabilités du token service (partie 3) (PIX-19242)

### DIFF
--- a/api/src/identity-access-management/domain/models/UserReconciliationToken.js
+++ b/api/src/identity-access-management/domain/models/UserReconciliationToken.js
@@ -1,0 +1,39 @@
+import { config } from '../../../shared/config.js';
+import { InvalidExternalUserTokenError } from '../../../shared/domain/errors.js';
+import { tokenService } from '../../../shared/domain/services/token-service.js';
+
+export class UserReconciliationToken {
+  constructor({ firstName, lastName, samlId }) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.samlId = samlId;
+  }
+
+  static decode(token) {
+    const decoded = tokenService.getDecodedToken(token, config.authentication.secret);
+
+    if (!decoded) {
+      throw new InvalidExternalUserTokenError(
+        'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.',
+      );
+    }
+
+    return new UserReconciliationToken({
+      firstName: decoded.first_name,
+      lastName: decoded.last_name,
+      samlId: decoded.saml_id,
+    });
+  }
+
+  static generate({ firstName, lastName, samlId }) {
+    return tokenService.encodeToken(
+      {
+        first_name: firstName,
+        last_name: lastName,
+        saml_id: samlId,
+      },
+      config.authentication.secret,
+      { expiresIn: config.authentication.tokenForStudentReconciliationLifespan },
+    );
+  }
+}

--- a/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js
@@ -8,6 +8,7 @@ import { MissingOrInvalidCredentialsError, PasswordNotMatching, UserShouldChange
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 import { PasswordExpirationToken } from '../models/PasswordExpirationToken.js';
 import { UserAccessToken } from '../models/UserAccessToken.js';
+import { UserReconciliationToken } from '../models/UserReconciliationToken.js';
 
 /**
  * @param {Object} params
@@ -93,11 +94,10 @@ async function authenticateForSaml({
 async function _addGarAuthenticationMethod({
   userId,
   externalUserToken,
-  tokenService,
   authenticationMethodRepository,
   userRepository,
 }) {
-  const { samlId, firstName, lastName } = await tokenService.extractExternalUserFromIdToken(externalUserToken);
+  const { samlId, firstName, lastName } = UserReconciliationToken.decode(externalUserToken);
   await _checkIfSamlIdIsNotReconciledWithAnotherUser({ samlId, userId, userRepository });
 
   const garAuthenticationMethod = new AuthenticationMethod({

--- a/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
+++ b/api/src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js
@@ -1,6 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { AuthenticationMethod } from '../models/AuthenticationMethod.js';
 import { UserAccessToken } from '../models/UserAccessToken.js';
+import { UserReconciliationToken } from '../models/UserReconciliationToken.js';
 
 const getSamlAuthenticationRedirectionUrl = async function ({
   userAttributes,
@@ -8,7 +9,6 @@ const getSamlAuthenticationRedirectionUrl = async function ({
   userLoginRepository,
   authenticationMethodRepository,
   lastUserApplicationConnectionsRepository,
-  tokenService,
   config,
   audience,
   requestedApplication,
@@ -40,7 +40,8 @@ const getSamlAuthenticationRedirectionUrl = async function ({
     return `/connexion/gar#${encodeURIComponent(accessToken)}`;
   }
 
-  return _getUrlForReconciliationPage({ tokenService, externalUser });
+  const userReconciliationToken = UserReconciliationToken.generate(externalUser);
+  return `/campagnes?externalUser=${encodeURIComponent(userReconciliationToken)}`;
 };
 
 export { getSamlAuthenticationRedirectionUrl };
@@ -53,11 +54,6 @@ function _externalUserFirstAndLastNameMatchesAuthenticationMethodFirstAndLastNam
     externalUser.firstName === authenticationMethod.authenticationComplement?.firstName &&
     externalUser.lastName === authenticationMethod.authenticationComplement?.lastName
   );
-}
-
-function _getUrlForReconciliationPage({ tokenService, externalUser }) {
-  const externalUserToken = tokenService.createIdTokenForUserReconciliation(externalUser);
-  return `/campagnes?externalUser=${encodeURIComponent(externalUserToken)}`;
 }
 
 async function _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser }) {

--- a/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -2,6 +2,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../identity-access-managem
 import { AuthenticationMethod } from '../../../../identity-access-management/domain/models/AuthenticationMethod.js';
 import { User } from '../../../../identity-access-management/domain/models/User.js';
 import { UserAccessToken } from '../../../../identity-access-management/domain/models/UserAccessToken.js';
+import { UserReconciliationToken } from '../../../../identity-access-management/domain/models/UserReconciliationToken.js';
 import { STUDENT_RECONCILIATION_ERRORS } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ObjectValidationError } from '../../../../shared/domain/errors.js';
@@ -16,7 +17,6 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   organizationId,
   token,
   obfuscationService,
-  tokenService,
   audience,
   requestedApplication,
   userReconciliationService,
@@ -30,10 +30,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   lastUserApplicationConnectionsRepository,
   studentRepository,
 }) {
-  const externalUser = await tokenService.extractExternalUserFromIdToken(token);
-  const firstName = externalUser.firstName;
-  const lastName = externalUser.lastName;
-  const samlId = externalUser.samlId;
+  const { firstName, lastName, samlId } = UserReconciliationToken.decode(token);
 
   if (!firstName || !lastName || !samlId) {
     throw new ObjectValidationError('Missing claim(s) in IdToken');
@@ -64,7 +61,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
       studentRepository,
     );
 
-    userWithSamlId = await userRepository.getBySamlId(externalUser.samlId);
+    userWithSamlId = await userRepository.getBySamlId(samlId);
     if (!userWithSamlId) {
       const domainUser = new User({
         firstName,

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -2,7 +2,6 @@ import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../../src/shared/config.js';
 import {
-  InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
@@ -19,18 +18,6 @@ const CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE = 'certificationResult
  */
 function encodeToken(payload, secret, options) {
   return jsonwebtoken.sign(payload, secret, options);
-}
-
-function createIdTokenForUserReconciliation(externalUser) {
-  return jsonwebtoken.sign(
-    {
-      first_name: externalUser.firstName,
-      last_name: externalUser.lastName,
-      saml_id: externalUser.samlId,
-    },
-    config.authentication.secret,
-    { expiresIn: config.authentication.tokenForStudentReconciliationLifespan },
-  );
 }
 
 function createCertificationResultsByRecipientEmailLinkToken({
@@ -90,11 +77,6 @@ function getDecodedToken(token, secret = config.authentication.secret) {
   }
 }
 
-function extractSamlId(token) {
-  const decoded = getDecodedToken(token);
-  return decoded.saml_id || null;
-}
-
 function extractCertificationResultsByRecipientEmailLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id || !decoded.result_recipient_email) {
@@ -131,31 +113,13 @@ function extractUserId(token) {
   return decoded.user_id || null;
 }
 
-async function extractExternalUserFromIdToken(token) {
-  const externalUser = getDecodedToken(token);
-
-  if (!externalUser) {
-    throw new InvalidExternalUserTokenError(
-      'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.',
-    );
-  }
-
-  return {
-    firstName: externalUser['first_name'],
-    lastName: externalUser['last_name'],
-    samlId: externalUser['saml_id'],
-  };
-}
 const tokenService = {
-  createIdTokenForUserReconciliation,
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
   decodeIfValid,
   getDecodedToken,
   encodeToken,
-  extractExternalUserFromIdToken,
   extractCertificationResultsByRecipientEmailLink,
-  extractSamlId,
   extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
@@ -168,12 +132,9 @@ const tokenService = {
 export {
   createCertificationResultsByRecipientEmailLinkToken,
   createCertificationResultsLinkToken,
-  createIdTokenForUserReconciliation,
   decodeIfValid,
   extractCertificationResultsByRecipientEmailLink,
   extractCertificationResultsLink,
-  extractExternalUserFromIdToken,
-  extractSamlId,
   extractTokenFromAuthChain,
   extractUserId,
   getDecodedToken,

--- a/api/tests/identity-access-management/acceptance/application/saml.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/saml.route.test.js
@@ -2,8 +2,9 @@ import _ from 'lodash';
 import samlify from 'samlify';
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { UserReconciliationToken } from '../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import { config as settings } from '../../../../src/shared/config.js';
-import { decodeIfValid, tokenService } from '../../../../src/shared/domain/services/token-service.js';
+import { decodeIfValid } from '../../../../src/shared/domain/services/token-service.js';
 import { createServer, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 
 const testCertificate = `MIICCzCCAXQCCQD2MlHh/QmGmjANBgkqhkiG9w0BAQsFADBKMQswCQYDVQQGEwJG
@@ -261,18 +262,17 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
       it('returns a 200 with accessToken', async function () {
         // given
         const password = 'Pix123';
-        const userAttributes = {
-          firstName: 'saml',
-          lastName: 'jackson',
-          samlId: 'SAMLJACKSONID',
-        };
         const user = databaseBuilder.factory.buildUser.withRawPassword({
           username: 'saml.jackson1234',
           rawPassword: password,
         });
         await databaseBuilder.commit();
 
-        const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
+        const expectedExternalToken = UserReconciliationToken.generate({
+          firstName: 'saml',
+          lastName: 'jackson',
+          samlId: 'SAMLJACKSONID',
+        });
 
         const options = {
           method: 'POST',
@@ -310,18 +310,17 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
       it('adds a GAR authentication method', async function () {
         // given
         const password = 'Pix123';
-        const userAttributes = {
-          firstName: 'saml',
-          lastName: 'jackson',
-          samlId: 'SAMLJACKSONID',
-        };
         const user = databaseBuilder.factory.buildUser.withRawPassword({
           username: 'saml.jackson1234',
           rawPassword: password,
         });
         await databaseBuilder.commit();
 
-        const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
+        const expectedExternalToken = UserReconciliationToken.generate({
+          firstName: 'saml',
+          lastName: 'jackson',
+          samlId: 'SAMLJACKSONID',
+        });
 
         const options = {
           method: 'POST',
@@ -427,11 +426,6 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             // given
             const email = 'i.am.blocked@example.net';
             const password = 'pix123';
-            const userAttributes = {
-              firstName: 'I_am',
-              lastName: 'Blocked',
-              samlId: 'someSamlId',
-            };
             const user = databaseBuilder.factory.buildUser.withRawPassword({
               email,
               rawPassword: password,
@@ -439,7 +433,11 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             databaseBuilder.factory.buildUserLogin({ userId: user.id, failureCount: 50, blockedAt: new Date() });
             await databaseBuilder.commit();
 
-            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
+            const expectedExternalToken = UserReconciliationToken.generate({
+              firstName: 'I_am',
+              lastName: 'Blocked',
+              samlId: 'someSamlId',
+            });
 
             const options = {
               method: 'POST',
@@ -470,11 +468,6 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             // given
             const username = 'i_am_blocked';
             const password = 'pix123';
-            const userAttributes = {
-              firstName: 'I_am',
-              lastName: 'Blocked',
-              samlId: 'someSamlId',
-            };
             const user = databaseBuilder.factory.buildUser.withRawPassword({
               username,
               rawPassword: password,
@@ -482,7 +475,11 @@ describe('Acceptance | Identity Access Management | Route | Saml', function () {
             databaseBuilder.factory.buildUserLogin({ userId: user.id, failureCount: 50, blockedAt: new Date() });
             await databaseBuilder.commit();
 
-            const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
+            const expectedExternalToken = UserReconciliationToken.generate({
+              firstName: 'I_am',
+              lastName: 'Blocked',
+              samlId: 'someSamlId',
+            });
 
             const options = {
               method: 'POST',

--- a/api/tests/identity-access-management/unit/domain/models/UserReconciliationToken.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/UserReconciliationToken.test.js
@@ -1,0 +1,63 @@
+import { UserReconciliationToken } from '../../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
+import { config } from '../../../../../src/shared/config.js';
+import { InvalidExternalUserTokenError } from '../../../../../src/shared/domain/errors.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Model | UserReconciliationToken', function () {
+  beforeEach(function () {
+    sinon.stub(config.authentication, 'secret').value('secret!');
+    sinon.stub(config.authentication, 'tokenForStudentReconciliationLifespan').value(1000);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('UserReconciliationToken.decode', function () {
+    it('decodes a valid token', function () {
+      // given
+      const token = UserReconciliationToken.generate({
+        firstName: 'John',
+        lastName: 'Doe',
+        samlId: 'saml-id-123',
+      });
+
+      // when
+      const decoded = UserReconciliationToken.decode(token);
+
+      // then
+      expect(decoded).to.be.instanceOf(UserReconciliationToken);
+      expect(decoded).to.deep.include({
+        firstName: 'John',
+        lastName: 'Doe',
+        samlId: 'saml-id-123',
+      });
+    });
+
+    it('throws InvalidExternalUserTokenError for invalid token', function () {
+      // given / when / then
+      expect(() => UserReconciliationToken.decode('invalid.token')).to.throw(InvalidExternalUserTokenError);
+    });
+  });
+
+  describe('UserReconciliationToken.generate', function () {
+    it('builds a user reconciliation token', function () {
+      // given / when
+      const token = UserReconciliationToken.generate({
+        firstName: 'Jane',
+        lastName: 'Smith',
+        samlId: 'saml-id-456',
+      });
+
+      // then
+      expect(token).to.be.a('string');
+
+      const decoded = UserReconciliationToken.decode(token);
+      expect(decoded).to.deep.include({
+        firstName: 'Jane',
+        lastName: 'Smith',
+        samlId: 'saml-id-456',
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -7,6 +7,7 @@ import {
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
 import { PasswordExpirationToken } from '../../../../../src/identity-access-management/domain/models/PasswordExpirationToken.js';
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
+import { UserReconciliationToken } from '../../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import { authenticateForSaml } from '../../../../../src/identity-access-management/domain/usecases/authenticate-for-saml.usecase.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import {
@@ -18,7 +19,6 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.
 
 describe('Unit | Identity Access Management | Domain | UseCase | authenticate-for-saml', function () {
   let lastUserApplicationConnectionsRepository;
-  let tokenService;
   let pixAuthenticationService;
   let obfuscationService;
   let authenticationMethodRepository;
@@ -28,9 +28,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
   const requestedApplication = new RequestedApplication('app');
 
   beforeEach(function () {
-    tokenService = {
-      extractExternalUserFromIdToken: sinon.stub(),
-    };
     pixAuthenticationService = {
       getUserByUsernameAndPassword: sinon.stub(),
     };
@@ -67,7 +64,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
       _stubToEnableAddGarAuthenticationMethod({
         user,
         externalUserToken,
-        tokenService,
         userRepository,
         authenticationMethodRepository,
       });
@@ -86,7 +82,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         externalUserToken,
         expectedUserId: user.id,
         audience,
-        tokenService,
         pixAuthenticationService,
         obfuscationService,
         authenticationMethodRepository,
@@ -117,7 +112,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
       _stubToEnableAddGarAuthenticationMethod({
         user,
         externalUserToken,
-        tokenService,
         userRepository,
         authenticationMethodRepository,
       });
@@ -136,7 +130,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         externalUserToken,
         expectedUserId: user.id,
         audience,
-        tokenService,
         pixAuthenticationService,
         obfuscationService,
         authenticationMethodRepository,
@@ -186,7 +179,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
         password,
         externalUserToken: 'an external user token',
         expectedUserId,
-        tokenService,
         pixAuthenticationService,
         obfuscationService,
         authenticationMethodRepository,
@@ -215,7 +207,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
 
         const externalUserToken = 'EXTERNAL_USER_TOKEN';
         const samlId = 'samlId';
-        tokenService.extractExternalUserFromIdToken.withArgs(externalUserToken).returns({ samlId });
+        sinon.stub(UserReconciliationToken, 'decode').withArgs(externalUserToken).returns({ samlId });
 
         const userFromExternalUserToken = domainBuilder.buildUser({ id: userFromCredentials.id + 1 });
         userRepository.getBySamlId.withArgs(samlId).resolves(userFromExternalUserToken);
@@ -226,7 +218,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           password,
           externalUserToken: externalUserToken,
           expectedUserId: userFromCredentials.id,
-          tokenService,
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
@@ -256,7 +247,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           samlId,
           firstName: 'Hervé',
           lastName: 'Le Terrier',
-          tokenService,
           userRepository,
           authenticationMethodRepository,
         });
@@ -267,7 +257,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           password,
           externalUserToken,
           expectedUserId: user.id,
-          tokenService,
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
@@ -310,7 +299,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           samlId: externalIdentifier,
           firstName: 'Monique',
           lastName: 'Samoëns',
-          tokenService,
           userRepository,
           authenticationMethodRepository,
         });
@@ -321,7 +309,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           password: oneTimePassword,
           externalUserToken,
           expectedUserId: user.id,
-          tokenService,
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
@@ -362,7 +349,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           user,
           externalUserToken,
           samlId: externalIdentifier,
-          tokenService,
           userRepository,
           authenticationMethodRepository,
         });
@@ -373,7 +359,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
           password: oneTimePassword,
           externalUserToken,
           expectedUserId: user.id,
-          tokenService,
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
@@ -407,7 +392,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
       const error = await catchErr(authenticateForSaml)({
         username: unknownUserEmail,
         password,
-        tokenService,
         pixAuthenticationService,
         userRepository,
         userLoginRepository,
@@ -434,7 +418,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
       const error = await catchErr(authenticateForSaml)({
         username: email,
         password: invalidPassword,
-        tokenService,
         pixAuthenticationService,
         userRepository,
         userLoginRepository,
@@ -499,13 +482,12 @@ function _stubToEnableAddGarAuthenticationMethod({
   user,
   externalUserToken,
   samlId = 'samlId',
-  tokenService,
   userRepository,
   authenticationMethodRepository,
   firstName = 'Hervé',
   lastName = 'Le Terrier',
 }) {
-  tokenService.extractExternalUserFromIdToken.withArgs(externalUserToken).returns({ samlId, firstName, lastName });
+  sinon.stub(UserReconciliationToken, 'decode').withArgs(externalUserToken).returns({ samlId, firstName, lastName });
   userRepository.getBySamlId.withArgs(samlId).resolves(user);
   authenticationMethodRepository.create.resolves();
 }

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -2,6 +2,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../src/identity-access-
 import { AuthenticationMethod } from '../../../../../src/identity-access-management/domain/models/AuthenticationMethod.js';
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
+import { UserReconciliationToken } from '../../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import { getSamlAuthenticationRedirectionUrl } from '../../../../../src/identity-access-management/domain/usecases/get-saml-authentication-redirection-url.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { domainBuilder, expect, sinon } from '../../../../test-helper.js';
@@ -11,7 +12,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   let userLoginRepository;
   let authenticationMethodRepository;
   let lastUserApplicationConnectionsRepository;
-  let tokenService;
   let samlSettings;
   const audience = 'https://app.pix.fr';
   const requestedApplication = new RequestedApplication('app');
@@ -29,10 +29,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       findOneByUserIdAndIdentityProvider: sinon.stub(),
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
       update: sinon.stub(),
-    };
-
-    tokenService = {
-      createIdTokenForUserReconciliation: sinon.stub(),
     };
 
     samlSettings = {
@@ -58,9 +54,8 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         NOM: 'Lopez',
         PRE: 'Adèle',
       };
-
-      tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
       userRepository.getBySamlId.resolves(null);
+      sinon.stub(UserReconciliationToken, 'generate').returns('external-user-token');
 
       // when
       const result = await getSamlAuthenticationRedirectionUrl({
@@ -68,7 +63,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userRepository,
         userLoginRepository,
         lastUserApplicationConnectionsRepository,
-        tokenService,
         config: samlSettings,
       });
 
@@ -121,7 +115,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userLoginRepository,
         authenticationMethodRepository,
         lastUserApplicationConnectionsRepository,
-        tokenService,
         config: samlSettings,
         requestedApplication,
       });
@@ -144,7 +137,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(
         domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider(),
       );
-      tokenService.createIdTokenForUserReconciliation.returns('external-user-token');
+      sinon.stub(UserReconciliationToken, 'generate').returns('external-user-token');
 
       // when
       await getSamlAuthenticationRedirectionUrl({
@@ -153,7 +146,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
         userLoginRepository,
         authenticationMethodRepository,
         lastUserApplicationConnectionsRepository,
-        tokenService,
         config: samlSettings,
         requestedApplication,
       });
@@ -197,7 +189,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
-          tokenService,
           config: samlSettings,
           requestedApplication,
         });
@@ -236,7 +227,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
-          tokenService,
           config: samlSettings,
           requestedApplication,
         });
@@ -274,7 +264,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
-          tokenService,
           config: samlSettings,
           requestedApplication,
         });
@@ -312,7 +301,6 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
           userLoginRepository,
           authenticationMethodRepository,
           lastUserApplicationConnectionsRepository,
-          tokenService,
           config: samlSettings,
           requestedApplication,
         });

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -1,4 +1,5 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
+import { UserReconciliationToken } from '../../../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import { RequestedApplication } from '../../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 import {
@@ -28,11 +29,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     context('When the firstName is empty', function () {
       it('should throw an ObjectValidationError', async function () {
         // given
-        const externalUser = {
+        const token = UserReconciliationToken.generate({
           lastName: 'Jackson',
           samlId: 'samlId',
-        };
-        const token = tokenService.createIdTokenForUserReconciliation(externalUser);
+        });
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
@@ -50,11 +50,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     context('When the lastName is empty', function () {
       it('should throw an ObjectValidationError', async function () {
         // given
-        const externalUser = {
+        const token = UserReconciliationToken.generate({
           firstName: 'Saml',
           samlId: 'samlId',
-        };
-        const token = tokenService.createIdTokenForUserReconciliation(externalUser);
+        });
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
@@ -72,11 +71,10 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     context('When the samlId is empty', function () {
       it('should throw an ObjectValidationError', async function () {
         // given
-        const externalUser = {
+        const token = UserReconciliationToken.generate({
           firstName: 'Saml',
           lastName: 'Jackson',
-        };
-        const token = tokenService.createIdTokenForUserReconciliation(externalUser);
+        });
 
         // when
         const error = await catchErr(usecases.createUserAndReconcileToOrganizationLearnerFromExternalUser)({
@@ -98,12 +96,11 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     beforeEach(async function () {
       organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
-      const externalUser = {
+      token = UserReconciliationToken.generate({
         firstName: 'Saml',
         lastName: 'Jackson',
         samlId: 'samlId',
-      };
-      token = tokenService.createIdTokenForUserReconciliation(externalUser);
+      });
     });
 
     it('should throw a Not Found error', async function () {
@@ -132,11 +129,9 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
     let token;
 
     beforeEach(async function () {
+      token = UserReconciliationToken.generate({ firstName, lastName, samlId });
       organizationId = databaseBuilder.factory.buildOrganization().id;
       await databaseBuilder.commit();
-
-      const externalUser = { firstName, lastName, samlId };
-      token = tokenService.createIdTokenForUserReconciliation(externalUser);
     });
 
     it('creates the external user, reconciles it and creates GAR authentication method', async function () {

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -1,5 +1,6 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { UserAccessToken } from '../../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
+import { UserReconciliationToken } from '../../../../../../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import { RequestedApplication } from '../../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { createUserAndReconcileToOrganizationLearnerFromExternalUser } from '../../../../../../src/prescription/organization-learner/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
@@ -7,7 +8,6 @@ import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-from-external-user', function () {
   const organizationId = 1;
   let obfuscationService;
-  let tokenService;
   let userReconciliationService;
   let userService;
   let authenticationMethodRepository;
@@ -20,9 +20,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   const requestedApplication = new RequestedApplication('app');
 
   beforeEach(function () {
-    tokenService = {
-      extractExternalUserFromIdToken: sinon.stub(),
-    };
     userReconciliationService = {
       findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo: sinon.stub(),
       assertStudentHasAnAlreadyReconciledAccount: sinon.stub(),
@@ -53,7 +50,8 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const organizationLearner = domainBuilder.buildOrganizationLearner(user);
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
 
-      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      sinon.stub(UserReconciliationToken, 'decode').returns(externalUser);
+
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
@@ -65,7 +63,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationId,
         token: 'a token',
         obfuscationService,
-        tokenService,
         userReconciliationService,
         userService,
         authenticationMethodRepository,
@@ -97,7 +94,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
       const token = Symbol('token');
 
-      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      sinon.stub(UserReconciliationToken, 'decode').returns(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
@@ -114,7 +111,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationId,
         token: 'a token',
         obfuscationService,
-        tokenService,
         audience,
         userReconciliationService,
         userService,
@@ -139,7 +135,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const organizationLearner = domainBuilder.buildOrganizationLearner(user);
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
 
-      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      sinon.stub(UserReconciliationToken, 'decode').returns(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
@@ -152,7 +148,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationId,
         token: 'a token',
         obfuscationService,
-        tokenService,
         userReconciliationService,
         userService,
         authenticationMethodRepository,
@@ -175,7 +170,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
       const externalUser = { firstName: user.firstName, lastName: user.lastName, samlId: '123' };
       const token = Symbol('token');
 
-      tokenService.extractExternalUserFromIdToken.resolves(externalUser);
+      sinon.stub(UserReconciliationToken, 'decode').returns(externalUser);
       userReconciliationService.findMatchingOrganizationLearnerForGivenOrganizationIdAndReconciliationInfo.resolves(
         organizationLearner,
       );
@@ -193,7 +188,6 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         organizationId,
         token: 'a token',
         obfuscationService,
-        tokenService,
         audience,
         userReconciliationService,
         userService,

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -4,7 +4,6 @@ import lodash from 'lodash';
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { config, config as settings } from '../../../../../src/shared/config.js';
 import {
-  InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
@@ -15,60 +14,6 @@ import { catchErr, expect } from '../../../../test-helper.js';
 const { omit } = lodash;
 
 describe('Unit | Shared | Domain | Services | Token Service', function () {
-  describe('#createIdTokenForUserReconciliation', function () {
-    it('should return a valid idToken with firstName, lastName, samlId', function () {
-      // given
-      const externalUser = {
-        firstName: 'Adèle',
-        lastName: 'Lopez',
-        samlId: 'IDO-for-adele',
-      };
-      const expectedTokenAttributes = {
-        first_name: 'Adèle',
-        last_name: 'Lopez',
-        saml_id: 'IDO-for-adele',
-      };
-
-      // when
-      const idToken = tokenService.createIdTokenForUserReconciliation(externalUser);
-
-      // then
-      const decodedToken = jsonwebtoken.verify(idToken, settings.authentication.secret);
-      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
-    });
-  });
-
-  describe('#extractExternalUserFromIdToken', function () {
-    it('should return external user if the idToken is valid', async function () {
-      // given
-      const externalUser = {
-        firstName: 'Saml',
-        lastName: 'Jackson',
-        samlId: 'SamlId',
-      };
-
-      const idToken = tokenService.createIdTokenForUserReconciliation(externalUser);
-
-      // when
-      const result = await tokenService.extractExternalUserFromIdToken(idToken);
-
-      // then
-      expect(result).to.deep.equal(externalUser);
-    });
-
-    it('should throw an InvalidExternalUserTokenError if the idToken is invalid', async function () {
-      // given
-      const idToken = 'WRONG_DATA';
-
-      // when
-      const error = await catchErr(tokenService.extractExternalUserFromIdToken)(idToken);
-      expect(error).to.be.an.instanceof(InvalidExternalUserTokenError);
-      expect(error.message).to.be.equal(
-        'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.',
-      );
-    });
-  });
-
   describe('#extractUserId', function () {
     it('should return userId if the accessToken is valid', function () {
       // given
@@ -106,36 +51,6 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
 
       // then
       expect(error).to.be.an.instanceof(InvalidTemporaryKeyError);
-    });
-  });
-
-  describe('#extractSamlId', function () {
-    it('should return samlId if the idToken is valid', function () {
-      // given
-      const expectedSamlId = 'SAMLID';
-      const userAttributes = {
-        firstName: 'firstName',
-        lastName: 'lastName',
-        samlId: expectedSamlId,
-      };
-      const idToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
-
-      // when
-      const samlId = tokenService.extractSamlId(idToken);
-
-      // then
-      expect(samlId).to.equal(expectedSamlId);
-    });
-
-    it('should return null if the idToken is invalid', function () {
-      // given
-      const invalidIdToken = 'ABCD';
-
-      // when
-      const result = tokenService.extractSamlId(invalidIdToken);
-
-      // then
-      expect(result).to.equal(null);
     });
   });
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -27,10 +27,10 @@ import { PIX_ADMIN } from '../src/authorization/domain/constants.js';
 import * as tutorialRepository from '../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import { ApplicationAccessToken } from '../src/identity-access-management/domain/models/ApplicationAccessToken.js';
 import { UserAccessToken } from '../src/identity-access-management/domain/models/UserAccessToken.js';
+import { UserReconciliationToken } from '../src/identity-access-management/domain/models/UserReconciliationToken.js';
 import * as missionRepository from '../src/school/infrastructure/repositories/mission-repository.js';
 import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
 import { Membership } from '../src/shared/domain/models/Membership.js';
-import * as tokenService from '../src/shared/domain/services/token-service.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
 import * as areaRepository from '../src/shared/infrastructure/repositories/area-repository.js';
 import * as challengeRepository from '../src/shared/infrastructure/repositories/challenge-repository.js';
@@ -143,7 +143,7 @@ function generateValidRequestAuthorizationHeaderForApplication(clientId = 'clien
 }
 
 function generateIdTokenForExternalUser(externalUser) {
-  return tokenService.createIdTokenForUserReconciliation(externalUser);
+  return UserReconciliationToken.generate(externalUser);
 }
 
 async function insertUserWithRoleSuperAdmin() {


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le `token-service` à beaucoup de dépendances et trop de responsabilités. On retrouve des cas d'usage spécifiques à des contextes différents et du code "métier" dans ce fichier. Exemples :
- Contexte IAM : `createAccessTokenFromUser`, `createAccessTokenForSaml`...
- Contexte Certif : `createCertificationResultsByRecipientEmailLinkToken`...
- Contexte Prescription : `createIdTokenForUserReconciliation`...

Ce couplage entraîne des **soucis de dépendances cycliques** quand on souhaite encoder / décoder des tokens.

## ⛱️ Proposition

**Isoler la génération des tokens par cas d'usage et par contexte** tout en conservant le `token-service` pour l'encodage et décodage de base avec `jsonwebtoken`. À la fin du refactoring, le `token-service` devrait avoir uniquement 2 fonctions: `encodeToken` et `decodeToken`. Et on aura plus les soucis de dépendances cyclique causées par ce fichier.

Cette isolation sera faite en plusieurs PR.

**Cette PR** isole: 
- la création **de token de réconciliation SAML** via la classe `UserReconciliationToken`

## 🏄 Pour tester

**Se connecter et reconcilier avec le GAR :**

1. Se connecter avec le SSO GAR (faux GAR)  (RA: https://gar.review.pix.fr/)
  - Indiquer un samlId aléatoire, le prénom `Hermione` et le nom `Granger`  
  - Se connecter avec le bouton _« Sign in »_
2. Sur la page _« Saisissez votre code »_ indiquer le code campagne `SCOBADGE1`
3. Cliquer sur le bouton _« Accéder au parcours »_
4. Cliquer sur le bouton _« Je commence »_
5. Indiquer la date de naissance `05-05-2013`
6. Cliquer sur le bouton _« C'est parti ! »_
7. Cliquer sur le bouton _« Continuer avec mon compte Pix »_
8. Sur le formulaire _« J’ai déjà un compte Pix »_ indiquer l'adresse email `hermione@school.net`
