### PR TITLE
[TECH] Récupérer les challenges actifs pour la création des référentiels cadres (PIX -19274)

### DIFF
--- a/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
+++ b/api/src/certification/configuration/domain/usecases/create-consolidated-framework.js
@@ -31,7 +31,7 @@ export const createConsolidatedFramework = async ({
   const skillIds = tubes.flatMap((tube) => tube.skillIds);
   const skills = await skillRepository.findActiveByRecordIds(skillIds);
 
-  const challenges = await challengeRepository.findOperativeBySkills(skills, FRENCH_FRANCE);
+  const challenges = await challengeRepository.findValidatedBySkills(skills, FRENCH_FRANCE);
 
   return consolidatedFrameworkRepository.create({
     complementaryCertificationKey,

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -104,6 +104,21 @@ export async function findOperativeBySkills(skills, locale) {
   return challengesDtosWithSkills.map(([challengeDto, skill]) => toDomain({ challengeDto, skill }));
 }
 
+export async function findValidatedBySkills(skills, locale) {
+  _assertLocaleIsDefined(locale);
+  const skillIds = skills.map((skill) => skill.id);
+  const cacheKey = `findOperativeBySkillIds([${skillIds.sort()}], ${locale})`;
+  const findOperativeByLocaleBySkillIdsCallback = (knex) =>
+    knex
+      .whereRaw('?=ANY(??)', [locale, 'locales'])
+      .where('status', VALIDATED_STATUS)
+      .whereIn('skillId', skillIds)
+      .orderBy('id');
+  const challengeDtos = await getInstance().find(cacheKey, findOperativeByLocaleBySkillIdsCallback);
+  const challengesDtosWithSkills = await loadChallengeDtosSkills(challengeDtos);
+  return challengesDtosWithSkills.map(([challengeDto, skill]) => toDomain({ challengeDto, skill }));
+}
+
 export async function findActiveFlashCompatible({
   date,
   locale,

--- a/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-consolidated-framework_test.js
@@ -14,7 +14,7 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
       findActiveByRecordIds: sinon.stub(),
     };
     challengeRepository = {
-      findOperativeBySkills: sinon.stub(),
+      findValidatedBySkills: sinon.stub(),
     };
     consolidatedFrameworkRepository = {
       create: sinon.stub(),
@@ -43,7 +43,7 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
 
     tubeRepository.findActiveByRecordIds.resolves([tube1, tube2]);
     skillRepository.findActiveByRecordIds.resolves([...tube1.skills, ...tube2.skills]);
-    challengeRepository.findOperativeBySkills.resolves(frFrChallenges);
+    challengeRepository.findValidatedBySkills.resolves(frFrChallenges);
     consolidatedFrameworkRepository.create.resolves();
     sinon.useFakeTimers({ now: new Date('2019-01-01T05:06:07Z'), toFake: ['Date'] });
     const version = '20190101050607';
@@ -64,7 +64,7 @@ describe('Certification | Configuration | Unit | UseCase | create-consolidated-f
       ...tube1.skillIds,
       ...tube2.skillIds,
     ]);
-    expect(challengeRepository.findOperativeBySkills).to.have.been.calledOnceWithExactly(
+    expect(challengeRepository.findValidatedBySkills).to.have.been.calledOnceWithExactly(
       [...tube1.skills, ...tube2.skills],
       FRENCH_FRANCE,
     );

--- a/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
+++ b/api/tests/integration/scripts/certification/target-profile-to-calibrated-framework_test.js
@@ -14,7 +14,10 @@ describe('Integration | Scripts | Certification | target-profile-to-calibrated-f
     const learningContent = {
       tubes: [{ id: 'tube1', skillIds: ['skill1'] }],
       skills: [{ id: 'skill1', status: 'actif', tubeId: 'tube1' }],
-      challenges: [{ id: 'challenge1', skillId: 'skill1', locales: ['fr-fr'] }],
+      challenges: [
+        { id: 'challenge1', skillId: 'skill1', locales: ['fr-fr'], status: 'validé' },
+        { id: 'challenge2', skillId: 'skill1', locales: ['fr-fr'], status: 'archivé' },
+      ],
     };
     await mockLearningContent(learningContent);
 

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1500,6 +1500,204 @@ describe('Integration | Repository | challenge-repository', function () {
     });
   });
 
+  describe('#findValidatedBySkills', function () {
+    context('when locale is not defined', function () {
+      it('should throw an Error', async function () {
+        // when
+        const err = await catchErr(challengeRepository.findValidatedBySkills)(domainBuilder.buildSkill());
+
+        // then
+        expect(err.message).to.equal('Locale shall be defined');
+      });
+    });
+
+    context('when locale is defined', function () {
+      context('when no operative challenges found for given locale', function () {
+        it('should return an empty array', async function () {
+          // given
+          const skill00 = domainBuilder.buildSkill({
+            ...skillData00_tube00competence00_actif,
+            difficulty: skillData00_tube00competence00_actif.level,
+            hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+          });
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills([skill00], 'catalan');
+
+          // then
+          expect(challenges).to.deep.equal([]);
+        });
+      });
+
+      context('when operative challenges are found for given locale', function () {
+        it('should return the challenges', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+
+        it('should avoid duplicates', async function () {
+          // given
+          const skills = [
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData02_tube02competence01_perime,
+              difficulty: skillData02_tube02competence01_perime.level,
+              hint: skillData02_tube02competence01_perime.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData01_tube01competence00_actif,
+              difficulty: skillData01_tube01competence00_actif.level,
+              hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+            }),
+            domainBuilder.buildSkill({
+              ...skillData00_tube00competence00_actif,
+              difficulty: skillData00_tube00competence00_actif.level,
+              hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+            }),
+          ];
+
+          // when
+          const challenges = await challengeRepository.findValidatedBySkills(skills, 'en');
+
+          // then
+          expect(challenges).to.deep.equal([
+            domainBuilder.buildChallenge({
+              ...challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson,
+              blindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.accessibility2,
+              focused: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.focusable,
+              discriminant: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.alpha,
+              difficulty: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.id,
+                  type: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.type,
+                  value: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.solution,
+                  isT1Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t1Status,
+                  isT2Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t2Status,
+                  isT3Enabled: challengeData01_skill00_qcu_valide_flashCompatible_fren_withEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData00_tube00competence00_actif,
+                difficulty: skillData00_tube00competence00_actif.level,
+                hint: skillData00_tube00competence00_actif.hint_i18n.fr,
+              }),
+            }),
+            domainBuilder.buildChallenge({
+              ...challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson,
+              blindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility1,
+              colorBlindnessCompatibility:
+                challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.accessibility2,
+              focused: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.focusable,
+              discriminant: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.alpha,
+              difficulty: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.delta,
+              validator: new ValidatorQCU({
+                solution: domainBuilder.buildSolution({
+                  id: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.id,
+                  type: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.type,
+                  value: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.solution,
+                  isT1Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t1Status,
+                  isT2Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t2Status,
+                  isT3Enabled: challengeData04_skill01_qcu_valide_flashCompatible_ennl_noEmbedJson.t3Status,
+                  qrocBlocksTypes: {},
+                }),
+              }),
+              skill: domainBuilder.buildSkill({
+                ...skillData01_tube01competence00_actif,
+                difficulty: skillData01_tube01competence00_actif.level,
+                hint: skillData01_tube01competence00_actif.hint_i18n.fr,
+              }),
+            }),
+          ]);
+        });
+      });
+    });
+  });
+
   describe('#findActiveFlashCompatible', function () {
     let defaultSuccessProbabilityThreshold;
     let skillsLC = [];


### PR DESCRIPTION
## 🔆 Problème

La fonction utilisée  actuellement pour créer les référentiels cadres, findOperativeBySkills, remonte les challenges aux statut archivés et validés, or,  nous ne voulons remonter que des challenges valides.

## ⛱️ Proposition

Créer une seconde fonction findValidatedBySkills  ne remontant que les challenges au statut validé.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Créer un référentiel cadre dans Pix Admin et vérifier que tous les challenges ajoutés sont au statut validé (et aucun n'est archivé)
