### PR TITLE
[TECH] :truck: Déplace le modèle `CertificationResult` vers le contexte `certification/results`

### DIFF
--- a/api/src/certification/results/domain/models/CertificationResult.js
+++ b/api/src/certification/results/domain/models/CertificationResult.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import { CompetenceMark } from '../../../certification/shared/domain/models/CompetenceMark.js';
-import { ComplementaryCertificationCourseResult } from '../../../certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
-import { JuryComment, JuryCommentContexts } from '../../../certification/shared/domain/models/JuryComment.js';
+import { CompetenceMark } from '../../../shared/domain/models/CompetenceMark.js';
+import { ComplementaryCertificationCourseResult } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
+import { JuryComment, JuryCommentContexts } from '../../../shared/domain/models/JuryComment.js';
 
 /**
  * @readonly

--- a/api/src/certification/results/infrastructure/repositories/certification-result-repository.js
+++ b/api/src/certification/results/infrastructure/repositories/certification-result-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { CertificationResult } from '../../../../shared/domain/models/CertificationResult.js';
 import { ComplementaryCertificationCourseResult } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
+import { CertificationResult } from '../../domain/models/CertificationResult.js';
 
 const findBySessionId = async function ({ sessionId }) {
   const certificationResultDTOs = await _selectCertificationResults()

--- a/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/certification/results/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -1,8 +1,8 @@
+import { CertificationResult } from '../../../../../../src/certification/results/domain/models/CertificationResult.js';
 import * as certificationResultRepository from '../../../../../../src/certification/results/infrastructure/repositories/certification-result-repository.js';
 import { ComplementaryCertificationCourseResult } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationCourseResult.js';
 import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { CertificationResult } from '../../../../../../src/shared/domain/models/CertificationResult.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Results | Integration | Infrastructure | Repository | Certification Result', function () {

--- a/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
+++ b/api/tests/certification/results/unit/domain/models/CertificationResult_test.js
@@ -1,6 +1,6 @@
-import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
-import { CertificationResult } from '../../../../src/shared/domain/models/CertificationResult.js';
-import { domainBuilder, expect } from '../../../test-helper.js';
+import { CertificationResult } from '../../../../../../src/certification/results/domain/models/CertificationResult.js';
+import { AutoJuryCommentKeys } from '../../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 const CERTIFICATION_RESULT_STATUS_CANCELLED = CertificationResult.status.CANCELLED;
 const CERTIFICATION_RESULT_STATUS_ERROR = CertificationResult.status.ERROR;

--- a/api/tests/certification/results/unit/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues_test.js
+++ b/api/tests/certification/results/unit/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues_test.js
@@ -1,6 +1,6 @@
+import { CertificationResult } from '../../../../../../../../src/certification/results/domain/models/CertificationResult.js';
 import { CertificationResultsCsvValues } from '../../../../../../../../src/certification/results/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues.js';
 import { AutoJuryCommentKeys } from '../../../../../../../../src/certification/shared/domain/models/JuryComment.js';
-import { CertificationResult } from '../../../../../../../../src/shared/domain/models/CertificationResult.js';
 import { getI18n } from '../../../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect } from '../../../../../../../test-helper.js';
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,4 +1,4 @@
-import { CertificationResult } from '../../../../src/shared/domain/models/CertificationResult.js';
+import { CertificationResult } from '../../../../src/certification/results/domain/models/CertificationResult.js';
 
 const buildCertificationResult = function ({
   id = 123,


### PR DESCRIPTION
## 🔆 Problème

Le modèle `CertificationResult` est dans le contexte partagé alors qu'il n'est utilisé que dans le contexte `certification/results`

## ⛱️ Proposition

Déplacer le modèle `CertificationResult` vers le contexte `certification/results`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
