### PR TITLE
[BUGFIX] Corriger les problèmes d'affichage sur la double mire Pix Certif (PIX-16112)

### DIFF
--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -56,7 +56,7 @@
 
   <PixCheckbox @size="small" required={{true}} aria-required={{true}} {{on "click" this.validateCgu}}>
     <:label>
-      <p>
+      <p class="register-form__cgu-label">
         {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
         <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
           {{t "pages.login-or-register.register-form.fields.cgu.terms-of-use"}}

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -9,6 +9,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
+    margin-bottom: var(--pix-spacing-4x);
     padding: var(--pix-spacing-6x) 0 var(--pix-spacing-8x);
 
     @include breakpoints.device-is('tablet') {

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -14,6 +14,10 @@
     @extend %pix-body-s;
   }
 
+  &__cgu-label .link{
+    display: inline;
+  }
+
   &__cgu-error {
     color: var(--pix-error-700);
     font-size: 0.75rem;


### PR DESCRIPTION
## 🔆 Problème

Sur l’application **https://certif.pix.org/**, au niveau de la double mire d’invitation, il y a une régression graphique au niveau des éléments suivants : 

- Le language switcher est collé à la double-mire 

- La checkbox pour accepter les CGU d’inscription à Pix App s’arrête au milieu pour revenir à la ligne


<img width="590" height="894" alt="image" src="https://github.com/user-attachments/assets/e61dacda-9a24-4cb1-9eda-3add4e0c85cb" />


## ⛱️ Proposition

L’objectif est de reproduire ce que nous avons sur Pix Orga actuellement.

<img width="2850" height="1746" alt="image" src="https://github.com/user-attachments/assets/2960a182-2f85-416f-84fa-3b3f247acc3e" />


## 🌊 Remarques

_ Le problème apparaît sur .org  mais sa cause est la longueur des mots/groupes de mots résultant de la traduction de certaines clés en anglais (langue par défaut de .org).

_ La classe `link` est différente sur **Pix Certif** et **Pix Orga**, ce qui explique la nécessité d'écraser   `display: inline-flex;`  sur **Pix Certif** (voir `certif/app/styles/globals/texts.scss` et `orga/app/styles/globals/texts.scss`)


## 🏄 Pour tester

Attention il faut récupérer une adresse de redirection dans un mail. 

- En local, se connecter sur **Pix Certif** (.org) avec un compte d'administrateur (ex :` james-paledroits@example.net`)
- Dans l'onglet invitations, inviter à nouveau quelqu'un 
- Récupérer l'url de redirection dans les logs et l'adapter à votre nom de domaine
- Vérifier l'affichage correct de la double mire
- Vérifier la non régression en .fr
