### PR TITLE
[TECH] Suppression de la table `certification-data-calibrations` (PIX-19296).

### DIFF
--- a/api/db/migrations/20250828150929_drop-certification-data-calibrations-table.js
+++ b/api/db/migrations/20250828150929_drop-certification-data-calibrations-table.js
@@ -1,0 +1,37 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable('certification-data-active-calibrated-challenges', function (table) {
+    table.dropColumn('calibrationId');
+    table.primary('challengeId');
+  });
+
+  await knex.schema.dropTable('certification-data-calibrations');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.createTable('certification-data-calibrations', function (table) {
+    table.increments('id').primary();
+    table.dateTime('calibrationDate').notNullable().comment('Date of calibration');
+    table.string('status').notNullable().comment('Validation status of the calibration');
+    table.string('scope').notNullable().comment('Calibration scope');
+
+    table.index(['calibrationDate', 'scope', 'status']);
+  });
+
+  await knex.schema.alterTable('certification-data-active-calibrated-challenges', function (table) {
+    table.integer('calibrationId').notNullable().comment('link to calibration');
+
+    table.dropPrimary();
+    table.primary(['calibrationId', 'challengeId']);
+    table.foreign('calibrationId').references(`certification-data-calibrations.id`);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Cette table ne sera pas utilisée puisque nous nous baserons uniquement sur la dernière calibration enregistrée (la seule utilisée dans l'environnement de production) pour gérer le rescoring des certifications qui ont été passées entre octobre 2024 et le 6 octobre 2025.

## ⛱️ Proposition

Suppression de la clé étrangère dans `certification-data-active-calibrated-challenges`
Suppression de la table `certification-data-calibrations`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

• Lancer la migration en RA, vérifier que la table `certification-data-calibrations` a été supprimée tout comme la clé étrangère dans `certification-data-active-calibrated-challenges`
• Puis lancer npm run db:rollback:latest et vérifier que la tables a bien été reconstruite avec la clé étrangère dans `certification-data-active-calibrated-challenges`