### PR TITLE
[FEATURE] remplacer le wording anonymised par un tiret (PIX-19198)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
+++ b/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
@@ -126,7 +126,7 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
     userId: secondUser.id,
     campaignId: CAMPAIGN_PROASSMUL_ID,
     masteryRate: 0.1,
-    isImproved: true,
+    isImproved: false,
     createdAt: '2024-03-12T15:07:57.376Z',
     sharedAt: '2024-03-24T15:07:57.376Z',
   });
@@ -183,7 +183,7 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
     userId: thirdUser.id,
     campaignId: CAMPAIGN_PROASSMUL_ID,
     masteryRate: 0.5,
-    isImproved: true,
+    isImproved: false,
     createdAt: '2024-03-12T15:07:57.376Z',
     sharedAt: '2024-03-24T15:07:57.376Z',
   });

--- a/api/src/prescription/campaign-participation/domain/models/ParticipationForCampaignManagement.js
+++ b/api/src/prescription/campaign-participation/domain/models/ParticipationForCampaignManagement.js
@@ -22,7 +22,7 @@ class ParticipationForCampaignManagement {
     if (userFirstName && userLastName) {
       this.userFullName = `${userFirstName} ${userLastName}`;
     } else {
-      this.userFullName = '(Anonymised)';
+      this.userFullName = '-';
     }
     this.participantExternalId = participantExternalId;
     this.status = status;

--- a/api/tests/prescription/campaign-participation/unit/domain/models/ParticipationForCampaignManagement_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/ParticipationForCampaignManagement_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Models | ParticipationForCampaignManagement', function
       });
 
       // then
-      expect(participationForCampaignManagement.userFullName).to.equal('(Anonymised)');
+      expect(participationForCampaignManagement.userFullName).to.equal('-');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

Dans le cas d'un participation anonymisée, on affiche "(Anonymized)" or on souhaiterai plutot afficher un tiret

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition
 remplacer (Anonymized) par -
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques
RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- [x] passer le feature toggle de suppression - anonymisation a true
- [ ] Aller sur learner de l'orga `PRO_CLASSIC` 
- [ ] supprimer  sarah croche

#### Dans admin
- afficher les participations à la campagne PROASSMUL
- constater qu'on affiche un tiret à la place du prescrit

