### PR TITLE
[TECH] Suppression des imports de 'translations' dans l'API

### DIFF
--- a/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
+++ b/api/src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js
@@ -25,7 +25,6 @@ async function getAttendanceSheetPdfBuffer({
   session,
   i18n,
 } = {}) {
-  const translate = i18n.__;
   const lang = i18n.getLocale();
 
   const templatePath = `${dirname}/files/attendance-sheet.pdf`;
@@ -55,22 +54,22 @@ async function getAttendanceSheetPdfBuffer({
     page.drawPage(templatePage);
     const pagesCount = certificationCandidatesSplitByPage.length;
 
-    _drawHeaderLabels({ page, titleFont, pageInformationFont, translate });
+    _drawHeaderLabels({ page, titleFont, pageInformationFont, i18n });
     _drawCertificationInformationLabels({
       page,
       titleFont,
       sessionLabelsAndCandidatesInformationFont,
-      translate,
+      i18n,
       lang,
     });
-    _drawExaminerSectionLabels({ page, titleFont, sessionLabelsAndCandidatesInformationFont, translate });
+    _drawExaminerSectionLabels({ page, titleFont, sessionLabelsAndCandidatesInformationFont, i18n });
     _drawCandidatesTableLabels({
       page,
       session,
       titleFont,
       sessionLabelsAndCandidatesInformationFont,
       tableLabelsFont,
-      translate,
+      i18n,
       lang,
     });
 
@@ -105,7 +104,7 @@ async function getAttendanceSheetPdfBuffer({
 
   const pdfBytes = await pdfDoc.save();
 
-  const fileName = `${translate('attendance-sheet.file-name')}${session.id}.pdf`;
+  const fileName = `${i18n.__('attendance-sheet.file-name')}${session.id}.pdf`;
   const attendanceSheet = Buffer.from(pdfBytes);
 
   return { fileName, attendanceSheet };
@@ -116,9 +115,9 @@ async function _embedFontIntoPdf({ pdfDoc, dirname, font }) {
   return pdfDoc.embedFont(fontFile, { subset: true });
 }
 
-function _drawHeaderLabels({ page, titleFont, pageInformationFont, translate }) {
-  const pageLabel = translate('attendance-sheet.header.page');
-  const titleLabel = translate('attendance-sheet.header.title');
+function _drawHeaderLabels({ page, titleFont, pageInformationFont, i18n }) {
+  const pageLabel = i18n.__('attendance-sheet.header.page');
+  const titleLabel = i18n.__('attendance-sheet.header.title');
   [
     [42, 807, pageLabel, SESSION_DETAIL_FONT_SIZE, pageInformationFont],
     [42, 784, titleLabel, 24, titleFont],
@@ -137,15 +136,15 @@ function _drawCertificationInformationLabels({
   page,
   titleFont,
   sessionLabelsAndCandidatesInformationFont,
-  translate,
+  i18n,
   lang,
 }) {
-  const certificationSessionLabel = translate('attendance-sheet.certification-information.session');
-  const numberLabel = translate('attendance-sheet.certification-information.number');
-  const dateLabel = translate('attendance-sheet.certification-information.date');
-  const localTimeLabel = translate('attendance-sheet.certification-information.local-time');
-  const locationNameLabel = translate('attendance-sheet.certification-information.location-name');
-  const roomNameLabel = translate('attendance-sheet.certification-information.room-name');
+  const certificationSessionLabel = i18n.__('attendance-sheet.certification-information.session');
+  const numberLabel = i18n.__('attendance-sheet.certification-information.number');
+  const dateLabel = i18n.__('attendance-sheet.certification-information.date');
+  const localTimeLabel = i18n.__('attendance-sheet.certification-information.local-time');
+  const locationNameLabel = i18n.__('attendance-sheet.certification-information.location-name');
+  const roomNameLabel = i18n.__('attendance-sheet.certification-information.room-name');
 
   const labels = [
     [
@@ -191,10 +190,10 @@ function _drawCertificationInformationLabels({
   );
 }
 
-function _drawExaminerSectionLabels({ page, titleFont, sessionLabelsAndCandidatesInformationFont, translate }) {
-  const titleLabel = translate('attendance-sheet.examiner-information.title');
-  const invigilatedByLabel = translate('attendance-sheet.examiner-information.invigilated-by');
-  const signatureLabel = translate('attendance-sheet.examiner-information.signature');
+function _drawExaminerSectionLabels({ page, titleFont, sessionLabelsAndCandidatesInformationFont, i18n }) {
+  const titleLabel = i18n.__('attendance-sheet.examiner-information.title');
+  const invigilatedByLabel = i18n.__('attendance-sheet.examiner-information.invigilated-by');
+  const signatureLabel = i18n.__('attendance-sheet.examiner-information.signature');
 
   [
     [356, 739, titleLabel, 9, titleFont],
@@ -217,16 +216,16 @@ function _drawCandidatesTableLabels({
   titleFont,
   sessionLabelsAndCandidatesInformationFont,
   tableLabelsFont,
-  translate,
+  i18n,
   lang,
 }) {
   const divisionOrExternalIdLabel = session.isSco
-    ? translate('attendance-sheet.table.division')
-    : translate('attendance-sheet.table.external-id');
-  const titleLabel = translate('attendance-sheet.table.title');
-  const birthNameLabel = translate('attendance-sheet.table.birth-name');
-  const firstNameLabel = translate('attendance-sheet.table.first-name');
-  const signatureLabel = translate('attendance-sheet.table.signature');
+    ? i18n.__('attendance-sheet.table.division')
+    : i18n.__('attendance-sheet.table.external-id');
+  const titleLabel = i18n.__('attendance-sheet.table.title');
+  const birthNameLabel = i18n.__('attendance-sheet.table.birth-name');
+  const firstNameLabel = i18n.__('attendance-sheet.table.first-name');
+  const signatureLabel = i18n.__('attendance-sheet.table.signature');
 
   [
     [26, 660, titleLabel, 12, titleFont],
@@ -244,12 +243,12 @@ function _drawCandidatesTableLabels({
     });
   });
 
-  _drawDateOfBirthLabel({ page, tableLabelsFont, sessionLabelsAndCandidatesInformationFont, translate, lang });
+  _drawDateOfBirthLabel({ page, tableLabelsFont, sessionLabelsAndCandidatesInformationFont, i18n, lang });
 }
 
-function _drawDateOfBirthLabel({ page, tableLabelsFont, sessionLabelsAndCandidatesInformationFont, translate, lang }) {
-  const dateOfBirthExampleLabel = translate('attendance-sheet.table.date-of-birth.example');
-  const dateOfBirthLabel = translate('attendance-sheet.table.date-of-birth.label');
+function _drawDateOfBirthLabel({ page, tableLabelsFont, sessionLabelsAndCandidatesInformationFont, i18n, lang }) {
+  const dateOfBirthExampleLabel = i18n.__('attendance-sheet.table.date-of-birth.example');
+  const dateOfBirthLabel = i18n.__('attendance-sheet.table.date-of-birth.label');
 
   const dateParts = _getDateOfBirthPartsByLang({
     lang,

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
 import { ChallengeAlreadyAnsweredError } from '../../certification/evaluation/domain/errors.js';
 import { CertificateGenerationError } from '../../certification/results/domain/errors.js';
@@ -22,6 +21,7 @@ import {
 } from '../../team/domain/errors.js';
 import * as SharedDomainErrors from '../domain/errors.js';
 import { getBaseLocale } from '../domain/services/locale-service.js';
+import { getI18n } from '../infrastructure/i18n/i18n.js';
 import { getChallengeLocale } from '../infrastructure/utils/request-response-utils.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
 import { HttpErrors } from './http-errors.js';
@@ -29,10 +29,17 @@ import { HttpErrors } from './http-errors.js';
 const NOT_VALID_RELATIONSHIPS = ['externalId', 'participantExternalId'];
 
 function translateMessage(locale, key) {
-  if (translations[locale]['entity-validation-errors'][key]) {
-    return translations[locale]['entity-validation-errors'][key];
-  }
-  return key;
+  const i18n = getI18n(locale);
+  if (!key) return key;
+
+  // use regexp to remove i18n key special chars from key
+  const i18nKey = `entity-validation-errors.${key}`.replace(/[:{}%]/g, '');
+  const translation = i18n.__(i18nKey);
+
+  // when the i18n key is returned, so the translation does not exist
+  if (translation === i18nKey) return key;
+
+  return translation;
 }
 
 function _formatUndefinedAttribute({ message, locale, meta }) {

--- a/api/tests/certification/session-management/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
@@ -1,8 +1,6 @@
 import { writeFile } from 'node:fs/promises';
-import path from 'node:path';
 import * as url from 'node:url';
 
-import i18n from 'i18n';
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
 
 import { getAttendanceSheetPdfBuffer } from '../../../../../../../src/certification/enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js';
@@ -10,8 +8,6 @@ import { getI18n } from '../../../../../../../src/shared/infrastructure/i18n/i18
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';
 import { isSameBinary } from '../../../../../../tooling/binary-comparator.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-
-const directory = path.resolve(path.join(__dirname, '../../../../../../../translations'));
 
 describe('Integration | Infrastructure | Utils | Pdf | Attendance sheet Pdf', function () {
   beforeEach(function () {
@@ -185,12 +181,7 @@ describe('Integration | Infrastructure | Utils | Pdf | Attendance sheet Pdf', fu
     });
     const outputFilename = '/attendance-sheet-EN_expected.pdf';
 
-    i18n.configure({
-      defaultLocale: 'en',
-      directory,
-      objectNotation: true,
-      updateFiles: false,
-    });
+    const i18n = getI18n('en');
 
     // when
     const { attendanceSheet: buffer } = await getAttendanceSheetPdfBuffer({

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -146,6 +146,36 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
     });
 
+    it('should fallback to the message if the translation is not found with special chars', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [{ attribute: 'name', message: 'special-:{%}/_chars' }],
+      });
+
+      // when
+      const response = await handle(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'special-:{%}/_chars',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
     it('should translate EntityValidationError even if invalidAttributes is undefined', async function () {
       // given
       const request = {

--- a/api/translations/index.js
+++ b/api/translations/index.js
@@ -1,6 +1,0 @@
-import en from './en.json' with { type: 'json' };
-import es from './es.json' with { type: 'json' };
-import fr from './fr.json' with { type: 'json' };
-import nl from './nl.json' with { type: 'json' };
-
-export { en, es, fr, nl };


### PR DESCRIPTION
## 🔆 Problème

Dans l'API on importe les fichiers de traduction au lieu d'utiliser la librarie i18n.

## ⛱️ Proposition

Ne plus importer les fichiers de traduction et directement utiliser l'instance i18n via `const i18n = getI18n(locale)`

## 🏄 Pour tester

**Certification :**
Générer le PDF de feuille de surveillance en Français et en Anglais.

<img width="1790" height="1235" alt="SCR-20250828-njjf" src="https://github.com/user-attachments/assets/a142825e-0cd7-41be-a604-16671773a0d0" />

