### PR TITLE
[FEATURE] Afficher le numéro d'étape courante dans le Stepper horizontal (PIX-19287)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -2,7 +2,7 @@
 @use 'pix-design-tokens/breakpoints';
 @use '../passage';
 
-.stepper--horizontal {
+.stepper__steps {
   display: grid;
   grid-template-rows: auto auto;
   gap: 8px;

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -24,6 +24,8 @@ export default class ModulixStepper extends Component {
     return this.modulixPreviewMode.isEnabled ? this.displayableSteps : [firstDisplayableStep];
   }
 
+  @tracked displayedStepIndex = 0;
+
   @action
   hasStepJustAppeared(index) {
     return this.stepsToDisplay.length - 1 === index;
@@ -44,6 +46,7 @@ export default class ModulixStepper extends Component {
     }
 
     this.args.onStepperNextStep(currentStepPosition);
+    this.displayedStepIndex = currentStepPosition;
   }
 
   get currentStepIndex() {
@@ -69,36 +72,86 @@ export default class ModulixStepper extends Component {
     return this.hasNextStep && this.allAnswerableElementsAreAnsweredInCurrentStep;
   }
 
+  get totalSteps() {
+    return this.displayableSteps.length;
+  }
+
+  get isHorizontalDirection() {
+    return this.args.direction === 'horizontal';
+  }
+
   <template>
     <div
       class="stepper stepper--{{@direction}}"
       aria-live="assertive"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
-      {{#if this.hasDisplayableSteps}}
-        {{#each this.stepsToDisplay as |step index|}}
-          <Step
-            @step={{step}}
-            @currentStep={{inc index}}
-            @totalSteps={{this.displayableSteps.length}}
-            @onElementAnswer={{@onElementAnswer}}
-            @onElementRetry={{@onElementRetry}}
-            @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-            @hasJustAppeared={{this.hasStepJustAppeared index}}
-            @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
-            @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
-            @onVideoPlay={{@onVideoPlay}}
-            @onFileDownload={{@onFileDownload}}
-            @onExpandToggle={{@onExpandToggle}}
-          />
-        {{/each}}
-        {{#if this.shouldDisplayNextButton}}
-          <PixButton
-            aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
-            @variant="primary"
-            @triggerAction={{this.displayNextStep}}
-            class="stepper__next-button"
-          >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+      {{#if this.isHorizontalDirection}}
+        <div class="stepper__control">
+          <p
+            aria-label="{{t
+              'pages.modulix.stepper.step.position'
+              currentStep=(inc this.displayedStepIndex)
+              totalSteps=this.totalSteps
+            }}"
+          >
+            {{inc this.displayedStepIndex}}/{{this.totalSteps}}
+          </p>
+        </div>
+        <div class="stepper__steps">
+          {{#if this.hasDisplayableSteps}}
+            {{#each this.stepsToDisplay as |step index|}}
+              <Step
+                @step={{step}}
+                @currentStep={{inc index}}
+                @totalSteps={{this.totalSteps}}
+                @onElementAnswer={{@onElementAnswer}}
+                @onElementRetry={{@onElementRetry}}
+                @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+                @hasJustAppeared={{this.hasStepJustAppeared index}}
+                @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+                @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+                @onVideoPlay={{@onVideoPlay}}
+                @onFileDownload={{@onFileDownload}}
+                @onExpandToggle={{@onExpandToggle}}
+              />
+            {{/each}}
+            {{#if this.shouldDisplayNextButton}}
+              <PixButton
+                aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
+                @variant="primary"
+                @triggerAction={{this.displayNextStep}}
+                class="stepper__next-button"
+              >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+            {{/if}}
+          {{/if}}
+        </div>
+      {{else}}
+        {{#if this.hasDisplayableSteps}}
+          {{#each this.stepsToDisplay as |step index|}}
+            <Step
+              @step={{step}}
+              @currentStep={{inc index}}
+              @totalSteps={{this.totalSteps}}
+              @onElementAnswer={{@onElementAnswer}}
+              @onElementRetry={{@onElementRetry}}
+              @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+              @hasJustAppeared={{this.hasStepJustAppeared index}}
+              @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
+              @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
+              @onVideoPlay={{@onVideoPlay}}
+              @onFileDownload={{@onFileDownload}}
+              @onExpandToggle={{@onExpandToggle}}
+            />
+          {{/each}}
+          {{#if this.shouldDisplayNextButton}}
+            <PixButton
+              aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
+              @variant="primary"
+              @triggerAction={{this.displayNextStep}}
+              class="stepper__next-button"
+            >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+          {{/if}}
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -692,6 +692,65 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert.dom(find('.stepper--horizontal')).exists();
       });
 
+      test('it should display current step number', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+        function stepperIsFinished() {}
+
+        function onStepperNextStepStub() {}
+
+        // when
+        const screen = await render(
+          <template>
+            <ModulixStepper
+              @stepperIsFinished={{stepperIsFinished}}
+              @onStepperNextStep={{onStepperNextStepStub}}
+              @steps={{steps}}
+              @direction="horizontal"
+            />
+          </template>,
+        );
+
+        // then
+        const title = screen.getByLabelText(
+          t('pages.modulix.stepper.step.position', {
+            currentStep: 1,
+            totalSteps: 2,
+          }),
+        );
+        assert.dom(title).exists();
+        await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+        assert
+          .dom(
+            screen.getByLabelText(
+              t('pages.modulix.stepper.step.position', {
+                currentStep: 2,
+                totalSteps: 2,
+              }),
+            ),
+          )
+          .exists();
+      });
+
       test('should display the first step with the button Next', async function (assert) {
         // given
         const steps = [


### PR DESCRIPTION
## ⛱️ Proposition

En suivant la maquette Figma, afficher le numéro d'étape courante au dessus de chaque Step dans le Stepper horizontal
https://www.figma.com/design/0RcwMBD5KmmbAxVOf2OH0D/Modulix?node-id=172-1579&m=dev

## 🌊 Remarques

- Les contrôles avec les flèches seront dans un prochain ticket

## 🏄 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr13336.review.pix.fr/modules/bac-a-sable/passage)
- Afficher un stepper horizontal
- Vérifier que le n° d'étape s'affiche
- Cliquer sur Suivant
- Vérifier que le n° d'étape est mis à jour et s'affiche 
