### PR TITLE
[FEATURE] Ajouter les titres de section dans le passage de module (PIX-19231)

### DIFF
--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -160,6 +160,10 @@ export default class ModuleGrain extends Component {
 
   @action
   focusAndScroll(htmlElement) {
+    if (!this.args.shouldFocusAndScroll) {
+      return;
+    }
+
     if (!this.args.hasJustAppeared) {
       return;
     }

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -9,6 +9,7 @@ import didInsert from '../../modifiers/modifier-did-insert';
 import ModuleGrain from './grain/grain';
 import BetaBanner from './layout/beta-banner';
 import ModuleNavbar from './layout/navbar';
+import ModuleSectionTitle from './section-title';
 
 export default class ModulePassage extends Component {
   @service router;
@@ -16,6 +17,27 @@ export default class ModulePassage extends Component {
   @service store;
   @service modulixAutoScroll;
   @service passageEvents;
+
+  get sectionsWithFirstGrain() {
+    return this.args.module.sections.map((section) => {
+      return {
+        firstGrainId: section.grains[0].id,
+        sectionType: section.type,
+      };
+    });
+  }
+
+  @action
+  getSectionTypeForGrain(grain) {
+    return this.sectionsWithFirstGrain.find((section) => section.firstGrainId === grain.id).sectionType;
+  }
+
+  @action
+  shouldDisplaySectionTitle(grain) {
+    return this.sectionsWithFirstGrain.some(
+      (section) => section.firstGrainId === grain.id && section.sectionType !== 'blank',
+    );
+  }
 
   get flatGrains() {
     return this.args.module.sections.flatMap((section) => section.grains);
@@ -231,6 +253,9 @@ export default class ModulePassage extends Component {
         {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
       >
         {{#each this.grainsToDisplay as |grain index|}}
+          {{#if (this.shouldDisplaySectionTitle grain)}}
+            <ModuleSectionTitle @sectionType={{this.getSectionTypeForGrain grain}} />
+          {{/if}}
           <ModuleGrain
             @grain={{grain}}
             @currentStep={{inc index}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -39,6 +39,11 @@ export default class ModulePassage extends Component {
     );
   }
 
+  @action
+  shouldFocusAndScrollToGrain(grain) {
+    return !this.shouldDisplaySectionTitle(grain);
+  }
+
   get flatGrains() {
     return this.args.module.sections.flatMap((section) => section.grains);
   }
@@ -246,6 +251,7 @@ export default class ModulePassage extends Component {
           {{/if}}
           <ModuleGrain
             @grain={{grain}}
+            @shouldFocusAndScroll={{this.shouldFocusAndScrollToGrain grain}}
             @currentStep={{inc index}}
             @totalSteps={{this.displayableGrains.length}}
             @onElementRetry={{this.onElementRetry}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -210,18 +210,6 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async goToGrain(grainId) {
-    const element = document.getElementById(`grain_${grainId}`);
-    this.modulixAutoScroll.focusAndScroll(element);
-
-    this.pixMetrics.trackEvent(`Click sur le grain ${grainId} de la barre de navigation`, {
-      disabled: true,
-      category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
-    });
-  }
-
-  @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -1,6 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -11,14 +10,7 @@ import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 import { notEq } from 'ember-truth-helpers';
 import ModulixGrain from 'mon-pix/components/module/grain/grain';
-
-const SECTION_TITLE_ICONS = {
-  'question-yourself': 'think',
-  'explore-to-understand': 'signpost',
-  'retain-the-essentials': 'doorOpen',
-  practise: 'mountain',
-  'go-further': 'lightBulb',
-};
+import ModulixSectionTitle from 'mon-pix/components/module/section-title';
 
 export default class ModulixPreview extends Component {
   @service store;
@@ -128,16 +120,6 @@ export default class ModulixPreview extends Component {
   }
 
   @action
-  sectionTitle(section) {
-    return this.intl.t(`pages.modulix.section.${section.type}`);
-  }
-
-  @action
-  sectionTitleIcon(section) {
-    return SECTION_TITLE_ICONS[section.type];
-  }
-
-  @action
   noop() {}
 
   @action
@@ -189,10 +171,7 @@ export default class ModulixPreview extends Component {
         <div class="module-preview-passage__content">
           {{#each this.formattedModule.sections as |section|}}
             {{#if (notEq section.type "blank")}}
-              <div class="module-preview-passage-content-section">
-                <PixIcon @name={{this.sectionTitleIcon section}} @ariaHidden={{true}} />
-                <h2>{{this.sectionTitle section}}</h2>
-              </div>
+              <ModulixSectionTitle @sectionType={{section.type}} />
             {{/if}}
             {{#each section.grains as |grain|}}
               <ModulixGrain

--- a/mon-pix/app/components/module/section-title.gjs
+++ b/mon-pix/app/components/module/section-title.gjs
@@ -1,0 +1,33 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+const SECTION_TITLE_ICONS = {
+  'question-yourself': 'think',
+  'explore-to-understand': 'signpost',
+  'retain-the-essentials': 'doorOpen',
+  practise: 'mountain',
+  'go-further': 'lightBulb',
+};
+
+export default class ModuleSectionTitle extends Component {
+  @service intl;
+
+  @action
+  sectionTitle(type) {
+    return this.intl.t(`pages.modulix.section.${type}`);
+  }
+
+  @action
+  sectionTitleIcon(type) {
+    return SECTION_TITLE_ICONS[type];
+  }
+
+  <template>
+    <div class="module-preview-passage-content-section">
+      <PixIcon @name={{this.sectionTitleIcon @sectionType}} @ariaHidden={{true}} />
+      <h2>{{this.sectionTitle @sectionType}}</h2>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/section-title.gjs
+++ b/mon-pix/app/components/module/section-title.gjs
@@ -4,11 +4,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 const SECTION_TITLE_ICONS = {
-  'question-yourself': 'think',
+  'question-yourself': 'doorOpen',
   'explore-to-understand': 'signpost',
-  'retain-the-essentials': 'doorOpen',
-  practise: 'mountain',
-  'go-further': 'lightBulb',
+  'retain-the-essentials': 'lightBulb',
+  practise: 'think',
+  'go-further': 'mountain',
 };
 
 export default class ModuleSectionTitle extends Component {

--- a/mon-pix/app/components/module/section-title.gjs
+++ b/mon-pix/app/components/module/section-title.gjs
@@ -2,6 +2,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 const SECTION_TITLE_ICONS = {
   'question-yourself': 'doorOpen',
@@ -13,6 +14,7 @@ const SECTION_TITLE_ICONS = {
 
 export default class ModuleSectionTitle extends Component {
   @service intl;
+  @service modulixAutoScroll;
 
   @action
   sectionTitle(type) {
@@ -24,8 +26,13 @@ export default class ModuleSectionTitle extends Component {
     return SECTION_TITLE_ICONS[type];
   }
 
+  @action
+  focusAndScroll(htmlElement) {
+    this.modulixAutoScroll.focusAndScroll(htmlElement);
+  }
+
   <template>
-    <div class="module-preview-passage-content-section">
+    <div class="module-preview-passage-content-section" {{didInsert this.focusAndScroll}}>
       <PixIcon @name={{this.sectionTitleIcon @sectionType}} @ariaHidden={{true}} />
       <h2>{{this.sectionTitle @sectionType}}</h2>
     </div>

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -27,10 +27,12 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
 
       const section = server.create('section', {
         id: 'sectionId-1',
-        grains: {
-          id: 'grain1',
-          components: [{ type: 'element', element: text }],
-        },
+        grains: [
+          {
+            id: 'grain1',
+            components: [{ type: 'element', element: text }],
+          },
+        ],
       });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -239,7 +239,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       };
       const section = store.createRecord('section', {
         id: 'section1',
-        type: 'blank',
+        type: 'practise',
         grains: [
           { components: [{ type: 'element', element: textElement }] },
           { components: [{ type: 'element', element: qcuElement }] },
@@ -254,6 +254,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       // then
       assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+      assert.dom(screen.getByRole('heading', { name: 'S’exercer', level: 2 })).exists();
       assert.strictEqual(findAll('.element-text').length, 1);
       assert.strictEqual(findAll('.element-qcu').length, 0);
 

--- a/mon-pix/tests/integration/components/module/section-title_test.gjs
+++ b/mon-pix/tests/integration/components/module/section-title_test.gjs
@@ -1,0 +1,20 @@
+import { render } from '@1024pix/ember-testing-library';
+import ModuleSectionTitle from 'mon-pix/components/module/section-title';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Section title', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a section title', async function (assert) {
+    // given
+    const sectionType = 'practise';
+
+    // when
+    const screen = await render(<template><ModuleSectionTitle @sectionType={{sectionType}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'S’exercer', level: 2 })).exists();
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Les titres de section ne sont pas affichés.

## ⛱️ Proposition

Afficher le titre de section en même temps que le premier grain qu’il contient

## 🌊 Remarques

- Les icones ont été mises à jour
- On a ajusté le focus and scroll pour qu'il prenne en compte le titre mais on n'a pas su tester
- On a supprimé au passage une méthode `goToGrain`qui servait pour la barre navigation et qui n'était plus utilisé

## 🏄 Pour tester

- Se rendre sur le [module bac à sable](https://app-pr13319.review.pix.fr/modules/bac-a-sable/passage)
- Constater que les titres de section apparaissent au-dessus du premier grain et que le scroll est positionné dessus
