### PR TITLE
[BUGFIX] Corriger l'affichage sur la page de changement d'email (PIX-14089)

### DIFF
--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -32,17 +32,17 @@
   }
 
   &__input-code {
-    margin: 24px 0;
+    margin: var(--pix-spacing-6x) 0;
   }
 
   &__error {
-    max-width: 520px;
-    margin-bottom: 20px;
+    max-width: 32.5rem;;
+    margin-bottom: 1.25rem;
   }
 
   &__resend {
     display: flex;
-    margin-bottom: 12px;
+    margin-bottom: var(--pix-spacing-3x);
     opacity: 0;
     transition: opacity 0.2s ease-in;
 
@@ -55,7 +55,7 @@
     }
 
     button {
-      margin-left: 2px;
+      margin-left: 0.125rem;
       padding: 0;
       color: var(--pix-primary-500);
       background-color: transparent;
@@ -65,6 +65,6 @@
   }
 
   &__resend-confirmation-message {
-    margin-bottom: 12px;
+    margin-bottom: var(--pix-spacing-3x);
   }
 }

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -42,12 +42,14 @@
 
   &__resend {
     display: flex;
+    align-items: baseline;
     margin-bottom: var(--pix-spacing-3x);
     opacity: 0;
     transition: opacity 0.2s ease-in;
 
     p {
       margin: 0;
+      font-size: 0.875rem;
     }
 
     &.visible {
@@ -58,6 +60,7 @@
       margin-left: 0.125rem;
       padding: 0;
       color: var(--pix-primary-500);
+      font-size: 0.875rem;
       background-color: transparent;
       border: none;
       cursor: pointer;


### PR DESCRIPTION
## 🔆 Problème

Au niveau de “Je n’ai rien reçu, me renvoyer le code”, on note une différence de taille ainsi qu’un léger décalage.

<img width="2274" height="1110" alt="image" src="https://github.com/user-attachments/assets/b1cccec7-3236-4736-8a86-a793823b863a" />


## ⛱️ Proposition

Il faut corriger en harmonisant avec la police & taille du texte “Saisissez le code de vérification reçu …”

## 🌊 Remarques
[indépendant de cette PR] La phrase “Je n’ai rien reçu, me renvoyer le code” est chargée/affichée une à deux secondes après le reste de la page.

## 🏄 Pour tester

- Se connecter sur Pix App
- Dans "Mon compte"/ "Mes méthodes de connexion", remplir les champs pour modifier l'adresse email et cliquer sur "Recevoir un code de vérification"
- Vérifier que l'affichage de "Je n'ai rien reçu, me renvoyer le code" est correct, c'est à dire que la police et la taille sont identiques (vous pouvez faire cette vérification avant d'entrer un code invalide ou après l'avoir fait comme dans la capture d'écran ci-dessus)
