### PR TITLE
[FEATURE] Ne pas afficher le filtre sur les classes dans la page attestations si les participants n'ont pas de classe (PIX-19168)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
+++ b/api/db/seeds/data/team-prescription/build-organization-learners-with-multiple-participations.js
@@ -17,6 +17,7 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
     lastName: 'Terieur',
     userId: firstUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
 
   const { id: firstUserFirstCampaignParticipationId, createdAt } =
@@ -99,6 +100,7 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
     lastName: 'Yoyo',
     userId: secondUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
   const { id: secondUserFirstCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
     campaignId: CAMPAIGN_PROASSMUL_ID,
@@ -156,6 +158,7 @@ async function _buildMultipleParticipationsForPROASSMULCampaign(databaseBuilder)
     lastName: 'Croche',
     userId: thirdUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
   const { id: thirdUserFirstCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
     campaignId: CAMPAIGN_PROASSMUL_ID,
@@ -215,6 +218,7 @@ async function _buildMultipleParticipationsForPROCOLMULCampaign(databaseBuilder)
     lastName: 'Sapin',
     userId: firstUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
 
   await databaseBuilder.factory.buildCampaignParticipation({
@@ -252,6 +256,7 @@ async function _buildMultipleParticipationsForPROCOLMULCampaign(databaseBuilder)
     lastName: 'Lopez',
     userId: secondUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
 
   await databaseBuilder.factory.buildCampaignParticipation({
@@ -289,6 +294,7 @@ async function _buildMultipleParticipationsForPROCOLMULCampaign(databaseBuilder)
     lastName: 'Quiroule',
     userId: thirdUser.id,
     organizationId: PRO_ORGANIZATION_ID,
+    division: null,
   });
 
   await databaseBuilder.factory.buildCampaignParticipation({

--- a/orga/app/components/attestations/list.gjs
+++ b/orga/app/components/attestations/list.gjs
@@ -24,7 +24,7 @@ export default class AttestationList extends Component {
     ];
   }
 
-  get shouldShowDivisionColumn() {
+  get shouldShowDivisions() {
     return this.args.participantStatuses?.some((participantStatus) => Boolean(participantStatus.division));
   }
 
@@ -48,14 +48,16 @@ export default class AttestationList extends Component {
       >
         <:label>{{t "common.filters.fullname.label"}}</:label>
       </PixSearchInput>
-      <MultiSelectFilter
-        @field="divisions"
-        @label={{t "pages.attestations.table.filter.divisions.label"}}
-        @onSelect={{@onFilter}}
-        @selectedOption={{@divisionsFilter}}
-        @options={{@divisionsOptions}}
-        @placeholder={{t "pages.attestations.table.filter.divisions.empty-option"}}
-      />
+      {{#if this.shouldShowDivisions}}
+        <MultiSelectFilter
+          @field="divisions"
+          @label={{t "pages.attestations.table.filter.divisions.label"}}
+          @onSelect={{@onFilter}}
+          @selectedOption={{@divisionsFilter}}
+          @options={{@divisionsOptions}}
+          @placeholder={{t "pages.attestations.table.filter.divisions.empty-option"}}
+        />
+      {{/if}}
 
       <MultiSelectFilter
         @field="statuses"
@@ -85,7 +87,7 @@ export default class AttestationList extends Component {
             {{participantStatus.firstName}}
           </:cell>
         </PixTableColumn>
-        {{#if this.shouldShowDivisionColumn}}
+        {{#if this.shouldShowDivisions}}
           <PixTableColumn @context={{context}}>
             <:header>
               {{t "pages.attestations.table.column.division"}}

--- a/orga/tests/integration/components/attestations/list_test.gjs
+++ b/orga/tests/integration/components/attestations/list_test.gjs
@@ -1,0 +1,71 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import AttestationList from 'pix-orga/components/attestations/list';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Attestations | List', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display division column and filter if at least one participant has division', async function (assert) {
+    // given
+    const triggerFiltering = sinon.stub();
+    const participantStatuses = [
+      {
+        lastName: 'jean',
+        firstName: 'michel',
+        division: '6emeA',
+        obtainedAt: '2020-01-01',
+      },
+      {
+        lastName: 'pierre',
+        firstName: 'paul',
+        division: null,
+        obtainedAt: '2020-01-01',
+      },
+    ];
+
+    // when
+    const screen = await render(
+      <template>
+        <AttestationList @participantStatuses={{participantStatuses}} @onFilter={{triggerFiltering}} />
+      </template>,
+    );
+
+    // then
+    assert.ok(screen.getByRole('textbox', { name: t('pages.attestations.table.filter.divisions.label') }));
+    assert.ok(screen.getByRole('columnheader', { name: t('pages.attestations.table.column.division') }));
+  });
+
+  test('it should not display division column and filter if participant does not have divisions', async function (assert) {
+    // given
+    const triggerFiltering = sinon.stub();
+    const participantStatuses = [
+      {
+        lastName: 'jean',
+        firstName: 'michel',
+        division: null,
+        obtainedAt: '2020-01-01',
+      },
+      {
+        lastName: 'pierre',
+        firstName: 'paul',
+        division: null,
+        obtainedAt: '2020-01-01',
+      },
+    ];
+
+    // when
+    const screen = await render(
+      <template>
+        <AttestationList @participantStatuses={{participantStatuses}} @onFilter={{triggerFiltering}} />
+      </template>,
+    );
+
+    // then
+    assert.notOk(screen.queryByRole('textbox', { name: t('pages.attestations.table.filter.divisions.label') }));
+    assert.notOk(screen.queryByRole('columnheader', { name: t('pages.attestations.table.column.division') }));
+  });
+});


### PR DESCRIPTION
## 🔆 Problème
Les organisations de type AEFE (avec un tag AEFE) n’ont pas d’import de participants, de fait ils n’ont pas de classe renseignée pour les participants. 

Or, sur la page Attestations, on leur propose de filtrer sur la classe. 


## ⛱️ Proposition
Il faudrait donc que ce filtre sur la classe ne soit disponible que lorsqu’une classe est renseignée.
Reprendre la même logique que sur le tableau, ou affiche la colonne classe seulement dans ce cas

## 🌊 Remarques
On en profite pour remettre les seeds au propre pour l'orga PRO Classic. Les participants avaient des classes ajoutée par défaut. Or c'est une orga sans import, donc ils ne sont pas censés avoir de classe

## 🏄 Pour tester
Se connecter a PixOrga 
Aller sur l'orga Attestations
C'est une orga avec Import, donc des classes, vérifier que la colonne + le filtre sur les classes apparait
Aller sur l'orga PRO Classic
C'est une orga sans import, donc vérifier cette fois que la colonne + le filtre n'apparait plus
