### PR TITLE
[TECH] Ajoute script pour importer les challenges calibrés (PIX-19279)

### DIFF
--- a/api/scripts/certification/import-active-calibrated-challenges-csv.js
+++ b/api/scripts/certification/import-active-calibrated-challenges-csv.js
@@ -1,0 +1,47 @@
+import Joi from 'joi';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { csvFileParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const columnSchemas = [
+  { name: 'challenge_id', schema: Joi.string() },
+  { name: 'delta', schema: Joi.number() },
+  { name: 'alpha', schema: Joi.number() },
+];
+
+export class ImportActiveCalibratedChallengesCsv extends Script {
+  constructor() {
+    super({
+      description: 'Import calibrations from csv',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe:
+            'CSV File with `challenge_id`, `alpha` and `delta` columns extracted from `datawarehouse.data_active_calibrated_challenges`',
+          demandOption: true,
+          coerce: csvFileParser(columnSchemas),
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { file: calibratedChallengesFromDatawarehouse } = options;
+    logger.info(calibratedChallengesFromDatawarehouse);
+    const calibratedChallengesToInsert = [];
+
+    for (const calibratedChallenge of calibratedChallengesFromDatawarehouse) {
+      calibratedChallengesToInsert.push({
+        challengeId: calibratedChallenge.challenge_id,
+        delta: calibratedChallenge.delta,
+        alpha: calibratedChallenge.alpha,
+      });
+    }
+    return knex.batchInsert('certification-data-active-calibrated-challenges', calibratedChallengesToInsert);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, ImportActiveCalibratedChallengesCsv);

--- a/api/tests/integration/scripts/certification/import-active-calibrated-challenges-csv_test.js
+++ b/api/tests/integration/scripts/certification/import-active-calibrated-challenges-csv_test.js
@@ -1,0 +1,37 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { ImportActiveCalibratedChallengesCsv } from '../../../../scripts/certification/import-active-calibrated-challenges-csv.js';
+import { createTempFile, expect, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | import-active-calibrated-challenges-csv', function () {
+  it('should parse input file', async function () {
+    const script = new ImportActiveCalibratedChallengesCsv();
+    const options = script.metaInfo.options;
+    const file = 'active-calibrated-chalenges-to-import.csv';
+    const data = 'challenge_id;delta;alpha\n123;1;2\n456;4;5\n789;7;8';
+    const csvFilePath = await createTempFile(file, data);
+    const parsedData = await options.file.coerce(csvFilePath);
+
+    expect(parsedData).to.deep.equals([
+      { challenge_id: '123', delta: 1, alpha: 2 },
+      { challenge_id: '456', delta: 4, alpha: 5 },
+      { challenge_id: '789', delta: 7, alpha: 8 },
+    ]);
+  });
+
+  it('should insert the active calibrated challenges', async function () {
+    const script = new ImportActiveCalibratedChallengesCsv();
+    const logger = { info: sinon.spy(), error: sinon.spy() };
+    const file = [
+      { challenge_id: '123', delta: 1, alpha: 2 },
+      { challenge_id: '456', delta: 4, alpha: 5 },
+      { challenge_id: '789', delta: 7, alpha: 8 },
+    ];
+
+    // when
+    await script.handle({ logger, options: { file } });
+
+    // then
+    const [{ count: addedChallenges }] = await knex('certification-data-active-calibrated-challenges').count();
+    expect(addedChallenges).to.equal(3);
+  });
+});

--- a/api/tests/integration/scripts/certification/import-active-calibrated-challenges-csv_test.js
+++ b/api/tests/integration/scripts/certification/import-active-calibrated-challenges-csv_test.js
@@ -20,7 +20,7 @@ describe('Integration | Scripts | Certification | import-active-calibrated-chall
 
   it('should insert the active calibrated challenges', async function () {
     const script = new ImportActiveCalibratedChallengesCsv();
-    const logger = { info: sinon.spy(), error: sinon.spy() };
+    const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy() };
     const file = [
       { challenge_id: '123', delta: 1, alpha: 2 },
       { challenge_id: '456', delta: 4, alpha: 5 },
@@ -28,7 +28,7 @@ describe('Integration | Scripts | Certification | import-active-calibrated-chall
     ];
 
     // when
-    await script.handle({ logger, options: { file } });
+    await script.handle({ logger, options: { file, dryRun: false } });
 
     // then
     const [{ count: addedChallenges }] = await knex('certification-data-active-calibrated-challenges').count();


### PR DESCRIPTION
## 🔆 Problème

Nous avons besoin d'importer le contenu de la table `datawarehouse.data_active_calibrated_challenges` sous forme d'un CSV.

## ⛱️ Proposition

Écrire un script réalisant cet import.

## 🌊 Remarques

En attente de la migration https://github.com/1024pix/pix/pull/13341
## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Enregister le fichier suivant pour l'import : 
[calibration.csv](https://github.com/user-attachments/files/22078869/calibration.csv)

Exécuter le script avec la commande suivante : 

```
scalingo -a pix-api-review-pr13338 run --file="<FILE_PATH>" "node scripts/certification/import-active-calibrated-challenges-csv.js --dryRun=true --file=/tmp/uploads/<FILE_NAME>"
```

Si pas de problème, ré-exécuter la commande avec le dryRun à false: 
```
scalingo -a pix-api-review-pr13338 run --file="<FILE_PATH>" "node scripts/certification/import-active-calibrated-challenges-csv.js --dryRun=false --file=/tmp/uploads/<FILE_NAME>"
```