### PR TITLE
[TECH] Améliorer la performance de la requête qui remonte les targetProfiles à disposition d'une organisation

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js
@@ -3,10 +3,11 @@ import { CampaignCreator } from '../../domain/models/CampaignCreator.js';
 
 async function get(organizationId) {
   const availableTargetProfileIds = await knex('target-profiles')
-    .leftJoin('target-profile-shares', 'targetProfileId', 'target-profiles.id')
     .where({ outdated: false })
     .andWhere((queryBuilder) => {
-      queryBuilder.where({ ownerOrganizationId: organizationId }).orWhere({ organizationId });
+      queryBuilder
+        .where({ ownerOrganizationId: organizationId })
+        .orWhere('id', 'in', knex.select('targetProfileId').from('target-profile-shares').where({ organizationId }));
     })
     .pluck('target-profiles.id');
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -44,7 +44,11 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
         const { id: targetProfileSharedId } = databaseBuilder.factory.buildTargetProfile({
           outdated: false,
         });
+        const { id: targetProfileSharedId2 } = databaseBuilder.factory.buildTargetProfile({
+          outdated: false,
+        });
         databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId, organizationId });
+        databaseBuilder.factory.buildTargetProfileShare({ targetProfileId: targetProfileSharedId2, organizationId });
         databaseBuilder.factory.buildTargetProfile({
           outdated: false,
         });
@@ -52,7 +56,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
         await databaseBuilder.commit();
 
         const creator = await campaignCreatorRepository.get(organizationId);
-        expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfileSharedId]);
+        expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfileSharedId, targetProfileSharedId2]);
       });
 
       it('returns the target profiles is owned by the organization', async function () {


### PR DESCRIPTION
## 🔆 Problème

Les captains, nous ont remonté une optimisation possible d'une requête sql : 

> La première c'est
/* path: /api/campaigns */ select "target-profiles"."id" from "target-profiles" left join "target-profile-shares" on "targetProfileId" = "target-profiles"."id" where "outdated" = $1 and ("ownerOrganizationId" = $2 or ("organizationId" = $3))
Elle a un coût de 62000 d'après PG
Hash Right Join  (cost=404.84..61974.02 rows=1269 width=4)
  Hash Cond: ("target-profile-shares"."targetProfileId" = "target-profiles".id)
  Filter: (("target-profiles"."ownerOrganizationId" = 829) OR ("target-profile-shares"."organizationId" = 829))
  ->  Seq Scan on "target-profile-shares"  (cost=0.00..53054.69 rows=3239969 width=8)
  ->  Hash  (cost=361.50..361.50 rows=3467 width=8)
        ->  Seq Scan on "target-profiles"  (cost=0.00..361.50 rows=3467 width=8)
              Filter: (NOT outdated)
Que l'on peut remplacer par
select "target-profiles"."id" from "target-profiles" where "outdated" = $1 and ("ownerOrganizationId" = $2 or ("id" in (select "targetProfileId" from "target-profile-shares" where "organizationId" = $3)))
Qui a un coût de 397
Seq Scan on "target-profiles"  (cost=8.15..396.90 rows=1734 width=4)
  Filter: ((NOT outdated) AND (("ownerOrganizationId" = 829) OR (hashed SubPlan 1)))
  SubPlan 1
    ->  Index Only Scan using target_profile_shares_organizationid_index on "target-profile-shares"  (cost=0.43..7.68 rows=188 width=4)
          Index Cond: ("organizationId" = 829)


## ⛱️ Proposition

Faire ce qui nous est proposé

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
