### PR TITLE
[FEATURE] Ajouter les titres de section dans la preview (PIX-19230)

### DIFF
--- a/mon-pix/app/components/module/_module-preview.scss
+++ b/mon-pix/app/components/module/_module-preview.scss
@@ -1,6 +1,6 @@
 @use 'pix-design-tokens/typography';
-@use './module';
-@use '../components/module/passage';
+@use '../../styles/pages/module';
+@use './passage';
 
 .module-preview {
   @extend .modulix;

--- a/mon-pix/app/components/module/_module-preview.scss
+++ b/mon-pix/app/components/module/_module-preview.scss
@@ -54,3 +54,15 @@
     height: 100%;
   }
 }
+
+.module-preview-passage-content-section {
+  @extend %pix-title-xs;
+
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+  width: 100%;
+  padding: var(--pix-spacing-4x);
+  background-color: var(--pix-primary-100);
+  border-radius: var(--pix-spacing-4x);
+}

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -8,11 +9,21 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
+import { notEq } from 'ember-truth-helpers';
 import ModulixGrain from 'mon-pix/components/module/grain/grain';
+
+const SECTION_TITLE_ICONS = {
+  'question-yourself': 'think',
+  'explore-to-understand': 'signpost',
+  'retain-the-essentials': 'doorOpen',
+  practise: 'mountain',
+  'go-further': 'lightBulb',
+};
 
 export default class ModulixPreview extends Component {
   @service store;
   @service modulixPreviewMode;
+  @service intl;
 
   @tracked moduleCodeDisplayed = false;
 
@@ -117,6 +128,16 @@ export default class ModulixPreview extends Component {
   }
 
   @action
+  sectionTitle(section) {
+    return this.intl.t(`pages.modulix.section.${section.type}`);
+  }
+
+  @action
+  sectionTitleIcon(section) {
+    return SECTION_TITLE_ICONS[section.type];
+  }
+
+  @action
   noop() {}
 
   @action
@@ -167,6 +188,12 @@ export default class ModulixPreview extends Component {
 
         <div class="module-preview-passage__content">
           {{#each this.formattedModule.sections as |section|}}
+            {{#if (notEq section.type "blank")}}
+              <div class="module-preview-passage-content-section">
+                <PixIcon @name={{this.sectionTitleIcon section}} @ariaHidden={{true}} />
+                <h2>{{this.sectionTitle section}}</h2>
+              </div>
+            {{/if}}
             {{#each section.grains as |grain|}}
               <ModulixGrain
                 @grain={{grain}}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -180,7 +180,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use 'pages/inscription' as *;
 @use 'pages/join-restricted-campaign' as *;
 @use 'pages/module' as *;
-@use 'pages/module-preview' as *;
+@use '../components/module/module-preview' as *;
 @use 'pages/student-sco' as *;
 @use 'pages/not-connected' as *;
 @use 'pages/profile' as *;

--- a/mon-pix/tests/integration/components/module/preview_test.gjs
+++ b/mon-pix/tests/integration/components/module/preview_test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModulixPreview from 'mon-pix/components/module/preview';
 import { module, test } from 'qunit';
 
@@ -62,6 +63,56 @@ module('Integration | Component | Module | Preview', function (hooks) {
       assert.dom(linkToModulixEditor).doesNotExist();
       const displayJsonButton = screen.queryByRole('button', { name: 'Afficher le JSON' });
       assert.dom(displayJsonButton).doesNotExist();
+    });
+
+    module('when has a section', function () {
+      module('when section is type "blank"', function () {
+        test('should not display section title', async function (assert) {
+          // given
+          const moduleData = { title: 'Existing module', sections: [{ type: 'blank' }] };
+          const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+          // then
+          const h2 = screen.queryByRole('heading', { level: 2 });
+          assert.dom(h2).doesNotExist();
+        });
+      });
+
+      module('when section is type "question-yourself"', function () {
+        test('should display section title', async function (assert) {
+          // given
+          const moduleData = {
+            title: 'Existing module',
+            sections: [{ type: 'question-yourself' }],
+          };
+          const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+          // then
+          const h2 = screen.queryByRole('heading', {
+            level: 2,
+            name: t(`pages.modulix.section.${moduleData.sections[0].type}`),
+          });
+          assert.dom(h2).exists();
+        });
+      });
+
+      module('when section is type "practise"', function () {
+        test('should display section title', async function (assert) {
+          // given
+          const moduleData = {
+            title: 'Existing module',
+            sections: [{ type: 'practise' }],
+          };
+          const screen = await render(<template><ModulixPreview @module={{moduleData}} /></template>);
+
+          // then
+          const h2 = screen.queryByRole('heading', {
+            level: 2,
+            name: t(`pages.modulix.section.${moduleData.sections[0].type}`),
+          });
+          assert.dom(h2).exists();
+        });
+      });
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1782,6 +1782,13 @@
         "subtitle": "You have worked on the following objectives:",
         "title": "Module completed!"
       },
+      "section": {
+        "explore-to-understand": "Explore to understand",
+        "go-further": "Go further",
+        "practise": "Practise",
+        "question-yourself": "Question yourself",
+        "retain-the-essentials": "Retain the essentials"
+      },
       "sidebar": {
         "button": "Display the steps of the module"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1768,6 +1768,13 @@
         "subtitle": "Has trabajado en los siguientes objetivos:",
         "title": "¡Módulo completado!"
       },
+      "section": {
+        "question-yourself": "Pregúntate a ti mismo",
+        "explore-to-understand": "Explora para comprender",
+        "retain-the-essentials": "Retén lo esencial",
+        "practise": "Practica",
+        "go-further": "Ve más allá"
+      },
       "sidebar": {
         "button": "Visualizar los pasos del módulo"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1782,6 +1782,13 @@
         "subtitle": "Vous avez travaillé les objectifs suivants :",
         "title": "Module terminé !"
       },
+      "section": {
+        "explore-to-understand": "Explorer pour comprendre",
+        "go-further": "Aller plus loin",
+        "practise": "S’exercer",
+        "question-yourself": "Se questionner",
+        "retain-the-essentials": "Retenir l’essentiel"
+      },
       "sidebar": {
         "button": "Afficher les étapes du module"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1772,6 +1772,13 @@
         "subtitle": "Je hebt aan de volgende doelstellingen gewerkt:",
         "title": "Module voltooid!"
       },
+      "section": {
+        "question-yourself": "Stel jezelf vragen",
+        "explore-to-understand": "Onderzoek om te begrijpen",
+        "retain-the-essentials": "Onthoud de essentie",
+        "practise": "Oefen",
+        "go-further": "Ga verder"
+      },
       "sidebar": {
         "button": "De modulestappen weergeven"
       },


### PR DESCRIPTION
## 🔆 Problème

Nous ne pouvons pas visualiser les titres des section des modules.

## ⛱️ Proposition

L'afficher sur la page de preview des modules. On fera l'affichage sur les pages dans une prochaine PR.

## 🌊 Remarques

- On en profite pour déplacer le .scss de module preview dans le dossier modules
- Les icônes pour chaque titre ont été déterminé de façon totalement arbitraire. A voir pour mettre à jour cela avec le design.

## 🏄 Pour tester

- Aller sur la page de preview du  [/modules/preview/bac-a-sable](https://app-pr13297.review.pix.fr/modules/preview/bac-a-sable)
- Vérifier que les titres de section apparaisse bien
### En local 
- Lancer modulix editor
- Modifier le code pour faire pointer l'url sur la [RA](https://app-pr13297.review.pix.fr/modules/preview) 
- Copier le json du bac-a-sable
- Vérifier que les titres apparaisse bien 
