### PR TITLE
[TECH]  rendre le nom de l'évènement obligatoire dans la fonction trackEvent de pixMetrics (PIX-19276)

### DIFF
--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -153,11 +153,10 @@ export default class ParticipationFilters extends Component {
   onSelectBadge(badges) {
     this.args.onFilter('badges', badges);
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
+    this.pixMetrics.trackEvent('Usage du filtre par Badges', {
+      disabled: true,
       'pix-event-category': 'Campagnes',
       'pix-event-action': 'Filtrer les participations',
-      'pix-event-name': 'Usage du filtre par Badges',
     });
   }
 
@@ -165,11 +164,10 @@ export default class ParticipationFilters extends Component {
   onSelectUnacquiredBadge(unacquiredBadges) {
     this.args.onFilter('unacquiredBadges', unacquiredBadges);
 
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
+    this.pixMetrics.trackEvent('Utilisation du filtre "Badges non obtenus"', {
+      disabled: true,
       'pix-event-category': 'Campagnes',
       'pix-event-action': 'Filtrer les participations',
-      'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
     });
   }
 

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -25,12 +25,7 @@ export default class CampaignTabs extends Component {
     try {
       const token = this.session.data.authenticated.access_token;
       await this.fileSaver.save({ url: this.args.campaign.urlToResult, token });
-      this.pixMetrics.trackEvent({
-        event: 'custom-event',
-        'pix-event-category': 'Campagnes',
-        'pix-event-action': "Cliquer sur le bouton d'export des résultats d'une campagne",
-        'pix-event-name': "Clic sur le bouton d'export",
-      });
+      this.pixMetrics.trackEvent('exportCampaignResultClic');
     } catch {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
     }

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -67,11 +67,10 @@ export default class AuthenticatedAttestationsController extends Controller {
   }
 
   sendMetrics() {
-    this.pixMetrics.trackEvent({
-      event: 'custom-event',
+    this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestations)', {
+      disabled: true,
       'pix-event-category': 'Attestations',
       'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
-      'pix-event-name': 'Clic sur le bouton Télécharger (attestations)',
     });
   }
 }

--- a/orga/app/services/pix-metrics.js
+++ b/orga/app/services/pix-metrics.js
@@ -4,7 +4,8 @@ export default class PixMetricsService extends Service {
   @service metrics;
   @service router;
 
-  trackEvent({ event: _, 'pix-event-name': eventName, ...props }) {
+  trackEvent(eventName, { disabled, ...props }) {
+    if (disabled) return;
     const url = this.getRedactedPageUrl();
     this.metrics.trackEvent({ eventName, plausibleAttributes: { u: url }, ...props });
   }
@@ -17,14 +18,17 @@ export default class PixMetricsService extends Service {
   getRedactedPageUrl() {
     const params = extractParamsFromRouteInfo(this.router.currentRoute);
     const currentUrl = this.router.currentURL;
+    if (!currentUrl) return null;
+
     const [base, queryParams] = currentUrl.split('?');
+    if (!base) return null;
+
     const redactedUrl = base
       .split('/')
       .map((token) => {
         return params.includes(token) ? '_ID_' : token;
       })
       .join('/');
-
     const baseUrl = new URL(window.location).origin;
     return queryParams ? `${baseUrl}${redactedUrl}?${queryParams}` : `${baseUrl}${redactedUrl}`;
   }

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -581,11 +581,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         // then
         assert.ok(triggerFiltering.calledWith('unacquiredBadges', ['badge1']));
 
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
+        sinon.assert.calledWithExactly(metrics.trackEvent, 'Utilisation du filtre "Badges non obtenus"', {
+          disabled: true,
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
         });
       });
 
@@ -627,11 +626,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         // then
         assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
 
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
+        sinon.assert.calledWithExactly(metrics.trackEvent, 'Usage du filtre par Badges', {
+          disabled: true,
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Usage du filtre par Badges',
         });
       });
     });
@@ -741,11 +739,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         // then
         assert.ok(triggerFiltering.calledWith('unacquiredBadges', ['badge1']));
 
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
+        sinon.assert.calledWithExactly(metrics.trackEvent, 'Utilisation du filtre "Badges non obtenus"', {
+          disabled: true,
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Utilisation du filtre "Badges non obtenus"',
         });
       });
 
@@ -787,11 +784,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         // then
         assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
 
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
+        sinon.assert.calledWithExactly(metrics.trackEvent, 'Usage du filtre par Badges', {
+          disabled: true,
           'pix-event-category': 'Campagnes',
           'pix-event-action': 'Filtrer les participations',
-          'pix-event-name': 'Usage du filtre par Badges',
         });
       });
     });

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -188,12 +188,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
       // when
       await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
 
-      sinon.assert.calledWithExactly(pixMetrics.trackEvent, {
-        event: 'custom-event',
-        'pix-event-category': 'Campagnes',
-        'pix-event-action': "Cliquer sur le bouton d'export des résultats d'une campagne",
-        'pix-event-name': "Clic sur le bouton d'export",
-      });
+      sinon.assert.calledWithExactly(pixMetrics.trackEvent, 'exportCampaignResultClic');
       assert.ok(true);
     });
 

--- a/orga/tests/unit/controllers/authenticated/attestations-test.js
+++ b/orga/tests/unit/controllers/authenticated/attestations-test.js
@@ -67,11 +67,10 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
         //when
         await controller.downloadAttestations(SIXTH_GRADE_ATTESTATION_KEY, selectedDivision);
 
-        sinon.assert.calledWithExactly(metrics.trackEvent, {
-          event: 'custom-event',
+        sinon.assert.calledWithExactly(metrics.trackEvent, 'Clic sur le bouton Télécharger (attestations)', {
+          disabled: true,
           'pix-event-category': 'Attestations',
           'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
-          'pix-event-name': 'Clic sur le bouton Télécharger (attestations)',
         });
         assert.ok(true);
       });

--- a/orga/tests/unit/services/pix-metrics-test.js
+++ b/orga/tests/unit/services/pix-metrics-test.js
@@ -111,7 +111,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       sinon.stub(routerService, 'currentURL').value(currentURL);
 
       // when
-      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
@@ -145,7 +145,7 @@ module('Unit | Service | PixMetrics', function (hooks) {
       sinon.stub(routerService, 'currentURL').value(currentURL);
 
       // when
-      pixMetricsService.trackEvent({ 'pix-event-name': 'mon-event', params: 1 });
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
 
       // then
       sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {


### PR DESCRIPTION
## 🔆 Problème

le service pix-metrics d'orga diverge de celui de mon-pix

## ⛱️ Proposition

modifier le service d'orga pour qu'il fonctionne comme celui de mon-pix

## 🌊 Remarques

On a desactivé tout les évènement par défaut sauf l'export de résultat

## 🏄 Pour tester

Aller sur orga et vérifier que l'export de résultat remonté bien dans plausible