### PR TITLE
[FEATURE] Stepper horizontal ajouter un `aria-hidden="true"` sur les étapes cachés et une bordure sur les contrôles (PIX-19295)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -3,7 +3,7 @@
 @use '../passage';
 
 .stepper {
-  &__control {
+  &__controls {
     @extend %pix-cta-s;
 
     display: flex;
@@ -15,7 +15,7 @@
     border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
 
-    .stepper-control__position {
+    .stepper-controls__position {
       margin: 0;
     }
   }

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -2,59 +2,78 @@
 @use 'pix-design-tokens/breakpoints';
 @use '../passage';
 
-.stepper__steps {
-  display: grid;
-  grid-template-rows: auto auto;
-  gap: 8px;
+.stepper {
+  &__control {
+    @extend %pix-cta-s;
 
-  .stepper__step {
-    --previous-slide-visible-width: 10px;
-
-    grid-row: 1 / 1;
-    grid-column: 1 / 1;
+    display: flex;
+    display: inline-flex;
+    gap: var(--pix-spacing-2x);
     align-items: center;
-    padding: var(--pix-spacing-4x);
+    margin-bottom: var(--pix-spacing-2x);
+    padding: var(--pix-spacing-1x) var(--pix-spacing-4x) var(--pix-spacing-1x) var(--pix-spacing-2x);
     border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
 
-    &:not(.stepper-step__active) {
-      position: relative;
-      transform: translateX(calc((-50vw - 50%) + var(--previous-slide-visible-width)));
-      pointer-events: none;
-
-      &::after {
-        position: absolute;
-        top: 50%;
-        left: calc(100% + 4px);
-        width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
-        border-bottom: 1px solid var(--pix-neutral-500);
-        opacity: 0.3;
-        content: '';
-      }
+    .stepper-control__position {
+      margin: 0;
     }
+  }
 
-    &.stepper-step__active:not(.stepper-step--last-step) {
-      position: relative;
+  &__steps {
+    display: grid;
+    grid-template-rows: auto auto;
+    gap: 8px;
 
-      &::after {
-        position: absolute;
-        top: 50%;
-        left: calc(100% + 4px);
-        width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
-        border-bottom: 1px solid var(--pix-neutral-500);
-        opacity: 0.3;
-        content: '';
+    .stepper__step {
+      --previous-slide-visible-width: 10px;
+
+      grid-row: 1 / 1;
+      grid-column: 1 / 1;
+      align-items: center;
+      padding: var(--pix-spacing-4x);
+      border: 1px solid var(--pix-neutral-100);
+      border-radius: 8px;
+
+      &:not(.stepper-step__active) {
+        position: relative;
+        transform: translateX(calc((-50vw - 50%) + var(--previous-slide-visible-width)));
+        pointer-events: none;
+
+        &::after {
+          position: absolute;
+          top: 50%;
+          left: calc(100% + 4px);
+          width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
+          border-bottom: 1px solid var(--pix-neutral-500);
+          opacity: 0.3;
+          content: '';
+        }
       }
 
-      &::before {
-        position: absolute;
-        top: 0;
-        left: calc((50vw + 50%) - var(--previous-slide-visible-width));
-        width: 100%;
-        height: 100%;
-        border: 1px solid var(--pix-neutral-100);
-        border-radius: 8px;
-        content: '';
+      &.stepper-step__active:not(.stepper-step--last-step) {
+        position: relative;
+
+        &::after {
+          position: absolute;
+          top: 50%;
+          left: calc(100% + 4px);
+          width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
+          border-bottom: 1px solid var(--pix-neutral-500);
+          opacity: 0.3;
+          content: '';
+        }
+
+        &::before {
+          position: absolute;
+          top: 0;
+          left: calc((50vw + 50%) - var(--previous-slide-visible-width));
+          width: 100%;
+          height: 100%;
+          border: 1px solid var(--pix-neutral-100);
+          border-radius: 8px;
+          content: '';
+        }
       }
     }
   }

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -39,7 +39,8 @@ export default class ModulixStep extends Component {
           {{if this.isLastStep 'stepper-step--last-step'}}"
         tabindex="-1"
         {{didInsert this.focusAndScroll}}
-        inert={{unless @hasJustAppeared true}}
+        inert={{if @isHidden true}}
+        aria-hidden={{if @isHidden "true"}}
       >
         <h3 class="stepper__step__position screen-reader-only">
           {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -89,6 +89,7 @@ export default class ModulixStepper extends Component {
       {{#if this.isHorizontalDirection}}
         <div class="stepper__control">
           <p
+            class="stepper-control__position"
             aria-label="{{t
               'pages.modulix.stepper.step.position'
               currentStep=(inc this.displayedStepIndex)

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -31,6 +31,15 @@ export default class ModulixStepper extends Component {
     return this.stepsToDisplay.length - 1 === index;
   }
 
+  @action
+  stepIsHidden(index) {
+    if (this.modulixPreviewMode.isEnabled) {
+      return false;
+    }
+
+    return !this.hasStepJustAppeared(index);
+  }
+
   get hasDisplayableSteps() {
     return this.displayableSteps.length > 0;
   }
@@ -110,6 +119,7 @@ export default class ModulixStepper extends Component {
                 @onElementRetry={{@onElementRetry}}
                 @getLastCorrectionForElement={{@getLastCorrectionForElement}}
                 @hasJustAppeared={{this.hasStepJustAppeared index}}
+                @isHidden={{this.stepIsHidden index}}
                 @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                 @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                 @onVideoPlay={{@onVideoPlay}}
@@ -138,6 +148,7 @@ export default class ModulixStepper extends Component {
               @onElementRetry={{@onElementRetry}}
               @getLastCorrectionForElement={{@getLastCorrectionForElement}}
               @hasJustAppeared={{this.hasStepJustAppeared index}}
+              @isHidden={{false}}
               @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
               @onVideoPlay={{@onVideoPlay}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -96,9 +96,9 @@ export default class ModulixStepper extends Component {
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
       {{#if this.isHorizontalDirection}}
-        <div class="stepper__control">
+        <div class="stepper__controls">
           <p
-            class="stepper-control__position"
+            class="stepper-controls__position"
             aria-label="{{t
               'pages.modulix.stepper.step.position'
               currentStep=(inc this.displayedStepIndex)

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -23,7 +23,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
       // when
       const screen = await render(
-        <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+        <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} @isHidden={{false}} /></template>,
       );
 
       // then
@@ -50,7 +50,11 @@ module('Integration | Component | Module | Step', function (hooks) {
       // when
       const screen = await render(
         <template>
-          <ModulixStep @step={{step}} @getLastCorrectionForElement={{getLastCorrectionForElementStub}} />
+          <ModulixStep
+            @step={{step}}
+            @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+            @isHidden={{false}}
+          />
         </template>,
       );
 
@@ -58,8 +62,8 @@ module('Integration | Component | Module | Step', function (hooks) {
       assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).exists();
     });
 
-    module('when hasJustAppeared attribute is false', function () {
-      test('should disabled all interactions in the step', async function (assert) {
+    module('when isHidden attribute is false', function () {
+      test('should disable all interactions in the step', async function (assert) {
         // given
         const element = {
           id: 'd0690f26-978c-41c3-9a21-da931857739c',
@@ -69,21 +73,32 @@ module('Integration | Component | Module | Step', function (hooks) {
         const step = {
           elements: [element],
         };
-        const getLastCorrectionForElementStub = () => {};
 
         // when
-        await render(
-          <template>
-            <ModulixStep
-              @hasJustAppeared={{false}}
-              @step={{step}}
-              @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
-            />
-          </template>,
-        );
+        await render(<template><ModulixStep @isHidden={{true}} @step={{step}} /></template>);
 
         // then
         assert.dom(find('.stepper__step[inert]')).exists();
+      });
+
+      test('should set aria-hidden="true" in the step', async function (assert) {
+        // given
+        const element = {
+          id: 'd0690f26-978c-41c3-9a21-da931857739c',
+          content: '<button type="button">Mon bouton</button>',
+          type: 'text',
+        };
+        const step = {
+          elements: [element],
+        };
+
+        // when
+        await render(<template><ModulixStep @isHidden={{true}} @step={{step}} /></template>);
+
+        // then
+        const stepElement = find('.stepper__step');
+        assert.dom(stepElement).exists();
+        assert.dom(stepElement).hasAttribute('aria-hidden', 'true');
       });
     });
   });
@@ -103,7 +118,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
         // when
         const screen = await render(
-          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} @isHidden={{false}} /></template>,
         );
 
         // then
@@ -131,7 +146,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
         // when
         const screen = await render(
-          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} @isHidden={{false}} /></template>,
         );
 
         // then

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1234,7 +1234,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3, disabled: true }).length, 1);
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème

Les étapes cachées après avoir cliqué sur “suivant” restent navigables au lecteur d'écran. On ne souhaite pas que l’utilisateur puisse y aller, ni qu’il puisse interagir dessus.

## ⛱️ Proposition

- Ajouter un `aria-hidden="true"` sur les étapes cachées.
- Ajouter la bordure autour des controles.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- [Bac a sable](https://app-pr13345.review.pix.fr/modules/bac-a-sable/passage)
- Tester au lecteur d'écran