### PR TITLE
[TECH] Ajouter de la validation au model back Combined Course

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -186,6 +186,7 @@
     "start:job:fast:watch": "nodemon worker.js fast",
     "test": "npm run test:db:reset && npm run test:api",
     "test:db:reset": "NODE_ENV=test run-p db:prepare datamart:prepare datawarehouse:prepare",
+    "test:db:empty": "NODE_ENV=test run-p db:empty",
     "test:api": "for testType in 'unit' 'integration' 'acceptance'; do npm run test:api:$testType || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=${MOCHA_REPORTER:-dot}",
     "test:api:scripts": "npm run test:api:path -- tests/integration/scripts",

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -1,11 +1,20 @@
+import Joi from 'joi';
+
 import {
   CombinedCourseParticipationStatuses,
   CombinedCourseStatuses,
 } from '../../../prescription/shared/domain/constants.js';
+import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { CombinedCourseItem, ITEM_TYPE } from './CombinedCourseItem.js';
 import { Quest } from './Quest.js';
 import { TYPES } from './Requirement.js';
 
+const schema = Joi.object({
+  id: Joi.number().allow(null),
+  code: Joi.string().required(),
+  organizationId: Joi.number().required(),
+  name: Joi.string().required(),
+});
 export class CombinedCourse {
   #quest;
 
@@ -14,11 +23,21 @@ export class CombinedCourse {
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
+
+    this.#validate({ id, code, organizationId, name });
+
     this.#quest = quest;
   }
 
   get quest() {
     return this.#quest;
+  }
+
+  #validate(combinedCourse) {
+    const { error } = schema.validate(combinedCourse);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details, undefined, { data: combinedCourse });
+    }
   }
 }
 

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -14,6 +14,13 @@ import { domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
   describe('CombinedCourseDetails', function () {
+    let id, organizationId, name, code;
+    beforeEach(function () {
+      id = 1;
+      organizationId = 1;
+      name = 'name';
+      code = 'code';
+    });
     describe('#campaignIds', function () {
       it('should only return ids of all campaigns included in the given combined course', function () {
         // given
@@ -46,7 +53,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse({ id, organizationId, name, code }), quest);
 
         // when
         const campaignIds = combinedCourse.campaignIds;
@@ -88,7 +95,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             },
           ],
         });
-        const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+        const combinedCourse = new CombinedCourseDetails(new CombinedCourse({ id, organizationId, name, code }), quest);
 
         // when
         const moduleIds = combinedCourse.moduleIds;
@@ -155,7 +162,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -218,7 +228,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -282,7 +295,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -344,7 +360,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -411,7 +430,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -475,7 +497,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const dataForQuest = new DataForQuest({ eligibility });
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // when
           const result = combinedCourse.isCompleted(dataForQuest);
@@ -560,7 +585,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               ],
             });
             const dataForQuest = new DataForQuest({ eligibility });
-            const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+            const combinedCourse = new CombinedCourseDetails(
+              new CombinedCourse({ id, organizationId, name, code }),
+              quest,
+            );
 
             // when
             const result = combinedCourse.isCompleted(
@@ -647,7 +675,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               ],
             });
             const dataForQuest = new DataForQuest({ eligibility });
-            const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+            const combinedCourse = new CombinedCourseDetails(
+              new CombinedCourse({ id, organizationId, name, code }),
+              quest,
+            );
 
             // when
             const result = combinedCourse.isCompleted(
@@ -683,7 +714,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
 
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
@@ -721,7 +755,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
         });
@@ -762,7 +799,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([]);
-          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
           const module = new Module({ id: 7, title: 'module' });
           const dataForQuest = new DataForQuest({
             eligibility: new Eligibility({
@@ -826,7 +866,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
 
           const dataForQuest = new DataForQuest({
             eligibility: new Eligibility({
@@ -892,7 +935,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             ],
           });
           const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-          const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
           const dataForQuest = new DataForQuest({
             eligibility: new Eligibility({
               campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }],
@@ -1270,7 +1316,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign1, campaign2]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({
             campaignParticipations: [{ campaignId: campaign1.id, status: 'STARTED' }],
@@ -1333,7 +1382,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign1, campaign2]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({
             campaignParticipations: [{ campaignId: campaign1.id, status: 'STARTED' }],
@@ -1394,7 +1446,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({
             passages: [{ id: module.id, status: 'COMPLETED' }],
@@ -1431,7 +1486,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           ],
         });
         const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-        const combinedCourse = new CombinedCourseDetails({}, combinedCourseQuestFormat);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code }),
+          combinedCourseQuestFormat,
+        );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({
             campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }],
@@ -1463,7 +1521,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           };
 
           // when
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+          );
 
           // then
           expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.NOT_STARTED);
@@ -1483,7 +1544,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           };
 
           // when
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest, participation);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+            participation,
+          );
 
           // then
           expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.STARTED);
@@ -1502,7 +1567,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
           };
 
           // when
-          const combinedCourse = new CombinedCourseDetails(new CombinedCourse(), quest, participation);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            quest,
+            participation,
+          );
 
           // then
           expect(combinedCourse.status).to.deep.equal(CombinedCourseStatuses.COMPLETED);
@@ -1526,6 +1595,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
       expect(combinedCourse.name).to.deep.equal(name);
       expect(combinedCourse.organizationId).to.deep.equal(organizationId);
       expect(combinedCourse.id).to.deep.equal(id);
+    });
+    it('should throw when combined course model does not pass validation', function () {
+      // given
+      const id = 1;
+      const organizationId = 1;
+      const name = 'name';
+      const code = 123;
+
+      // when
+      expect(() => {
+        new CombinedCourse({ id, organizationId, name, code });
+      }).to.throw();
     });
   });
 });

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -129,5 +129,11 @@ async function createDataForCombinedCourse() {
     },
   ]);
   const eligibilityRequirements = JSON.stringify([]);
-  await knex('quests').insert({ code: 'COMBINIX1', organizationId, successRequirements, eligibilityRequirements });
+  await knex('quests').insert({
+    name: 'Mon parcours combiné',
+    code: 'COMBINIX1',
+    organizationId,
+    successRequirements,
+    eligibilityRequirements,
+  });
 }


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir valider le type d'input pour chaque champ de création du parcours combiné dans Admin.

## ⛱️ Proposition
On ajoute de la validation Joi au model back CombinedCourse.

## 🌊 Remarques
On a mis id en optionnel dans le schéma de validation Joi car l'id ne fait pas partie de l'input qu'on aura dans admin.

## 🏄 Pour tester
Test de non-régression sur un parcours combiné.