### PR TITLE
[TECH] Ajouter de la gestion d'erreur si le lien d'un contenu formatif "modulix" recommandé ne passe pas la regex

### DIFF
--- a/api/src/devcomp/application/api/models/RecommendableModule.js
+++ b/api/src/devcomp/application/api/models/RecommendableModule.js
@@ -1,0 +1,10 @@
+import { RecommendedModule } from './RecommendedModule.js';
+
+class RecommendableModule extends RecommendedModule {
+  constructor({ id, moduleId, targetProfileIds } = {}) {
+    super({ id, moduleId });
+    this.targetProfileIds = targetProfileIds;
+  }
+}
+
+export { RecommendableModule };

--- a/api/src/devcomp/application/api/models/RecommendedModule.js
+++ b/api/src/devcomp/application/api/models/RecommendedModule.js
@@ -1,8 +1,7 @@
 class RecommendedModule {
-  constructor({ id, moduleId, targetProfileIds } = {}) {
+  constructor({ id, moduleId } = {}) {
     this.id = id;
     this.moduleId = moduleId;
-    this.targetProfileIds = targetProfileIds;
   }
 }
 

--- a/api/src/devcomp/application/api/models/UserRecommendedModule.js
+++ b/api/src/devcomp/application/api/models/UserRecommendedModule.js
@@ -1,8 +1,0 @@
-class UserRecommendedModule {
-  constructor({ id, moduleId } = {}) {
-    this.id = id;
-    this.moduleId = moduleId;
-  }
-}
-
-export { UserRecommendedModule };

--- a/api/src/devcomp/application/api/recommended-modules-api.js
+++ b/api/src/devcomp/application/api/recommended-modules-api.js
@@ -1,7 +1,7 @@
 import { DomainError } from '../../../shared/domain/errors.js';
 import { usecases } from '../../domain/usecases/index.js';
+import { RecommendableModule } from './models/RecommendableModule.js';
 import { RecommendedModule } from './models/RecommendedModule.js';
-import { UserRecommendedModule } from './models/UserRecommendedModule.js';
 
 const findByCampaignParticipationIds = async ({ campaignParticipationIds }) => {
   if (campaignParticipationIds.length === 0) {
@@ -12,7 +12,7 @@ const findByCampaignParticipationIds = async ({ campaignParticipationIds }) => {
     campaignParticipationIds,
   });
 
-  return recommendedModules.map((recommendedModule) => new UserRecommendedModule(recommendedModule));
+  return recommendedModules.map((recommendedModule) => new RecommendedModule(recommendedModule));
 };
 
 const findByTargetProfileIds = async ({ targetProfileIds }) => {
@@ -20,11 +20,11 @@ const findByTargetProfileIds = async ({ targetProfileIds }) => {
     throw new DomainError('targetProfileIds can not be empty');
   }
 
-  const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
+  const recommendableModules = await usecases.findRecommendableModulesByTargetProfileIds({
     targetProfileIds,
   });
 
-  return recommendedModules.map((recommendedModule) => new RecommendedModule(recommendedModule));
+  return recommendableModules.map((recommendableModule) => new RecommendableModule(recommendableModule));
 };
 
 export { findByCampaignParticipationIds, findByTargetProfileIds };

--- a/api/src/devcomp/domain/read-models/RecommendableModule.js
+++ b/api/src/devcomp/domain/read-models/RecommendableModule.js
@@ -1,0 +1,10 @@
+import { RecommendedModule } from './RecommendedModule.js';
+
+class RecommendableModule extends RecommendedModule {
+  constructor({ id, moduleId, targetProfileIds } = {}) {
+    super({ id, moduleId });
+    this.targetProfileIds = targetProfileIds;
+  }
+}
+
+export { RecommendableModule };

--- a/api/src/devcomp/domain/read-models/RecommendedModule.js
+++ b/api/src/devcomp/domain/read-models/RecommendedModule.js
@@ -1,8 +1,7 @@
 class RecommendedModule {
-  constructor({ id, moduleId, targetProfileIds } = {}) {
+  constructor({ id, moduleId } = {}) {
     this.id = id;
     this.moduleId = moduleId;
-    this.targetProfileIds = targetProfileIds;
   }
 }
 

--- a/api/src/devcomp/domain/read-models/UserRecommendedModule.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedModule.js
@@ -1,8 +1,0 @@
-class UserRecommendedModule {
-  constructor({ id, moduleId } = {}) {
-    this.id = id;
-    this.moduleId = moduleId;
-  }
-}
-
-export { UserRecommendedModule };

--- a/api/src/devcomp/domain/services/module-service.js
+++ b/api/src/devcomp/domain/services/module-service.js
@@ -1,0 +1,19 @@
+import { ModuleDoesNotExistError } from '../errors.js';
+
+const getModuleByLink = async function ({ link, moduleRepository }) {
+  const regexp = /\/modules\/([a-z0-9-]*)/;
+
+  const result = regexp.exec(link);
+  if (!result) {
+    throw new ModuleDoesNotExistError(`No module found for link: ${link}`);
+  }
+  const slug = result[1];
+
+  try {
+    return await moduleRepository.getBySlug({ slug });
+  } catch {
+    throw new ModuleDoesNotExistError(`No module found for link: ${link}`);
+  }
+};
+
+export default { getModuleByLink };

--- a/api/src/devcomp/domain/usecases/find-recommendable-modules-by-target-profile-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommendable-modules-by-target-profile-ids.js
@@ -1,7 +1,7 @@
-import { RecommendedModule } from '../read-models/RecommendedModule.js';
+import { RecommendableModule } from '../read-models/RecommendableModule.js';
 import moduleService from '../services/module-service.js';
 
-const findRecommendedModulesByTargetProfileIds = async function ({
+const findRecommendableModulesByTargetProfileIds = async function ({
   targetProfileIds,
   trainingRepository,
   moduleRepository,
@@ -21,7 +21,7 @@ const findRecommendedModulesByTargetProfileIds = async function ({
     }),
   );
 
-  return recommendedModules.filter((module) => module !== undefined).map((module) => new RecommendedModule(module));
+  return recommendedModules.filter((module) => module !== undefined).map((module) => new RecommendableModule(module));
 };
 
-export { findRecommendedModulesByTargetProfileIds };
+export { findRecommendableModulesByTargetProfileIds };

--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
@@ -1,23 +1,28 @@
 import { UserRecommendedModule } from '../read-models/UserRecommendedModule.js';
+import moduleService from '../services/module-service.js';
 
 export const findRecommendedModulesByCampaignParticipationIds = async function ({
   campaignParticipationIds,
   moduleRepository,
   userRecommendedTrainingRepository,
+  logger,
 }) {
   const userRecommendedTrainings = await userRecommendedTrainingRepository.findModulesByCampaignParticipationIds({
     campaignParticipationIds,
   });
   const userRecommendedModules = await Promise.all(
     userRecommendedTrainings.map(async ({ id, link }) => {
-      const regexp = /\/modules\/([a-z0-9-]*)/;
-
-      const result = regexp.exec(link);
-      const slug = result[1];
-      const module = await moduleRepository.getBySlug({ slug });
-      return { id, moduleId: module.id };
+      try {
+        const module = await moduleService.getModuleByLink({ link, moduleRepository });
+        return { id, moduleId: module.id };
+      } catch {
+        logger.error({ message: `Erreur sur le lien de la ressource : ${link}` });
+        return;
+      }
     }),
   );
 
-  return userRecommendedModules.map((module) => new UserRecommendedModule(module));
+  return userRecommendedModules
+    .filter((module) => module !== undefined)
+    .map((module) => new UserRecommendedModule(module));
 };

--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
@@ -1,4 +1,4 @@
-import { UserRecommendedModule } from '../read-models/UserRecommendedModule.js';
+import { RecommendedModule } from '../read-models/RecommendedModule.js';
 import moduleService from '../services/module-service.js';
 
 export const findRecommendedModulesByCampaignParticipationIds = async function ({
@@ -22,7 +22,5 @@ export const findRecommendedModulesByCampaignParticipationIds = async function (
     }),
   );
 
-  return userRecommendedModules
-    .filter((module) => module !== undefined)
-    .map((module) => new UserRecommendedModule(module));
+  return userRecommendedModules.filter((module) => module !== undefined).map((module) => new RecommendedModule(module));
 };

--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-target-profile-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-target-profile-ids.js
@@ -1,24 +1,27 @@
 import { RecommendedModule } from '../read-models/RecommendedModule.js';
+import moduleService from '../services/module-service.js';
 
 const findRecommendedModulesByTargetProfileIds = async function ({
   targetProfileIds,
   trainingRepository,
   moduleRepository,
+  logger,
 }) {
   const recommendedTrainings = await trainingRepository.findModulesByTargetProfileIds({ targetProfileIds });
 
   const recommendedModules = await Promise.all(
     recommendedTrainings.map(async ({ id, link, targetProfileIds }) => {
-      const regexp = /\/modules\/([a-z0-9-]*)/;
-
-      const result = regexp.exec(link);
-      const slug = result[1];
-      const module = await moduleRepository.getBySlug({ slug });
-      return { id, moduleId: module.id, targetProfileIds };
+      try {
+        const module = await moduleService.getModuleByLink({ link, moduleRepository });
+        return { id, moduleId: module.id, targetProfileIds };
+      } catch {
+        logger.error({ message: `Erreur sur le lien de la ressource : ${link}` });
+        return;
+      }
     }),
   );
 
-  return recommendedModules.map((module) => new RecommendedModule(module));
+  return recommendedModules.filter((module) => module !== undefined).map((module) => new RecommendedModule(module));
 };
 
 export { findRecommendedModulesByTargetProfileIds };

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -27,8 +27,10 @@ const dependencies = {
   skillRepository,
   userRepository,
   llmApi,
+  logger,
 };
 
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { addTutorialEvaluation } from './add-tutorial-evaluation.js';
 import { addTutorialToUser } from './add-tutorial-to-user.js';
 import { attachTargetProfilesToTraining } from './attach-target-profiles-to-training.js';

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -45,8 +45,8 @@ import { findPaginatedFilteredTutorials } from './find-paginated-filtered-tutori
 import { findPaginatedTargetProfileTrainingSummaries } from './find-paginated-target-profile-training-summaries.js';
 import { findPaginatedTrainingSummaries } from './find-paginated-training-summaries.js';
 import { findPaginatedUserRecommendedTrainings } from './find-paginated-user-recommended-trainings.js';
+import { findRecommendableModulesByTargetProfileIds } from './find-recommendable-modules-by-target-profile-ids.js';
 import { findRecommendedModulesByCampaignParticipationIds } from './find-recommended-modules-by-campaign-participation-ids.js';
-import { findRecommendedModulesByTargetProfileIds } from './find-recommended-modules-by-target-profile-ids.js';
 import { findTargetProfileSummariesForTraining } from './find-target-profile-summaries-for-training.js';
 import { findTutorials } from './find-tutorials.js';
 import { getModule } from './get-module.js';
@@ -77,7 +77,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedTrainingSummaries,
   findPaginatedUserRecommendedTrainings,
   findRecommendedModulesByCampaignParticipationIds,
-  findRecommendedModulesByTargetProfileIds,
+  findRecommendableModulesByTargetProfileIds,
   findTargetProfileSummariesForTraining,
   findTutorials,
   getModuleMetadataList,

--- a/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
@@ -1,5 +1,5 @@
+import { RecommendableModule } from '../../../../../src/devcomp/application/api/models/RecommendableModule.js';
 import { RecommendedModule } from '../../../../../src/devcomp/application/api/models/RecommendedModule.js';
-import { UserRecommendedModule } from '../../../../../src/devcomp/application/api/models/UserRecommendedModule.js';
 import * as recommendedModulesApi from '../../../../../src/devcomp/application/api/recommended-modules-api.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
@@ -29,7 +29,7 @@ describe('Integration | Devcomp | Application | Api | RecommendedModules', funct
 
       // then
       const expectedResult = [
-        new UserRecommendedModule({ id: trainingId, moduleId: '5df14039-803b-4db4-9778-67e4b84afbbd' }),
+        new RecommendedModule({ id: trainingId, moduleId: '5df14039-803b-4db4-9778-67e4b84afbbd' }),
       ];
 
       expect(result).to.deep.equal(expectedResult);
@@ -77,23 +77,23 @@ describe('Integration | Devcomp | Application | Api | RecommendedModules', funct
 
       // then
       const expectedResult = [
-        new RecommendedModule({
+        new RecommendableModule({
           id: trainingId,
           moduleId: '5df14039-803b-4db4-9778-67e4b84afbbd',
           targetProfileIds: [targetProfileId],
         }),
-        new RecommendedModule({
+        new RecommendableModule({
           id: trainingId2,
           moduleId: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
           targetProfileIds: [targetProfileId2],
         }),
       ];
 
-      expect(results[0]).to.be.an.instanceOf(RecommendedModule);
+      expect(results[0]).to.be.an.instanceOf(RecommendableModule);
       expect(results[0].targetProfileIds[0]).to.deep.equal(expectedResult[0].targetProfileIds[0]);
       expect(results[0].moduleId).to.deep.equal(expectedResult[0].moduleId);
       expect(results[0].id).to.deep.equal(expectedResult[0].id);
-      expect(results[1]).to.be.an.instanceOf(RecommendedModule);
+      expect(results[1]).to.be.an.instanceOf(RecommendableModule);
       expect(results[1].targetProfileIds[0]).to.deep.equal(expectedResult[1].targetProfileIds[0]);
       expect(results[1].moduleId).to.deep.equal(expectedResult[1].moduleId);
       expect(results[1].id).to.deep.equal(expectedResult[1].id);

--- a/api/tests/devcomp/integration/domain/usecases/find-recommendable-modules-by-target-profile-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommendable-modules-by-target-profile-ids_test.js
@@ -1,9 +1,9 @@
-import { RecommendedModule } from '../../../../../src/devcomp/domain/read-models/RecommendedModule.js';
+import { RecommendableModule } from '../../../../../src/devcomp/domain/read-models/RecommendableModule.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTargetProfileIds', function () {
+describe('DevComp | Integration | Domain | Usecases | findRecommendableModulesByTargetProfileIds', function () {
   it('it returns recommended modules for given target-profile ids', async function () {
     // given
     const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
@@ -18,12 +18,12 @@ describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTa
     databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfileId2, trainingId: training.id });
     await databaseBuilder.commit();
 
-    const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
+    const recommendedModules = await usecases.findRecommendableModulesByTargetProfileIds({
       targetProfileIds: [targetProfileId1, targetProfileId2],
     });
 
     expect(recommendedModules).to.have.lengthOf(1);
-    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendableModule);
     expect(recommendedModules[0]).to.be.deep.equal({
       id: training.id,
       moduleId,
@@ -43,13 +43,13 @@ describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTa
     await databaseBuilder.commit();
 
     //when
-    const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
+    const recommendedModules = await usecases.findRecommendableModulesByTargetProfileIds({
       targetProfileIds: [targetProfileId1],
     });
 
     //then
     expect(recommendedModules).to.have.lengthOf(1);
-    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendableModule);
     expect(recommendedModules[0]).to.be.deep.equal({
       id: training.id,
       moduleId,
@@ -78,7 +78,7 @@ describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTa
     await databaseBuilder.commit();
 
     // when
-    const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
+    const recommendedModules = await usecases.findRecommendableModulesByTargetProfileIds({
       targetProfileIds: [targetProfileId1],
     });
     // then
@@ -86,7 +86,7 @@ describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTa
       message: `Erreur sur le lien de la ressource : ${training.link}`,
     });
     expect(recommendedModules).to.have.lengthOf(1);
-    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendableModule);
     expect(recommendedModules[0]).to.be.deep.equal({
       id: training2.id,
       moduleId: module2Id,

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -41,27 +41,35 @@ describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCa
     expect(recommendedModules[1]).to.be.an.instanceOf(UserRecommendedModule);
     expect(recommendedModules[1]).to.be.deep.equal({ id: secondTraining.id, moduleId: secondModuleId });
   });
-
-  it('it returns recommended modules for given participation ids even if link is absolute', async function () {
+  it('ignores module when its slug does not pass regex', async function () {
     // given
-    const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+    const { id: campaignParticipationId1, userId } = databaseBuilder.factory.buildCampaignParticipation();
+    const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
 
     const moduleId = '5df14039-803b-4db4-9778-67e4b84afbbd';
     const training = databaseBuilder.factory.buildTraining({
       type: 'modulix',
-      link: 'https://app.pix.fr/modules/adresse-ip-publique-et-vous/details',
+      link: '/modules/adresse-ip-publique-et-vous/details',
+    });
+    const secondTraining = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: '/campagnes/module123',
     });
 
     databaseBuilder.factory.buildUserRecommendedTraining({
       userId,
       trainingId: training.id,
-      campaignParticipationId: campaignParticipationId,
+      campaignParticipationId: campaignParticipationId1,
     }).id;
-
+    databaseBuilder.factory.buildUserRecommendedTraining({
+      userId,
+      trainingId: secondTraining.id,
+      campaignParticipationId: campaignParticipationId2,
+    }).id;
     await databaseBuilder.commit();
 
     const recommendedModules = await usecases.findRecommendedModulesByCampaignParticipationIds({
-      campaignParticipationIds: [campaignParticipationId],
+      campaignParticipationIds: [campaignParticipationId1, campaignParticipationId2],
     });
 
     expect(recommendedModules).to.have.lengthOf(1);

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -1,4 +1,4 @@
-import { UserRecommendedModule } from '../../../../../src/devcomp/domain/read-models/UserRecommendedModule.js';
+import { RecommendedModule } from '../../../../../src/devcomp/domain/read-models/RecommendedModule.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -36,9 +36,9 @@ describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCa
     });
 
     expect(recommendedModules).to.have.lengthOf(2);
-    expect(recommendedModules[0]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
     expect(recommendedModules[0]).to.be.deep.equal({ id: training.id, moduleId });
-    expect(recommendedModules[1]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[1]).to.be.an.instanceOf(RecommendedModule);
     expect(recommendedModules[1]).to.be.deep.equal({ id: secondTraining.id, moduleId: secondModuleId });
   });
   it('ignores module when its slug does not pass regex', async function () {
@@ -73,7 +73,7 @@ describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCa
     });
 
     expect(recommendedModules).to.have.lengthOf(1);
-    expect(recommendedModules[0]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
     expect(recommendedModules[0]).to.be.deep.equal({ id: training.id, moduleId });
   });
 });

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-target-profile-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-target-profile-ids_test.js
@@ -1,6 +1,7 @@
 import { RecommendedModule } from '../../../../../src/devcomp/domain/read-models/RecommendedModule.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
-import { databaseBuilder, expect } from '../../../../test-helper.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
+import { databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTargetProfileIds', function () {
   it('it returns recommended modules for given target-profile ids', async function () {
@@ -41,15 +42,54 @@ describe('DevComp | Integration | Domain | Usecases | findRecommendedModulesByTa
     databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfileId1, trainingId: training.id });
     await databaseBuilder.commit();
 
+    //when
     const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
       targetProfileIds: [targetProfileId1],
     });
 
+    //then
     expect(recommendedModules).to.have.lengthOf(1);
     expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
     expect(recommendedModules[0]).to.be.deep.equal({
       id: training.id,
       moduleId,
+      targetProfileIds: [targetProfileId1],
+    });
+  });
+  it('ignores module when its slug does not pass regex', async function () {
+    // given
+    sinon.stub(logger, 'error').returns();
+
+    const targetProfileId1 = databaseBuilder.factory.buildTargetProfile().id;
+    const training = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: 'http://app.pix.fr/campagnes/COMBINIX1',
+    });
+    const module2Id = '5df14039-803b-4db4-9778-67e4b84afbbd';
+
+    const training2 = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: 'http://app.pix.fr/modules/adresse-ip-publique-et-vous/details',
+    });
+
+    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfileId1, trainingId: training.id });
+    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfileId1, trainingId: training2.id });
+
+    await databaseBuilder.commit();
+
+    // when
+    const recommendedModules = await usecases.findRecommendedModulesByTargetProfileIds({
+      targetProfileIds: [targetProfileId1],
+    });
+    // then
+    expect(logger.error).to.have.been.calledWithExactly({
+      message: `Erreur sur le lien de la ressource : ${training.link}`,
+    });
+    expect(recommendedModules).to.have.lengthOf(1);
+    expect(recommendedModules[0]).to.be.an.instanceOf(RecommendedModule);
+    expect(recommendedModules[0]).to.be.deep.equal({
+      id: training2.id,
+      moduleId: module2Id,
       targetProfileIds: [targetProfileId1],
     });
   });

--- a/api/tests/devcomp/unit/domain/services/module-service_test.js
+++ b/api/tests/devcomp/unit/domain/services/module-service_test.js
@@ -1,0 +1,46 @@
+import sinon from 'sinon';
+
+import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
+import moduleService from '../../../../../src/devcomp/domain/services/module-service.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, expect } from '../../../../test-helper.js';
+
+const { getModuleByLink } = moduleService;
+
+describe('#getModuleByLink', function () {
+  it('should throw an error if link does not match /modules/<slug> pattern', async function () {
+    const error = await catchErr(getModuleByLink)({ link: 'bidule' });
+    expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+    expect(error.message).to.contain('bidule');
+  });
+  it('should throw an error if link slug does not match any module', async function () {
+    const moduleRepository = { getBySlug: sinon.stub() };
+    moduleRepository.getBySlug.withArgs({ slug: 'wrong-slug' }).rejects(new NotFoundError());
+    const error = await catchErr(getModuleByLink)({ link: '/modules/wrong-slug', moduleRepository });
+    expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+  });
+  it('should return module if link slug matches a module', async function () {
+    //given
+    const moduleRepository = { getBySlug: sinon.stub() };
+    const expectedModule = Symbol('module');
+    moduleRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
+
+    //when
+    const module = await getModuleByLink({ link: '/modules/good-slug', moduleRepository });
+
+    //then
+    expect(module).to.equal(expectedModule);
+  });
+  it('should return module if absolute link slug matches a module', async function () {
+    //given
+    const moduleRepository = { getBySlug: sinon.stub() };
+    const expectedModule = Symbol('module');
+    moduleRepository.getBySlug.withArgs({ slug: 'good-slug' }).resolves(expectedModule);
+
+    //when
+    const module = await getModuleByLink({ link: 'https://app.pix.fr/modules/good-slug', moduleRepository });
+
+    //then
+    expect(module).to.equal(expectedModule);
+  });
+});


### PR DESCRIPTION
## 🔆 Problème
On a besoin de remonter une erreur si le lien dans un module recommandé à l'utilisateur dans le cadre d'un parcours combiné ne respecte pas un certain format en '/modules/...'.

## ⛱️ Proposition
On remonte une erreur si le format d'URL ne correspond pas et on ignore le training correspondant.
Remarque : le module étant présent dans le parcours combiné, il sera considéré comme un module en dur et donc non recommandable (on le verra avant la campagne de diagnostic).

## 🏄 Pour tester
Test de non-régression sur un parcours combiné (aller au bout de la campagne de diagnostic, jusqu'à voir les modules recommandés sur l'écran récapitulatif du parcours combiné).