### PR TITLE
[TECH] Utiliser getI18n dans les emails (PIX-18984)

### DIFF
--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import i18n from 'i18n';
 
 import { usecases as enrolmentUseCases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
 import pickChallengeService from '../../../../../src/certification/evaluation/domain/services/pick-challenge-service.js';
@@ -118,5 +117,5 @@ export default async function publishSessionWithValidatedCertification({
 
   await databaseBuilder.commit();
 
-  await sessionManagementUseCases.publishSession({ sessionId, i18n });
+  await sessionManagementUseCases.publishSession({ sessionId });
 }

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -1,9 +1,6 @@
 import 'dotenv/config';
 
-import path from 'node:path';
 import * as url from 'node:url';
-
-import i18n from 'i18n';
 
 import { databaseConnections } from '../../db/database-connections.js';
 import { manageEmails } from '../../src/certification/session-management/domain/services/session-publication-service.js';
@@ -11,7 +8,6 @@ import * as certificationCenterRepository from '../../src/certification/shared/i
 import * as sharedSessionRepository from '../../src/certification/shared/infrastructure/repositories/session-repository.js';
 import * as mailService from '../../src/shared/domain/services/mail-service.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * Usage: LOG_LEVEL=info NODE_TLS_REJECT_UNAUTHORIZED='0' PGSSLMODE=require node scripts/certification/send-certification-result-emails.js 1234,5678,9012
@@ -25,15 +21,6 @@ async function main() {
     );
     return;
   }
-
-  const directory = path.resolve(path.join(__dirname, '../../translations'));
-  i18n.configure({
-    locales: ['fr', 'en'],
-    defaultLocale: 'fr',
-    directory,
-    objectNotation: true,
-    updateFiles: false,
-  });
 
   const sessionIds = process.argv[2].split(',');
   let successes = 0;
@@ -57,7 +44,6 @@ async function main() {
 
     try {
       await manageEmails({
-        i18n,
         session,
         publishedAt,
         certificationCenterRepository,

--- a/api/src/certification/session-management/application/session-publication-controller.js
+++ b/api/src/certification/session-management/application/session-publication-controller.js
@@ -1,15 +1,12 @@
 import { SessionPublicationBatchError } from '../../../shared/application/http-errors.js';
-import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as sessionManagementSerializer from '../infrastructure/serializers/session-serializer.js';
 
 const publish = async function (request, h, dependencies = { sessionManagementSerializer }) {
-  const i18n = await getI18nFromRequest(request);
-
   const sessionId = request.params.id;
 
-  const session = await usecases.publishSession({ sessionId, i18n });
+  const session = await usecases.publishSession({ sessionId });
 
   return dependencies.sessionManagementSerializer.serialize({ session });
 };
@@ -23,11 +20,9 @@ const unpublish = async function (request, h, dependencies = { sessionManagement
 };
 
 const publishInBatch = async function (request, h) {
-  const i18n = await getI18nFromRequest(request);
-
   const sessionIds = request.payload.data.attributes.ids;
 
-  const result = await usecases.publishSessionsInBatch({ sessionIds, i18n });
+  const result = await usecases.publishSessionsInBatch({ sessionIds });
 
   if (result.hasPublicationErrors()) {
     _logSessionBatchPublicationErrors(result);

--- a/api/src/certification/session-management/domain/services/mail-service.js
+++ b/api/src/certification/session-management/domain/services/mail-service.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 
-import * as translations from '../../../../../translations/index.js';
 import { tokenService } from '../../../../shared/domain/services/token-service.js';
 import { getPixAppUrl, getPixWebsiteDomain, getPixWebsiteUrl } from '../../../../shared/domain/services/url-service.js';
+import { getI18n } from '../../../../shared/infrastructure/i18n/i18n.js';
 import { mailer } from '../../../../shared/mail/infrastructure/services/mailer.js';
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
@@ -10,9 +10,11 @@ const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 function sendNotificationToCertificationCenterRefererForCleaResults({ email, sessionId, sessionDate }) {
   const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
 
+  const i18nFr = getI18n('fr');
+
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: translations.fr['email-sender-name']['pix-app'],
+    fromName: i18nFr.__('email-sender-name.pix-app'),
     to: email,
     template: mailer.acquiredCleaResultTemplateId,
     variables: { sessionId, sessionDate: formattedSessionDate },
@@ -28,7 +30,6 @@ function sendCertificationResultEmail({
   certificationCenterName,
   resultRecipientEmail,
   daysBeforeExpiration,
-  translate,
 }) {
   const token = tokenService.createCertificationResultsByRecipientEmailLinkToken({
     sessionId,
@@ -37,31 +38,56 @@ function sendCertificationResultEmail({
   });
   const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
 
+  const i18nFr = getI18n('fr');
+  const i18nEn = getI18n('en');
+
   const templateVariables = {
     certificationCenterName,
     sessionId,
     sessionDate: formattedSessionDate,
     fr: {
-      ...translations.fr['certification-result-email'].params,
       homeName: getPixWebsiteDomain('fr-FR'),
       homeUrl: getPixWebsiteUrl('fr-FR'),
       homeNameInternational: getPixWebsiteDomain('fr'),
       homeUrlInternational: getPixWebsiteUrl('fr'),
-      title: translate({ phrase: 'certification-result-email.title', locale: 'fr' }, { sessionId }),
       link: getPixAppUrl('fr', { pathname: `/api/sessions/download-results/${token}` }),
+      title: i18nFr.__('certification-result-email.title', { sessionId }),
+      doNotReply: i18nFr.__('certification-result-email.params.doNotReply'),
+      download: i18nFr.__('certification-result-email.params.download'),
+      emailValidFor: i18nFr.__('certification-result-email.params.emailValidFor'),
+      findOutMore: i18nFr.__('certification-result-email.params.findOutMore'),
+      findOutMoreFranceSuffix: i18nFr.__('certification-result-email.params.findOutMoreFranceSuffix'),
+      findOutMoreInternationalSuffix: i18nFr.__('certification-result-email.params.findOutMoreInternationalSuffix'),
+      guidelines: i18nFr.__('certification-result-email.params.guidelines'),
+      guidelinesLinkName: i18nFr.__('certification-result-email.params.guidelinesLinkName'),
+      overviewText: i18nFr.__('certification-result-email.params.overviewText'),
+      resultsAvailable: i18nFr.__('certification-result-email.params.resultsAvailable'),
+      subject: i18nFr.__('certification-result-email.params.subject'),
+      viewResultsInProfile: i18nFr.__('certification-result-email.params.viewResultsInProfile'),
     },
     en: {
-      ...translations.en['certification-result-email'].params,
       homeName: getPixWebsiteDomain('en'),
       homeUrl: getPixWebsiteUrl('en'),
-      title: translate({ phrase: 'certification-result-email.title', locale: 'en' }, { sessionId }),
       link: getPixAppUrl('en', { pathname: `/api/sessions/download-results/${token}` }),
+      title: i18nEn.__('certification-result-email.title', { sessionId }),
+      doNotReply: i18nEn.__('certification-result-email.params.doNotReply'),
+      download: i18nEn.__('certification-result-email.params.download'),
+      emailValidFor: i18nEn.__('certification-result-email.params.emailValidFor'),
+      findOutMore: i18nEn.__('certification-result-email.params.findOutMore'),
+      findOutMoreFranceSuffix: i18nEn.__('certification-result-email.params.findOutMoreFranceSuffix'),
+      findOutMoreInternationalSuffix: i18nEn.__('certification-result-email.params.findOutMoreInternationalSuffix'),
+      guidelines: i18nEn.__('certification-result-email.params.guidelines'),
+      guidelinesLinkName: i18nEn.__('certification-result-email.params.guidelinesLinkName'),
+      overviewText: i18nEn.__('certification-result-email.params.overviewText'),
+      resultsAvailable: i18nEn.__('certification-result-email.params.resultsAvailable'),
+      subject: i18nEn.__('certification-result-email.params.subject'),
+      viewResultsInProfile: i18nEn.__('certification-result-email.params.viewResultsInProfile'),
     },
   };
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: `${translations.fr['email-sender-name']['pix-app']} / ${translations.en['email-sender-name']['pix-app']}`,
+    fromName: `${i18nFr.__('email-sender-name.pix-app')} / ${i18nEn.__('email-sender-name.pix-app')}`,
     to: email,
     template: mailer.certificationResultTemplateId,
     variables: templateVariables,

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -60,7 +60,6 @@ async function publishSession({
  * @param {mailService} params.dependencies.mailService
  */
 async function manageEmails({
-  i18n,
   session,
   publishedAt,
   certificationCenterRepository,
@@ -72,7 +71,6 @@ async function manageEmails({
     sessionRepository,
     certificationCenterRepository,
     mailService: dependencies.mailService,
-    i18n,
   });
 
   const prescribersEmailingAttempts = await _managerPrescriberEmails({

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -78,7 +78,6 @@ async function manageEmails({
   const prescribersEmailingAttempts = await _managerPrescriberEmails({
     session,
     mailService: dependencies.mailService,
-    i18n,
   });
 
   if (_someHaveSucceeded(prescribersEmailingAttempts) && _noneHaveFailed(prescribersEmailingAttempts)) {
@@ -135,7 +134,7 @@ async function _manageCleaEmails({ session, certificationCenterRepository, sessi
  * @param {Object} params
  * @param {MailService} params.mailService
  */
-async function _managerPrescriberEmails({ session, mailService, i18n }) {
+async function _managerPrescriberEmails({ session, mailService }) {
   const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);
 
   const emailingAttempts = [];
@@ -147,7 +146,6 @@ async function _managerPrescriberEmails({ session, mailService, i18n }) {
       certificationCenterName: session.certificationCenter,
       resultRecipientEmail: recipientEmail,
       daysBeforeExpiration: 30,
-      translate: i18n.__,
     });
     emailingAttempts.push(emailingAttempt);
   }

--- a/api/src/certification/session-management/domain/usecases/publish-session.js
+++ b/api/src/certification/session-management/domain/usecases/publish-session.js
@@ -14,7 +14,6 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  * @param {SessionPublicationService} params.sessionPublicationService
  */
 const publishSession = async function ({
-  i18n,
   sessionId,
   publishedAt = new Date(),
   certificationRepository,
@@ -35,7 +34,6 @@ const publishSession = async function ({
     });
 
     await sessionPublicationService.manageEmails({
-      i18n,
       session,
       publishedAt,
       certificationCenterRepository,

--- a/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
+++ b/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
@@ -4,7 +4,6 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 
 const publishSessionsInBatch = async function ({
-  i18n,
   sessionIds,
   publishedAt = new Date(),
   batchId = randomUUID(),
@@ -29,7 +28,6 @@ const publishSessionsInBatch = async function ({
         });
 
         await sessionPublicationService.manageEmails({
-          i18n,
           session,
           publishedAt,
           certificationCenterRepository,

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -216,7 +216,7 @@ const selfDeleteUserAccount = async function (request, h) {
 const sendVerificationCode = async function (request, h, dependencies = { emailVerificationSerializer }) {
   const locale = getUserLocale(request);
 
-  const userId = request.params.id;
+  const userId = request.auth.credentials.userId;
   const { newEmail, password } = await dependencies.emailVerificationSerializer.deserialize(request.payload);
 
   await usecases.sendVerificationCode({ locale, newEmail, password, userId });

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -214,13 +214,12 @@ const selfDeleteUserAccount = async function (request, h) {
 };
 
 const sendVerificationCode = async function (request, h, dependencies = { emailVerificationSerializer }) {
-  const locale = await getChallengeLocale(request);
-  const i18n = await getI18nFromRequest(request);
+  const locale = getUserLocale(request);
 
   const userId = request.params.id;
   const { newEmail, password } = await dependencies.emailVerificationSerializer.deserialize(request.payload);
 
-  await usecases.sendVerificationCode({ i18n, locale, newEmail, password, userId });
+  await usecases.sendVerificationCode({ locale, newEmail, password, userId });
   return h.response().code(204);
 };
 

--- a/api/src/identity-access-management/domain/usecases/send-verification-code.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/send-verification-code.usecase.js
@@ -13,7 +13,6 @@ const { get } = lodash;
 /**
  * @param {Object} params
  *
- * @param {*} params.i18n
  * @param {*} params.locale
  * @param {string} params.newEmail
  * @param {string} params.password
@@ -27,7 +26,6 @@ const { get } = lodash;
  */
 
 const sendVerificationCode = async function ({
-  i18n,
   locale,
   newEmail,
   password,
@@ -69,7 +67,7 @@ const sendVerificationCode = async function ({
   const code = codeUtils.generateNumericalString(6);
 
   await userEmailRepository.saveEmailModificationDemand({ userId, code, newEmail });
-  await mailService.sendVerificationCodeEmail({ code, locale, translate: i18n.__, email: newEmail });
+  await mailService.sendVerificationCodeEmail({ code, locale, email: newEmail });
 };
 
 function _manageError(error, errorType, attribute, message) {

--- a/api/src/shared/domain/services/mail-service.js
+++ b/api/src/shared/domain/services/mail-service.js
@@ -1,13 +1,6 @@
-import * as translations from '../../../../translations/index.js';
+import { getI18n } from '../../infrastructure/i18n/i18n.js';
 import { mailer } from '../../mail/infrastructure/services/mailer.js';
-import {
-  DUTCH_SPOKEN,
-  ENGLISH_SPOKEN,
-  FRENCH_FRANCE,
-  FRENCH_SPOKEN,
-  isFranceLocale,
-  SPANISH_SPOKEN,
-} from '../services/locale-service.js';
+import { FRENCH_FRANCE, isFranceLocale } from '../services/locale-service.js';
 import {
   getPixAppUrl,
   getPixCertifUrl,
@@ -38,32 +31,36 @@ function sendOrganizationInvitationEmail({
   locale = FRENCH_FRANCE,
   tags,
 }) {
-  const mailerConfig = _getMailerTranslation(locale);
-
-  const pixOrgaName = mailerConfig.translation['email-sender-name']['pix-orga'];
-  const sendOrganizationInvitationEmailSubject = mailerConfig.translation['organization-invitation-email'].subject;
-
-  const templateVariables = {
-    organizationName,
-    pixHomeName: getPixWebsiteDomain(locale),
-    pixHomeUrl: getPixWebsiteUrl(locale),
-    pixOrgaHomeUrl: getPixOrgaUrl(locale),
-    redirectionUrl: getPixOrgaUrl(locale, {
-      pathname: '/rejoindre',
-      queryParams: { invitationId: organizationInvitationId, code },
-    }),
-    supportUrl: getSupportUrl(locale),
-    ...mailerConfig.translation['organization-invitation-email'].params,
-  };
+  const i18n = getI18n(locale);
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixOrgaName,
+    fromName: i18n.__('email-sender-name.pix-orga'),
     to: email,
-    subject: sendOrganizationInvitationEmailSubject,
+    subject: i18n.__('organization-invitation-email.subject'),
     template: mailer.organizationInvitationTemplateId,
-    variables: templateVariables,
     tags: tags || null,
+    variables: {
+      organizationName,
+      pixHomeName: getPixWebsiteDomain(locale),
+      pixHomeUrl: getPixWebsiteUrl(locale),
+      pixOrgaHomeUrl: getPixOrgaUrl(locale),
+      redirectionUrl: getPixOrgaUrl(locale, {
+        pathname: '/rejoindre',
+        queryParams: { invitationId: organizationInvitationId, code },
+      }),
+      supportUrl: getSupportUrl(locale),
+      acceptInvitation: i18n.__('organization-invitation-email.params.acceptInvitation'),
+      doNotAnswer: i18n.__('organization-invitation-email.params.doNotAnswer'),
+      here: i18n.__('organization-invitation-email.params.here'),
+      moreAbout: i18n.__('organization-invitation-email.params.moreAbout'),
+      needHelp: i18n.__('organization-invitation-email.params.needHelp'),
+      oneTimeLink: i18n.__('organization-invitation-email.params.oneTimeLink'),
+      pixPresentation: i18n.__('organization-invitation-email.params.pixPresentation'),
+      subtitle: i18n.__('organization-invitation-email.params.subtitle'),
+      title: i18n.__('organization-invitation-email.params.title'),
+      yourOrganization: i18n.__('organization-invitation-email.params.yourOrganization'),
+    },
   });
 }
 
@@ -88,29 +85,27 @@ function sendScoOrganizationInvitationEmail({
   locale = FRENCH_FRANCE,
   tags,
 }) {
-  const mailerConfig = _getMailerTranslation(locale);
-
-  const templateVariables = {
-    organizationName,
-    firstName,
-    lastName,
-    pixHomeName: getPixWebsiteDomain(locale),
-    pixHomeUrl: getPixWebsiteUrl(locale),
-    pixOrgaHomeUrl: getPixOrgaUrl(locale),
-    redirectionUrl: getPixOrgaUrl(locale, {
-      pathname: '/rejoindre',
-      queryParams: { invitationId: organizationInvitationId, code },
-    }),
-  };
+  const i18n = getI18n(locale);
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: mailerConfig.translation['email-sender-name']['pix-orga'],
+    fromName: i18n.__('email-sender-name.pix-orga'),
     to: email,
     subject: 'Accès à votre espace Pix Orga',
     template: mailer.organizationInvitationScoTemplateId,
-    variables: templateVariables,
     tags: tags || null,
+    variables: {
+      organizationName,
+      firstName,
+      lastName,
+      pixHomeName: getPixWebsiteDomain(locale),
+      pixHomeUrl: getPixWebsiteUrl(locale),
+      pixOrgaHomeUrl: getPixOrgaUrl(locale),
+      redirectionUrl: getPixOrgaUrl(locale, {
+        pathname: '/rejoindre',
+        queryParams: { invitationId: organizationInvitationId, code },
+      }),
+    },
   });
 }
 
@@ -129,30 +124,34 @@ function sendCertificationCenterInvitationEmail({
   code,
   locale = FRENCH_FRANCE,
 }) {
-  const mailerConfig = _getMailerTranslation(locale);
-
-  const subject = mailerConfig.translation['certification-center-invitation-email'].subject;
-  const fromName = mailerConfig.translation['email-sender-name']['pix-certif'];
-  const templateVariables = {
-    certificationCenterName,
-    pixHomeName: getPixWebsiteDomain(locale),
-    pixHomeUrl: getPixWebsiteUrl(locale),
-    pixCertifHomeUrl: getPixCertifUrl(locale),
-    redirectionUrl: getPixCertifUrl(locale, {
-      pathname: '/rejoindre',
-      queryParams: { invitationId: certificationCenterInvitationId, code },
-    }),
-    supportUrl: getSupportUrl(locale),
-    ...mailerConfig.translation['certification-center-invitation-email'].params,
-  };
+  const i18n = getI18n(locale);
 
   return mailer.sendEmail({
-    subject,
+    subject: i18n.__('certification-center-invitation-email.subject'),
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName,
+    fromName: i18n.__('email-sender-name.pix-certif'),
     to: email,
     template: mailer.certificationCenterInvitationTemplateId,
-    variables: templateVariables,
+    variables: {
+      certificationCenterName,
+      pixHomeName: getPixWebsiteDomain(locale),
+      pixHomeUrl: getPixWebsiteUrl(locale),
+      pixCertifHomeUrl: getPixCertifUrl(locale),
+      redirectionUrl: getPixCertifUrl(locale, {
+        pathname: '/rejoindre',
+        queryParams: { invitationId: certificationCenterInvitationId, code },
+      }),
+      supportUrl: getSupportUrl(locale),
+      acceptInvitation: i18n.__('certification-center-invitation-email.params.acceptInvitation'),
+      doNotAnswer: i18n.__('certification-center-invitation-email.params.doNotAnswer'),
+      here: i18n.__('certification-center-invitation-email.params.here'),
+      moreAbout: i18n.__('certification-center-invitation-email.params.moreAbout'),
+      needHelp: i18n.__('certification-center-invitation-email.params.needHelp'),
+      oneTimeLink: i18n.__('certification-center-invitation-email.params.oneTimeLink'),
+      pixCertifPresentation: i18n.__('certification-center-invitation-email.params.pixCertifPresentation'),
+      title: i18n.__('certification-center-invitation-email.params.title'),
+      yourCertificationCenter: i18n.__('certification-center-invitation-email.params.yourCertificationCenter'),
+    },
   });
 }
 
@@ -163,24 +162,28 @@ function sendCertificationCenterInvitationEmail({
  * @returns {Promise<EmailingAttempt>}
  */
 function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
-  const mailerConfig = _getMailerTranslation(FRENCH_FRANCE);
-  const fromName = mailerConfig.translation['email-sender-name']['pix-app'];
-  const redirectionUrl = getPixAppUrl(FRENCH_FRANCE, { pathname: `/recuperer-mon-compte/${temporaryKey}` });
-  const templateVariables = {
-    firstName,
-    redirectionUrl,
-    homeName: getPixWebsiteDomain(FRENCH_FRANCE),
-    ...mailerConfig.translation['account-recovery-email'].params,
-  };
+  const i18nFr = getI18n(FRENCH_FRANCE);
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName,
+    fromName: i18nFr.__('email-sender-name.pix-app'),
     to: email,
     subject: 'Récupération de votre compte Pix',
     template: mailer.accountRecoveryTemplateId,
     tags: [SCO_ACCOUNT_RECOVERY_TAG],
-    variables: templateVariables,
+    variables: {
+      firstName,
+      redirectionUrl: getPixAppUrl(FRENCH_FRANCE, { pathname: `/recuperer-mon-compte/${temporaryKey}` }),
+      homeName: getPixWebsiteDomain(FRENCH_FRANCE),
+      choosePassword: i18nFr.__('account-recovery-email.params.choosePassword'),
+      context: i18nFr.__('account-recovery-email.params.context'),
+      doNotAnswer: i18nFr.__('account-recovery-email.params.doNotAnswer'),
+      instruction: i18nFr.__('account-recovery-email.params.instruction'),
+      linkValidFor: i18nFr.__('account-recovery-email.params.linkValidFor'),
+      moreOn: i18nFr.__('account-recovery-email.params.moreOn'),
+      pixPresentation: i18nFr.__('account-recovery-email.params.pixPresentation'),
+      signing: i18nFr.__('account-recovery-email.params.signing'),
+    },
   });
 }
 
@@ -188,31 +191,31 @@ function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
  * @param code
  * @param email
  * @param locale
- * @param translate
  * @returns {Promise<EmailingAttempt>}
  */
-function sendVerificationCodeEmail({ code, email, locale = FRENCH_FRANCE, translate }) {
-  const mailerConfig = _getMailerTranslation(locale);
+function sendVerificationCodeEmail({ code, email, locale = FRENCH_FRANCE }) {
+  const i18n = getI18n(locale);
 
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: mailerConfig.translation['email-sender-name']['pix-app'],
+    fromName: i18n.__('email-sender-name.pix-app'),
     to: email,
     template: mailer.emailVerificationCodeTemplateId,
     tags: [EMAIL_VERIFICATION_CODE_TAG],
-    subject: translate(
-      {
-        phrase: 'verification-code-email.subject',
-        locale: locale === FRENCH_FRANCE ? 'fr' : locale,
-      },
-      { code },
-    ),
+    subject: i18n.__('verification-code-email.subject', { code }),
     variables: {
       code,
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       displayNationalLogo: isFranceLocale(locale),
-      ...mailerConfig.translation['verification-code-email'].body,
+      context: i18n.__('verification-code-email.body.context'),
+      doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+      greeting: i18n.__('verification-code-email.body.greeting'),
+      moreOn: i18n.__('verification-code-email.body.moreOn'),
+      pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+      seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+      signing: i18n.__('verification-code-email.body.signing'),
+      warningMessage: i18n.__('verification-code-email.body.warningMessage'),
     },
   };
 
@@ -220,41 +223,15 @@ function sendVerificationCodeEmail({ code, email, locale = FRENCH_FRANCE, transl
 }
 
 function sendCpfEmail({ email, generatedFiles }) {
-  const options = {
+  const i18nFr = getI18n(FRENCH_FRANCE);
+
+  return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: translations.fr['email-sender-name']['pix-app'],
+    fromName: i18nFr.__('email-sender-name.pix-app'),
     to: email,
     template: mailer.cpfEmailTemplateId,
     variables: { generatedFiles },
-  };
-
-  return mailer.sendEmail(options);
-}
-
-/**
- * @typedef {Object} mailerConfig
- * @property {JSON} translation
- */
-
-/**
- * @param locale
- * @returns {mailerConfig}
- * @private
- */
-function _getMailerTranslation(locale) {
-  switch (locale) {
-    case FRENCH_SPOKEN:
-    case SPANISH_SPOKEN:
-    case ENGLISH_SPOKEN:
-    case DUTCH_SPOKEN:
-      return {
-        translation: translations[locale],
-      };
-    default:
-      return {
-        translation: translations.fr,
-      };
-  }
+  });
 }
 
 const mailService = {

--- a/api/tests/certification/session-management/integration/domain/usecases/publish-session_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/publish-session_test.js
@@ -73,7 +73,6 @@ describe('Certification | Session Management | Integration | Domain | UseCase | 
       await databaseBuilder.commit();
 
       await usecases.publishSession({
-        i18n: { __: sinon.stub() },
         sessionId: session.id,
         publishedAt: new Date('2020-01-02'),
       });

--- a/api/tests/certification/session-management/unit/application/session-publication-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/session-publication-controller_test.js
@@ -2,7 +2,6 @@ import { sessionPublicationController } from '../../../../../src/certification/s
 import { SessionPublicationBatchResult } from '../../../../../src/certification/session-management/domain/models/SessionPublicationBatchResult.js';
 import { usecases } from '../../../../../src/certification/session-management/domain/usecases/index.js';
 import { SessionPublicationBatchError } from '../../../../../src/shared/application/http-errors.js';
-import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, expect, hFake, sinon } from '../../../../test-helper.js';
 
@@ -13,21 +12,13 @@ describe('Certification | Session-management | Unit | Application | Controller |
       const sessionId = 123;
       const session = Symbol('session');
       const serializedSession = Symbol('serializedSession');
-      const i18n = getI18n();
       const sessionManagementSerializer = { serialize: sinon.stub() };
-      sinon
-        .stub(usecases, 'publishSession')
-        .withArgs({
-          sessionId,
-          i18n,
-        })
-        .resolves(session);
+      sinon.stub(usecases, 'publishSession').withArgs({ sessionId }).resolves(session);
       sessionManagementSerializer.serialize.withArgs({ session }).resolves(serializedSession);
 
       // when
       const response = await sessionPublicationController.publish(
         {
-          i18n,
           params: {
             id: sessionId,
           },
@@ -82,10 +73,7 @@ describe('Certification | Session-management | Unit | Application | Controller |
   describe('#publishInBatch', function () {
     it('returns 204 when no error occurred', async function () {
       // given
-      const i18n = getI18n();
-
       const request = {
-        i18n,
         payload: {
           data: {
             attributes: {
@@ -96,10 +84,7 @@ describe('Certification | Session-management | Unit | Application | Controller |
       };
       sinon
         .stub(usecases, 'publishSessionsInBatch')
-        .withArgs({
-          sessionIds: ['sessionId1', 'sessionId2'],
-          i18n,
-        })
+        .withArgs({ sessionIds: ['sessionId1', 'sessionId2'] })
         .resolves(new SessionPublicationBatchResult('batchId'));
 
       // when
@@ -111,13 +96,11 @@ describe('Certification | Session-management | Unit | Application | Controller |
 
     it('logs errors when errors occur', async function () {
       // given
-      const i18n = getI18n();
       const result = new SessionPublicationBatchResult('batchId');
       result.addPublicationError('sessionId1', new Error('an error'));
       result.addPublicationError('sessionId2', new Error('another error'));
 
       const request = {
-        i18n,
         payload: {
           data: {
             attributes: {
@@ -156,12 +139,10 @@ describe('Certification | Session-management | Unit | Application | Controller |
 
     it('returns the serialized batch id', async function () {
       // given
-      const i18n = getI18n();
       const result = new SessionPublicationBatchResult('batchId');
       result.addPublicationError('sessionId1', new Error('an error'));
 
       const request = {
-        i18n,
         payload: {
           data: {
             attributes: {

--- a/api/tests/certification/session-management/unit/domain/services/mail-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/mail-service_test.js
@@ -3,20 +3,7 @@ import { ENGLISH_SPOKEN, FRENCH_FRANCE } from '../../../../../../src/shared/doma
 import { tokenService } from '../../../../../../src/shared/domain/services/token-service.js';
 import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { mailer } from '../../../../../../src/shared/mail/infrastructure/services/mailer.js';
-import en from '../../../../../../translations/en.json' with { type: 'json' };
-import fr from '../../../../../../translations/fr.json' with { type: 'json' };
-import { es } from '../../../../../../translations/index.js';
-import nl from '../../../../../../translations/nl.json' with { type: 'json' };
 import { expect, sinon } from '../../../../../test-helper.js';
-
-const mainTranslationsMapping = {
-  fr,
-  en,
-  nl,
-  es,
-};
-
-const i18n = getI18n();
 
 describe('Unit | Certification | Session-Management | Domain | Services | MailService', function () {
   beforeEach(function () {
@@ -51,7 +38,6 @@ describe('Unit | Certification | Session-Management | Domain | Services | MailSe
   describe('#sendCertificationResultEmail', function () {
     it(`should call sendEmail with from, to, template, tags, ${FRENCH_FRANCE} and ${ENGLISH_SPOKEN} translations`, async function () {
       // given
-      const translate = i18n.__;
       const sessionDate = '2020-10-03';
       const sessionId = '3';
       const userEmailAddress = 'user@example.net';
@@ -70,11 +56,13 @@ describe('Unit | Certification | Session-Management | Domain | Services | MailSe
         certificationCenterName,
         resultRecipientEmail,
         daysBeforeExpiration,
-        translate,
       });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
+
+      const i18nFr = getI18n('fr');
+      const i18nEn = getI18n('en');
 
       expect(options).to.deep.equal({
         from: 'ne-pas-repondre@pix.fr',
@@ -83,20 +71,46 @@ describe('Unit | Certification | Session-Management | Domain | Services | MailSe
         template: 'test-certification-result-template-id',
         variables: {
           fr: {
-            ...mainTranslationsMapping.fr['certification-result-email'].params,
-            title: translate('certification-result-email.title', { sessionId }),
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
             homeNameInternational: 'pix.org',
             homeUrlInternational: 'https://pix.org/fr',
             link: `${link}?lang=fr`,
+            title: i18nFr.__('certification-result-email.title', { sessionId }),
+            doNotReply: i18nFr.__('certification-result-email.params.doNotReply'),
+            download: i18nFr.__('certification-result-email.params.download'),
+            emailValidFor: i18nFr.__('certification-result-email.params.emailValidFor'),
+            findOutMore: i18nFr.__('certification-result-email.params.findOutMore'),
+            findOutMoreFranceSuffix: i18nFr.__('certification-result-email.params.findOutMoreFranceSuffix'),
+            findOutMoreInternationalSuffix: i18nFr.__(
+              'certification-result-email.params.findOutMoreInternationalSuffix',
+            ),
+            guidelines: i18nFr.__('certification-result-email.params.guidelines'),
+            guidelinesLinkName: i18nFr.__('certification-result-email.params.guidelinesLinkName'),
+            overviewText: i18nFr.__('certification-result-email.params.overviewText'),
+            resultsAvailable: i18nFr.__('certification-result-email.params.resultsAvailable'),
+            subject: i18nFr.__('certification-result-email.params.subject'),
+            viewResultsInProfile: i18nFr.__('certification-result-email.params.viewResultsInProfile'),
           },
           en: {
-            ...mainTranslationsMapping.en['certification-result-email'].params,
-            title: translate({ phrase: 'certification-result-email.title', locale: 'en' }, { sessionId }),
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en',
             link: `${link}?lang=en`,
+            title: i18nEn.__('certification-result-email.title', { sessionId }),
+            doNotReply: i18nEn.__('certification-result-email.params.doNotReply'),
+            download: i18nEn.__('certification-result-email.params.download'),
+            emailValidFor: i18nEn.__('certification-result-email.params.emailValidFor'),
+            findOutMore: i18nEn.__('certification-result-email.params.findOutMore'),
+            findOutMoreFranceSuffix: i18nEn.__('certification-result-email.params.findOutMoreFranceSuffix'),
+            findOutMoreInternationalSuffix: i18nEn.__(
+              'certification-result-email.params.findOutMoreInternationalSuffix',
+            ),
+            guidelines: i18nEn.__('certification-result-email.params.guidelines'),
+            guidelinesLinkName: i18nEn.__('certification-result-email.params.guidelinesLinkName'),
+            overviewText: i18nEn.__('certification-result-email.params.overviewText'),
+            resultsAvailable: i18nEn.__('certification-result-email.params.resultsAvailable'),
+            subject: i18nEn.__('certification-result-email.params.subject'),
+            viewResultsInProfile: i18nEn.__('certification-result-email.params.viewResultsInProfile'),
           },
           sessionId,
           sessionDate: '03/10/2020',

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -502,7 +502,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           certificationCenterName: 'certificationCenter',
           sessionDate: originalSession.date,
           email: 'email1@example.net',
-          translate: i18n.__,
         });
         expect(mailService.sendCertificationResultEmail).to.have.been.calledWithExactly({
           sessionId,
@@ -511,7 +510,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           certificationCenterName: 'certificationCenter',
           sessionDate: originalSession.date,
           email: 'email2@example.net',
-          translate: i18n.__,
         });
         expect(sessionRepository.flagResultsAsSentToPrescriber).to.not.have.been.called;
         expect(error).to.be.an.instanceOf(SendingEmailToResultRecipientError);

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -10,13 +10,11 @@ import {
   publishSession,
 } from '../../../../../../src/certification/session-management/domain/services/session-publication-service.js';
 import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
-import { getI18n } from '../../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { EmailingAttempt } from '../../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Domain | Services | session-publication-service', function () {
   const sessionId = 123;
-  let i18n;
   let certificationRepository,
     sessionRepository,
     sharedSessionRepository,
@@ -214,7 +212,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
   describe('#manageEmails', function () {
     beforeEach(function () {
-      i18n = getI18n();
       sessionRepository = {
         hasSomeCleaAcquired: sinon.stub(),
         flagResultsAsSentToPrescriber: sinon.stub(),
@@ -235,7 +232,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
       // when
       await manageEmails({
-        i18n,
         session: originalSession,
         certificationCenterRepository,
         sessionRepository,
@@ -267,7 +263,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           sessionId,
           resultRecipientEmail: 'email1@example.net',
           daysBeforeExpiration: 30,
-          translate: i18n,
         })
         .returns('token-1');
       mailService.sendCertificationResultEmail
@@ -275,7 +270,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
           sessionId,
           resultRecipientEmail: 'email2@example.net',
           daysBeforeExpiration: 30,
-          translate: i18n,
         })
         .returns('token-2');
       mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
@@ -283,7 +277,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
       // when
       await manageEmails({
-        i18n,
         session: originalSession,
         certificationCenterRepository,
         sessionRepository,
@@ -317,7 +310,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
         // when
         await manageEmails({
-          i18n,
           session: originalSession,
           publishedAt: now,
           certificationCenterRepository,
@@ -351,7 +343,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
         // when
         await manageEmails({
-          i18n,
           session: updatedSessionWithPublishedAt,
           certificationCenterRepository,
           sessionRepository,
@@ -391,7 +382,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
           // when
           await manageEmails({
-            i18n,
             session: updatedSessionWithPublishedAt,
             certificationCenterRepository,
             sessionRepository,
@@ -436,7 +426,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
             // when
             const error = await catchErr(manageEmails)({
-              i18n,
               session: updatedSessionWithPublishedAt,
               certificationCenterRepository,
               sessionRepository,
@@ -463,7 +452,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
           // when
           await manageEmails({
-            i18n,
             session: originalSession,
             certificationCenterRepository,
             sessionRepository,
@@ -487,7 +475,6 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
         // when
         const error = await catchErr(manageEmails)({
-          i18n,
           session: originalSession,
           certificationCenterRepository,
           sessionRepository,

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
@@ -6,7 +6,6 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
   it('delegates the action to the session-publication-service and return the session', async function () {
     // given
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
-    const i18n = Symbol('i18n');
     const sessionId = Symbol('a session id');
     const session = Symbol('a session');
     const certificationRepository = Symbol('the certification repository');
@@ -27,7 +26,6 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
 
     // when
     const result = await publishSession({
-      i18n,
       sessionId,
       certificationRepository,
       certificationCenterRepository,
@@ -48,7 +46,6 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
       sharedSessionRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
-      i18n,
       session,
       publishedAt,
       certificationCenterRepository,

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -30,7 +30,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     const session1 = domainBuilder.certification.sessionManagement.buildSession({ id: 1 });
     const session2 = domainBuilder.certification.sessionManagement.buildSession({ id: 2 });
     const publishedAt = Symbol('a publication date');
-    const i18n = Symbol('i18n');
 
     sessionPublicationService.publishSession.onCall(0).resolves(session1);
     sessionPublicationService.publishSession.onCall(1).resolves(session2);
@@ -40,7 +39,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       sessionIds: [session1.id, session2.id],
       batchId: 'batch id',
       publishedAt,
-      i18n,
       certificationRepository,
       certificationCenterRepository,
       finalizedSessionRepository,
@@ -59,7 +57,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       sharedSessionRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
-      i18n,
       session: session1,
       publishedAt,
       certificationCenterRepository,
@@ -75,7 +72,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       sessionRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
-      i18n,
       session: session2,
       publishedAt,
       certificationCenterRepository,
@@ -86,7 +82,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
   context('when one or many session publication fail', function () {
     it('should continue', async function () {
       // given
-      const i18n = Symbol('i18n');
       const session1 = domainBuilder.certification.sessionManagement.buildSession({ id: 1 });
       const session2 = domainBuilder.certification.sessionManagement.buildSession({ id: 2 });
       const publishedAt = Symbol('a publication date');
@@ -108,7 +103,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         sessionIds: [session1.id, session2.id],
         publishedAt,
         batchId: 'batch id',
-        i18n,
         certificationCenterRepository,
         certificationRepository,
         finalizedSessionRepository,
@@ -126,7 +120,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         sharedSessionRepository,
       });
       expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
-        i18n,
         session: session2,
         publishedAt,
         certificationCenterRepository,
@@ -139,7 +132,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       const sessionId1 = Symbol('first session id');
       const sessionId2 = Symbol('second session id');
       const publishedAt = Symbol('a publication date');
-      const i18n = Symbol('i18n');
 
       const error1 = new Error('an error');
       const error2 = new Error('another error');
@@ -166,7 +158,6 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
 
       // when
       const result = await publishSessionsInBatch({
-        i18n,
         sessionIds: [sessionId1, sessionId2],
         publishedAt,
         batchId: 'batch id',

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -370,30 +370,19 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       // given
       sinon.stub(usecases, 'sendVerificationCode');
       usecases.sendVerificationCode.resolves();
-      const i18n = getI18n();
       const userId = 1;
-      const locale = 'fr';
+      const locale = 'fr-FR';
       const newEmail = 'user@example.net';
       const password = 'Password123';
 
       const request = {
-        headers: { 'accept-language': locale },
-        i18n,
-        auth: {
-          credentials: {
-            userId,
-          },
-        },
-        params: {
-          id: userId,
-        },
+        state: { locale },
+        auth: { credentials: { userId } },
+        params: { id: userId },
         payload: {
           data: {
             type: 'users',
-            attributes: {
-              newEmail,
-              password,
-            },
+            attributes: { newEmail, password },
           },
         },
       };
@@ -402,13 +391,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       await userController.sendVerificationCode(request, hFake);
 
       // then
-      expect(usecases.sendVerificationCode).to.have.been.calledWithExactly({
-        i18n,
-        locale,
-        newEmail,
-        password,
-        userId,
-      });
+      expect(usecases.sendVerificationCode).to.have.been.calledWithExactly({ locale, newEmail, password, userId });
     });
   });
 

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -378,7 +378,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
       const request = {
         state: { locale },
         auth: { credentials: { userId } },
-        params: { id: userId },
         payload: {
           data: {
             type: 'users',

--- a/api/tests/identity-access-management/unit/domain/usecases/send-verification-code.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/send-verification-code.usecase.test.js
@@ -5,7 +5,6 @@ import {
   InvalidPasswordForUpdateEmailError,
   UserNotAuthorizedToUpdateEmailError,
 } from '../../../../../src/shared/domain/errors.js';
-import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | send-verification-code', function () {
@@ -47,7 +46,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | send-verificati
     const password = 'pix123';
     const passwordHash = 'ABCD';
     const locale = 'fr';
-    const i18n = getI18n();
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
     userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);
@@ -66,7 +64,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | send-verificati
 
     // when
     await usecases.sendVerificationCode({
-      i18n,
       locale,
       newEmail,
       password,
@@ -91,8 +88,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | send-verificati
     const passwordHash = 'ABCD';
     const code = '999999';
     const locale = 'fr';
-    const i18n = getI18n();
-    const translate = i18n.__;
 
     userRepository.get.withArgs(userId).resolves({ email: 'oldEmail@example.net' });
     userRepository.checkIfEmailIsAvailable.withArgs(newEmail).resolves(newEmail);
@@ -111,7 +106,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | send-verificati
 
     // when
     await usecases.sendVerificationCode({
-      i18n,
       locale,
       newEmail,
       password,
@@ -129,7 +123,6 @@ describe('Unit | Identity Access Management | Domain | UseCase | send-verificati
       code,
       locale,
       email: newEmail,
-      translate,
     });
   });
 

--- a/api/tests/shared/unit/domain/services/mail-service_test.js
+++ b/api/tests/shared/unit/domain/services/mail-service_test.js
@@ -8,15 +8,7 @@ import {
 import * as mailService from '../../../../../src/shared/domain/services/mail-service.js';
 import { getI18n } from '../../../../../src/shared/infrastructure/i18n/i18n.js';
 import { mailer } from '../../../../../src/shared/mail/infrastructure/services/mailer.js';
-import en from '../../../../../translations/en.json' with { type: 'json' };
-import fr from '../../../../../translations/fr.json' with { type: 'json' };
-import { es } from '../../../../../translations/index.js';
-import nl from '../../../../../translations/nl.json' with { type: 'json' };
 import { expect, sinon } from '../../../../test-helper.js';
-
-const mainTranslationsMapping = { fr, en, nl, es };
-
-const i18n = getI18n();
 
 describe('Unit | Service | MailService', function () {
   const senderEmailAddress = 'ne-pas-repondre@pix.fr';
@@ -102,98 +94,150 @@ describe('Unit | Service | MailService', function () {
     context('according to locale', function () {
       context('should call sendEmail with localized variable options', function () {
         it(`when locale is ${FRENCH_SPOKEN}`, async function () {
+          // given
+          const locale = FRENCH_SPOKEN;
+          const i18n = getI18n(locale);
+
           // when
           await mailService.sendOrganizationInvitationEmail({
             email: userEmailAddress,
             organizationName,
             organizationInvitationId,
             code,
-            locale: FRENCH_SPOKEN,
+            locale,
           });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
           expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
-          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.subject).to.equal(i18n.__('organization-invitation-email.subject'));
           expect(options.variables).to.include({
             pixHomeName: 'pix.org',
             pixHomeUrl: 'https://pix.org/fr',
             pixOrgaHomeUrl: 'https://orga.pix.org/?lang=fr',
             redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=fr`,
             supportUrl: 'https://pix.org/fr/support',
-            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+            acceptInvitation: i18n.__('organization-invitation-email.params.acceptInvitation'),
+            doNotAnswer: i18n.__('organization-invitation-email.params.doNotAnswer'),
+            here: i18n.__('organization-invitation-email.params.here'),
+            moreAbout: i18n.__('organization-invitation-email.params.moreAbout'),
+            needHelp: i18n.__('organization-invitation-email.params.needHelp'),
+            oneTimeLink: i18n.__('organization-invitation-email.params.oneTimeLink'),
+            pixPresentation: i18n.__('organization-invitation-email.params.pixPresentation'),
+            subtitle: i18n.__('organization-invitation-email.params.subtitle'),
+            title: i18n.__('organization-invitation-email.params.title'),
+            yourOrganization: i18n.__('organization-invitation-email.params.yourOrganization'),
           });
         });
 
         it(`when locale is ${FRENCH_FRANCE}`, async function () {
+          // given
+          const locale = FRENCH_FRANCE;
+          const i18n = getI18n(locale);
+
           // when
           await mailService.sendOrganizationInvitationEmail({
             email: userEmailAddress,
             organizationName,
             organizationInvitationId,
             code,
-            locale: FRENCH_FRANCE,
+            locale,
           });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
           expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
-          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.subject).to.equal(i18n.__('organization-invitation-email.subject'));
           expect(options.variables).to.include({
             pixHomeName: 'pix.fr',
             pixHomeUrl: 'https://pix.fr',
             pixOrgaHomeUrl: 'https://orga.pix.fr/',
             redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
             supportUrl: 'https://pix.fr/support',
-            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+            acceptInvitation: i18n.__('organization-invitation-email.params.acceptInvitation'),
+            doNotAnswer: i18n.__('organization-invitation-email.params.doNotAnswer'),
+            here: i18n.__('organization-invitation-email.params.here'),
+            moreAbout: i18n.__('organization-invitation-email.params.moreAbout'),
+            needHelp: i18n.__('organization-invitation-email.params.needHelp'),
+            oneTimeLink: i18n.__('organization-invitation-email.params.oneTimeLink'),
+            pixPresentation: i18n.__('organization-invitation-email.params.pixPresentation'),
+            subtitle: i18n.__('organization-invitation-email.params.subtitle'),
+            title: i18n.__('organization-invitation-email.params.title'),
+            yourOrganization: i18n.__('organization-invitation-email.params.yourOrganization'),
           });
         });
 
         it('when locale is undefined', async function () {
+          // given
+          const locale = undefined;
+          const i18n = getI18n(locale);
+
           // when
           await mailService.sendOrganizationInvitationEmail({
             email: userEmailAddress,
             organizationName,
             organizationInvitationId,
             code,
-            locale: undefined,
+            locale,
           });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
           expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
-          expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
+          expect(options.subject).to.equal(i18n.__('organization-invitation-email.subject'));
           expect(options.variables).to.include({
             pixHomeName: 'pix.fr',
             pixHomeUrl: 'https://pix.fr',
             pixOrgaHomeUrl: 'https://orga.pix.fr/',
             redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
             supportUrl: 'https://pix.fr/support',
-            ...mainTranslationsMapping.fr['organization-invitation-email'].params,
+            acceptInvitation: i18n.__('organization-invitation-email.params.acceptInvitation'),
+            doNotAnswer: i18n.__('organization-invitation-email.params.doNotAnswer'),
+            here: i18n.__('organization-invitation-email.params.here'),
+            moreAbout: i18n.__('organization-invitation-email.params.moreAbout'),
+            needHelp: i18n.__('organization-invitation-email.params.needHelp'),
+            oneTimeLink: i18n.__('organization-invitation-email.params.oneTimeLink'),
+            pixPresentation: i18n.__('organization-invitation-email.params.pixPresentation'),
+            subtitle: i18n.__('organization-invitation-email.params.subtitle'),
+            title: i18n.__('organization-invitation-email.params.title'),
+            yourOrganization: i18n.__('organization-invitation-email.params.yourOrganization'),
           });
         });
 
         it(`when locale is ${ENGLISH_SPOKEN}`, async function () {
+          // given
+          const locale = ENGLISH_SPOKEN;
+          const i18n = getI18n(locale);
+
           // when
           await mailService.sendOrganizationInvitationEmail({
             email: userEmailAddress,
             organizationName,
             organizationInvitationId,
             code,
-            locale: ENGLISH_SPOKEN,
+            locale,
           });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
           expect(options.fromName).to.equal('Pix Orga - Noreply');
-          expect(options.subject).to.equal(mainTranslationsMapping.en['organization-invitation-email'].subject);
+          expect(options.subject).to.equal(i18n.__('organization-invitation-email.subject'));
           expect(options.variables).to.include({
             pixHomeName: 'pix.org',
             pixHomeUrl: 'https://pix.org/en',
             pixOrgaHomeUrl: 'https://orga.pix.org/?lang=en',
             redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
             supportUrl: 'https://pix.org/en/support',
-            ...mainTranslationsMapping.en['organization-invitation-email'].params,
+            acceptInvitation: i18n.__('organization-invitation-email.params.acceptInvitation'),
+            doNotAnswer: i18n.__('organization-invitation-email.params.doNotAnswer'),
+            here: i18n.__('organization-invitation-email.params.here'),
+            moreAbout: i18n.__('organization-invitation-email.params.moreAbout'),
+            needHelp: i18n.__('organization-invitation-email.params.needHelp'),
+            oneTimeLink: i18n.__('organization-invitation-email.params.oneTimeLink'),
+            pixPresentation: i18n.__('organization-invitation-email.params.pixPresentation'),
+            subtitle: i18n.__('organization-invitation-email.params.subtitle'),
+            title: i18n.__('organization-invitation-email.params.title'),
+            yourOrganization: i18n.__('organization-invitation-email.params.yourOrganization'),
           });
         });
       });
@@ -243,21 +287,23 @@ describe('Unit | Service | MailService', function () {
 
   describe('#sendCertificationCenterInvitationEmail', function () {
     it('should send an email and set subject, sender, receiver in french as default', async function () {
-      // given & when
+      // given
+      const locale = undefined;
+      const i18n = getI18n(locale);
+
+      // when
       await mailService.sendCertificationCenterInvitationEmail({
         email: 'invited@example.net',
         certificationCenterName: 'Centre Pixou',
         certificationCenterInvitationId: 7,
         code: 'ABCDEFGH01',
-        locale: undefined,
+        locale,
       });
 
       // then
       const sendEmailParameters = mailer.sendEmail.firstCall.args[0];
 
-      expect(sendEmailParameters.subject).to.equal(
-        mainTranslationsMapping.fr['certification-center-invitation-email'].subject,
-      );
+      expect(sendEmailParameters.subject).to.equal(i18n.__('certification-center-invitation-email.subject'));
       expect(sendEmailParameters.from).to.equal(senderEmailAddress);
       expect(sendEmailParameters.fromName).to.equal('Pix Certif - Ne pas répondre');
       expect(sendEmailParameters.to).to.equal('invited@example.net');
@@ -269,7 +315,15 @@ describe('Unit | Service | MailService', function () {
         pixCertifHomeUrl: 'https://certif.pix.fr/',
         redirectionUrl: `https://certif.pix.fr/rejoindre?invitationId=7&code=ABCDEFGH01`,
         supportUrl: 'https://pix.fr/support',
-        ...mainTranslationsMapping.fr['certification-center-invitation-email'].params,
+        acceptInvitation: i18n.__('certification-center-invitation-email.params.acceptInvitation'),
+        doNotAnswer: i18n.__('certification-center-invitation-email.params.doNotAnswer'),
+        here: i18n.__('certification-center-invitation-email.params.here'),
+        moreAbout: i18n.__('certification-center-invitation-email.params.moreAbout'),
+        needHelp: i18n.__('certification-center-invitation-email.params.needHelp'),
+        oneTimeLink: i18n.__('certification-center-invitation-email.params.oneTimeLink'),
+        pixCertifPresentation: i18n.__('certification-center-invitation-email.params.pixCertifPresentation'),
+        title: i18n.__('certification-center-invitation-email.params.title'),
+        yourCertificationCenter: i18n.__('certification-center-invitation-email.params.yourCertificationCenter'),
       });
     });
 
@@ -277,6 +331,7 @@ describe('Unit | Service | MailService', function () {
       it('should call sendEmail with localized variable options', async function () {
         // given
         const locale = FRENCH_SPOKEN;
+        const i18n = getI18n(locale);
 
         // when
         await mailService.sendCertificationCenterInvitationEmail({
@@ -289,9 +344,7 @@ describe('Unit | Service | MailService', function () {
 
         // then
         const sendEmailParameters = mailer.sendEmail.firstCall.args[0];
-        expect(sendEmailParameters.subject).to.equal(
-          mainTranslationsMapping.fr['certification-center-invitation-email'].subject,
-        );
+        expect(sendEmailParameters.subject).to.equal(i18n.__('certification-center-invitation-email.subject'));
         expect(sendEmailParameters.fromName).to.equal('Pix Certif - Ne pas répondre');
         expect(sendEmailParameters.variables).to.include({
           certificationCenterName: 'Centre Pixi',
@@ -300,7 +353,15 @@ describe('Unit | Service | MailService', function () {
           pixCertifHomeUrl: 'https://certif.pix.org/?lang=fr',
           redirectionUrl: `https://certif.pix.org/rejoindre?invitationId=7&code=AAABBBCCC7&lang=fr`,
           supportUrl: 'https://pix.org/fr/support',
-          ...mainTranslationsMapping.fr['certification-center-invitation-email'].params,
+          acceptInvitation: i18n.__('certification-center-invitation-email.params.acceptInvitation'),
+          doNotAnswer: i18n.__('certification-center-invitation-email.params.doNotAnswer'),
+          here: i18n.__('certification-center-invitation-email.params.here'),
+          moreAbout: i18n.__('certification-center-invitation-email.params.moreAbout'),
+          needHelp: i18n.__('certification-center-invitation-email.params.needHelp'),
+          oneTimeLink: i18n.__('certification-center-invitation-email.params.oneTimeLink'),
+          pixCertifPresentation: i18n.__('certification-center-invitation-email.params.pixCertifPresentation'),
+          title: i18n.__('certification-center-invitation-email.params.title'),
+          yourCertificationCenter: i18n.__('certification-center-invitation-email.params.yourCertificationCenter'),
         });
       });
     });
@@ -309,6 +370,7 @@ describe('Unit | Service | MailService', function () {
       it('should call sendEmail with localized variable options', async function () {
         // given
         const locale = ENGLISH_SPOKEN;
+        const i18n = getI18n(locale);
 
         // when
         await mailService.sendCertificationCenterInvitationEmail({
@@ -321,9 +383,7 @@ describe('Unit | Service | MailService', function () {
 
         // then
         const sendEmailParameters = mailer.sendEmail.firstCall.args[0];
-        expect(sendEmailParameters.subject).to.equal(
-          mainTranslationsMapping.en['certification-center-invitation-email'].subject,
-        );
+        expect(sendEmailParameters.subject).to.equal(i18n.__('certification-center-invitation-email.subject'));
         expect(sendEmailParameters.fromName).to.equal('Pix Certif - Noreply');
         expect(sendEmailParameters.variables).to.include({
           certificationCenterName: 'Centre Pixi',
@@ -332,7 +392,15 @@ describe('Unit | Service | MailService', function () {
           pixCertifHomeUrl: 'https://certif.pix.org/?lang=en',
           redirectionUrl: `https://certif.pix.org/rejoindre?invitationId=777&code=LLLJJJVVV1&lang=en`,
           supportUrl: 'https://pix.org/en/support',
-          ...mainTranslationsMapping.en['certification-center-invitation-email'].params,
+          acceptInvitation: i18n.__('certification-center-invitation-email.params.acceptInvitation'),
+          doNotAnswer: i18n.__('certification-center-invitation-email.params.doNotAnswer'),
+          here: i18n.__('certification-center-invitation-email.params.here'),
+          moreAbout: i18n.__('certification-center-invitation-email.params.moreAbout'),
+          needHelp: i18n.__('certification-center-invitation-email.params.needHelp'),
+          oneTimeLink: i18n.__('certification-center-invitation-email.params.oneTimeLink'),
+          pixCertifPresentation: i18n.__('certification-center-invitation-email.params.pixCertifPresentation'),
+          title: i18n.__('certification-center-invitation-email.params.title'),
+          yourCertificationCenter: i18n.__('certification-center-invitation-email.params.yourCertificationCenter'),
         });
       });
     });
@@ -341,7 +409,8 @@ describe('Unit | Service | MailService', function () {
   describe('#sendAccountRecoveryEmail', function () {
     it('calls sendEmail with from, to, template, tags', async function () {
       // given
-      const translationsMapping = mainTranslationsMapping.fr['account-recovery-email'];
+      const locale = FRENCH_FRANCE;
+      const i18n = getI18n(locale);
 
       const firstName = 'Carla';
       const temporaryKey = 'a-temporary-key';
@@ -349,11 +418,7 @@ describe('Unit | Service | MailService', function () {
       const redirectionUrl = `https://test.app.pix.fr/recuperer-mon-compte/${temporaryKey}`;
 
       // when
-      await mailService.sendAccountRecoveryEmail({
-        email,
-        firstName,
-        temporaryKey,
-      });
+      await mailService.sendAccountRecoveryEmail({ email, firstName, temporaryKey });
 
       // then
       const expectedOptions = {
@@ -366,7 +431,14 @@ describe('Unit | Service | MailService', function () {
           firstName,
           redirectionUrl,
           homeName: 'pix.fr',
-          ...translationsMapping.params,
+          choosePassword: i18n.__('account-recovery-email.params.choosePassword'),
+          context: i18n.__('account-recovery-email.params.context'),
+          doNotAnswer: i18n.__('account-recovery-email.params.doNotAnswer'),
+          instruction: i18n.__('account-recovery-email.params.instruction'),
+          linkValidFor: i18n.__('account-recovery-email.params.linkValidFor'),
+          moreOn: i18n.__('account-recovery-email.params.moreOn'),
+          pixPresentation: i18n.__('account-recovery-email.params.pixPresentation'),
+          signing: i18n.__('account-recovery-email.params.signing'),
         },
       };
       const options = mailer.sendEmail.firstCall.args[0];
@@ -377,21 +449,17 @@ describe('Unit | Service | MailService', function () {
   describe('#sendVerificationCodeEmail', function () {
     it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_SPOKEN}`, async function () {
       // given
-      const translate = i18n.__;
+      const locale = FRENCH_SPOKEN;
+      const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
 
       // when
-      await mailService.sendVerificationCodeEmail({
-        code,
-        email: userEmail,
-        locale: FRENCH_SPOKEN,
-        translate,
-      });
+      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(translate('verification-code-email.subject', { code }));
+      expect(options.subject).to.equal(i18n.__('verification-code-email.subject', { code }));
       expect(options.fromName).to.equal('PIX - Ne pas répondre');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
@@ -399,27 +467,30 @@ describe('Unit | Service | MailService', function () {
         homeUrl: 'https://pix.org/fr',
         displayNationalLogo: false,
         code,
-        ...mainTranslationsMapping.fr['verification-code-email'].body,
+        context: i18n.__('verification-code-email.body.context'),
+        doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+        greeting: i18n.__('verification-code-email.body.greeting'),
+        moreOn: i18n.__('verification-code-email.body.moreOn'),
+        pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+        seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+        signing: i18n.__('verification-code-email.body.signing'),
+        warningMessage: i18n.__('verification-code-email.body.warningMessage'),
       });
     });
 
     it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_FRANCE}`, async function () {
       // given
-      const translate = i18n.__;
+      const locale = FRENCH_FRANCE;
+      const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
 
       // when
-      await mailService.sendVerificationCodeEmail({
-        code,
-        email: userEmail,
-        locale: FRENCH_FRANCE,
-        translate,
-      });
+      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(translate('verification-code-email.subject', { code }));
+      expect(options.subject).to.equal(i18n.__('verification-code-email.subject', { code }));
       expect(options.fromName).to.equal('PIX - Ne pas répondre');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
@@ -427,29 +498,30 @@ describe('Unit | Service | MailService', function () {
         homeUrl: 'https://pix.fr',
         displayNationalLogo: true,
         code,
-        ...mainTranslationsMapping.fr['verification-code-email'].body,
+        context: i18n.__('verification-code-email.body.context'),
+        doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+        greeting: i18n.__('verification-code-email.body.greeting'),
+        moreOn: i18n.__('verification-code-email.body.moreOn'),
+        pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+        seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+        signing: i18n.__('verification-code-email.body.signing'),
+        warningMessage: i18n.__('verification-code-email.body.warningMessage'),
       });
     });
 
     it(`calls sendEmail with from, to, template, tags and locale ${ENGLISH_SPOKEN}`, async function () {
       // given
-      const translate = i18n.__;
+      const locale = ENGLISH_SPOKEN;
+      const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
 
       // when
-      await mailService.sendVerificationCodeEmail({
-        code,
-        email: userEmail,
-        locale: ENGLISH_SPOKEN,
-        translate,
-      });
+      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(
-        translate({ phrase: 'verification-code-email.subject', locale: 'en' }, { code }),
-      );
+      expect(options.subject).to.equal(i18n.__('verification-code-email.subject', { code }));
       expect(options.fromName).to.equal('PIX - Noreply');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
@@ -457,29 +529,30 @@ describe('Unit | Service | MailService', function () {
         homeUrl: 'https://pix.org/en',
         displayNationalLogo: false,
         code,
-        ...mainTranslationsMapping.en['verification-code-email'].body,
+        context: i18n.__('verification-code-email.body.context'),
+        doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+        greeting: i18n.__('verification-code-email.body.greeting'),
+        moreOn: i18n.__('verification-code-email.body.moreOn'),
+        pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+        seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+        signing: i18n.__('verification-code-email.body.signing'),
+        warningMessage: i18n.__('verification-code-email.body.warningMessage'),
       });
     });
 
     it(`calls sendEmail with from, to, template, tags and locale ${DUTCH_SPOKEN}`, async function () {
       // given
-      const translate = i18n.__;
+      const locale = DUTCH_SPOKEN;
+      const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
 
       // when
-      await mailService.sendVerificationCodeEmail({
-        code,
-        email: userEmail,
-        locale: DUTCH_SPOKEN,
-        translate,
-      });
+      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(
-        translate({ phrase: 'verification-code-email.subject', locale: 'nl' }, { code }),
-      );
+      expect(options.subject).to.equal(i18n.__('verification-code-email.subject', { code }));
       expect(options.fromName).to.equal('PIX - Niet beantwoorden');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
@@ -487,29 +560,30 @@ describe('Unit | Service | MailService', function () {
         homeUrl: 'https://pix.org/nl-be',
         displayNationalLogo: false,
         code,
-        ...mainTranslationsMapping.nl['verification-code-email'].body,
+        context: i18n.__('verification-code-email.body.context'),
+        doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+        greeting: i18n.__('verification-code-email.body.greeting'),
+        moreOn: i18n.__('verification-code-email.body.moreOn'),
+        pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+        seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+        signing: i18n.__('verification-code-email.body.signing'),
+        warningMessage: i18n.__('verification-code-email.body.warningMessage'),
       });
     });
 
     it(`calls sendEmail with from, to, template, tags and locale ${SPANISH_SPOKEN}`, async function () {
       // given
-      const translate = i18n.__;
+      const locale = SPANISH_SPOKEN;
+      const i18n = getI18n(locale);
       const userEmail = 'user@example.net';
       const code = '999999';
 
       // when
-      await mailService.sendVerificationCodeEmail({
-        code,
-        email: userEmail,
-        locale: SPANISH_SPOKEN,
-        translate,
-      });
+      await mailService.sendVerificationCodeEmail({ code, email: userEmail, locale });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
-      expect(options.subject).to.equal(
-        translate({ phrase: 'verification-code-email.subject', locale: 'es' }, { code }),
-      );
+      expect(options.subject).to.equal(i18n.__('verification-code-email.subject', { code }));
       expect(options.fromName).to.equal('PIX - No responder');
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
@@ -517,7 +591,14 @@ describe('Unit | Service | MailService', function () {
         homeUrl: 'https://pix.org/en',
         displayNationalLogo: false,
         code,
-        ...mainTranslationsMapping.es['verification-code-email'].body,
+        context: i18n.__('verification-code-email.body.context'),
+        doNotAnswer: i18n.__('verification-code-email.body.doNotAnswer'),
+        greeting: i18n.__('verification-code-email.body.greeting'),
+        moreOn: i18n.__('verification-code-email.body.moreOn'),
+        pixPresentation: i18n.__('verification-code-email.body.pixPresentation'),
+        seeYouSoon: i18n.__('verification-code-email.body.seeYouSoon'),
+        signing: i18n.__('verification-code-email.body.signing'),
+        warningMessage: i18n.__('verification-code-email.body.warningMessage'),
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème

Dans les services d'envoie d'emails, on importe les fichiers de traduction au lieu d'utiliser la librairie i18n.

## ⛱️ Proposition

Ne plus importer les fichiers de traduction et directement utiliser l'instance i18n via `const i18n = getI18n(locale)`

## 🏄 Pour tester

**Accès :**
- Email invitation orga - `sendOrganizationInvitationEmail` (test fr et en) ✅
- Email invitation orga SCO - `sendScoOrganizationInvitationEmail` (test fr uniquement) ✅
- Email invitation CDC - `sendCertificationCenterInvitationEmail` (test fr et en) ✅
- Email de récupération de compte - `sendAccountRecoveryEmail` (test fr uniquement) ✅
- Email d'envoie de code au changement d'email - `sendVerificationCodeEmail` (test fr et en) ✅

**Certif :**
- Publication de session (vérifier les emails cléa result et certification result) ✅
- Publication de session en batch (vérifier les emails cléa result et certification result) ✅
