### PR TITLE
[FEATURE] Gestion de la locale dans les emails d'accès (PIX-19266).

### DIFF
--- a/api/src/identity-access-management/application/password/password.controller.js
+++ b/api/src/identity-access-management/application/password/password.controller.js
@@ -1,5 +1,5 @@
 import * as userSerializer from '../../../shared/infrastructure/serializers/jsonapi/user-serializer.js';
-import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const checkResetDemand = async function (request, h, dependencies = { userSerializer }) {
@@ -9,7 +9,7 @@ const checkResetDemand = async function (request, h, dependencies = { userSerial
 };
 const createResetPasswordDemand = async function (request, h) {
   const email = request.payload.email;
-  const locale = await getChallengeLocale(request);
+  const locale = getUserLocale(request);
 
   await usecases.createResetPasswordDemand({ email, locale });
 

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -206,7 +206,7 @@ const rememberUserHasSeenLastDataProtectionPolicyInformation = async function (
 
 const selfDeleteUserAccount = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const locale = await getChallengeLocale(request);
+  const locale = getUserLocale(request);
 
   await usecases.selfDeleteUserAccount({ userId: authenticatedUserId, locale });
 

--- a/api/tests/identity-access-management/integration/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/password/password.controller.test.js
@@ -9,14 +9,12 @@ import { databaseBuilder, domainBuilder, expect, hFake, HttpTestServer, sinon } 
 describe('Integration | Identity Access Management | Application | Controller | password', function () {
   describe('#createResetPasswordDemand', function () {
     const email = 'user@example.net';
-    const headers = {
-      'accept-language': 'fr',
-    };
+    const state = { locale: 'fr-FR' };
     const payload = { email };
 
     it('returns a 204 HTTP status code', async function () {
       // given
-      const request = { headers, payload };
+      const request = { state, payload };
 
       const userId = databaseBuilder.factory.buildUser({ email }).id;
       databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
@@ -32,7 +30,7 @@ describe('Integration | Identity Access Management | Application | Controller | 
     context('when user account does not exist with given email', function () {
       it('returns a 204 HTTP status code', async function () {
         // given
-        const request = { headers, payload };
+        const request = { state, payload };
 
         // when
         const response = await passwordController.createResetPasswordDemand(request, hFake);

--- a/api/tests/identity-access-management/unit/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/password/password.controller.test.js
@@ -35,13 +35,11 @@ describe('Unit | Identity Access Management | Application | Controller | passwor
 
   describe('#createResetPasswordDemand', function () {
     const email = 'user@example.net';
-    const locale = 'fr';
+    const locale = 'fr-FR';
     const temporaryKey = 'ABCDEF123';
     const request = {
-      headers: {
-        'accept-language': locale,
-      },
       payload: { email },
+      state: { locale },
     };
     const resetPasswordDemand = {
       id: 1,

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -365,6 +365,27 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
     });
   });
 
+  describe('#selfDeleteUserAccount', function () {
+    it('calls the usecase to delete user account', async function () {
+      // given
+      sinon.stub(usecases, 'selfDeleteUserAccount');
+      usecases.selfDeleteUserAccount.resolves();
+      const userId = 1;
+      const locale = 'fr-FR';
+
+      const request = {
+        state: { locale },
+        auth: { credentials: { userId } },
+      };
+
+      // when
+      await userController.selfDeleteUserAccount(request, hFake);
+
+      // then
+      expect(usecases.selfDeleteUserAccount).to.have.been.calledWithExactly({ locale, userId });
+    });
+  });
+
   describe('#sendVerificationCode', function () {
     it('calls the usecase to send verification code with code, email and locale', async function () {
       // given


### PR DESCRIPTION
## 🔆 Problème
On utilise la locale issue du challenge dans les envois d'email. On veut désormais utiliser la locale de l'utilisateur. 

## ⛱️ Proposition
Remplacer getChallengeLocale par getUserLocale dans les controllers des emails passwordResetTemplateId et  selfAccountDeletionTemplateId.

## 🏄 Pour tester
- Utiliser Mot de passe oublié sur Pix App dans 2 langues
- Supprimer son compte depuis Pix App dans 2 langues
