### PR TITLE
[BUGFIX] Corriger UrlBaseService.pixAppForgottenPasswordUrl (PIX-19264)

### DIFF
--- a/admin/app/services/url-base.js
+++ b/admin/app/services/url-base.js
@@ -30,7 +30,7 @@ export default class UrlBaseService extends Service {
   get pixAppForgottenPasswordUrl() {
     const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
     const currentLocale = this.locale.currentLocale;
-    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+    return this.currentDomain.isFranceDomain ? url : `${url}?lang=${currentLocale}`;
   }
 
   getPixWebsiteUrl(pathname = '') {

--- a/admin/tests/unit/services/url-base-test.js
+++ b/admin/tests/unit/services/url-base-test.js
@@ -97,7 +97,7 @@ module('Unit | Service | url-base', function (hooks) {
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
 
       const domainService = this.owner.lookup('service:current-domain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
+      sinon.stub(domainService, 'getExtension').returns('org');
 
       await setCurrentLocale('en');
 
@@ -105,7 +105,7 @@ module('Unit | Service | url-base', function (hooks) {
       const homeUrl = service.pixAppForgottenPasswordUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+      assert.strictEqual(homeUrl, 'https://app.pix.org/mot-de-passe-oublie?lang=en');
     });
   });
 

--- a/certif/app/services/url-base.js
+++ b/certif/app/services/url-base.js
@@ -30,7 +30,7 @@ export default class UrlBaseService extends Service {
   get pixAppForgottenPasswordUrl() {
     const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
     const currentLocale = this.locale.currentLocale;
-    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+    return this.currentDomain.isFranceDomain ? url : `${url}?lang=${currentLocale}`;
   }
 
   getPixWebsiteUrl(pathname = '') {

--- a/certif/tests/integration/components/login-test.gjs
+++ b/certif/tests/integration/components/login-test.gjs
@@ -114,9 +114,8 @@ module('Integration | Component | login', function (hooks) {
         errors: [{ status: '401', code: 'SHOULD_CHANGE_PASSWORD' }],
       },
     };
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
-
+    const currentDomainService = this.owner.lookup('service:current-domain');
+    sinon.stub(currentDomainService, 'getExtension').returns('fr');
     sessionStub.authenticate.callsFake(() => reject(errorResponse));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');

--- a/certif/tests/unit/services/url-base-test.js
+++ b/certif/tests/unit/services/url-base-test.js
@@ -97,7 +97,7 @@ module('Unit | Service | url-base', function (hooks) {
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
 
       const domainService = this.owner.lookup('service:current-domain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
+      sinon.stub(domainService, 'getExtension').returns('org');
 
       await setCurrentLocale('en');
 
@@ -105,7 +105,7 @@ module('Unit | Service | url-base', function (hooks) {
       const homeUrl = service.pixAppForgottenPasswordUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+      assert.strictEqual(homeUrl, 'https://app.pix.org/mot-de-passe-oublie?lang=en');
     });
   });
 

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -30,7 +30,7 @@ export default class UrlBaseService extends Service {
   get pixAppForgottenPasswordUrl() {
     const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
     const currentLocale = this.locale.currentLocale;
-    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+    return this.currentDomain.isFranceDomain ? url : `${url}?lang=${currentLocale}`;
   }
 
   getPixWebsiteUrl(pathname = '') {

--- a/mon-pix/tests/unit/services/url-base-test.js
+++ b/mon-pix/tests/unit/services/url-base-test.js
@@ -97,7 +97,7 @@ module('Unit | Service | url-base', function (hooks) {
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
 
       const domainService = this.owner.lookup('service:current-domain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
+      sinon.stub(domainService, 'getExtension').returns('org');
 
       await setCurrentLocale('en');
 
@@ -105,7 +105,7 @@ module('Unit | Service | url-base', function (hooks) {
       const homeUrl = service.pixAppForgottenPasswordUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+      assert.strictEqual(homeUrl, 'https://app.pix.org/mot-de-passe-oublie?lang=en');
     });
   });
 

--- a/orga/app/services/url-base.js
+++ b/orga/app/services/url-base.js
@@ -30,7 +30,7 @@ export default class UrlBaseService extends Service {
   get pixAppForgottenPasswordUrl() {
     const url = `${this.pixAppUrl}/mot-de-passe-oublie`;
     const currentLocale = this.locale.currentLocale;
-    return currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;
+    return this.currentDomain.isFranceDomain ? url : `${url}?lang=${currentLocale}`;
   }
 
   getPixWebsiteUrl(pathname = '') {

--- a/orga/tests/integration/components/auth/login-form-test.js
+++ b/orga/tests/integration/components/auth/login-form-test.js
@@ -195,7 +195,8 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
         errors: [{ status: '401', code: 'SHOULD_CHANGE_PASSWORD' }],
       },
     };
-
+    const currentDomainService = this.owner.lookup('service:current-domain');
+    sinon.stub(currentDomainService, 'getExtension').returns('fr');
     sinon.stub(sessionService, 'authenticate');
     sessionService.authenticate.rejects(errorResponse);
 
@@ -208,7 +209,7 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
     // then
     const expectedErrorMessage = t('pages.login-form.errors.should-change-password', {
-      url: 'https://app.pix.localhost/mot-de-passe-oublie',
+      url: 'https://app.pix.fr/mot-de-passe-oublie',
       htmlSafe: true,
     });
     assert

--- a/orga/tests/unit/services/url-base-test.js
+++ b/orga/tests/unit/services/url-base-test.js
@@ -97,7 +97,7 @@ module('Unit | Service | url-base', function (hooks) {
       sinon.stub(ENV, 'APP').value({ PIX_APP_URL_WITHOUT_EXTENSION: 'https://app.pix.' });
 
       const domainService = this.owner.lookup('service:current-domain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
+      sinon.stub(domainService, 'getExtension').returns('org');
 
       await setCurrentLocale('en');
 
@@ -105,7 +105,7 @@ module('Unit | Service | url-base', function (hooks) {
       const homeUrl = service.pixAppForgottenPasswordUrl;
 
       // then
-      assert.strictEqual(homeUrl, 'https://app.pix.fr/mot-de-passe-oublie?lang=en');
+      assert.strictEqual(homeUrl, 'https://app.pix.org/mot-de-passe-oublie?lang=en');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

Dans le url-base, il y a un souci avec pixAppForgottenPasswordUrl, qui se base sur la locale au lieu du domaine pour définir la langue du lien

## ⛱️ Proposition

Au lieu de currentLocale === 'fr' ? url : `${url}?lang=${currentLocale}`;

Faire this.currentDomain.isFranceDomain ? url : `${url}?lang=${currentLocale}`;

Se changement doit être appliqué dans TOUS les url-base des applications frontend.

## 🏄 Pour tester

- Verifier que pour chaque app, la bonne url est fournie en cas d'oublie de mot de passe lors du login
  - .`fr/mot-de-passe-oublie` pour une origine en `.fr`
  - `.org/mot-de-passe-oublie?lang=foo` pour origine `.org`
  - ⚠ Depuis pix-app, pas de slug `?lang=foo`

<img width="1732" height="865" alt="image" src="https://github.com/user-attachments/assets/85aca2ec-4490-4c29-93e5-c80984407086" />
<img width="1732" height="865" alt="image" src="https://github.com/user-attachments/assets/9435597f-d0ca-47e2-90b3-aaf60c16adb9" />

 