### PR TITLE
[TECH] Gestion des locales dans les emails (partie 3) (PIX-19267)

### DIFF
--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.controller.js
@@ -1,3 +1,4 @@
+import { getNearestSupportedLocale } from '../../../shared/domain/services/locale-service.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 
@@ -22,7 +23,7 @@ const sendInvitationForAdmin = async function (request, h, dependencies = { cert
     await usecases.createOrUpdateCertificationCenterInvitationForAdmin({
       certificationCenterId,
       email: invitationInformation.email,
-      locale: invitationInformation.language,
+      locale: getNearestSupportedLocale(invitationInformation.language),
       role: invitationInformation.role,
     });
 

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
@@ -63,7 +63,7 @@ export const certificationCenterInvitationAdminRoutes = [
           data: {
             attributes: {
               email: Joi.string().email().required(),
-              language: Joi.string().valid('fr-fr', 'fr', 'en'),
+              language: Joi.string().valid('fr-fr', 'fr-FR', 'fr-BE', 'fr', 'nl', 'nl-BE', 'en'),
               role: Joi.string().valid('ADMIN', 'MEMBER').allow(null),
             },
           },

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -1,4 +1,4 @@
-import { getChallengeLocale, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { certificationCenterInvitationSerializer } from '../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js';
 
@@ -52,11 +52,9 @@ const sendInvitations = async function (request, h) {
 
 const resendCertificationCenterInvitation = async function (request, h) {
   const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
-  const locale = await getChallengeLocale(request);
 
   const certificationCenterInvitation = await usecases.resendCertificationCenterInvitation({
     certificationCenterInvitationId,
-    locale,
   });
 
   return h.response(certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitation)).code(200);

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -43,7 +43,7 @@ const getCertificationCenterInvitation = async function (request) {
 const sendInvitations = async function (request, h) {
   const certificationCenterId = request.params.certificationCenterId;
   const emails = request.payload.data.attributes.emails;
-  const locale = await getChallengeLocale(request);
+  const locale = getUserLocale(request);
 
   await usecases.createOrUpdateCertificationCenterInvitation({ certificationCenterId, emails, locale });
 

--- a/api/src/team/application/organization-invitations/organization-invitation.admin.route.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.admin.route.js
@@ -90,7 +90,7 @@ export const organizationInvitationAdminRoutes = [
           data: {
             attributes: {
               email: Joi.string().email().required(),
-              lang: Joi.string().valid('fr-fr', 'fr', 'en'),
+              lang: Joi.string().valid('fr-fr', 'fr-FR', 'fr-BE', 'fr', 'nl', 'nl-BE', 'en'),
               role: Joi.string().valid('ADMIN', 'MEMBER').allow(null),
             },
           },

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -95,7 +95,7 @@ const sendScoInvitation = async function (request, h, dependencies = { scoOrgani
 const sendInvitations = async function (request, h) {
   const organizationId = request.params.id;
   const emails = request.payload.data.attributes.email.split(',');
-  const locale = await getChallengeLocale(request);
+  const locale = getUserLocale(request);
 
   const organizationInvitations = await usecases.createOrganizationInvitations({ organizationId, emails, locale });
   return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { MissingQueryParamError } from '../../../shared/application/http-errors.js';
-import { getChallengeLocale, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
 import { serializer as scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
@@ -79,8 +79,7 @@ const getOrganizationInvitation = async function (request, h, dependencies = { o
  */
 const sendScoInvitation = async function (request, h, dependencies = { scoOrganizationInvitationSerializer }) {
   const { uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
-
-  const locale = await getChallengeLocale(request);
+  const locale = getUserLocale(request);
 
   const organizationScoInvitation = await usecases.sendScoInvitation({
     uai,

--- a/api/src/team/domain/services/certification-center-invitation-service.js
+++ b/api/src/team/domain/services/certification-center-invitation-service.js
@@ -6,6 +6,11 @@ import {
 } from '../../../shared/domain/errors.js';
 import { CertificationCenterInvitation } from '../models/CertificationCenterInvitation.js';
 
+/**
+ * @param certificationCenterInvitationRepository
+ * @param mailService
+ * @returns {function({certificationCenter: *, email: *, locale: *}): Promise<void>}
+ */
 const createOrUpdateCertificationCenterInvitation = function ({
   certificationCenterInvitationRepository,
   mailService = maillingService,
@@ -21,6 +26,7 @@ const createOrUpdateCertificationCenterInvitation = function ({
       const certificationCenterInvitationToCreate = CertificationCenterInvitation.create({
         certificationCenterId: certificationCenter.id,
         email,
+        locale,
       });
 
       certificationCenterInvitation = await certificationCenterInvitationRepository.create(

--- a/api/src/team/domain/services/certification-center-invitation-service.js
+++ b/api/src/team/domain/services/certification-center-invitation-service.js
@@ -34,43 +34,48 @@ const createOrUpdateCertificationCenterInvitation = function ({
       );
     }
 
-    await _sendInvitationEmail(
+    await _sendInvitationEmail({
       mailService,
       certificationCenterInvitation,
       certificationCenter,
       email,
       locale,
       certificationCenterInvitationRepository,
-    );
+    });
   };
 };
 
+/**
+ * @param certificationCenterInvitationRepository
+ * @param mailService
+ * @returns {function({certificationCenterInvitation: *, certificationCenter: *}): Promise<void>}
+ */
 const resendCertificationCenterInvitation = function ({
   certificationCenterInvitationRepository,
   mailService = maillingService,
 }) {
-  return async function ({ certificationCenter, certificationCenterInvitation, locale }) {
-    await _sendInvitationEmail(
+  return async function ({ certificationCenter, certificationCenterInvitation }) {
+    await _sendInvitationEmail({
       mailService,
       certificationCenterInvitation,
       certificationCenter,
-      certificationCenterInvitation.email,
-      locale,
+      email: certificationCenterInvitation.email,
+      locale: certificationCenterInvitation.locale,
       certificationCenterInvitationRepository,
-    );
+    });
   };
 };
 
 export { createOrUpdateCertificationCenterInvitation, resendCertificationCenterInvitation };
 
-async function _sendInvitationEmail(
+async function _sendInvitationEmail({
   mailService,
   certificationCenterInvitation,
   certificationCenter,
   email,
   locale,
   certificationCenterInvitationRepository,
-) {
+}) {
   const emailingAttempt = await mailService.sendCertificationCenterInvitationEmail({
     certificationCenterInvitationId: certificationCenterInvitation.id,
     certificationCenterName: certificationCenter.name,

--- a/api/src/team/domain/usecases/resend-certification-center-invitation.usecase.js
+++ b/api/src/team/domain/usecases/resend-certification-center-invitation.usecase.js
@@ -1,6 +1,5 @@
 const resendCertificationCenterInvitation = async function ({
   certificationCenterInvitationId,
-  locale,
   certificationCenterRepository,
   certificationCenterInvitationRepository,
   certificationCenterInvitationService,
@@ -16,7 +15,6 @@ const resendCertificationCenterInvitation = async function ({
   })({
     certificationCenter,
     certificationCenterInvitation,
-    locale,
   });
 
   return certificationCenterInvitationRepository.get(certificationCenterInvitationId);

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -106,7 +106,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
           data: {
             attributes: {
               email: 'some.user@example.net',
-              lang: 'fr-fr',
+              language: 'fr-fr',
               role: CertificationCenterInvitation.Roles.ADMIN,
             },
           },
@@ -122,7 +122,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
         'updated-at': now,
         email: 'some.user@example.net',
         role: 'ADMIN',
-        language: 'fr',
+        language: 'fr-FR',
       });
     });
   });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -52,11 +52,12 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
       it('returns 204 HTTP status code', async function () {
         const emails = ['dev@example.net', 'com@example.net'];
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId, role: 'ADMIN' });
+        const locale = 'fr-FR';
 
         await databaseBuilder.commit();
 
         request = {
-          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+          headers: { ...generateAuthenticatedUserRequestHeaders({ userId }), cookie: `locale=${locale}` },
           method: 'POST',
           url: `/api/certification-centers/${certificationCenterId}/invitations`,
           payload: {
@@ -77,6 +78,8 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
           .whereIn('email', emails);
         expect(response.statusCode).to.equal(204);
         expect(certificationCenterInvitations).to.have.lengthOf(2);
+        expect(certificationCenterInvitations[0].locale).to.equal(locale);
+        expect(certificationCenterInvitations[1].locale).to.equal(locale);
       });
     });
   });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -57,7 +57,7 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
         await databaseBuilder.commit();
 
         request = {
-          headers: { ...generateAuthenticatedUserRequestHeaders({ userId }), cookie: `locale=${locale}` },
+          headers: generateAuthenticatedUserRequestHeaders({ userId, locale }),
           method: 'POST',
           url: `/api/certification-centers/${certificationCenterId}/invitations`,
           payload: {

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -423,11 +423,12 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
 
       user1 = databaseBuilder.factory.buildUser();
       user2 = databaseBuilder.factory.buildUser();
+      const locale = 'fr-FR';
 
       options = {
         method: 'POST',
         url: `/api/organizations/${organization.id}/invitations`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUserId }),
+        headers: { ...generateAuthenticatedUserRequestHeaders({ userId: adminUserId }), cookie: `locale=${locale}` },
         payload: {
           data: {
             type: 'organization-invitations',
@@ -453,7 +454,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
               email: user1.email,
               status,
               role: null,
-              lang: 'fr-fr',
+              lang: 'fr-FR',
             },
           },
           {
@@ -463,7 +464,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
               email: user2.email,
               status,
               role: null,
-              lang: 'fr-fr',
+              lang: 'fr-FR',
             },
           },
         ];

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -429,7 +429,7 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
       options = {
         method: 'POST',
         url: `/api/organizations/${organization.id}/invitations`,
-        headers: { ...generateAuthenticatedUserRequestHeaders({ userId: adminUserId }), cookie: `locale=${locale}` },
+        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUserId, locale }),
         payload: {
           data: {
             type: 'organization-invitations',

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -8,6 +8,7 @@ import {
   expect,
   generateAuthenticatedUserRequestHeaders,
   insertOrganizationUserWithRoleAdmin,
+  knex,
   sinon,
 } from '../../../../../tests/test-helper.js';
 
@@ -613,6 +614,44 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
 
       // then
       expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('POST /api/organization-invitations/sco', function () {
+    it('creates an organization invitation with the right locale', async function () {
+      // given
+      const locale = 'fr-FR';
+      const organization = databaseBuilder.factory.buildOrganization({
+        id: 12345,
+        externalId: '0751234X',
+        type: 'SCO',
+        email: 'contact@ecole.fr',
+        isActive: true,
+      });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'POST',
+        url: '/api/organization-invitations/sco',
+        headers: { cookie: `locale=${locale}` },
+        payload: {
+          data: {
+            attributes: {
+              uai: organization.externalId,
+              'first-name': 'Jean',
+              'last-name': 'Dupont',
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const organizationInvitation = await knex('organization-invitations').where({ organizationId: 12345 }).first();
+      expect(response.statusCode).to.equal(201);
+      expect(organizationInvitation.locale).to.equal(locale);
     });
   });
 });

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.admin.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.admin.controller.test.js
@@ -50,7 +50,7 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
     it('should return 201 HTTP status code with data if there isn’t an already pending invitation', async function () {
       // given
       const email = 'some.user@example.net';
-      const language = 'fr-fr';
+      const language = 'fr-FR';
       const role = null;
       const certificationCenterId = 7;
       const payload = {

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.controller.test.js
@@ -46,7 +46,7 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
       const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
         id: certificationCenterInvitationId,
       });
-      const locale = 'nl';
+
       const serializerResult = {
         type: 'certification-center-invitation',
         id: certificationCenterInvitation.id,
@@ -59,7 +59,7 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
 
       sinon.stub(usecases, 'resendCertificationCenterInvitation');
       usecases.resendCertificationCenterInvitation
-        .withArgs({ certificationCenterInvitationId, locale })
+        .withArgs({ certificationCenterInvitationId })
         .resolves(certificationCenterInvitation);
 
       sinon.stub(certificationCenterInvitationSerializer, 'serializeForAdmin');
@@ -72,7 +72,6 @@ describe('Unit | Team | Application | Controller | Certification-center-invitati
         {
           auth: { credentials: { userId: 1 } },
           params: { certificationCenterInvitationId },
-          headers: { 'accept-language': locale },
         },
         hFake,
       );

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
@@ -192,7 +192,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
     let invitation;
     let organizationId;
     let emails;
-    const locale = 'fr-fr';
+    const locale = 'fr-FR';
 
     beforeEach(function () {
       invitation = domainBuilder.buildOrganizationInvitation();
@@ -209,6 +209,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
             },
           },
         },
+        state: { locale },
       };
     });
 

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -291,13 +291,14 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           });
           const code = 'AZERTY007';
           const email = 'dick.cionère@example.net';
-          const locale = 'fr-fr';
+          const locale = 'fr-FR';
           const certificationCenterInvitation = new CertificationCenterInvitation({
             certificationCenterId: certificationCenter.id,
             code,
             createdAt: new Date('2023-10-10'),
             email,
             updatedAt: new Date('2023-10-11'),
+            locale,
           });
 
           certificationCenterInvitationRepository.get.resolves(certificationCenterInvitation);
@@ -312,7 +313,6 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           })({
             certificationCenter,
             certificationCenterInvitation,
-            locale,
           });
 
           // then

--- a/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
+++ b/api/tests/team/unit/domain/services/certification-center-invitation-service_test.js
@@ -36,12 +36,13 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           });
           const code = 'AZERTY007';
           const email = 'dick.cionère@example.net';
-          const locale = 'fr-fr';
+          const locale = 'fr-FR';
 
           const certificationCenterInvitationToCreate = CertificationCenterInvitation.create({
             certificationCenterId: certificationCenter.id,
             code,
             email,
+            locale,
           });
           const createdCertificationCenterInvitation = new CertificationCenterInvitation({
             ...certificationCenterInvitationToCreate,
@@ -141,13 +142,14 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
             name: 'Best Certification Center',
           });
           const code = 'AZERTY005';
-          const locale = 'fr-fr';
+          const locale = 'fr-FR';
           const certificationCenterInvitation = new CertificationCenterInvitation({
             certificationCenterId: certificationCenter.id,
             code,
             createdAt: new Date('2023-10-10'),
             email: emailWithInvalidDomain,
             updatedAt: new Date('2023-10-11'),
+            locale,
           });
 
           certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
@@ -186,13 +188,14 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
           name: 'Best Certification Center',
         });
         const code = 'AZERTY006';
-        const locale = 'fr-fr';
+        const locale = 'fr-FR';
         const certificationCenterInvitation = new CertificationCenterInvitation({
           certificationCenterId: certificationCenter.id,
           code,
           createdAt: new Date('2023-10-10'),
           email: invalidEmail,
           updatedAt: new Date('2023-10-11'),
+          locale,
         });
 
         certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(
@@ -230,13 +233,14 @@ describe('Unit | Team | Domain | Services | CertificationCenterInvitationService
         });
         const code = 'AZERTY007';
         const email = 'dick.cionère@example.net';
-        const locale = 'fr-fr';
+        const locale = 'fr-FR';
         const certificationCenterInvitation = new CertificationCenterInvitation({
           certificationCenterId: certificationCenter.id,
           code,
           createdAt: new Date('2023-10-10'),
           email,
           updatedAt: new Date('2023-10-11'),
+          locale,
         });
 
         certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId.resolves(

--- a/api/tests/team/unit/domain/usecases/create-or-update-certification-center-invitation_test.js
+++ b/api/tests/team/unit/domain/usecases/create-or-update-certification-center-invitation_test.js
@@ -8,7 +8,7 @@ describe('Unit | Domain | UseCases | CreateOrUpdateCertificationCenterInvitation
       const certificationCenterInvitationRepository = {};
       const certificationCenterId = 1;
       const emails = ['   naruto@e    xample.net   '];
-      const locale = 'fr-fr';
+      const locale = 'fr-FR';
       const certificationCenter = domainBuilder.buildCertificationCenter({
         id: 1,
         name: 'Konoha Certification Center',
@@ -54,7 +54,7 @@ describe('Unit | Domain | UseCases | CreateOrUpdateCertificationCenterInvitation
       const certificationCenterInvitationRepository = {};
       const certificationCenterId = 1;
       const emails = ['naruto@example.net', 'jiraya@example.net'];
-      const locale = 'fr-fr';
+      const locale = 'fr-FR';
       const certificationCenter = domainBuilder.buildCertificationCenter({
         id: 1,
         name: 'Konoha Certification Center',

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -118,11 +118,21 @@ function toStream(data, encoding = 'utf8') {
   });
 }
 
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {string} params.source
+ * @param {string} params.audience
+ * @param {string} params.acceptLanguage
+ * @param {string} params.locale
+ * @returns {Object} Header
+ */
 function generateAuthenticatedUserRequestHeaders({
   userId = 1234,
   source = 'pix',
   audience = 'https://app.pix.org',
   acceptLanguage,
+  locale = 'fr-FR',
 } = {}) {
   const url = new URL(audience);
   const protoHeader = url.protocol.slice(0, -1);
@@ -133,6 +143,7 @@ function generateAuthenticatedUserRequestHeaders({
     authorization: `Bearer ${accessToken}`,
     'x-forwarded-proto': protoHeader,
     'x-forwarded-host': hostHeader,
+    cookie: `locale=${locale}`,
     ...(acceptLanguage && { 'accept-language': acceptLanguage }),
   };
 }


### PR DESCRIPTION
## 🔆 Problème

On utilise la locale issue du challenge dans les envois d'email. On veut désormais utiliser la locale de l'utilisateur.

## ⛱️ Proposition

utilliser `getUserLocale` lorsque `getChallengeLocale` est utilisée pour l'envoi de mail des template suivant:
- organizationInvitationTemplateId 
- certificationCenterInvitationTemplateId 
- organizationInvitationScoTemplateId

## 🏄 Pour tester

- Depuis pix-orga
  - Vérifier que le mail d'invitation à une orga est envoyé dans la bonne langue ( locale de la personne qui envoie l'invitation) 
  - Mêmes vérifications pour une invitation pour rejoindre une organisation de type SCO en tant que ADMIN (via [demande-administration-sco](https://orga-pr13347.review.pix.fr/demande-administration-sco)
  
- Depuis pix-certif
  - Vérifier que la locale est enregistrée en base lors de la création d'une invitation à un centre de certification
  - Vérifier que le mail est envoyé dans la bonne langue
  - Vérifier que lors du renvoie d'une invitation, le mail est généré dans la locale de l'invitation initiale
  
- Depuis pix-admin
  - Vérifier que le mail est envoyé dans la bonne langue (locale séléctionnée)
  - Vérifier que lors du renvoie d'une invitation (crées via pix-admin, pix-certif et pix-orga ), le mail est généré dans la locale de l'invitation initiale et pas dans la locale de l'utilisateur de pix-admin
