### PR TITLE
[FEATURE] Ajouter le mode horizontal du stepper (PIX-19272)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -128,7 +128,7 @@
           ]
         },
         {
-          "id": "005b3848-5cad-49fb-876b-1cc430854d71",
+          "id": "1dc50ca6-355c-4d7f-941b-608788faa4db",
           "type": "lesson",
           "title": "Exemple de stepper leçon",
           "components": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -30,6 +30,150 @@
               }
             }
           ]
+        },
+        {
+          "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
+          "type": "activity",
+          "title": "Voici un vrai-faux",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
+                      "type": "qcu",
+                      "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
+                      "type": "qcu",
+                      "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Bien vu !</p>"
+                          }
+                        }
+                      ],
+                      "solution": "2"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
+                      "type": "qcu",
+                      "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "Vrai",
+                          "feedback": {
+                            "state": "Correct&#8239;!",
+                            "diagnosis": "<p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
+                          }
+                        },
+                        {
+                          "id": "2",
+                          "content": "Faux",
+                          "feedback": {
+                            "state": "Incorrect.",
+                            "diagnosis": "<p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
+                          }
+                        }
+                      ],
+                      "solution": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "005b3848-5cad-49fb-876b-1cc430854d71",
+          "type": "lesson",
+          "title": "Exemple de stepper leçon",
+          "components": [
+            {
+              "type": "stepper",
+              "steps": [
+                {
+                  "elements": [
+                    {
+                      "id": "868a2c39-d70b-45ba-847d-76d11a83a6fd",
+                      "type": "text",
+                      "content": "<p>Pour apprendre à une IA générative à produire du texte, on lui fait analyser des milliards de textes variés. 📚</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "3875f579-e152-4309-a630-cd91196381f5",
+                      "type": "text",
+                      "content": "<p>L’IA générative s’entraîne à masquer puis&nbsp;deviner&nbsp;des mots au hasard parmi tous ces textes. 🙈</p><p>Petit à petit elle s'améliore&nbsp;: elle apprend quels mots apparaissent&nbsp;souvent&nbsp;ensemble. 🐈 🐁</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7b58e24b-b751-4000-b3b6-554e548b9dd9",
+                      "type": "text",
+                      "content": "<p>Ainsi à partir d'un début de phrase, l'IA générative&nbsp;prédit le mot suivant&nbsp;📝.<br>Puis elle recommence depuis le début de la phrase pour trouver le mot qui suit.<br>Et ... elle recommence encore et encore ! 🔁</p>"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "1687e720-8346-4821-b60a-79937bdda1cb",
+                      "type": "text",
+                      "content": "<p>À la fin de cette étape, l'IA générative est capable de prolonger ou compléter des débuts de texte. 😮</p>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -671,102 +815,6 @@
                 "type": "text",
                 "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
               }
-            }
-          ]
-        },
-        {
-          "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
-          "type": "activity",
-          "title": "Voici un vrai-faux",
-          "components": [
-            {
-              "type": "stepper",
-              "steps": [
-                {
-                  "elements": [
-                    {
-                      "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
-                      "type": "qcu",
-                      "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
-                      "proposals": [
-                        {
-                          "id": "1",
-                          "content": "Vrai",
-                          "feedback": {
-                            "state": "Correct&#8239;!",
-                            "diagnosis": "<p> Ces 16 compétences sont rangées dans 5 domaines.</p>"
-                          }
-                        },
-                        {
-                          "id": "2",
-                          "content": "Faux",
-                          "feedback": {
-                            "state": "Incorrect.",
-                            "diagnosis": "<p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
-                          }
-                        }
-                      ],
-                      "solution": "1"
-                    }
-                  ]
-                },
-                {
-                  "elements": [
-                    {
-                      "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
-                      "type": "qcu",
-                      "instruction": "<p>Pix est découpé en 6 domaines.</p>",
-                      "proposals": [
-                        {
-                          "id": "1",
-                          "content": "Vrai",
-                          "feedback": {
-                            "state": "Incorrect.",
-                            "diagnosis": "<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
-                          }
-                        },
-                        {
-                          "id": "2",
-                          "content": "Faux",
-                          "feedback": {
-                            "state": "Correct&#8239;!",
-                            "diagnosis": "<p> Bien vu !</p>"
-                          }
-                        }
-                      ],
-                      "solution": "2"
-                    }
-                  ]
-                },
-                {
-                  "elements": [
-                    {
-                      "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
-                      "type": "qcu",
-                      "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
-                      "proposals": [
-                        {
-                          "id": "1",
-                          "content": "Vrai",
-                          "feedback": {
-                            "state": "Correct&#8239;!",
-                            "diagnosis": "<p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
-                          }
-                        },
-                        {
-                          "id": "2",
-                          "content": "Faux",
-                          "feedback": {
-                            "state": "Incorrect.",
-                            "diagnosis": "<p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
-                          }
-                        }
-                      ],
-                      "solution": "1"
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 @use '../passage';
 
 .stepper--horizontal {
@@ -7,7 +8,7 @@
   gap: 8px;
 
   .stepper__step {
-    --previous-slide-visible-width: 100px;
+    --previous-slide-visible-width: 10px;
 
     grid-row: 1 / 1;
     grid-column: 1 / 1;
@@ -95,4 +96,20 @@
   justify-self: start;
   width: fit-content;
   min-width: 140px;
+}
+
+@include breakpoints.device-is('tablet') {
+  .stepper--horizontal {
+    .stepper__step {
+      --previous-slide-visible-width: 20px;
+    }
+  }
+}
+
+@include breakpoints.device-is('desktop') {
+  .stepper--horizontal {
+    .stepper__step {
+      --previous-slide-visible-width: 100px;
+    }
+  }
 }

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -1,25 +1,80 @@
 @use 'pix-design-tokens/typography';
 @use '../passage';
 
-.stepper {
+.stepper--horizontal {
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: 8px;
+
+  .stepper__step {
+    --previous-slide-visible-width: 100px;
+
+    grid-row: 1 / 1;
+    grid-column: 1 / 1;
+    align-items: center;
+    padding: var(--pix-spacing-4x);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: 8px;
+
+    &:not(.stepper-step__active) {
+      position: relative;
+      transform: translateX(calc((-50vw - 50%) + var(--previous-slide-visible-width)));
+      pointer-events: none;
+
+      &::after {
+        position: absolute;
+        top: 50%;
+        left: calc(100% + 4px);
+        width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
+        border-bottom: 1px solid var(--pix-neutral-500);
+        opacity: 0.3;
+        content: '';
+      }
+    }
+
+    &.stepper-step__active:not(.stepper-step--last-step) {
+      position: relative;
+
+      &::after {
+        position: absolute;
+        top: 50%;
+        left: calc(100% + 4px);
+        width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
+        border-bottom: 1px solid var(--pix-neutral-500);
+        opacity: 0.3;
+        content: '';
+      }
+
+      &::before {
+        position: absolute;
+        top: 0;
+        left: calc((50vw + 50%) - var(--previous-slide-visible-width));
+        width: 100%;
+        height: 100%;
+        border: 1px solid var(--pix-neutral-100);
+        border-radius: 8px;
+        content: '';
+      }
+    }
+  }
+}
+
+.stepper--vertical {
   display: flex;
   flex-direction: column;
 
-  &__step {
+  /* stylelint-disable-next-line no-descending-specificity */
+  .stepper__step {
     margin-bottom: var(--pix-spacing-6x);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
 
     &--active {
       @extend .auto-scroll;
 
       outline: none;
-    }
-
-    &--disabled {
-      pointer-events: none;
-    }
-
-    &:last-child {
-      margin-bottom: 0;
     }
 
     &__position {
@@ -34,9 +89,10 @@
       border-radius: var(--modulix-radius-l);
     }
   }
+}
 
-  &__next-button {
-    width: fit-content;
-    min-width: 140px;
-  }
+.stepper__next-button {
+  justify-self: start;
+  width: fit-content;
+  min-width: 140px;
 }

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -14,6 +14,10 @@
       outline: none;
     }
 
+    &--disabled {
+      pointer-events: none;
+    }
+
     &:last-child {
       margin-bottom: 0;
     }

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -18,6 +18,10 @@ export default class ModulixStep extends Component {
     return this.displayableElements.length > 0;
   }
 
+  get isLastStep() {
+    return this.args.currentStep === this.args.totalSteps;
+  }
+
   @action
   focusAndScroll(htmlElement) {
     if (!this.args.hasJustAppeared) {
@@ -29,7 +33,14 @@ export default class ModulixStep extends Component {
 
   <template>
     {{#if this.hasDisplayableElements}}
-      <section class="stepper__step" tabindex="-1" {{didInsert this.focusAndScroll}} inert={{@isDisabled}}>
+      <section
+        class="stepper__step
+          {{if @hasJustAppeared 'stepper-step__active'}}
+          {{if this.isLastStep 'stepper-step--last-step'}}"
+        tabindex="-1"
+        {{didInsert this.focusAndScroll}}
+        inert={{unless @hasJustAppeared true}}
+      >
         <h3 class="stepper__step__position screen-reader-only">
           {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}
         </h3>

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -30,11 +30,8 @@ export default class ModulixStep extends Component {
   <template>
     {{#if this.hasDisplayableElements}}
       <section class="stepper__step" tabindex="-1" {{didInsert this.focusAndScroll}}>
-        <h3
-          class="stepper__step__position"
-          aria-label="{{t 'pages.modulix.stepper.step.position' currentStep=@currentStep totalSteps=@totalSteps}}"
-        >
-          {{@currentStep}}/{{@totalSteps}}
+        <h3 class="stepper__step__position screen-reader-only">
+          {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}
         </h3>
         {{#each this.displayableElements as |element|}}
           <div class="grain-card-content__element">

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -29,7 +29,7 @@ export default class ModulixStep extends Component {
 
   <template>
     {{#if this.hasDisplayableElements}}
-      <section class="stepper__step" tabindex="-1" {{didInsert this.focusAndScroll}}>
+      <section class="stepper__step" tabindex="-1" {{didInsert this.focusAndScroll}} inert={{@isDisabled}}>
         <h3 class="stepper__step__position screen-reader-only">
           {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}
         </h3>

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -26,10 +26,6 @@ export default class ModulixStepper extends Component {
 
   @action
   hasStepJustAppeared(index) {
-    if (this.stepsToDisplay.length === 1) {
-      return false;
-    }
-
     return this.stepsToDisplay.length - 1 === index;
   }
 
@@ -94,7 +90,6 @@ export default class ModulixStepper extends Component {
             @onVideoPlay={{@onVideoPlay}}
             @onFileDownload={{@onFileDownload}}
             @onExpandToggle={{@onExpandToggle}}
-            @isDisabled={{false}}
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -75,7 +75,7 @@ export default class ModulixStepper extends Component {
 
   <template>
     <div
-      class="stepper"
+      class="stepper stepper--{{@direction}}"
       aria-live="assertive"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
@@ -94,6 +94,7 @@ export default class ModulixStepper extends Component {
             @onVideoPlay={{@onVideoPlay}}
             @onFileDownload={{@onFileDownload}}
             @onExpandToggle={{@onExpandToggle}}
+            @isDisabled={{false}}
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -42,6 +42,13 @@ export default class ModuleGrain extends Component {
 
   @tracked isStepperFinished = this.hasStepper === false;
 
+  get stepperDirection() {
+    if(['challenge', 'activity', 'discovery'].includes(this.grainType)) {
+      return "horizontal";
+    }
+    return 'vertical';
+  }
+
   get hasStepper() {
     return this.args.grain.components.some((component) => component.type === 'stepper');
   }
@@ -290,6 +297,7 @@ export default class ModuleGrain extends Component {
                   @onVideoPlay={{@onVideoPlay}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
+                  @direction={{this.stepperDirection}}
                 />
               </div>
             {{/if}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -43,8 +43,8 @@ export default class ModuleGrain extends Component {
   @tracked isStepperFinished = this.hasStepper === false;
 
   get stepperDirection() {
-    if(['challenge', 'activity', 'discovery'].includes(this.grainType)) {
-      return "horizontal";
+    if (['challenge', 'activity', 'discovery'].includes(this.grainType)) {
+      return 'horizontal';
     }
     return 'vertical';
   }

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -11,6 +11,7 @@
   --modulix-z-index-above-all: 10;
 
   flex-grow: 1;
+  overflow-x: hidden;
   color: var(--pix-neutral-900);
   background: var(--pix-neutral-0);
 }

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1,5 +1,6 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import { click, find, findAll } from "@ember/test-helpers";
+// eslint-disable-next-line no-restricted-imports
+import { click, find, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
@@ -684,8 +685,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when grain contains a stepper', function () {
-    module('when grain is type activity', function() {
-      test('it should set direction param to horizontal', async function(assert) {
+    module('when grain is type activity', function () {
+      test('it should set direction param to horizontal', async function (assert) {
         // given
         const textElement = {
           content: 'element content',
@@ -705,8 +706,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('when grain is type discovery', function() {
-      test('it should set direction param to horizontal', async function(assert) {
+    module('when grain is type discovery', function () {
+      test('it should set direction param to horizontal', async function (assert) {
         // given
         const textElement = {
           content: 'element content',
@@ -726,8 +727,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('when grain is type challenge', function() {
-      test('it should set direction param to horizontal', async function(assert) {
+    module('when grain is type challenge', function () {
+      test('it should set direction param to horizontal', async function (assert) {
         // given
         const textElement = {
           content: 'element content',
@@ -747,8 +748,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('when grain is type lesson', function() {
-      test('it should set direction param to vertical', async function(assert) {
+    module('when grain is type lesson', function () {
+      test('it should set direction param to vertical', async function (assert) {
         // given
         const textElement = {
           content: 'element content',
@@ -768,8 +769,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('when grain is type summary', function() {
-      test('it should set direction param to vertical', async function(assert) {
+    module('when grain is type summary', function () {
+      test('it should set direction param to vertical', async function (assert) {
         // given
         const textElement = {
           content: 'element content',
@@ -789,8 +790,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('when grain is type transition', function() {
-      test('it should set direction param to vertical', async function(assert) {
+    module('when grain is type transition', function () {
+      test('it should set direction param to vertical', async function (assert) {
         // given
         const textElement = {
           content: 'element content',

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1,5 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-import { click, findAll } from '@ember/test-helpers';
+import { click, find, findAll } from "@ember/test-helpers";
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
@@ -684,6 +684,132 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when grain contains a stepper', function () {
+    module('when grain is type activity', function() {
+      test('it should set direction param to horizontal', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'activity',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--horizontal')).exists();
+      });
+    });
+
+    module('when grain is type discovery', function() {
+      test('it should set direction param to horizontal', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'discovery',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--horizontal')).exists();
+      });
+    });
+
+    module('when grain is type challenge', function() {
+      test('it should set direction param to horizontal', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'challenge',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--horizontal')).exists();
+      });
+    });
+
+    module('when grain is type lesson', function() {
+      test('it should set direction param to vertical', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'lesson',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--vertical')).exists();
+      });
+    });
+
+    module('when grain is type summary', function() {
+      test('it should set direction param to vertical', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'summary',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--vertical')).exists();
+      });
+    });
+
+    module('when grain is type transition', function() {
+      test('it should set direction param to vertical', async function(assert) {
+        // given
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = {
+          type: 'transition',
+          components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom(find('.stepper--vertical')).exists();
+      });
+    });
+
     test('should display the stepper', async function (assert) {
       // given
       const textElement = {

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -58,7 +58,7 @@ module('Integration | Component | Module | Step', function (hooks) {
       assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
     });
 
-    module('when isDisabled attribute is true', function () {
+    module('when hasJustAppeared attribute is false', function () {
       test('should disabled all interactions in the step', async function (assert) {
         // given
         const element = {
@@ -75,7 +75,7 @@ module('Integration | Component | Module | Step', function (hooks) {
         await render(
           <template>
             <ModulixStep
-              @isDisabled={{true}}
+              @hasJustAppeared={{false}}
               @step={{step}}
               @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
             />

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -1,4 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
+// eslint-disable-next-line no-restricted-imports
+import { find } from '@ember/test-helpers';
 import ModulixStep from 'mon-pix/components/module/component/step';
 import { module, test } from 'qunit';
 
@@ -54,6 +56,35 @@ module('Integration | Component | Module | Step', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
+    });
+
+    module('when isDisabled attribute is true', function () {
+      test('should disabled all interactions in the step', async function (assert) {
+        // given
+        const element = {
+          id: 'd0690f26-978c-41c3-9a21-da931857739c',
+          content: '<button type="button">Mon bouton</button>',
+          type: 'text',
+        };
+        const step = {
+          elements: [element],
+        };
+        const getLastCorrectionForElementStub = () => {};
+
+        // when
+        await render(
+          <template>
+            <ModulixStep
+              @isDisabled={{true}}
+              @step={{step}}
+              @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(find('.stepper__step[inert]')).exists();
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1,6 +1,6 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
+import { click, find } from "@ember/test-helpers";
 import { t } from 'ember-intl/test-support';
 import ModulixStepper from 'mon-pix/components/module/component/stepper';
 import { module, test } from 'qunit';
@@ -13,6 +13,36 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
   module('When stepper is vertical', function () {
     module('A Stepper with 2 steps', function () {
+      test('it should set vertical class', async function(assert) {
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
+
+
+        // then
+        assert.dom(find('.stepper--vertical')).exists();
+      });
+
       test('should display the first step with the button Next', async function (assert) {
         // given
         const steps = [
@@ -633,6 +663,36 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
   module('When stepper is horizontal', function () {
     module('A Stepper with 2 steps', function () {
+      test('it should set horizontal class', async function(assert) {
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+
+        // then
+        assert.dom(find('.stepper--horizontal')).exists();
+      });
+
       test('should display the first step with the button Next', async function (assert) {
         // given
         const steps = [

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -11,569 +11,450 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Stepper', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('A Stepper with 2 steps', function () {
-    test('should display the first step with the button Next', async function (assert) {
-      // given
-      const steps = [
-        {
-          elements: [
-            {
-              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-              type: 'text',
-              content: '<p>Text 1</p>',
-            },
-          ],
-        },
-        {
-          elements: [
-            {
-              id: '768441a5-a7d6-4987-ada9-7253adafd842',
-              type: 'text',
-              content: '<p>Text 2</p>',
-            },
-          ],
-        },
-      ];
+  module('When stepper is vertical', function () {
+    module('A Stepper with 2 steps', function () {
+      test('should display the first step with the button Next', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
 
-      // when
-      const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+        // when
+        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
-      // then
-      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-      assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-      assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
-    });
-
-    module('When step contains answerable elements', function () {
-      module('When the only answerable element is unanswered', function () {
-        test('should not display the Next button', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio1' },
-                    { id: '2', content: 'radio2' },
-                  ],
-                  isAnswerable: true,
-                  type: 'qcu',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          function getLastCorrectionForElementStub() {}
-
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-          passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
-
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-            .doesNotExist();
-        });
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+        assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
-      module('When we verify an answerable element', function () {
-        test('should call the onElementAnswer action', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio1' },
-                    { id: '2', content: 'radio2' },
-                  ],
-                  isAnswerable: true,
-                  type: 'qcu',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          const passageEventService = this.owner.lookup('service:passage-events');
-          sinon.stub(passageEventService, 'record');
-          const getLastCorrectionForElementStub = sinon.stub();
-          const onElementAnswerStub = sinon.stub();
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-          passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+      module('When step contains answerable elements', function () {
+        module('When the only answerable element is unanswered', function () {
+          test('should not display the Next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
 
-          // when
-          await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @onElementAnswer={{onElementAnswerStub}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
 
-          // then
-          await clickByName('radio1');
-          await clickByName(t('pages.modulix.buttons.activity.verify'));
-          sinon.assert.calledOnce(onElementAnswerStub);
-          assert.ok(true);
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
         });
-      });
 
-      module('When we retry an answerable element', function () {
-        test('should call the onElementRetry action', async function (assert) {
-          // given
-          const passageEventService = this.owner.lookup('service:passage-events');
-          const steps = [
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio1', feedback: { state: 'ok' } },
-                    { id: '2', content: 'radio2', feedback: { state: 'ko' } },
-                  ],
-                  isAnswerable: true,
-                  solution: '1',
-                  type: 'qcu',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          const onElementRetryStub = sinon.stub();
-          const onElementAnswerStub = sinon.stub();
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-          sinon.stub(passageEventService, 'record');
-          function getLastCorrectionForElementStub(element) {
-            if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
-              return {};
-            }
-            return undefined;
-          }
+        module('When we verify an answerable element', function () {
+          test('should call the onElementAnswer action', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            const passageEventService = this.owner.lookup('service:passage-events');
+            sinon.stub(passageEventService, 'record');
+            const getLastCorrectionForElementStub = sinon.stub();
+            const onElementAnswerStub = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
 
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @onElementAnswer={{onElementAnswerStub}}
-                @onElementRetry={{onElementRetryStub}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
+            // when
+            await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @onElementAnswer={{onElementAnswerStub}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
 
-          // then
-          await clickByName('radio2');
-          const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
-          await click(verifyButton);
-          await clickByName(t('pages.modulix.buttons.activity.retry'));
-          sinon.assert.calledOnce(onElementRetryStub);
-          assert.ok(true);
+            // then
+            await clickByName('radio1');
+            await clickByName(t('pages.modulix.buttons.activity.verify'));
+            sinon.assert.calledOnce(onElementAnswerStub);
+            assert.ok(true);
+          });
         });
-      });
 
-      module('When at least one of the answerable elements is unanswered', function () {
-        test('should not display the Next button', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio1' },
-                    { id: '2', content: 'radio2' },
-                  ],
-                  isAnswerable: true,
-                  type: 'qcu',
-                },
-                {
-                  id: '69f08624-6e63-4be1-b662-6e6bc820d99f',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio3' },
-                    { id: '2', content: 'radio4' },
-                  ],
-                  isAnswerable: true,
-                  type: 'qcu',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          function getLastCorrectionForElementStub(element) {
-            if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
-              return Symbol('Correction');
-            } else {
+        module('When we retry an answerable element', function () {
+          test('should call the onElementRetry action', async function (assert) {
+            // given
+            const passageEventService = this.owner.lookup('service:passage-events');
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1', feedback: { state: 'ok' } },
+                      { id: '2', content: 'radio2', feedback: { state: 'ko' } },
+                    ],
+                    isAnswerable: true,
+                    solution: '1',
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            const onElementRetryStub = sinon.stub();
+            const onElementAnswerStub = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            sinon.stub(passageEventService, 'record');
+            function getLastCorrectionForElementStub(element) {
+              if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
+                return {};
+              }
               return undefined;
             }
-          }
 
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-          passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @onElementAnswer={{onElementAnswerStub}}
+                  @onElementRetry={{onElementRetryStub}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
 
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-            .doesNotExist();
-        });
-      });
-
-      module('When all answerable elements are answered', function () {
-        test('should display the next button', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  instruction: 'Instruction',
-                  proposals: [
-                    { id: '1', content: 'radio1' },
-                    { id: '2', content: 'radio2' },
-                  ],
-                  isAnswerable: true,
-                  type: 'qcu',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          function getLastCorrectionForElementStub() {}
-
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-          const correction = store.createRecord('correction-response');
-          store.createRecord('element-answer', {
-            elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
-            correction,
-            passage,
+            // then
+            await clickByName('radio2');
+            const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
+            await click(verifyButton);
+            await clickByName(t('pages.modulix.buttons.activity.retry'));
+            sinon.assert.calledOnce(onElementRetryStub);
+            assert.ok(true);
           });
+        });
 
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
+        module('When at least one of the answerable elements is unanswered', function () {
+          test('should not display the Next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                  {
+                    id: '69f08624-6e63-4be1-b662-6e6bc820d99f',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio3' },
+                      { id: '2', content: 'radio4' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub(element) {
+              if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
+                return Symbol('Correction');
+              } else {
+                return undefined;
+              }
+            }
 
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-            .exists();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
+
+        module('When all answerable elements are answered', function () {
+          test('should display the next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            const correction = store.createRecord('correction-response');
+            store.createRecord('element-answer', {
+              elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+              correction,
+              passage,
+            });
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .exists();
+          });
         });
       });
-    });
 
-    module('When stepper contains unsupported elements', function () {
-      module('When there is no supported elements in one step', function () {
-        test('should not display the Step', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'unknown',
-                  content: 'content',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                  isAnswerable: false,
-                },
-              ],
-            },
-          ];
-          function getLastCorrectionForElementStub() {}
+      module('When stepper contains unsupported elements', function () {
+        module('When there is no supported elements in one step', function () {
+          test('should not display the Step', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'unknown',
+                    content: 'content',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
 
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
 
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
 
-          // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
-          assert
-            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-            .doesNotExist();
+            // then
+            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
+
+        module('When there are no supported elements at all', function () {
+          test('should not display the Stepper', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'unknown',
+                    content: 'content',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    type: 'unknown',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="vertical"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
+            assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
+          });
         });
       });
 
-      module('When there are no supported elements at all', function () {
-        test('should not display the Stepper', async function (assert) {
-          // given
-          const steps = [
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'unknown',
-                  content: 'content',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                  type: 'unknown',
-                  content: '<p>Text 2</p>',
-                },
-              ],
-            },
-          ];
-          function getLastCorrectionForElementStub() {}
-
-          const store = this.owner.lookup('service:store');
-          const passage = store.createRecord('passage');
-
-          // when
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @passage={{passage}}
-                @steps={{steps}}
-                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-              />
-            </template>,
-          );
-
-          // then
-          assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
-          assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
-        });
-      });
-    });
-
-    module('When user clicks on the Next button', function () {
-      test('should display the next step', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
-
-        function stepperIsFinished() {}
-
-        function onStepperNextStepStub() {}
-
-        const screen = await render(
-          <template>
-            <ModulixStepper
-              @steps={{steps}}
-              @stepperIsFinished={{stepperIsFinished}}
-              @onStepperNextStep={{onStepperNextStepStub}}
-            />
-          </template>,
-        );
-
-        // when
-        await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
-
-        // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-      });
-
-      test('should not display the Next button when there are no steps left', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
-
-        function stepperIsFinished() {}
-
-        function onStepperNextStepStub() {}
-
-        const screen = await render(
-          <template>
-            <ModulixStepper
-              @steps={{steps}}
-              @stepperIsFinished={{stepperIsFinished}}
-              @onStepperNextStep={{onStepperNextStepStub}}
-            />
-          </template>,
-        );
-
-        // when
-        await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
-        assert
-          .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-          .doesNotExist();
-      });
-    });
-
-    module('when preview mode is enabled', function () {
-      test('should display all the steps', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
-        class PreviewModeServiceStub extends Service {
-          isEnabled = true;
-        }
-        this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
-
-        // when
-        const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
-
-        // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
-      });
-
-      module('when has unsupported elements', function () {
-        test('should display all the steps but filter out unsupported element', async function (assert) {
+      module('When user clicks on the Next button', function () {
+        test('should display the next step', async function (assert) {
           // given
           const steps = [
             {
@@ -594,11 +475,95 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 },
               ],
             },
+          ];
+
+          function stepperIsFinished() {}
+
+          function onStepperNextStepStub() {}
+
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="vertical"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
+
+          // when
+          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
+
+          // then
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+        });
+
+        test('should not display the Next button when there are no steps left', async function (assert) {
+          // given
+          const steps = [
             {
               elements: [
                 {
-                  id: 'd7870bf4-e018-482a-829c-6a124066b352',
-                  type: 'nope',
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          function stepperIsFinished() {}
+
+          function onStepperNextStepStub() {}
+
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="vertical"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
+
+          // when
+          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
+          assert
+            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when preview mode is enabled', function () {
+        test('should display all the steps', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
                 },
               ],
             },
@@ -609,12 +574,680 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
           // when
-          const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+          const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
           // then
           assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
           assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
           assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+        });
+
+        module('when has unsupported elements', function () {
+          test('should display all the steps but filter out unsupported element', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                    type: 'text',
+                    content: '<p>Text 1</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd7870bf4-e018-482a-829c-6a124066b352',
+                    type: 'nope',
+                  },
+                ],
+              },
+            ];
+            class PreviewModeServiceStub extends Service {
+              isEnabled = true;
+            }
+            this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+            // when
+            const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
+
+            // then
+            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+          });
+        });
+      });
+    });
+  });
+
+  module('When stepper is horizontal', function () {
+    module('A Stepper with 2 steps', function () {
+      test('should display the first step with the button Next', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+        assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
+      });
+
+      module('When step contains answerable elements', function () {
+        module('When the only answerable element is unanswered', function () {
+          test('should not display the Next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
+
+        module('When we verify an answerable element', function () {
+          test('should call the onElementAnswer action', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            const passageEventService = this.owner.lookup('service:passage-events');
+            sinon.stub(passageEventService, 'record');
+            const getLastCorrectionForElementStub = sinon.stub();
+            const onElementAnswerStub = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+
+            // when
+            await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @onElementAnswer={{onElementAnswerStub}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            await clickByName('radio1');
+            await clickByName(t('pages.modulix.buttons.activity.verify'));
+            sinon.assert.calledOnce(onElementAnswerStub);
+            assert.ok(true);
+          });
+        });
+
+        module('When we retry an answerable element', function () {
+          test('should call the onElementRetry action', async function (assert) {
+            // given
+            const passageEventService = this.owner.lookup('service:passage-events');
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1', feedback: { state: 'ok' } },
+                      { id: '2', content: 'radio2', feedback: { state: 'ko' } },
+                    ],
+                    isAnswerable: true,
+                    solution: '1',
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            const onElementRetryStub = sinon.stub();
+            const onElementAnswerStub = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            sinon.stub(passageEventService, 'record');
+            function getLastCorrectionForElementStub(element) {
+              if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
+                return {};
+              }
+              return undefined;
+            }
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @onElementAnswer={{onElementAnswerStub}}
+                  @onElementRetry={{onElementRetryStub}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            await clickByName('radio2');
+            const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
+            await click(verifyButton);
+            await clickByName(t('pages.modulix.buttons.activity.retry'));
+            sinon.assert.calledOnce(onElementRetryStub);
+            assert.ok(true);
+          });
+        });
+
+        module('When at least one of the answerable elements is unanswered', function () {
+          test('should not display the Next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                  {
+                    id: '69f08624-6e63-4be1-b662-6e6bc820d99f',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio3' },
+                      { id: '2', content: 'radio4' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub(element) {
+              if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
+                return Symbol('Correction');
+              } else {
+                return undefined;
+              }
+            }
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
+
+        module('When all answerable elements are answered', function () {
+          test('should display the next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            const correction = store.createRecord('correction-response');
+            store.createRecord('element-answer', {
+              elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+              correction,
+              passage,
+            });
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .exists();
+          });
+        });
+      });
+
+      module('When stepper contains unsupported elements', function () {
+        module('When there is no supported elements in one step', function () {
+          test('should not display the Step', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'unknown',
+                    content: 'content',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
+          });
+        });
+
+        module('When there are no supported elements at all', function () {
+          test('should not display the Stepper', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'unknown',
+                    content: 'content',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    type: 'unknown',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+            ];
+            function getLastCorrectionForElementStub() {}
+
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // then
+            assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
+            assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
+          });
+        });
+      });
+
+      module('When user clicks on the Next button', function () {
+        test('should display the next step', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          function stepperIsFinished() {}
+
+          function onStepperNextStepStub() {}
+
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
+
+          // when
+          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
+
+          // then
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+        });
+
+        test('should not display the Next button when there are no steps left', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          function stepperIsFinished() {}
+
+          function onStepperNextStepStub() {}
+
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
+
+          // when
+          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
+          assert
+            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when preview mode is enabled', function () {
+        test('should display all the steps', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+          class PreviewModeServiceStub extends Service {
+            isEnabled = true;
+          }
+          this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+          // when
+          const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+          // then
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+        });
+
+        module('when has unsupported elements', function () {
+          test('should display all the steps but filter out unsupported element', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                    type: 'text',
+                    content: '<p>Text 1</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd7870bf4-e018-482a-829c-6a124066b352',
+                    type: 'nope',
+                  },
+                ],
+              },
+            ];
+            class PreviewModeServiceStub extends Service {
+              isEnabled = true;
+            }
+            this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+            // when
+            const screen = await render(
+              <template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>,
+            );
+
+            // then
+            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+          });
         });
       });
     });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1,6 +1,7 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, find } from "@ember/test-helpers";
+// eslint-disable-next-line no-restricted-imports
+import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixStepper from 'mon-pix/components/module/component/stepper';
 import { module, test } from 'qunit';
@@ -13,7 +14,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
   module('When stepper is vertical', function () {
     module('A Stepper with 2 steps', function () {
-      test('it should set vertical class', async function(assert) {
+      test('it should set vertical class', async function (assert) {
         const steps = [
           {
             elements: [
@@ -37,7 +38,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
         // when
         await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
-
 
         // then
         assert.dom(find('.stepper--vertical')).exists();
@@ -663,7 +663,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
   module('When stepper is horizontal', function () {
     module('A Stepper with 2 steps', function () {
-      test('it should set horizontal class', async function(assert) {
+      test('it should set horizontal class', async function (assert) {
         const steps = [
           {
             elements: [
@@ -687,7 +687,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
         // when
         await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
-
 
         // then
         assert.dom(find('.stepper--horizontal')).exists();


### PR DESCRIPTION
## 🔆 Problème

Le stepper ne peut être qu'en mode vertical.

## ⛱️ Proposition

Ajouter le mode horizontal

## 🌊 Remarques

- On a dû désactiver une règle du linter SCSS parce qu'on a pas réussi à corriger l'erreur.
- On a utilisé l'attribut `inert` pour les steps précédents. A voir pour pouvoir supporter cet attribut sur tous les navigateurs.

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13325.review.pix.fr/modules/bac-a-sable/passage)
2. Constater que le stepper vertical s'affiche correctement
3. Bien tester avec des types de device différent : mobile, tablette, en portrait/paysage...
4. Bien tester avec lambdatest ce qui se passe sur Firefox 100, en particulier la tabulation, avec la présence de `inert`
