### PR TITLE
[FEATURE] Envoyer les solutions et les feedbacks des QCM à la récupération des données du module (PIX-19240)

### DIFF
--- a/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
@@ -10,7 +10,7 @@ class QCMForAnswerVerification extends QCM {
   userResponse;
 
   constructor({ id, instruction, locales, proposals, feedbacks, solutions, validator }) {
-    super({ id, instruction, locales, proposals, feedbacks });
+    super({ id, instruction, locales, proposals, feedbacks, solutions });
 
     assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM for verification');
 

--- a/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
-import { Feedbacks } from '../Feedbacks.js';
 import { QcmCorrectionResponse } from '../QcmCorrectionResponse.js';
 import { ValidatorQCM } from '../validator/ValidatorQCM.js';
 import { QCM } from './QCM.js';
@@ -10,18 +9,14 @@ import { QCM } from './QCM.js';
 class QCMForAnswerVerification extends QCM {
   userResponse;
 
-  constructor({ id, instruction, locales, proposals, solutions, feedbacks, validator }) {
-    super({ id, instruction, locales, proposals });
+  constructor({ id, instruction, locales, proposals, feedbacks, solutions, validator }) {
+    super({ id, instruction, locales, proposals, feedbacks });
 
     assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM for verification');
 
     this.solution = {
       value: solutions,
     };
-
-    if (feedbacks) {
-      this.feedbacks = new Feedbacks(feedbacks);
-    }
 
     if (validator) {
       this.validator = validator;

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -10,15 +10,14 @@ class QCM extends Element {
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
     assertIsArray(proposals, 'The proposals should be in a list');
     this.#assertProposalsAreNotEmpty(proposals);
+    assertNotNullOrUndefined(feedbacks, 'The feedbacks is required for a QCM');
 
     this.instruction = instruction;
     this.locales = locales;
     this.proposals = proposals;
     this.isAnswerable = true;
 
-    if (feedbacks) {
-      this.feedbacks = new Feedbacks(feedbacks);
-    }
+    this.feedbacks = new Feedbacks(feedbacks);
 
     if (solutions) {
       assertIsArray(solutions, 'The solutions should be in a list');

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -1,9 +1,10 @@
 import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { ModuleInstantiationError } from '../../errors.js';
+import { Feedbacks } from '../Feedbacks.js';
 import { Element } from './Element.js';
 
 class QCM extends Element {
-  constructor({ id, instruction, locales, proposals }) {
+  constructor({ id, instruction, locales, proposals, feedbacks }) {
     super({ id, type: 'qcm' });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
@@ -14,6 +15,10 @@ class QCM extends Element {
     this.locales = locales;
     this.proposals = proposals;
     this.isAnswerable = true;
+
+    if (feedbacks) {
+      this.feedbacks = new Feedbacks(feedbacks);
+    }
   }
 
   #assertProposalsAreNotEmpty(proposals) {

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -11,6 +11,9 @@ class QCM extends Element {
     assertIsArray(proposals, 'The proposals should be in a list');
     this.#assertProposalsAreNotEmpty(proposals);
     assertNotNullOrUndefined(feedbacks, 'The feedbacks is required for a QCM');
+    assertIsArray(solutions, 'The solutions should be in a list');
+    this.#assertSolutionsAreNotEmpty(solutions);
+    this.#assertSolutionsAreExistingProposals(solutions, proposals);
 
     this.instruction = instruction;
     this.locales = locales;
@@ -18,11 +21,12 @@ class QCM extends Element {
     this.isAnswerable = true;
 
     this.feedbacks = new Feedbacks(feedbacks);
+    this.solutions = solutions;
+  }
 
-    if (solutions) {
-      assertIsArray(solutions, 'The solutions should be in a list');
-      this.#assertSolutionsAreExistingProposals(solutions, proposals);
-      this.solutions = solutions;
+  #assertSolutionsAreNotEmpty(solutions) {
+    if (solutions.length === 0) {
+      throw new ModuleInstantiationError('The solutions are required for a QCM');
     }
   }
 

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -1,4 +1,4 @@
-import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { ModuleInstantiationError } from '../../errors.js';
 import { Element } from './Element.js';
 
@@ -7,7 +7,7 @@ class QCM extends Element {
     super({ id, type: 'qcm' });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
-    this.#assertProposalsIsAnArray(proposals);
+    assertIsArray(proposals, 'The proposals should be in a list');
     this.#assertProposalsAreNotEmpty(proposals);
 
     this.instruction = instruction;
@@ -19,12 +19,6 @@ class QCM extends Element {
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
       throw new ModuleInstantiationError('The proposals are required for a QCM');
-    }
-  }
-
-  #assertProposalsIsAnArray(proposals) {
-    if (!Array.isArray(proposals)) {
-      throw new ModuleInstantiationError('The proposals should be in a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -4,7 +4,7 @@ import { Feedbacks } from '../Feedbacks.js';
 import { Element } from './Element.js';
 
 class QCM extends Element {
-  constructor({ id, instruction, locales, proposals, feedbacks }) {
+  constructor({ id, instruction, locales, proposals, feedbacks, solutions }) {
     super({ id, type: 'qcm' });
 
     assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
@@ -19,11 +19,24 @@ class QCM extends Element {
     if (feedbacks) {
       this.feedbacks = new Feedbacks(feedbacks);
     }
+
+    if (solutions) {
+      assertIsArray(solutions, 'The solutions should be in a list');
+      this.#assertSolutionsAreExistingProposals(solutions, proposals);
+      this.solutions = solutions;
+    }
   }
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
       throw new ModuleInstantiationError('The proposals are required for a QCM');
+    }
+  }
+
+  #assertSolutionsAreExistingProposals(solutions, proposals) {
+    const proposalIds = proposals.map((proposal) => proposal.id);
+    if (!solutions.every((solution) => proposalIds.includes(solution))) {
+      throw new ModuleInstantiationError('At least one QCM solution is not an existing proposal');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
@@ -10,8 +10,8 @@ import { QROCM } from './QROCM.js';
 class QROCMForAnswerVerification extends QROCM {
   userResponse;
 
-  constructor({ id, instruction, feedbacks, proposals, locales, validator }) {
-    super({ id, instruction, proposals, locales });
+  constructor({ id, instruction, locales, proposals, feedbacks, validator }) {
+    super({ id, instruction, locales, proposals, feedbacks });
 
     assertNotNullOrUndefined(feedbacks, 'The feedbacks are required for a verification QROCM.');
 

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -241,6 +241,8 @@ export class ModuleFactory {
           content: proposal.content,
         });
       }),
+      feedbacks: element.feedbacks,
+      solutions: element.solutions,
     });
   }
 

--- a/api/tests/devcomp/unit/domain/models/element/Element_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Element_test.js
@@ -1,4 +1,5 @@
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
+import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
 import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
@@ -16,6 +17,16 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
         solution: 'proposal1',
       });
 
+      const qcmProposal1 = Symbol('proposal1');
+      const qcm = new QCM({
+        id: '1',
+        instruction: '',
+        locales: ['fr-FR'],
+        proposals: [{ id: qcmProposal1 }],
+        feedbacks: { valid: '', invalid: '' },
+        solutions: [qcmProposal1],
+      });
+
       const qrocm = new QROCM({
         id: '1',
         instruction: '',
@@ -23,7 +34,7 @@ describe('Unit | Devcomp | Domain | Models | Element', function () {
         proposals: [Symbol('block')],
       });
 
-      const answerableElements = [qcu, qrocm];
+      const answerableElements = [qcu, qcm, qrocm];
 
       // Then
       answerableElements.forEach((element) => expect(element.isAnswerable).to.be.true);

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -9,10 +9,10 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
   describe('#constructor', function () {
     it('should instanciate a QCM For Verification with right attributes', function () {
       // Given
-      const proposal1 = Symbol('proposal1');
-      const proposal2 = Symbol('proposal2');
+      const proposal1 = { id: Symbol('proposal1') };
+      const proposal2 = { id: Symbol('proposal2') };
       const feedbacks = { valid: { state: 'valid' }, invalid: { state: 'invalid' } };
-      const solutions = Symbol('solutions');
+      const solutions = [proposal1.id];
       const expectedSolution = { value: solutions };
 
       // When

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -45,6 +45,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
               id: '123',
               instruction: 'toto',
               proposals: [Symbol('proposal1')],
+              feedbacks: { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') },
             }),
         )();
 

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -30,6 +30,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
       expect(qcm.instruction).equal('instruction');
       expect(qcm.locales).deep.equal(['fr-FR']);
       expect(qcm.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcm.solutions).deep.equal(solutions);
       expect(qcm.solution).deep.equal(expectedSolution);
       expect(qcm.feedbacks).to.be.instanceof(Feedbacks);
       expect(qcm.type).to.be.equal('qcm');
@@ -51,7 +52,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
 
         // then
         expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The solutions are required for a QCM for verification');
+        expect(error.message).to.equal('The solutions should be in a list');
       });
     });
   });
@@ -159,7 +160,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
         const qcm = new QCMForAnswerVerification({
           id: 'qcm-id',
           instruction: '',
-          proposals: [{}],
+          proposals: [{ id: qcmSolution1 }, { id: qcmSolution2 }, { id: '3' }],
           feedbacks: { valid: { state: 'OK' }, invalid: { state: 'KO' } },
           solutions: qcmSolutions,
         });
@@ -211,7 +212,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
           const qcm = new QCMForAnswerVerification({
             id: 'qcm-id',
             instruction: '',
-            proposals: [{}],
+            proposals: [{ id: qcmSolution1 }, { id: qcmSolution2 }, { id: '3' }],
             feedbacks: { valid: { state: 'OK' }, invalid: { state: 'KO' } },
             solutions: qcmSolutions,
           });

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -67,7 +67,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       const error = catchErrSync(() => new QCM({ id: '123', instruction: 'toto', proposals: 'toto' }))();
 
       // then
-      expect(error).to.be.instanceOf(ModuleInstantiationError);
+      expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('The proposals should be in a list');
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -77,11 +77,36 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
     });
   });
 
+  describe('A QCM does not have feedbacks', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new QCM({
+            id: '123',
+            instruction: 'toto',
+            proposals: [Symbol('proposal1')],
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The feedbacks is required for a QCM');
+    });
+  });
+
   describe('A QCM does not have a list of solutions', function () {
     it('should throw an error', function () {
       // when
       const error = catchErrSync(
-        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: 'toto' }),
+        () =>
+          new QCM({
+            id: '123',
+            instruction: 'toto',
+            proposals: [Symbol('proposal1')],
+            feedbacks: { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') },
+            solutions: 'toto',
+          }),
       )();
 
       // then
@@ -94,7 +119,14 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
     it('should throw an error', function () {
       // when
       const error = catchErrSync(
-        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: [] }),
+        () =>
+          new QCM({
+            id: '123',
+            instruction: 'toto',
+            proposals: [Symbol('proposal1')],
+            feedbacks: { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') },
+            solutions: [],
+          }),
       )();
 
       // then
@@ -110,7 +142,14 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
 
       // when
       const error = catchErrSync(
-        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: ['toto'] }),
+        () =>
+          new QCM({
+            id: '123',
+            instruction: 'toto',
+            proposals: [proposal],
+            feedbacks: { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') },
+            solutions: [Symbol('invalid-proposal-id')],
+          }),
       )();
 
       // then

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -7,9 +7,10 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
   describe('#constructor', function () {
     it('should instanciate a QCM with right properties', function () {
       // Given
-      const proposal1 = Symbol('proposal1');
-      const proposal2 = Symbol('proposal2');
+      const proposal1 = { id: Symbol('proposal1') };
+      const proposal2 = { id: Symbol('proposal2') };
       const feedbacks = { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') };
+      const solutions = [proposal1.id];
 
       // When
       const qcm = new QCM({
@@ -18,6 +19,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
         locales: ['fr-FR'],
         proposals: [proposal1, proposal2],
         feedbacks,
+        solutions,
       });
 
       // Then
@@ -27,6 +29,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       expect(qcm.locales).deep.equal(['fr-FR']);
       expect(qcm.proposals).deep.equal([proposal1, proposal2]);
       expect(qcm.feedbacks).deep.equal(feedbacks);
+      expect(qcm.solutions).deep.equal(solutions);
     });
   });
 
@@ -71,6 +74,48 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       // then
       expect(error).to.be.instanceOf(DomainError);
       expect(error.message).to.equal('The proposals should be in a list');
+    });
+  });
+
+  describe('A QCM does not have a list of solutions', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: 'toto' }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solutions should be in a list');
+    });
+  });
+
+  describe('A QCM with an empty list of solutions', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: [] }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The solutions are required for a QCM');
+    });
+  });
+
+  describe('A QCM solution is not in proposals', function () {
+    it('should throw an error', function () {
+      // given
+      const proposal = { id: Symbol('proposal1') };
+
+      // when
+      const error = catchErrSync(
+        () => new QCM({ id: '123', instruction: 'toto', proposals: [Symbol('proposal1')], solutions: ['toto'] }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('At least one QCM solution is not an existing proposal');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -9,6 +9,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       // Given
       const proposal1 = Symbol('proposal1');
       const proposal2 = Symbol('proposal2');
+      const feedbacks = { valid: Symbol('valid-feedback'), invalid: Symbol('invalid-feedback') };
 
       // When
       const qcm = new QCM({
@@ -16,6 +17,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
         instruction: 'instruction',
         locales: ['fr-FR'],
         proposals: [proposal1, proposal2],
+        feedbacks,
       });
 
       // Then
@@ -24,7 +26,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
       expect(qcm.type).equal('qcm');
       expect(qcm.locales).deep.equal(['fr-FR']);
       expect(qcm.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcm.feedbacks).to.be.undefined;
+      expect(qcm.feedbacks).deep.equal(feedbacks);
     });
   });
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -363,7 +363,6 @@ function getComponents() {
           },
         ],
         instruction: 'question declarative',
-        isAnswerable: true,
       }),
     }),
     new ComponentElement({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -375,6 +375,8 @@ function getComponents() {
           { id: '3', content: 'titi' },
         ],
         instruction: 'hello',
+        feedbacks: { valid: { state: 'valid' }, invalid: { state: 'invalid' } },
+        solutions: ['1', '2'],
       }),
     }),
     new ComponentElement({
@@ -572,6 +574,8 @@ function getAttributesComponents() {
             id: '3',
           },
         ],
+        feedbacks: { valid: { state: 'valid' }, invalid: { state: 'invalid' } },
+        solutions: ['1', '2'],
         type: 'qcm',
       },
     },

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -407,6 +407,7 @@ function getComponents() {
         title: 'title',
         url: 'https://assets.pix.org/modules/mavideo.mp4',
         subtitles: 'https://assets.pix.org/modules/mavideo.vtt',
+        poster: 'https://assets.pix.org/modules/mavideo.jpg',
         transcription: 'transcription',
       }),
     }),
@@ -613,7 +614,7 @@ function getAttributesComponents() {
       element: {
         id: '4',
         isAnswerable: false,
-        poster: null,
+        poster: 'https://assets.pix.org/modules/mavideo.jpg',
         subtitles: 'https://assets.pix.org/modules/mavideo.vtt',
         title: 'title',
         transcription: 'transcription',


### PR DESCRIPTION
## 🔆 Problème

Actuellement, la validation des QCM se fait en appelant l'url /answers pour récupérer si les réponses saisies sont valides ou non. Cela peut entraîner, en cas de mauvaise connexion, des bugs.

## ⛱️ Proposition

Transmettre, lors de la récupération des données du module, ces 2 champs afin d'éviter de dépendre de l'API pour la validation.

## 🌊 Remarques

On a redécouvert l'existence d'un champ locales sur les QCU, QCM, QROCM. A voir pour l'enlever ensuite car non utilisé.

## 🏄 Pour tester

- Ouvrir la console navigateur -> Onglet Network
- Aller sur le module [principes fondateurs wikipedia](https://app-pr13298.review.pix.fr/modules/principes-fondateurs-wikipedia/details)
- Vérifier, dans la réponse de la requête récupérant les données du module, que les feedbacks et les solutions remontent bien pour chaque élément QCM (exemple de QCM dans `sections[0].attributes.grains[1].components[2].element`) 🎉
