### PR TITLE
[FEATURE] Modifier les trads du bloc pour gérer la session pix1D sur la page d'accueil (PIX-19294)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -379,8 +379,8 @@
           },
           "launch-session": {
             "buttonText": "Activate session",
-            "description": "Activate the session to allow students to access the missions by entering the school code at '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://junior.pix.fr\">junior.pix.fr</a>', or extend the session if you need more time.",
-            "title": "Launch a session"
+            "description": "The session allows students to access Pix Junior for a period of 4 hours. Once the session has been activated, it is possible to extend its duration.",
+            "title": "Manage session"
           }
         }
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -379,8 +379,8 @@
           },
           "launch-session": {
             "buttonText": "Activer la session",
-            "description": "Activer la session afin de permettre aux élèves d’accéder aux missions en renseignant le code école sur '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://junior.pix.fr\">junior.pix.fr</a>' ou prolonger la session si vous avez besoin de plus de temps.",
-            "title": "Activer une session"
+            "description": "La session permet aux élèves d'accéder à Pix Junior pour une durée de 4h. Une fois la session activée, il est possible de prolonger son ouverture.",
+            "title": "Gérer une session"
           }
         }
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -379,8 +379,8 @@
           },
           "launch-session": {
             "buttonText": "Sessie activeren",
-            "description": "Activeer de sessie zodat de leerlingen toegang krijgen tot de opdracht door de schoolcode in te voeren op '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://junior.pix.fr\">junior.pix.fr</a>' of verleng de sessie als u meer tijd nodig heeft.",
-            "title": "Een sessie starten"
+            "description": "De sessie geeft leerlingen gedurende 4 uur toegang tot Pix Junior. Zodra de sessie is geactiveerd, kan deze worden verlengd.",
+            "title": "Sessie beheren"
           }
         }
       },


### PR DESCRIPTION
## 🔆 Problème

Suite à des échanges avec FX, modifier la description du bloc pour gérer la session de pix1D : 
La session permet aux élèves d'accéder à Pix Junior pour une durée de 4h. Une fois la session activée, il est possible de prolonger son ouverture.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
