### PR TITLE
[FEATURE] Ajouter des champs à l'API Maddo (PIX-19247).

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -41,13 +41,15 @@ const register = async function (server) {
                   Joi.object({
                     id: Joi.number().description('ID de la participation à la campagne'),
                     createdAt: Joi.date().description('Date de début de participation'),
+                    participantId: Joi.number().description('ID du participant'),
+                    participantFirstName: Joi.string().description('Prénom du participant'),
+                    participantLastName: Joi.string().description('Nom du participant'),
                     participantExternalId: Joi.string().description(
                       'Identifiant Externe rempli en début de participation',
                     ),
                     status: Joi.string().description('Statut de la participation : STARTED, TO_SHARE, SHARED'),
                     sharedAt: Joi.date().description('Date de participation'),
                     campaignId: Joi.number().description('ID de la campagne liée à la participation'),
-                    userId: Joi.number().description('ID utilisateur du participant'),
                     organizationLearnerId: Joi.number().description("ID du participant au sein de l'organisation"),
                     pixScore: Joi.number().description(
                       'Score en pix pour une participation à une campagne de collecte de profil',

--- a/api/src/maddo/application/organizations-routes.js
+++ b/api/src/maddo/application/organizations-routes.js
@@ -28,6 +28,7 @@ const register = async function (server) {
                 Joi.object({
                   id: Joi.number().description("ID de l'organisation"),
                   name: Joi.string().description("Nom de l'organisation"),
+                  externalId: Joi.string().description("ID externe de l'organisation"),
                 }).label('Organization'),
               )
               .label('Organizations'),

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -4,6 +4,8 @@ import crypto from 'node:crypto';
 class CampaignParticipation {
   constructor({
     id,
+    participantFirstName,
+    participantLastName,
     participantExternalId,
     status,
     createdAt,
@@ -17,14 +19,15 @@ class CampaignParticipation {
   } = {}) {
     this.id = id;
     this.status = status;
+    this.participantFirstName = participantFirstName;
+    this.participantLastName = participantLastName;
     this.participantExternalId = participantExternalId;
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
     this.campaignId = campaignId;
     assert.ok(clientId, 'Client ID should be defined');
     assert.ok(userId, 'User ID should be defined');
-    this.learnerId = crypto.hash('sha1', `${userId}_${clientId}`);
-    this.status = status;
+    this.participantId = crypto.hash('sha1', `${userId}_${clientId}`);
     this.masteryRate = masteryRate;
     this.tubes = tubes;
     this.pixScore = pixScore;

--- a/api/src/maddo/domain/models/Organization.js
+++ b/api/src/maddo/domain/models/Organization.js
@@ -1,6 +1,7 @@
 export class Organization {
-  constructor({ id, name }) {
+  constructor({ id, name, externalId }) {
     this.id = id;
     this.name = name;
+    this.externalId = externalId;
   }
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -15,6 +15,8 @@ function toDomain(rawCampaignParticipation, clientId, campaignId) {
   return new CampaignParticipation({
     id: rawCampaignParticipation.campaignParticipationId,
     status: rawCampaignParticipation.status,
+    participantFirstName: rawCampaignParticipation.participantFirstName,
+    participantLastName: rawCampaignParticipation.participantLastName,
     participantExternalId: rawCampaignParticipation.participantExternalId,
     createdAt: rawCampaignParticipation.createdAt,
     sharedAt: rawCampaignParticipation.sharedAt,

--- a/api/src/maddo/infrastructure/repositories/organization-repository.js
+++ b/api/src/maddo/infrastructure/repositories/organization-repository.js
@@ -14,7 +14,7 @@ export async function findIdsByTagNames(tagNames) {
 
 export async function findByIds(organizationIds) {
   const rawOrganizations = await knex
-    .select('id', 'name')
+    .select('id', 'name', 'externalId')
     .from('organizations')
     .whereIn('id', organizationIds)
     .orderBy('id');

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -108,6 +108,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         expect(response.result.campaignParticipations).to.deep.members([
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation1,
+            participantFirstName: organizationLearner1.firstName,
+            participantLastName: organizationLearner1.lastName,
             clientId,
             tubes: [
               domainBuilder.maddo.buildTubeCoverage({
@@ -122,6 +124,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           }),
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation2,
+            participantFirstName: organizationLearner2.firstName,
+            participantLastName: organizationLearner2.lastName,
             clientId,
           }),
         ]);
@@ -183,6 +187,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         expect(response.result.campaignParticipations).to.deep.members([
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation,
+            participantFirstName: organizationLearner.firstName,
+            participantLastName: organizationLearner.lastName,
             clientId,
           }),
         ]);
@@ -286,6 +292,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation1,
             clientId,
+            participantFirstName: organizationLearner1.firstName,
+            participantLastName: organizationLearner1.lastName,
             tubes: [
               domainBuilder.maddo.buildTubeCoverage({
                 id: tube.id,
@@ -386,6 +394,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
 
       it('should returns only participation created or updated after a given date', async function () {
         // given
+        const organizationLearner = databaseBuilder.factory.buildOrganizationLearner();
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           status: CampaignParticipationStatuses.STARTED,
@@ -398,6 +407,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           participantExternalId: 'started after 1',
           masteryRate: null,
           createdAt: new Date('2025-01-03'),
+          organizationLearnerId: organizationLearner.id,
         });
 
         const participationSharedBefore = databaseBuilder.factory.buildCampaignParticipation({
@@ -427,6 +437,7 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           participantExternalId: 'shared after 1',
           createdAt: new Date('2025-01-04'),
           sharedAt: new Date('2025-01-05'),
+          organizationLearner: organizationLearner.id,
         });
 
         databaseBuilder.factory.buildKnowledgeElementSnapshot({
@@ -466,6 +477,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
         expect(response.result.campaignParticipations).to.deep.members([
           domainBuilder.maddo.buildCampaignParticipation({
             ...participationSharedAfterDate,
+            participantFirstName: organizationLearner.firstName,
+            participantLastName: organizationLearner.lastName,
             clientId,
             tubes: [
               domainBuilder.maddo.buildTubeCoverage({
@@ -480,6 +493,8 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
           }),
           domainBuilder.maddo.buildCampaignParticipation({
             ...participationCreatedAfterDate,
+            participantFirstName: organizationLearner.firstName,
+            participantLastName: organizationLearner.lastName,
             clientId,
           }),
         ]);

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -20,8 +20,14 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
   describe('GET /api/organizations', function () {
     it('returns the list of all organizations of the client jurisdiction with an HTTP status code 200', async function () {
       // given
-      const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-in-jurisdiction' });
-      const orgaAlsoInJurisdiction = databaseBuilder.factory.buildOrganization({ name: 'orga-also-in-jurisdiction' });
+      const orgaInJurisdiction = databaseBuilder.factory.buildOrganization({
+        name: 'orga-in-jurisdiction',
+        externalId: 'external-id1',
+      });
+      const orgaAlsoInJurisdiction = databaseBuilder.factory.buildOrganization({
+        name: 'orga-also-in-jurisdiction',
+        externalId: 'external-id2',
+      });
       databaseBuilder.factory.buildOrganization({ name: 'orga-not-in-jurisdiction' });
 
       const tag = databaseBuilder.factory.buildTag();
@@ -50,8 +56,12 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal([
-        new Organization({ id: orgaInJurisdiction.id, name: orgaInJurisdiction.name }),
-        new Organization({ id: orgaAlsoInJurisdiction.id, name: orgaAlsoInJurisdiction.name }),
+        new Organization({ id: orgaInJurisdiction.id, name: orgaInJurisdiction.name, externalId: 'external-id1' }),
+        new Organization({
+          id: orgaAlsoInJurisdiction.id,
+          name: orgaAlsoInJurisdiction.name,
+          externalId: 'external-id2',
+        }),
       ]);
     });
   });

--- a/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
+++ b/api/tests/maddo/infrastructure/integration/repositories/organization-repository_test.js
@@ -43,8 +43,8 @@ describe('Maddo | Infrastructure | Repositories | Integration | organization', f
   describe('#findByIds', function () {
     it('find organizations for given ids', async function () {
       //given
-      const organization1 = databaseBuilder.factory.buildOrganization();
-      const organization2 = databaseBuilder.factory.buildOrganization();
+      const organization1 = databaseBuilder.factory.buildOrganization({ externalId: 'external-id1' });
+      const organization2 = databaseBuilder.factory.buildOrganization({ externalId: 'external-id2' });
       databaseBuilder.factory.buildOrganization();
       await databaseBuilder.commit();
 
@@ -53,10 +53,11 @@ describe('Maddo | Infrastructure | Repositories | Integration | organization', f
 
       //then
       expect(organizations).to.deep.equal([
-        new Organization({ id: organization1.id, name: organization1.name }),
+        new Organization({ id: organization1.id, name: organization1.name, externalId: 'external-id1' }),
         new Organization({
           id: organization2.id,
           name: organization2.name,
+          externalId: 'external-id2',
         }),
       ]);
     });

--- a/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
@@ -3,6 +3,8 @@ import { CampaignParticipation } from '../../../../../src/maddo/domain/models/Ca
 export function buildCampaignParticipation({
   id,
   createdAt,
+  participantFirstName,
+  participantLastName,
   participantExternalId,
   status,
   sharedAt,
@@ -16,6 +18,8 @@ export function buildCampaignParticipation({
   return new CampaignParticipation({
     id,
     createdAt,
+    participantFirstName,
+    participantLastName,
     participantExternalId,
     status,
     sharedAt,


### PR DESCRIPTION
## 🔆 Problème

Des champs sont manquants à l'API Maddo, ce qui rend son utilisation par les partenaires pénible. En effet, il est difficile d'identifier facilement : 
- ses organisations autrement que via le nom
- ses prescrits dans les participations, car uniquement l'externalId est présent

## ⛱️ Proposition
Ajouter les infos manquantes pour résoudre ces problèmes

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr13307.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=maddo-client&client_secret=maddo-secret&scope=meta campaigns' | jq -r .access_token)
```

```
curl https://pix-api-maddo-review-pr13307.osc-fr1.scalingo.io/api/organizations/ -H "Authorization: Bearer $ACCESS_TOKEN"  | jq .
```

```
curl https://pix-api-maddo-review-pr13307.osc-fr1.scalingo.io/api/organizations/1000/campaigns -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```

```
curl https://pix-api-maddo-review-pr13307.osc-fr1.scalingo.io/api/campaigns/105354/participations -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
```