### PR TITLE
[FEATURE] Permettre enregistrement des réponses aux embed LLM autovalidés (PIX-19285)

### DIFF
--- a/api/src/devcomp/domain/models/element/Embed-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/Embed-for-answer-verification.js
@@ -38,7 +38,7 @@ class EmbedForAnswerVerification extends Embed {
 
   #validateUserResponseFormat(userResponse) {
     const embedSchema = Joi.string()
-      .pattern(/^[a-z]+$/)
+      .pattern(/^[a-z-]+$/)
       .required();
 
     const validUserResponseSchema = Joi.array().items(embedSchema).min(1).max(1).required();

--- a/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed-for-answer-verification_test.js
@@ -146,14 +146,14 @@ describe('Unit | Devcomp | Domain | Models | Element | EmbedForAnswerVerificatio
           height: 800,
           url: 'https://embed.example.net',
           instruction: '',
-          solution: 'toto',
+          solution: 'toto-with-dash',
         });
 
         // when
-        embed.setUserResponse(['toto']);
+        embed.setUserResponse(['toto-with-dash']);
 
         // then
-        expect(embed.userResponse).to.deep.equal('toto');
+        expect(embed.userResponse).to.deep.equal('toto-with-dash');
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

API retourne code 422 quand on envoie la réponse d'un embed auto-validé quand celle-ci contient des tirets.

## ⛱️ Proposition

Autoriser les tirets dans le userResponse pour un element Embed.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Ouvrir Pix et se connecter
- Ouvrir le module [demo-llm](https://app-pr13343.review.pix.fr/modules/demo-llm/details)
- Répondre à l'élément Embed 
- Vérifier que la réponse est bien envoyée à l'API (utiliser la console développeur dans le navigateur)
