### PR TITLE
[BUGFIX] Gerer l'erreur dans le cas ou un link de training est absolu (PIX-19308)

### DIFF
--- a/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
+++ b/api/src/devcomp/domain/usecases/find-recommended-modules-by-campaign-participation-ids.js
@@ -10,7 +10,7 @@ export const findRecommendedModulesByCampaignParticipationIds = async function (
   });
   const userRecommendedModules = await Promise.all(
     userRecommendedTrainings.map(async ({ id, link }) => {
-      const regexp = /^\/modules\/([a-z0-9-]*)/;
+      const regexp = /\/modules\/([a-z0-9-]*)/;
 
       const result = regexp.exec(link);
       const slug = result[1];

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -41,4 +41,31 @@ describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCa
     expect(recommendedModules[1]).to.be.an.instanceOf(UserRecommendedModule);
     expect(recommendedModules[1]).to.be.deep.equal({ id: secondTraining.id, moduleId: secondModuleId });
   });
+
+  it('it returns recommended modules for given participation ids even if link is absolute', async function () {
+    // given
+    const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+
+    const moduleId = '5df14039-803b-4db4-9778-67e4b84afbbd';
+    const training = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: 'https://app.pix.fr/modules/adresse-ip-publique-et-vous/details',
+    });
+
+    databaseBuilder.factory.buildUserRecommendedTraining({
+      userId,
+      trainingId: training.id,
+      campaignParticipationId: campaignParticipationId,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    const recommendedModules = await usecases.findRecommendedModulesByCampaignParticipationIds({
+      campaignParticipationIds: [campaignParticipationId],
+    });
+
+    expect(recommendedModules).to.have.lengthOf(1);
+    expect(recommendedModules[0]).to.be.an.instanceOf(UserRecommendedModule);
+    expect(recommendedModules[0]).to.be.deep.equal({ id: training.id, moduleId });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème
On a constaté un bug lors de la récupération des modules recommandés en recette. Effectivement dans ce commit : https://github.com/1024pix/pix/pull/13278/commits/c0eda00b1e8928c44430b810ec5d03c868490474 nous avions corrigé un soucis avec la regexp et les url absolue pour la récupération des modules recommandables
Ce soucis était également présent pour la récupération des modules recommandés.

## ⛱️ Proposition
Ajout d'un test qui mets en avant ce bug, et correction comme sur la précédente PR pour que la regexp ignore ce qu'il se passe avant le "/modules"

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Aller sur le parcours combiné COMBINIX1
- Passer la campagne d'éval
- Cliquer sur la redirection pour être redirigé
- Ne pas avoir d'erreur et bien être redirigé 

