### PR TITLE
[FEATURE] Cacher les contenus recommandés à l'issue d'une campagne dans le cadre d'un parcours combiné

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -27,7 +27,6 @@ test('pass a combined course as sco user and see the final result', async ({ pag
     //Le bouton "Voir mes résultats" existe deux fois à ce moment, on doit donc faire autrement en attendant de corriger cette page
     await page.locator('#ember138').click();
     await page.getByRole('button', { name: "J'envoie mes résultats" }).click();
-    await page.getByRole('button', { name: 'Fermer', exact: true }).click();
     await page.getByRole('link', { name: 'Continuer' }).click();
   });
 

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/competence-row.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/competence-row.gjs
@@ -4,7 +4,7 @@ import { t } from 'ember-intl';
 
 import ShowMoreText from '../../../../../../components/show-more-text';
 
-export default class EvaluationResultsDetailsTab extends Component {
+export default class CompetenceRow extends Component {
   getIcon(competenceId) {
     return competencesIcons[competenceId] || competencesIcons.pixplus;
   }

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/results-details/index.gjs
@@ -4,7 +4,7 @@ import { t } from 'ember-intl';
 
 import CompetenceRow from './competence-row';
 
-export default class EvaluationResultsDetailsTab extends Component {
+export default class ResultsDetails extends Component {
   @service pixMetrics;
 
   constructor() {

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -20,7 +20,7 @@ export default class EvaluationResults extends Component {
   }
 
   get hasTrainings() {
-    return Boolean(this.args.model.trainings.length);
+    return Boolean(this.trainings.length);
   }
 
   get isSharableCampaign() {
@@ -30,7 +30,15 @@ export default class EvaluationResults extends Component {
 
   get trainingsForModal() {
     const MAX_TRAININGS_MODAL_DISPLAYED = 3;
-    return this.args.model.trainings.slice(0, MAX_TRAININGS_MODAL_DISPLAYED);
+    return this.trainings.slice(0, MAX_TRAININGS_MODAL_DISPLAYED);
+  }
+
+  get trainings() {
+    if (this.args.model.campaign.isPartOfCombinedCourse) {
+      return [];
+    } else {
+      return this.args.model.trainings;
+    }
   }
 
   @action
@@ -86,7 +94,7 @@ export default class EvaluationResults extends Component {
         @campaignParticipationResult={{@model.campaignParticipationResult}}
         @questResults={{@model.questResults}}
         @isSharableCampaign={{this.isSharableCampaign}}
-        @trainings={{@model.trainings}}
+        @trainings={{this.trainings}}
         @onResultsShared={{this.shareResults}}
       />
       {{#if this.isResultsSharedModalEnabled}}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results.gjs
@@ -48,6 +48,9 @@ export default class EvaluationResults extends Component {
 
   @action
   shareResults() {
+    if (this.args.model.campaign.isPartOfCombinedCourse) {
+      return;
+    }
     this.showEvaluationResultsModal = true;
   }
 

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -53,4 +53,11 @@ export default class Campaign extends Model {
   get hasCustomResultPageButton() {
     return Boolean(this.customResultPageButtonUrl) && Boolean(this.customResultPageButtonText);
   }
+
+  get isPartOfCombinedCourse() {
+    if (!this.customResultPageButtonUrl) {
+      return false;
+    }
+    return this.customResultPageButtonUrl.includes('/parcours/');
+  }
 }

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-tabs-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-tabs-test.js
@@ -198,7 +198,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
       this.set('trainings', []);
 
       // when
-      const screen = await render(
+      screen = await render(
         hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs
   @campaignParticipationResult={{this.campaignParticipationResult}}
   @trainings={{this.trainings}}

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-tabs-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-tabs-test.js
@@ -164,4 +164,49 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
       assert.notOk(screen.queryByRole('tablist', { name: t('pages.skill-review.tabs.aria-label') }));
     });
   });
+  module('when in a combined course context', function (hooks) {
+    let screen;
+    let onResultsSharedStub;
+
+    hooks.beforeEach(async function () {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.set('campaignParticipationResult', {
+        campaignParticipationBadges: [],
+        isShared: false,
+        competenceResults: [],
+      });
+
+      const training = store.createRecord('training', { duration: { days: 2 } });
+      this.set('trainings', [training]);
+
+      onResultsSharedStub = sinon.stub();
+      this.set('onResultsShared', onResultsSharedStub);
+
+      // when
+      screen = await render(
+        hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+  @trainings={{this.trainings}}
+  @onResultsShared={{this.onResultsShared}}
+  @isSharableCampaign={{true}}
+/>`,
+      );
+    });
+    test('it should not display trainings', async function (assert) {
+      // given
+      this.set('trainings', []);
+
+      // when
+      const screen = await render(
+        hbs`<Campaigns::Assessment::Results::EvaluationResultsTabs
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+  @trainings={{this.trainings}}
+/>`,
+      );
+
+      // then
+      assert.notOk(screen.queryByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }));
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -100,6 +100,20 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
         .dom(screen.getByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }))
         .hasAttribute('aria-selected', 'true');
     });
+    module('when the campaign is part of a combined course', function (hooks) {
+      hooks.afterEach(async function () {
+        this.model.showTrainings = true;
+        this.model.campaign.customResultPageButtonUrl = undefined;
+      });
+      test('it should not display modal before show assessment result', async function (assert) {
+        this.model.showTrainings = false;
+        this.model.campaign.customResultPageButtonUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+        screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+        assert.notOk(
+          screen.queryByRole('dialog', { name: t('pages.skill-review.tabs.trainings.shared-results-modal.title') }),
+        );
+      });
+    });
   });
 
   module('when the campaign has not been shared yet and has trainings', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -113,6 +113,19 @@ module('Integration | Components | Routes | Campaigns | Assessment | Evaluation 
           screen.queryByRole('dialog', { name: t('pages.skill-review.tabs.trainings.shared-results-modal.title') }),
         );
       });
+      test('it should not display trainings tab', async function (assert) {
+        this.model.showTrainings = false;
+        this.model.campaign.customResultPageButtonUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+        screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+        assert.notOk(screen.queryByRole('tab', { name: t('pages.skill-review.tabs.trainings.tab-label') }));
+      });
+      test('it should not display trainings information and button in the hero', async function (assert) {
+        this.model.showTrainings = false;
+        this.model.campaign.customResultPageButtonUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+        screen = await render(hbs`<Routes::Campaigns::Assessment::EvaluationResults @model={{this.model}} />`);
+        assert.notOk(screen.queryByText(t('pages.skill-review.hero.explanations.trainings')));
+        assert.notOk(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') }));
+      });
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème
Lors d'une campagne de diagnostic, le fonctionnement normal des campagnes est gardé, c'est-à-dire que les contenus recommandés sont affichés à l'issue de la campagne (on a, dans l'encart de fin de campagne, un bouton "Voir mes formations", ainsi qu'un un onglet en-dessous "Formations").

## ⛱️ Proposition
Dans evaluation-results.gjs, on créé un getter "trainings" qui retourne un tableau vide si le parcours est un parcours combiné.

## 🏄 Pour tester
Utiliser le compte attestation-blank@example.net pour se connecter à Pix App.
Entrer le code COMBINIX1.
Aller au bout de la campagne de diagnostic et constater que l'onglet "Formations" ainsi que le bouton "Voir mes formations" sont cachés.
