### PR TITLE
[FEATURE] Cacher les sections Profils cibles actuels et Badges d'une complémentaire dans Pix Admin (PIX-19089)

### DIFF
--- a/admin/app/components/complementary-certifications/item/target-profile.gjs
+++ b/admin/app/components/complementary-certifications/item/target-profile.gjs
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -12,7 +11,6 @@ export default class TargetProfile extends Component {
   @service store;
 
   @tracked complementaryCertification;
-  @tracked isToggleSwitched = true;
   @tracked targetProfileId;
 
   constructor() {
@@ -35,22 +33,14 @@ export default class TargetProfile extends Component {
     return this.complementaryCertification?.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
   }
 
-  @action
-  switchTargetProfile() {
-    this.isToggleSwitched = !this.isToggleSwitched;
-    this.targetProfileId = this.complementaryCertification.currentTargetProfiles?.find(
-      ({ id }) => id !== this.targetProfileId,
-    ).id;
-  }
-
   <template>
-    <Information
-      @complementaryCertification={{this.complementaryCertification}}
-      @currentTargetProfile={{this.currentTargetProfile}}
-      @switchTargetProfile={{this.switchTargetProfile}}
-      @switchToggle={{this.isToggleSwitched}}
-    />
-    <BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
+    {{#unless this.complementaryCertification.hasComplementaryReferential}}
+      <Information
+        @complementaryCertification={{this.complementaryCertification}}
+        @currentTargetProfile={{this.currentTargetProfile}}
+      />
+      <BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
+    {{/unless}}
     <History @targetProfilesHistory={{this.complementaryCertification.targetProfilesHistory}} />
   </template>
 }

--- a/admin/app/components/complementary-certifications/item/target-profile/information.gjs
+++ b/admin/app/components/complementary-certifications/item/target-profile/information.gjs
@@ -1,5 +1,4 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixToggleButton from '@1024pix/pix-ui/components/pix-toggle-button';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
@@ -7,10 +6,6 @@ import LinkToCurrentTargetProfile from '../../common/link-to-current-target-prof
 
 export default class Information extends Component {
   @service currentUser;
-
-  get isMultipleCurrentTargetProfiles() {
-    return this.args.complementaryCertification?.currentTargetProfiles?.length > 1;
-  }
 
   get hasAccessToAttachNewTargetProfile() {
     return this.currentUser.adminMember.isSuperAdmin;
@@ -21,13 +16,6 @@ export default class Information extends Component {
       <div class="content-text content-text--small complementary-certification-details">
         {{#if @currentTargetProfile}}
           <LinkToCurrentTargetProfile @model={{@currentTargetProfile}} />
-        {{/if}}
-        {{#if this.isMultipleCurrentTargetProfiles}}
-          <PixToggleButton @toggled={{@switchToggle}} @onChange={{@switchTargetProfile}} @screenReaderOnly={{true}}>
-            <:label>Accéder aux détails des profils cibles courants</:label>
-            <:viewA>Profil 1</:viewA>
-            <:viewB>Profil 2</:viewB>
-          </PixToggleButton>
         {{/if}}
         {{#if this.hasAccessToAttachNewTargetProfile}}
           <div class="complementary-certification-details-target-profile__attach-button">

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
@@ -55,7 +55,7 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
       assert.dom(screen.getByText('TOINE')).exists({ count: 1 });
     });
 
-    test('it should redirect to complementary certification framework details on click ', async function (assert) {
+    test('it should redirect to complementary certification framework details on click if not double certification', async function (assert) {
       // given
       server.create('complementary-certification', {
         id: 1,
@@ -80,6 +80,33 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/complementary-certifications/1/framework');
+    });
+
+    test('it should redirect to complementary certification target profile details on click if double certification', async function (assert) {
+      // given
+      server.create('complementary-certification', {
+        id: 1,
+        key: 'AN',
+        label: 'TOINE',
+        hasComplementaryReferential: false,
+        targetProfilesHistory: [
+          {
+            id: 52,
+            name: 'Stephen target',
+            badges: [],
+          },
+        ],
+      });
+
+      server.create('target-profile', { id: 'AN' });
+
+      const screen = await visit('/complementary-certifications/list');
+
+      // when
+      await click(screen.getByRole('link', { name: 'TOINE' }));
+
+      // then
+      assert.strictEqual(currentURL(), '/complementary-certifications/1/target-profile');
     });
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
@@ -8,54 +8,110 @@ import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-render
 module('Integration | Component | complementary-certifications/item/target-profile', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display target profile information', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const serviceRouter = this.owner.lookup('service:router');
-    const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isSuperAdmin: true };
-    const complementaryCertification = store.createRecord('complementary-certification', {
-      id: 10,
-      key: 'DROIT',
-      label: 'Pix+Droit',
-      targetProfilesHistory: [
-        {
-          detachedAt: null,
-          name: 'ALEX TARGET',
-          id: 3,
-          badges: [
-            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
-            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
-          ],
-        },
-      ],
+  module('Double certification', function () {
+    test('it should display target profile information, badge list and history', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const serviceRouter = this.owner.lookup('service:router');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const complementaryCertification = store.createRecord('complementary-certification', {
+        id: 10,
+        key: 'CLEA',
+        label: 'CléA Numérique',
+        hasComplementaryReferential: false,
+        targetProfilesHistory: [
+          {
+            detachedAt: null,
+            name: 'ALEX TARGET',
+            id: 3,
+            badges: [
+              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
+              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
+            ],
+          },
+        ],
+      });
+
+      sinon
+        .stub(serviceRouter, 'currentRoute')
+        .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
+
+      // when
+      const screen = await render(<template><TargetProfile /></template>);
+
+      // then
+      assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+          }),
+        )
+        .exists();
+      assert.dom(screen.getByText('Badge Cascade')).exists();
+      assert.dom(screen.getByText('Badge Volcan')).exists();
+
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+          }),
+        )
+        .exists();
     });
+  });
+  module('Complementary V2', function () {
+    test('it should only display target profile history', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const serviceRouter = this.owner.lookup('service:router');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const complementaryCertification = store.createRecord('complementary-certification', {
+        id: 10,
+        key: 'DROIT',
+        label: 'Pix+Droit',
+        hasComplementaryReferential: true,
+        targetProfilesHistory: [
+          {
+            detachedAt: null,
+            name: 'ALEX TARGET',
+            id: 3,
+            badges: [
+              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
+              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
+            ],
+          },
+        ],
+      });
 
-    sinon
-      .stub(serviceRouter, 'currentRoute')
-      .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
+      sinon
+        .stub(serviceRouter, 'currentRoute')
+        .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
 
-    // when
-    const screen = await render(<template><TargetProfile /></template>);
+      // when
+      const screen = await render(<template><TargetProfile /></template>);
 
-    // then
-    assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
-    assert
-      .dom(
-        screen.getByRole('heading', {
-          name: t('components.complementary-certifications.target-profiles.badges-list.title'),
-        }),
-      )
-      .exists();
-    assert.dom(screen.getByText('Badge Cascade')).exists();
-    assert.dom(screen.getByText('Badge Volcan')).exists();
+      // then
+      assert.dom(screen.queryByText('Rattacher un nouveau profil cible')).doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+          }),
+        )
+        .doesNotExist();
+      assert.dom(screen.queryByText('Badge Cascade')).doesNotExist();
+      assert.dom(screen.queryByText('Badge Volcan')).doesNotExist();
 
-    assert
-      .dom(
-        screen.getByRole('heading', {
-          name: t('components.complementary-certifications.target-profiles.history-list.title'),
-        }),
-      )
-      .exists();
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+          }),
+        )
+        .exists();
+    });
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile/information-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile/information-test.gjs
@@ -31,65 +31,6 @@ module('Integration | Component | complementary-certifications/item/target-profi
     assert.dom(screen.getByRole('link', { name: 'ALEX TARGET' })).exists();
   });
 
-  module('when there is multiple current target profiles', function () {
-    test('it should display the target profile toggle', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const complementaryCertification = store.createRecord('complementary-certification', {
-        label: 'MARIANNE CERTIF',
-        targetProfilesHistory: [
-          { name: 'ALEX TARGET', id: 3 },
-          { name: 'JUDE TARGET', id: 4 },
-        ],
-      });
-      const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
-
-      // when
-      const screen = await render(
-        <template>
-          <Information
-            @complementaryCertification={{complementaryCertification}}
-            @currentTargetProfile={{currentTargetProfile}}
-          />
-        </template>,
-      );
-
-      // then
-      assert.dom(screen.getByRole('button', { name: 'Accéder aux détails des profils cibles courants' })).exists();
-    });
-  });
-
-  module('when there is only one current target profile', function () {
-    test('it should not display the target profile toggle', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const complementaryCertification = store.createRecord('complementary-certification', {
-        label: 'MARIANNE CERTIF',
-        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
-      });
-      const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
-
-      // when
-      const screen = await render(
-        <template>
-          <Information
-            @complementaryCertification={{complementaryCertification}}
-            @currentTargetProfile={{currentTargetProfile}}
-          />
-        </template>,
-      );
-
-      // then
-      assert
-        .dom(screen.queryByRole('button', { name: 'Accéder aux détails des profils cibles courants' }))
-        .doesNotExist();
-    });
-  });
-
   module('when admin member has role "CERTIF", "METIER" and "SUPPORT"', function () {
     test('it should not display the button to attach new target profile', async function (assert) {
       // given


### PR DESCRIPTION
## 🔆 Problème

En v2, on rattachait un profil cible à une certification complémentaire donnée via l’interface dédiée dans Pix Admin.

Le profil cible actuellement rattaché apparait en haut avec ses badges certifiés. Les anciens profils cibles détachés successivement au fil des versionning apparaissent dans la partie historique en bas de page.

Désormais, on ne rattachera plus jamais de nouveau profil cible à une certification complémentaire et il n’y aura pas de profil cible actuel puisqu’il sera remplacé par un référentiel cadre (onglet à côté).

## ⛱️ Proposition

Masquer le bouton qui permet de rattacher un nouveau profil cible mais aussi le profil cible actuel et ses badges, ne garder que la partie historique pour les complémentaires autre que CléA (distinction faite grace à hasComplementaryReferential ajouté dans la PR #13263).

## 🌊 Remarques

On en profite pour enlever le toogleSwitch présent sur les profils cibles Pix + Edu

## 🏄 Pour tester

Depuis Pix Admin, dans Certification Complémentaire, l'onglet Profil Cible ne doit pas avoir changé pour CléA et qu'il n'y ait que l'historique pour les autres. Pour CléA, on doit toujours pourvoir ajouter ou modifier des profils cibles.
