### PR TITLE
[BUGFIX] Empêcher l'accès au language switch depuis le compte sur domaine fr (PIX-7933)

### DIFF
--- a/mon-pix/app/routes/authenticated/user-account/language.js
+++ b/mon-pix/app/routes/authenticated/user-account/language.js
@@ -1,6 +1,16 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class UserAccountLanguageRoute extends Route {
+  @service router;
+  @service currentDomain;
+
+  beforeModel() {
+    if (this.currentDomain.isFranceDomain) {
+      this.router.replaceWith('authenticated.user-account');
+    }
+  }
+
   model() {
     return this.modelFor('authenticated.user-account');
   }

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -110,12 +110,14 @@ module('Acceptance | User account page', function (hooks) {
         });
       });
 
-      module('When in France domain', () => {
-        test('it does not display language menu link', async function (assert) {
-          // given
+      module('When in France domain', (hooks) => {
+        hooks.beforeEach(function () {
           const domainService = this.owner.lookup('service:currentDomain');
           sinon.stub(domainService, 'getExtension').returns('fr');
+        });
 
+        test('it does not display language menu link', async function (assert) {
+          // given
           const screen = await visit('/mon-compte');
 
           // when / then
@@ -124,6 +126,16 @@ module('Acceptance | User account page', function (hooks) {
           });
 
           assert.dom(languageMenuLink).doesNotExist();
+        });
+
+        module('When trying to access language route', function () {
+          test('it redirects to account main page', async function (assert) {
+            // when
+            await visit('/mon-compte/langue');
+
+            // then
+            assert.strictEqual(currentURL(), '/mon-compte/informations-personnelles');
+          });
         });
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Sur pix-app, il est possible d'accèder au language switcher depuis `/mon-compte/langue` en domaine .fr

## ⛱️ Proposition

Empêcher l'accès à cette route sur pix.fr


## 🏄 Pour tester

- Depuis pix-app.fr
  - Se connecter
  -  Tenter d'accéder via l'url à `/mon-compte/langue`
  - Constater la redirection à `/mon-compte/informations-personnelles`
