### PR TITLE
[TECH] Séparer les responsabilités du token service (partie 4)

### DIFF
--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
-import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
+import { CertificationResultsLinkByEmailToken } from '../domain/models/tokens/CertificationResultsLinkByEmailToken.js';
 import { CertificationResultsLinkToken } from '../domain/models/tokens/CertificationResultsLinkToken.js';
 import * as sessionResultsLinkService from '../domain/services/session-results-link-service.js';
 import { usecases } from '../domain/usecases/index.js';
@@ -31,14 +31,13 @@ const getCleaCertifiedCandidateDataCsv = async function (request, h, dependencie
 const getSessionResultsByRecipientEmail = async function (
   request,
   h,
-  dependencies = { tokenService, getSessionCertificationResultsCsv },
+  dependencies = { getSessionCertificationResultsCsv },
 ) {
   const i18n = await getI18nFromRequest(request);
 
   const token = request.params.token;
 
-  const { resultRecipientEmail, sessionId } =
-    dependencies.tokenService.extractCertificationResultsByRecipientEmailLink(token);
+  const { resultRecipientEmail, sessionId } = CertificationResultsLinkByEmailToken.decode(token);
   const { session, certificationResults } = await usecases.getSessionResultsByResultRecipientEmail({
     sessionId,
     resultRecipientEmail,

--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
+import { CertificationResultsLinkToken } from '../domain/models/tokens/CertificationResultsLinkToken.js';
 import * as sessionResultsLinkService from '../domain/services/session-results-link-service.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as certifiedProfileRepository from '../infrastructure/repositories/certified-profile-repository.js';
@@ -54,14 +55,10 @@ const getSessionResultsByRecipientEmail = async function (
     .header('Content-Disposition', `attachment; filename=${csvResult.filename}`);
 };
 
-const postSessionResultsToDownload = async function (
-  request,
-  h,
-  dependencies = { tokenService, getSessionCertificationResultsCsv },
-) {
+const postSessionResultsToDownload = async function (request, h, dependencies = { getSessionCertificationResultsCsv }) {
   const i18n = await getI18nFromRequest(request);
 
-  const { sessionId } = dependencies.tokenService.extractCertificationResultsLink(request.payload.token);
+  const { sessionId } = CertificationResultsLinkToken.decode(request.payload.token);
   const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
 
   const csvResult = await dependencies.getSessionCertificationResultsCsv({

--- a/api/src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js
+++ b/api/src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js
@@ -1,0 +1,47 @@
+import { config } from '../../../../../shared/config.js';
+import { InvalidResultRecipientTokenError } from '../../../../../shared/domain/errors.js';
+import { tokenService } from '../../../../../shared/domain/services/token-service.js';
+
+const CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE = 'certificationResultsByRecipientEmailLink';
+
+export class CertificationResultsLinkByEmailToken {
+  constructor({ sessionId, resultRecipientEmail, scope }) {
+    this.sessionId = sessionId;
+    this.resultRecipientEmail = resultRecipientEmail;
+    this.scope = scope;
+  }
+
+  static decode(token) {
+    const decoded = tokenService.getDecodedToken(token, config.authentication.secret);
+
+    if (!decoded) {
+      throw new InvalidResultRecipientTokenError();
+    }
+
+    if (!decoded.session_id || !decoded.result_recipient_email) {
+      throw new InvalidResultRecipientTokenError();
+    }
+
+    if (decoded.scope !== CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE) {
+      throw new InvalidResultRecipientTokenError();
+    }
+
+    return new CertificationResultsLinkByEmailToken({
+      sessionId: decoded.session_id,
+      resultRecipientEmail: decoded.result_recipient_email,
+      scope: decoded.scope,
+    });
+  }
+
+  static generate({ sessionId, resultRecipientEmail, daysBeforeExpiration }) {
+    return tokenService.encodeToken(
+      {
+        session_id: sessionId,
+        result_recipient_email: resultRecipientEmail,
+        scope: CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE,
+      },
+      config.authentication.secret,
+      { expiresIn: `${daysBeforeExpiration}d` },
+    );
+  }
+}

--- a/api/src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js
+++ b/api/src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js
@@ -1,0 +1,39 @@
+import { config } from '../../../../../shared/config.js';
+import { InvalidSessionResultTokenError } from '../../../../../shared/domain/errors.js';
+import { tokenService } from '../../../../../shared/domain/services/token-service.js';
+
+export class CertificationResultsLinkToken {
+  constructor({ sessionId, scope }) {
+    this.sessionId = sessionId;
+    this.scope = scope;
+  }
+
+  static decode(token) {
+    const decoded = tokenService.getDecodedToken(token, config.authentication.secret);
+
+    if (!decoded) {
+      throw new InvalidSessionResultTokenError();
+    }
+
+    if (!decoded.session_id) {
+      throw new InvalidSessionResultTokenError();
+    }
+
+    if (decoded.scope !== config.jwtConfig.certificationResults.scope) {
+      throw new InvalidSessionResultTokenError();
+    }
+
+    return new CertificationResultsLinkToken({ sessionId: decoded.session_id, scope: decoded.scope });
+  }
+
+  static generate({ sessionId }) {
+    return tokenService.encodeToken(
+      {
+        session_id: sessionId,
+        scope: config.jwtConfig.certificationResults.scope,
+      },
+      config.authentication.secret,
+      { expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}` },
+    );
+  }
+}

--- a/api/src/certification/results/domain/services/session-results-link-service.js
+++ b/api/src/certification/results/domain/services/session-results-link-service.js
@@ -1,8 +1,8 @@
-import { tokenService } from '../../../../shared/domain/services/token-service.js';
 import { getPixAppUrl } from '../../../../shared/domain/services/url-service.js';
+import { CertificationResultsLinkToken } from '../models/tokens/CertificationResultsLinkToken.js';
 
 export const generateResultsLink = function ({ sessionId, i18n }) {
-  const token = tokenService.createCertificationResultsLinkToken({ sessionId });
+  const token = CertificationResultsLinkToken.generate({ sessionId });
   const locale = i18n.getLocale();
   return getPixAppUrl(locale, {
     pathname: '/resultats-session',

--- a/api/src/certification/session-management/domain/services/mail-service.js
+++ b/api/src/certification/session-management/domain/services/mail-service.js
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
 
-import { tokenService } from '../../../../shared/domain/services/token-service.js';
 import { getPixAppUrl, getPixWebsiteDomain, getPixWebsiteUrl } from '../../../../shared/domain/services/url-service.js';
 import { getI18n } from '../../../../shared/infrastructure/i18n/i18n.js';
 import { mailer } from '../../../../shared/mail/infrastructure/services/mailer.js';
+import { CertificationResultsLinkByEmailToken } from '../../../results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 
@@ -31,7 +31,7 @@ function sendCertificationResultEmail({
   resultRecipientEmail,
   daysBeforeExpiration,
 }) {
-  const token = tokenService.createCertificationResultsByRecipientEmailLinkToken({
+  const token = CertificationResultsLinkByEmailToken.generate({
     sessionId,
     resultRecipientEmail,
     daysBeforeExpiration,

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -1,7 +1,7 @@
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../../src/shared/config.js';
-import { InvalidResultRecipientTokenError, InvalidSessionResultTokenError } from '../errors.js';
+import { InvalidResultRecipientTokenError } from '../errors.js';
 
 const CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE = 'certificationResultsByRecipientEmailLink';
 
@@ -48,19 +48,6 @@ function createCertificationResultsByRecipientEmailLinkToken({
   );
 }
 
-function createCertificationResultsLinkToken({ sessionId }) {
-  return jsonwebtoken.sign(
-    {
-      session_id: sessionId,
-      scope: config.jwtConfig.certificationResults.scope,
-    },
-    config.authentication.secret,
-    {
-      expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}`,
-    },
-  );
-}
-
 function extractTokenFromAuthChain(authChain) {
   if (!authChain) {
     return authChain;
@@ -88,21 +75,6 @@ function extractCertificationResultsByRecipientEmailLink(token) {
   };
 }
 
-function extractCertificationResultsLink(token) {
-  const decoded = getDecodedToken(token);
-  if (!decoded.session_id) {
-    throw new InvalidSessionResultTokenError();
-  }
-
-  if (decoded.scope !== config.jwtConfig.certificationResults.scope) {
-    throw new InvalidSessionResultTokenError();
-  }
-
-  return {
-    sessionId: decoded.session_id,
-  };
-}
-
 function extractUserId(token) {
   const decoded = getDecodedToken(token);
   return decoded.user_id || null;
@@ -110,11 +82,9 @@ function extractUserId(token) {
 
 const tokenService = {
   createCertificationResultsByRecipientEmailLinkToken,
-  createCertificationResultsLinkToken,
   getDecodedToken,
   encodeToken,
   extractCertificationResultsByRecipientEmailLink,
-  extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
 };
@@ -125,9 +95,7 @@ const tokenService = {
 
 export {
   createCertificationResultsByRecipientEmailLinkToken,
-  createCertificationResultsLinkToken,
   extractCertificationResultsByRecipientEmailLink,
-  extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
   getDecodedToken,

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -52,7 +52,7 @@ function extractUserIdFromRequest(request) {
 function getUserLocale(request = {}) {
   const locale = request.query?.locale || request.query?.lang || request.state?.locale;
   if (locale) {
-    return getNearestSupportedLocale(locale, acceptedLanguages);
+    return getNearestSupportedLocale(locale);
   }
 
   return getDefaultLocale();
@@ -64,7 +64,7 @@ function getUserLocale(request = {}) {
  * When no locale found, return the default challenge locale.
  *
  * @param {*} request - http request
- * @returns {string} - locale of a challenge (ie. fr-fr, fr, nl...)
+ * @returns {Promise<string>} - locale of a challenge (ie. fr-fr, fr, nl...)
  */
 async function getChallengeLocale(request) {
   const useCookieLocaleInApi = await featureToggles.get('useCookieLocaleInApi');

--- a/api/tests/certification/results/acceptance/application/certification-results-route_test.js
+++ b/api/tests/certification/results/acceptance/application/certification-results-route_test.js
@@ -1,8 +1,7 @@
-import jsonwebtoken from 'jsonwebtoken';
-
+import { CertificationResultsLinkByEmailToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
+import { CertificationResultsLinkToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
 import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
-import { config as settings } from '../../../../../src/shared/config.js';
 import {
   createServer,
   databaseBuilder,
@@ -103,15 +102,11 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
 
         dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
 
-        const token = jsonwebtoken.sign(
-          {
-            scope: 'certificationResultsByRecipientEmailLink',
-            result_recipient_email: 'recipientEmail@example.net',
-            session_id: sessionId,
-          },
-          settings.authentication.secret,
-          { expiresIn: '30d' },
-        );
+        const token = CertificationResultsLinkByEmailToken.generate({
+          sessionId,
+          resultRecipientEmail: 'recipientEmail@example.net',
+          daysBeforeExpiration: 30,
+        });
 
         const request = {
           method: 'GET',
@@ -175,14 +170,7 @@ describe('Certification | Results | Acceptance | Application | Routes | certific
 
         dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
 
-        const token = jsonwebtoken.sign(
-          {
-            scope: 'certificationResultsLink',
-            session_id: sessionId,
-          },
-          settings.authentication.secret,
-          { expiresIn: '30d' },
-        );
+        const token = CertificationResultsLinkToken.generate({ sessionId });
 
         const request = {
           method: 'POST',

--- a/api/tests/certification/results/unit/application/certification-results-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-results-controller_test.js
@@ -1,4 +1,5 @@
 import { certificationResultsController } from '../../../../../src/certification/results/application/certification-results-controller.js';
+import { CertificationResultsLinkToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
 import { usecases } from '../../../../../src/certification/results/domain/usecases/index.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
@@ -104,15 +105,12 @@ describe('Certification | Results | Unit | Controller | certification results', 
       };
       const dependencies = {
         getSessionCertificationResultsCsv: sinon.stub(),
-        tokenService: {
-          extractCertificationResultsLink: sinon.stub(),
-        },
       };
-      dependencies.tokenService.extractCertificationResultsLink.withArgs(token).returns({ sessionId });
       dependencies.getSessionCertificationResultsCsv
         .withArgs({ session, certificationResults, i18n: getI18n() })
         .returns({ content: 'csv-string', filename: fileName });
       sinon.stub(usecases, 'getSessionResults').withArgs({ sessionId }).resolves({ session, certificationResults });
+      sinon.stub(CertificationResultsLinkToken, 'decode').withArgs(token).returns({ sessionId });
 
       // when
       const response = await certificationResultsController.postSessionResultsToDownload(request, hFake, dependencies);

--- a/api/tests/certification/results/unit/application/certification-results-controller_test.js
+++ b/api/tests/certification/results/unit/application/certification-results-controller_test.js
@@ -1,4 +1,5 @@
 import { certificationResultsController } from '../../../../../src/certification/results/application/certification-results-controller.js';
+import { CertificationResultsLinkByEmailToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
 import { CertificationResultsLinkToken } from '../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
 import { usecases } from '../../../../../src/certification/results/domain/usecases/index.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
@@ -53,13 +54,10 @@ describe('Certification | Results | Unit | Controller | certification results', 
       // given
       const i18n = getI18n();
       const session = { id: 1, date: '2020/01/01', time: '12:00' };
-      const dependencies = {
-        getSessionCertificationResultsCsv: sinon.stub(),
-        tokenService: {
-          extractCertificationResultsByRecipientEmailLink: sinon.stub(),
-        },
-      };
-      dependencies.tokenService.extractCertificationResultsByRecipientEmailLink
+      const dependencies = { getSessionCertificationResultsCsv: sinon.stub() };
+
+      sinon
+        .stub(CertificationResultsLinkByEmailToken, 'decode')
         .withArgs('abcd1234')
         .returns({ sessionId: 1, resultRecipientEmail: 'user@example.net' });
 

--- a/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkByEmailToken.test.js
+++ b/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkByEmailToken.test.js
@@ -1,0 +1,91 @@
+import { CertificationResultsLinkByEmailToken } from '../../../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
+import { config } from '../../../../../../../src/shared/config.js';
+import { InvalidResultRecipientTokenError } from '../../../../../../../src/shared/domain/errors.js';
+import { tokenService } from '../../../../../../../src/shared/domain/services/token-service.js';
+import { expect, sinon } from '../../../../../../test-helper.js';
+
+describe('Unit | Certification | Results | Domain | Model | CertificationResultsLinkByEmailToken', function () {
+  beforeEach(function () {
+    sinon.stub(config.authentication, 'secret').value('secret!');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('CertificationResultsLinkByEmailToken.decode', function () {
+    it('decodes a valid token', function () {
+      // given
+      const token = CertificationResultsLinkByEmailToken.generate({
+        sessionId: 'sessionId!',
+        resultRecipientEmail: 'recipient@example.com',
+        daysBeforeExpiration: 1,
+      });
+
+      // when
+      const decoded = CertificationResultsLinkByEmailToken.decode(token);
+
+      // then
+      expect(decoded).to.be.instanceOf(CertificationResultsLinkByEmailToken);
+      expect(decoded).to.deep.include({
+        sessionId: 'sessionId!',
+        resultRecipientEmail: 'recipient@example.com',
+        scope: 'certificationResultsByRecipientEmailLink',
+      });
+    });
+
+    it('throws error for invalid token', function () {
+      expect(() => CertificationResultsLinkByEmailToken.decode('invalid.token')).to.throw(
+        InvalidResultRecipientTokenError,
+      );
+    });
+
+    it('throws error if session_id is missing', function () {
+      const token = tokenService.encodeToken(
+        { result_recipient_email: 'recipient@example.com', scope: 'certificationResultsByRecipientEmailLink' },
+        config.authentication.secret,
+        { expiresIn: '1d' },
+      );
+      expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
+    });
+
+    it('throws error if result_recipient_email is missing', function () {
+      const token = tokenService.encodeToken(
+        { session_id: 'sessionId!', scope: 'certificationResultsByRecipientEmailLink' },
+        config.authentication.secret,
+        { expiresIn: '1d' },
+      );
+      expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
+    });
+
+    it('throws error if scope is invalid', function () {
+      const token = tokenService.encodeToken(
+        { session_id: 'sessionId!', result_recipient_email: 'recipient@example.com', scope: 'wrong-scope' },
+        config.authentication.secret,
+        { expiresIn: '1d' },
+      );
+      expect(() => CertificationResultsLinkByEmailToken.decode(token)).to.throw(InvalidResultRecipientTokenError);
+    });
+  });
+
+  describe('CertificationResultsLinkByEmailToken.generate', function () {
+    it('builds a certification results link by email token', function () {
+      // given / when
+      const token = CertificationResultsLinkByEmailToken.generate({
+        sessionId: 'sessionId!',
+        resultRecipientEmail: 'recipient@example.com',
+        daysBeforeExpiration: 1,
+      });
+
+      // then
+      expect(token).to.be.a('string');
+
+      const decoded = CertificationResultsLinkByEmailToken.decode(token);
+      expect(decoded).to.deep.include({
+        sessionId: 'sessionId!',
+        resultRecipientEmail: 'recipient@example.com',
+        scope: 'certificationResultsByRecipientEmailLink',
+      });
+    });
+  });
+});

--- a/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkToken.test.js
+++ b/api/tests/certification/results/unit/domain/models/tokens/CertificationResultsLinkToken.test.js
@@ -1,0 +1,73 @@
+import { CertificationResultsLinkToken } from '../../../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
+import { config } from '../../../../../../../src/shared/config.js';
+import { InvalidSessionResultTokenError } from '../../../../../../../src/shared/domain/errors.js';
+import { tokenService } from '../../../../../../../src/shared/domain/services/token-service.js';
+import { expect, sinon } from '../../../../../../test-helper.js';
+
+describe('Unit | Certification | Results | Domain | Model | CertificationResultsLinkToken', function () {
+  beforeEach(function () {
+    sinon.stub(config.authentication, 'secret').value('secret!');
+    sinon.stub(config.jwtConfig.certificationResults, 'scope').value('certification-scope');
+    sinon.stub(config.jwtConfig.certificationResults, 'tokenLifespan').value(1000);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('CertificationResultsLinkToken.decode', function () {
+    it('decodes a valid token', function () {
+      // given
+      const token = CertificationResultsLinkToken.generate({ sessionId: 'sessionId!' });
+
+      // when
+      const decoded = CertificationResultsLinkToken.decode(token);
+
+      // then
+      expect(decoded).to.be.instanceOf(CertificationResultsLinkToken);
+      expect(decoded).to.deep.include({ sessionId: 'sessionId!', scope: 'certification-scope' });
+    });
+
+    it('throws error for invalid token', function () {
+      // given / when / then
+      expect(() => CertificationResultsLinkToken.decode('invalid.token')).to.throw(InvalidSessionResultTokenError);
+    });
+
+    it('throws error if session_id is missing', function () {
+      // given
+      const token = tokenService.encodeToken({ scope: 'certification-scope' }, config.authentication.secret, {
+        expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}`,
+      });
+
+      // when / then
+      expect(() => CertificationResultsLinkToken.decode(token)).to.throw(InvalidSessionResultTokenError);
+    });
+
+    it('throws error if scope is invalid', function () {
+      // given
+      const token = tokenService.encodeToken(
+        { session_id: 'sessionId!', scope: 'wrong-scope' },
+        config.authentication.secret,
+        {
+          expiresIn: `${config.jwtConfig.certificationResults.tokenLifespan}`,
+        },
+      );
+
+      // when / then
+      expect(() => CertificationResultsLinkToken.decode(token)).to.throw(InvalidSessionResultTokenError);
+    });
+  });
+
+  describe('CertificationResultsLinkToken.generate', function () {
+    it('builds a certification results link token', function () {
+      // given / when
+      const token = CertificationResultsLinkToken.generate({ sessionId: 'sessionId!' });
+
+      // then
+      expect(token).to.be.a('string');
+
+      const decoded = CertificationResultsLinkToken.decode(token);
+      expect(decoded).to.deep.include({ sessionId: 'sessionId!', scope: 'certification-scope' });
+    });
+  });
+});

--- a/api/tests/certification/results/unit/domain/services/session-results-link-service_test.js
+++ b/api/tests/certification/results/unit/domain/services/session-results-link-service_test.js
@@ -1,5 +1,5 @@
+import { CertificationResultsLinkToken } from '../../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkToken.js';
 import * as sessionResultsLinkService from '../../../../../../src/certification/results/domain/services/session-results-link-service.js';
-import { tokenService } from '../../../../../../src/shared/domain/services/token-service.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -9,8 +9,8 @@ describe('Certification | Results | Unit | Domain | Service | Session Results Li
       // given
       const sessionId = 12345;
       const i18n = getI18n();
-      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultsLinkToken');
-      tokenServiceStub.withArgs({ sessionId }).returns('a_valid_token');
+
+      sinon.stub(CertificationResultsLinkToken, 'generate').withArgs({ sessionId }).returns('a_valid_token');
 
       // when
       const link = sessionResultsLinkService.generateResultsLink({ sessionId, i18n });

--- a/api/tests/certification/session-management/unit/domain/services/mail-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/mail-service_test.js
@@ -1,6 +1,6 @@
+import { CertificationResultsLinkByEmailToken } from '../../../../../../src/certification/results/domain/models/tokens/CertificationResultsLinkByEmailToken.js';
 import * as mailService from '../../../../../../src/certification/session-management/domain/services/mail-service.js';
 import { ENGLISH_SPOKEN, FRENCH_FRANCE } from '../../../../../../src/shared/domain/services/locale-service.js';
-import { tokenService } from '../../../../../../src/shared/domain/services/token-service.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { mailer } from '../../../../../../src/shared/mail/infrastructure/services/mailer.js';
 import { expect, sinon } from '../../../../../test-helper.js';
@@ -44,9 +44,12 @@ describe('Unit | Certification | Session-Management | Domain | Services | MailSe
       const certificationCenterName = 'Vincennes';
       const resultRecipientEmail = 'email1@example.net';
       const daysBeforeExpiration = 30;
-      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultsByRecipientEmailLinkToken');
-      tokenServiceStub.withArgs({ sessionId, resultRecipientEmail, daysBeforeExpiration }).returns('token-1');
       const link = 'https://test.app.pix.org/api/sessions/download-results/token-1';
+
+      sinon
+        .stub(CertificationResultsLinkByEmailToken, 'generate')
+        .withArgs({ sessionId, resultRecipientEmail, daysBeforeExpiration })
+        .returns('token-1');
 
       // when
       await mailService.sendCertificationResultEmail({

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -1,13 +1,6 @@
-import jsonwebtoken from 'jsonwebtoken';
-import lodash from 'lodash';
-
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
-import { config as settings } from '../../../../../src/shared/config.js';
-import { InvalidResultRecipientTokenError } from '../../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
-import { catchErr, expect } from '../../../../test-helper.js';
-
-const { omit } = lodash;
+import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Services | Token Service', function () {
   describe('#extractUserId', function () {
@@ -33,112 +26,6 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
 
       // then
       expect(result).to.equal(null);
-    });
-  });
-
-  describe('#extractCertificationResultsByRecipientEmailLink', function () {
-    context('when the scope is valid', function () {
-      it('should return the session id and result recipient email if the token is valid', function () {
-        // given
-        const token = jsonwebtoken.sign(
-          {
-            result_recipient_email: 'recipientEmail@example.net',
-            session_id: 12345,
-            scope: 'certificationResultsByRecipientEmailLink',
-          },
-          settings.authentication.secret,
-          { expiresIn: '30d' },
-        );
-
-        // when
-        const tokenData = tokenService.extractCertificationResultsByRecipientEmailLink(token);
-
-        // then
-        expect(tokenData).to.deep.equal({
-          resultRecipientEmail: 'recipientEmail@example.net',
-          sessionId: 12345,
-        });
-      });
-    });
-
-    context('when the scope is invalid', function () {
-      it('should throw an InvalidResultRecipientTokenError', async function () {
-        // given
-        const invalidToken = jsonwebtoken.sign(
-          { result_recipient_email: 'recipientEmail@example.net', session_id: 12345 },
-          settings.authentication.secret,
-          { expiresIn: '30d' },
-        );
-
-        // when
-        const error = await catchErr(tokenService.extractCertificationResultsByRecipientEmailLink)(invalidToken);
-
-        // then
-        expect(error).to.be.an.instanceof(InvalidResultRecipientTokenError);
-      });
-    });
-
-    it('should throw if session id or result recipient email is missing', async function () {
-      // given
-      const invalidIdToken = jsonwebtoken.sign(
-        {
-          result_recipient_email: 'recipientEmail@example.net',
-        },
-        settings.authentication.secret,
-        { expiresIn: '30d' },
-      );
-
-      // when
-      const error = await catchErr(tokenService.extractCertificationResultsByRecipientEmailLink)(invalidIdToken);
-
-      // then
-      expect(error).to.be.an.instanceof(InvalidResultRecipientTokenError);
-    });
-
-    it('should throw if token is expired', async function () {
-      // given
-      const invalidIdToken = jsonwebtoken.sign(
-        {
-          result_recipient_email: 'recipientEmail@example.net',
-          session_id: 1234,
-        },
-        settings.authentication.secret,
-        { expiresIn: '1' },
-      );
-
-      // when
-      setTimeout(async () => {
-        return;
-      }, 100);
-      const error = await catchErr(tokenService.extractCertificationResultsByRecipientEmailLink)(invalidIdToken);
-
-      // then
-      expect(error).to.be.an.instanceof(InvalidResultRecipientTokenError);
-    });
-  });
-
-  describe('#createCertificationResultsByRecipientEmailLinkToken', function () {
-    it('should return a valid token with sessionId and resultRecipientEmail', function () {
-      // given
-      const sessionId = 'abcd1234';
-      const resultRecipientEmail = 'results@college-romain-rolland.edu';
-      const daysBeforeExpiration = 30;
-      const expectedTokenAttributes = {
-        session_id: 'abcd1234',
-        result_recipient_email: 'results@college-romain-rolland.edu',
-        scope: 'certificationResultsByRecipientEmailLink',
-      };
-
-      // when
-      const linkToken = tokenService.createCertificationResultsByRecipientEmailLinkToken({
-        sessionId,
-        resultRecipientEmail,
-        daysBeforeExpiration,
-      });
-
-      // then
-      const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);
-      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
     });
   });
 });

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -2,11 +2,8 @@ import jsonwebtoken from 'jsonwebtoken';
 import lodash from 'lodash';
 
 import { UserAccessToken } from '../../../../../src/identity-access-management/domain/models/UserAccessToken.js';
-import { config, config as settings } from '../../../../../src/shared/config.js';
-import {
-  InvalidResultRecipientTokenError,
-  InvalidSessionResultTokenError,
-} from '../../../../../src/shared/domain/errors.js';
+import { config as settings } from '../../../../../src/shared/config.js';
+import { InvalidResultRecipientTokenError } from '../../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../../src/shared/domain/services/token-service.js';
 import { catchErr, expect } from '../../../../test-helper.js';
 
@@ -36,80 +33,6 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
 
       // then
       expect(result).to.equal(null);
-    });
-  });
-
-  describe('#extractCertificationResultsLink', function () {
-    context('when the scope is valid', function () {
-      it('should return the session id', function () {
-        // given
-        const token = jsonwebtoken.sign(
-          {
-            session_id: 12345,
-            scope: 'certificationResultsLink',
-          },
-          settings.authentication.secret,
-          { expiresIn: config.jwtConfig.certificationResults.tokenLifespan },
-        );
-
-        // when
-        const tokenData = tokenService.extractCertificationResultsLink(token);
-
-        // then
-        expect(tokenData).to.deep.equal({
-          sessionId: 12345,
-        });
-      });
-    });
-
-    context('when the scope is invalid', function () {
-      it('should throw an InvalidSessionResultTokenError', async function () {
-        // given
-        const invalidToken = jsonwebtoken.sign(
-          {
-            session_id: 12345,
-          },
-          settings.authentication.secret,
-          { expiresIn: '30d' },
-        );
-
-        // when
-        const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidToken);
-
-        // then
-        expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
-      });
-    });
-
-    it('should throw if session id or result recipient email is missing', async function () {
-      // given
-      const invalidIdToken = jsonwebtoken.sign({}, settings.authentication.secret, { expiresIn: '30d' });
-
-      // when
-      const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
-
-      // then
-      expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
-    });
-
-    it('should throw if token is expired', async function () {
-      // given
-      const invalidIdToken = jsonwebtoken.sign(
-        {
-          session_id: 1234,
-        },
-        settings.authentication.secret,
-        { expiresIn: '1' },
-      );
-
-      // when
-      setTimeout(async () => {
-        return;
-      }, 100);
-      const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
-
-      // then
-      expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
     });
   });
 
@@ -212,24 +135,6 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
         resultRecipientEmail,
         daysBeforeExpiration,
       });
-
-      // then
-      const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);
-      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
-    });
-  });
-
-  describe('#createCertificationResultsLinkToken', function () {
-    it('should return a valid token with sessionId and resultRecipientEmail', function () {
-      // given
-      const sessionId = 'abcd1234';
-      const expectedTokenAttributes = {
-        session_id: 'abcd1234',
-        scope: 'certificationResultsLink',
-      };
-
-      // when
-      const linkToken = tokenService.createCertificationResultsLinkToken({ sessionId });
 
       // then
       const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);


### PR DESCRIPTION
## 🔆 Problème

Actuellement, le `token-service` à beaucoup de dépendances et trop de responsabilités. On retrouve des cas d'usage spécifiques à des contextes différents et du code "métier" dans ce fichier. Exemples :
- Contexte IAM : `createAccessTokenFromUser`, `createAccessTokenForSaml`...
- Contexte Certif : `createCertificationResultsByRecipientEmailLinkToken`...
- Contexte Prescription : `createIdTokenForUserReconciliation`...

Ce couplage entraîne des **soucis de dépendances cycliques** quand on souhaite encoder / décoder des tokens.

## ⛱️ Proposition

**Isoler la génération des tokens par cas d'usage et par contexte** tout en conservant le `token-service` pour l'encodage et décodage de base avec `jsonwebtoken`. Cette isolation sera faite en plusieurs PR.

**Cette PR** isole: 
- la création de **token pour le lien de résultat de certif** via la classe `CertificationResultsLinkToken`
- la création de **token pour le lien de résultat de certif envoyé par email** via la classe `CertificationResultsLinkByEmailToken`

## 🏄 Pour tester

- Créer une session de certification
- Ajouter un candidat en remplissant le mail d'envoi de résultats
- Réaliser le test et le compléter
- Finaliser la session
- Publier la session
- Vérifier que vous avez reçu le lien de téléchargement des résultats par mail
- Vérifier que vous pouvez utiliser ce lien
- Vérifier que vous pouvez utiliser le lien de résultats de certification de la session dans pix-admin
