### PR TITLE
[FEATURE] Ajouter des indicateurs pour suivre les clics sur la nouvelle page d'accueil (PIX-19007)

### DIFF
--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -152,23 +152,11 @@ export default class ParticipationFilters extends Component {
   @action
   onSelectBadge(badges) {
     this.args.onFilter('badges', badges);
-
-    this.pixMetrics.trackEvent('Usage du filtre par Badges', {
-      disabled: true,
-      'pix-event-category': 'Campagnes',
-      'pix-event-action': 'Filtrer les participations',
-    });
   }
 
   @action
   onSelectUnacquiredBadge(unacquiredBadges) {
     this.args.onFilter('unacquiredBadges', unacquiredBadges);
-
-    this.pixMetrics.trackEvent('Utilisation du filtre "Badges non obtenus"', {
-      disabled: true,
-      'pix-event-category': 'Campagnes',
-      'pix-event-action': 'Filtrer les participations',
-    });
   }
 
   @action

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -7,6 +7,8 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { or } from 'ember-truth-helpers';
 
+import { EVENT_NAME } from '../../../helpers/metrics-event-name';
+
 export default class CampaignTabs extends Component {
   @service intl;
   @service notifications;
@@ -25,7 +27,7 @@ export default class CampaignTabs extends Component {
     try {
       const token = this.session.data.authenticated.access_token;
       await this.fileSaver.save({ url: this.args.campaign.urlToResult, token });
-      this.pixMetrics.trackEvent('exportCampaignResultClic');
+      this.pixMetrics.trackEvent(EVENT_NAME.CAMPAIGN.EXPORT_DATA_CLICK);
     } catch {
       this.notifications.sendError(this.intl.t('api-error-messages.global'));
     }

--- a/orga/app/components/index/classic.gjs
+++ b/orga/app/components/index/classic.gjs
@@ -1,4 +1,7 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -9,12 +12,20 @@ import OrganizationInfo from 'pix-orga/components/index/organization-information
 import ParticipationStatistics from 'pix-orga/components/index/participation-statistics';
 import Welcome from 'pix-orga/components/index/welcome';
 
+import { EVENT_NAME } from '../../helpers/metrics-event-name';
+
 export default class IndexClassic extends Component {
   @service currentUser;
   @service intl;
+  @service pixMetrics;
 
   get description() {
     return this.intl.t('components.index.welcome.description.classic');
+  }
+
+  @action
+  trackEvent(eventName) {
+    this.pixMetrics.trackEvent(eventName);
   }
 
   <template>
@@ -34,7 +45,12 @@ export default class IndexClassic extends Component {
         @title={{t "components.index.action-cards.classic.create-campaign.title"}}
         @description={{t "components.index.action-cards.classic.create-campaign.description"}}
       >
-        <PixButtonLink @variant="secondary" type="button" @route="authenticated.campaigns.new">
+        <PixButtonLink
+          @variant="secondary"
+          type="button"
+          @route="authenticated.campaigns.new"
+          {{on "click" (fn this.trackEvent EVENT_NAME.HOMEPAGE.CREATE_CAMPAIGN_CLICK)}}
+        >
           {{t "components.index.action-cards.classic.create-campaign.buttonText"}}
         </PixButtonLink>
       </ActionCardsListItem>
@@ -43,7 +59,12 @@ export default class IndexClassic extends Component {
         @title={{t "components.index.action-cards.classic.follow-activity.title"}}
         @description={{t "components.index.action-cards.classic.follow-activity.description"}}
       >
-        <PixButtonLink @variant="secondary" type="button" @route="authenticated.campaigns.list.my-campaigns">
+        <PixButtonLink
+          @variant="secondary"
+          type="button"
+          @route="authenticated.campaigns.list.my-campaigns"
+          {{on "click" (fn this.trackEvent EVENT_NAME.HOMEPAGE.LIST_CAMPAIGNS_CLICK)}}
+        >
           {{t "components.index.action-cards.classic.follow-activity.buttonText"}}
         </PixButtonLink>
       </ActionCardsListItem>

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -23,7 +23,6 @@ export default class AuthenticatedAttestationsController extends Controller {
   @action
   async downloadAttestations(attestationKey, selectedDivisions) {
     try {
-      this.sendMetrics();
       let url;
       const organizationId = this.currentUser.organization.id;
       const baseUrl = `/api/organizations/${organizationId}/attestations/${attestationKey}`;
@@ -64,13 +63,5 @@ export default class AuthenticatedAttestationsController extends Controller {
   triggerFiltering(fieldName, value) {
     this[fieldName] = value || undefined;
     this.pageNumber = 1;
-  }
-
-  sendMetrics() {
-    this.pixMetrics.trackEvent('Clic sur le bouton Télécharger (attestations)', {
-      disabled: true,
-      'pix-event-category': 'Attestations',
-      'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
-    });
   }
 }

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -1,0 +1,6 @@
+export const EVENT_NAME = {
+  HOMEPAGE: {
+    CREATE_CAMPAIGN_CLICK: 'homepageCreateCampaignClick',
+    LIST_CAMPAIGNS_CLICK: 'homepageListCampaignsClick',
+  },
+};

--- a/orga/app/helpers/metrics-event-name.js
+++ b/orga/app/helpers/metrics-event-name.js
@@ -3,4 +3,7 @@ export const EVENT_NAME = {
     CREATE_CAMPAIGN_CLICK: 'homepageCreateCampaignClick',
     LIST_CAMPAIGNS_CLICK: 'homepageListCampaignsClick',
   },
+  CAMPAIGN: {
+    EXPORT_DATA_CLICK: 'campaignExportDataResultClick',
+  },
 };

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -553,9 +553,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         const selectedUnacquiredBadges = [];
         const selectedBadges = [];
 
-        const metrics = this.owner.lookup('service:pix-metrics');
-        metrics.trackEvent = sinon.stub();
-
         // when
         const screen = await render(
           <template>
@@ -580,12 +577,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // then
         assert.ok(triggerFiltering.calledWith('unacquiredBadges', ['badge1']));
-
-        sinon.assert.calledWithExactly(metrics.trackEvent, 'Utilisation du filtre "Badges non obtenus"', {
-          disabled: true,
-          'pix-event-category': 'Campagnes',
-          'pix-event-action': 'Filtrer les participations',
-        });
       });
 
       test('it triggers the filter when an acquired badge is selected', async function (assert) {
@@ -600,9 +591,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         const triggerFiltering = sinon.stub();
         const selectedBadges = [];
         const selectedUnacquiredBadges = [];
-
-        const metrics = this.owner.lookup('service:pix-metrics');
-        metrics.trackEvent = sinon.stub();
 
         // when
         const screen = await render(
@@ -625,12 +613,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // then
         assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
-
-        sinon.assert.calledWithExactly(metrics.trackEvent, 'Usage du filtre par Badges', {
-          disabled: true,
-          'pix-event-category': 'Campagnes',
-          'pix-event-action': 'Filtrer les participations',
-        });
       });
     });
 
@@ -711,9 +693,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         const selectedUnacquiredBadges = [];
         const selectedBadges = [];
 
-        const metrics = this.owner.lookup('service:pix-metrics');
-        metrics.trackEvent = sinon.stub();
-
         // when
         const screen = await render(
           <template>
@@ -738,12 +717,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // then
         assert.ok(triggerFiltering.calledWith('unacquiredBadges', ['badge1']));
-
-        sinon.assert.calledWithExactly(metrics.trackEvent, 'Utilisation du filtre "Badges non obtenus"', {
-          disabled: true,
-          'pix-event-category': 'Campagnes',
-          'pix-event-action': 'Filtrer les participations',
-        });
       });
 
       test('it triggers the filter when an acquired badge is selected', async function (assert) {
@@ -758,9 +731,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         const triggerFiltering = sinon.stub();
         const selectedBadges = [];
         const selectedUnacquiredBadges = [];
-
-        const metrics = this.owner.lookup('service:pix-metrics');
-        metrics.trackEvent = sinon.stub();
 
         // when
         const screen = await render(
@@ -783,12 +753,6 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
         // then
         assert.ok(triggerFiltering.calledWith('badges', ['badge1']));
-
-        sinon.assert.calledWithExactly(metrics.trackEvent, 'Usage du filtre par Badges', {
-          disabled: true,
-          'pix-event-category': 'Campagnes',
-          'pix-event-action': 'Filtrer les participations',
-        });
       });
     });
 

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -4,6 +4,7 @@ import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import ENV from 'pix-orga/config/environment';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -188,7 +189,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
       // when
       await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
 
-      sinon.assert.calledWithExactly(pixMetrics.trackEvent, 'exportCampaignResultClic');
+      sinon.assert.calledWithExactly(pixMetrics.trackEvent, EVENT_NAME.CAMPAIGN.EXPORT_DATA_CLICK);
       assert.ok(true);
     });
 

--- a/orga/tests/integration/components/index/classic_test.gjs
+++ b/orga/tests/integration/components/index/classic_test.gjs
@@ -1,8 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import IndexClassic from 'pix-orga/components/index/classic';
+import { EVENT_NAME } from 'pix-orga/helpers/metrics-event-name';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -71,6 +74,56 @@ module('Integration | Component | Index::Classic', function (hooks) {
 
       // then
       assert.notOk(screen.queryByText(t('banners.import.message')));
+    });
+  });
+
+  module('metrics', function () {
+    test('should call trackEvent on campaign creation click', async function (assert) {
+      class CurrentUserStub extends Service {
+        prescriber = {
+          firstName: 'Jean',
+        };
+      }
+
+      const router = this.owner.lookup('service:-routing');
+      sinon.stub(router, 'transitionTo');
+      this.owner.register('service:current-user', CurrentUserStub);
+      const pixMetrics = this.owner.lookup('service:pix-metrics');
+      const trackEventStub = sinon.stub(pixMetrics, 'trackEvent');
+      const screen = await render(<template><IndexClassic /></template>);
+
+      const createCampaignButton = screen.getByRole('link', {
+        name: t('components.index.action-cards.classic.create-campaign.buttonText'),
+      });
+      await click(createCampaignButton);
+
+      // then
+      sinon.assert.calledWith(trackEventStub, EVENT_NAME.HOMEPAGE.CREATE_CAMPAIGN_CLICK);
+      assert.ok(true);
+    });
+
+    test('should call trackEvent on campaigns list click', async function (assert) {
+      class CurrentUserStub extends Service {
+        prescriber = {
+          firstName: 'Jean',
+        };
+      }
+
+      const router = this.owner.lookup('service:-routing');
+      sinon.stub(router, 'transitionTo');
+      this.owner.register('service:current-user', CurrentUserStub);
+      const pixMetrics = this.owner.lookup('service:pix-metrics');
+      const trackEventStub = sinon.stub(pixMetrics, 'trackEvent');
+      const screen = await render(<template><IndexClassic /></template>);
+
+      const createCampaignButton = screen.getByRole('link', {
+        name: t('components.index.action-cards.classic.follow-activity.buttonText'),
+      });
+      await click(createCampaignButton);
+
+      // then
+      sinon.assert.calledWith(trackEventStub, EVENT_NAME.HOMEPAGE.LIST_CAMPAIGNS_CLICK);
+      assert.ok(true);
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/attestations-test.js
+++ b/orga/tests/unit/controllers/authenticated/attestations-test.js
@@ -59,21 +59,6 @@ module('Unit | Controller | authenticated/attestations', function (hooks) {
           }),
         );
       });
-      test('should call send metrics when download button is clicked', async function (assert) {
-        const metrics = this.owner.lookup('service:pix-metrics');
-        const controller = this.owner.lookup('controller:authenticated/attestations');
-        const selectedDivision = ['3èmea'];
-
-        //when
-        await controller.downloadAttestations(SIXTH_GRADE_ATTESTATION_KEY, selectedDivision);
-
-        sinon.assert.calledWithExactly(metrics.trackEvent, 'Clic sur le bouton Télécharger (attestations)', {
-          disabled: true,
-          'pix-event-category': 'Attestations',
-          'pix-event-action': 'Cliquer sur le bouton Télécharger sur la page Attestations',
-        });
-        assert.ok(true);
-      });
     });
 
     module('when selected divisions is empty', function () {


### PR DESCRIPTION
## 🔆 Problème
Maintenant que la nouvelle page d'accueil est prête, on voudrait suivre l'activité sur celle-ci et les clics sur les deux boutons présents sur cette page là.

## ⛱️ Proposition
Ajouter des évènements lors de ces clics afin de pouvoir suivre l'activité via Plausible

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter a PixOrga
- Aller sur ?preview=true
- Faire un clic sur le bouton de création de campagne -> Vérifier que l'event est bien envoyé et qu'il apparait sur Plausible
- Faire un clic sur le bouton voir mes campagnes -> Vérifier que l'event est bien envoyé et qu'il apparait sur Plausible
