### PR TITLE
[FEATURE] Mettre à jour les participants par statuts sur PixOrga (PIX-19307)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer.js
@@ -5,7 +5,7 @@ const { Serializer } = jsonapiSerializer;
 const serialize = function (model) {
   return new Serializer('campaign-participations-counts-by-status', {
     id: 'campaignId',
-    attributes: ['started', 'completed', 'shared'],
+    attributes: ['started', 'shared'],
   }).serialize(model);
 };
 

--- a/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-stats-route_test.js
@@ -119,7 +119,7 @@ describe('Acceptance | API | Campaign Stats Route', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(campaign.id.toString());
-      expect(response.result.data.attributes).to.deep.equal({ started: 0, completed: 0, shared: 0 });
+      expect(response.result.data.attributes).to.deep.equal({ started: 0, shared: 0 });
     });
 
     it('should return HTTP code 403 if the authenticated user is not authorize to access the campaign', async function () {

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-status_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-status_test.js
@@ -45,6 +45,6 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-status',
     const result = await usecases.getCampaignParticipationsCountsByStatus({ userId, campaignId });
 
     // then
-    expect(result).to.deep.equal({ started: 1, completed: 1, shared: 1 });
+    expect(result).to.deep.equal({ started: 2, shared: 1 });
   });
 });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -321,7 +321,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
           campaignType,
         );
 
-        expect(result).to.deep.equal({ started: 0, completed: 0, shared: 0 });
+        expect(result).to.deep.equal({ started: 0, shared: 0 });
       });
 
       it("should not count any participation regardless of it's status when participation is deleted ", async function () {
@@ -335,7 +335,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
           campaignType,
         );
 
-        expect(result).to.deep.equal({ started: 0, completed: 0, shared: 0 });
+        expect(result).to.deep.equal({ started: 0, shared: 0 });
       });
 
       describe('Count shared Participation', function () {
@@ -348,7 +348,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ started: 0, completed: 0, shared: 1 });
+          expect(result).to.deep.equal({ started: 0, shared: 1 });
         });
 
         it('counts the last participation shared by user', async function () {
@@ -361,16 +361,20 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ started: 0, completed: 0, shared: 1 });
+          expect(result).to.deep.equal({ started: 0, shared: 1 });
         });
       });
 
-      describe('Count completed Participation', function () {
-        it('counts participations completed', async function () {
+      describe('Count toShare and started Participation', function () {
+        it('counts toShare and started participations', async function () {
           databaseBuilder.factory.buildCampaignParticipation({ status: TO_SHARE });
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             status: TO_SHARE,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId,
+            status: STARTED,
           });
 
           await databaseBuilder.commit();
@@ -380,7 +384,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ started: 0, completed: 1, shared: 0 });
+          expect(result).to.deep.equal({ started: 2, shared: 0 });
         });
 
         it('counts the last participations completed by user', async function () {
@@ -391,25 +395,6 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
           });
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
-            status: TO_SHARE,
-          });
-
-          await databaseBuilder.commit();
-
-          const result = await campaignParticipationsStatsRepository.countParticipationsByStatus(
-            campaignId,
-            campaignType,
-          );
-
-          expect(result).to.deep.equal({ started: 0, completed: 1, shared: 0 });
-        });
-      });
-
-      describe('Count started Participation', function () {
-        it('counts participations started', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({ status: STARTED });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
             status: STARTED,
           });
 
@@ -420,28 +405,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ started: 1, completed: 0, shared: 0 });
-        });
-
-        it('counts the last participation started by user', async function () {
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            status: STARTED,
-            isImproved: true,
-          });
-          databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            status: STARTED,
-          });
-
-          await databaseBuilder.commit();
-
-          const result = await campaignParticipationsStatsRepository.countParticipationsByStatus(
-            campaignId,
-            campaignType,
-          );
-
-          expect(result).to.deep.equal({ started: 1, completed: 0, shared: 0 });
+          expect(result).to.deep.equal({ started: 1, shared: 0 });
         });
       });
     });
@@ -465,7 +429,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
           campaignType,
         );
 
-        expect(result).to.deep.equal({ completed: 0, shared: 0 });
+        expect(result).to.deep.equal({ started: 0, shared: 0 });
       });
 
       it("should not count any participation regardless of it's status when participation is deleted ", async function () {
@@ -478,7 +442,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
           campaignType,
         );
 
-        expect(result).to.deep.equal({ completed: 0, shared: 0 });
+        expect(result).to.deep.equal({ started: 0, shared: 0 });
       });
 
       describe('Count shared Participation', function () {
@@ -491,7 +455,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ completed: 0, shared: 1 });
+          expect(result).to.deep.equal({ started: 0, shared: 1 });
         });
 
         it('counts the last participation shared by user', async function () {
@@ -504,7 +468,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ completed: 0, shared: 1 });
+          expect(result).to.deep.equal({ started: 0, shared: 1 });
         });
       });
 
@@ -519,7 +483,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ completed: 1, shared: 0 });
+          expect(result).to.deep.equal({ started: 1, shared: 0 });
         });
 
         it('counts the last participation completed by user', async function () {
@@ -532,7 +496,7 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
             campaignType,
           );
 
-          expect(result).to.deep.equal({ completed: 1, shared: 0 });
+          expect(result).to.deep.equal({ started: 1, shared: 0 });
         });
       });
     });

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-participations-counts-by-status-serializer_test.js
@@ -7,7 +7,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participations-counts-by-status
       const json = serializer.serialize({
         campaignId: 1,
         started: 1,
-        completed: 1,
         shared: 1,
       });
 
@@ -17,7 +16,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participations-counts-by-status
           id: '1',
           attributes: {
             started: 1,
-            completed: 1,
             shared: 1,
           },
         },

--- a/orga/app/components/campaign/charts/participants-by-status.gjs
+++ b/orga/app/components/campaign/charts/participants-by-status.gjs
@@ -118,14 +118,6 @@ const LABELS_ASSESSMENT = {
     color: '#ffcb33',
     shape: 'diamond-box',
   },
-  completed: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.completed-assessment',
-    legend: 'charts.participants-by-status.labels-legend.completed-assessment',
-    legendTooltip: 'charts.participants-by-status.labels-legend.completed-assessment-tooltip',
-    a11y: 'charts.participants-by-status.labels-a11y.completed',
-    color: '#3D68FF',
-    shape: 'zigzag',
-  },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared',
     legend: 'charts.participants-by-status.labels-legend.shared',
@@ -144,14 +136,6 @@ const LABELS_PROFILE_COLLECTIONS = {
     a11y: 'charts.participants-by-status.labels-a11y.started',
     color: '#ffcb33',
     shape: 'diamond-box',
-  },
-  completed: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.completed-profile',
-    legend: 'charts.participants-by-status.labels-legend.completed-profile',
-    legendTooltip: 'charts.participants-by-status.labels-legend.completed-profile-tooltip',
-    a11y: 'charts.participants-by-status.labels-a11y.completed',
-    color: '#613fdd',
-    shape: 'zigzag',
   },
   shared: {
     tooltip: 'charts.participants-by-status.labels-tooltip.shared-profile',

--- a/orga/tests/integration/components/campaign/activity/dashboard-test.js
+++ b/orga/tests/integration/components/campaign/activity/dashboard-test.js
@@ -18,7 +18,6 @@ module('Integration | Component | Campaign::Activity::Dashboard', (hooks) => {
           data: {
             attributes: {
               started: 1,
-              completed: 2,
               shared: 3,
             },
           },
@@ -41,6 +40,6 @@ module('Integration | Component | Campaign::Activity::Dashboard', (hooks) => {
 
     const screen = await render(hbs`<Campaign::Activity::Dashboard @campaign={{this.campaign}} />`);
 
-    assert.ok(screen.getByText('6'));
+    assert.ok(screen.getByText('4'));
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
@@ -11,7 +11,6 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
   test('it should display status for assessment campaign', async function (assert) {
     this.participantCountByStatus = [
       ['started', 1],
-      ['completed', 1],
       ['shared', 1],
     ];
 
@@ -21,19 +20,12 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
   @shouldDisplayAssessmentLabels={{true}}
 />`,
     );
-    assert
-      .dom(screen.getByText(t('charts.participants-by-status.labels-legend.completed-assessment', { count: 1 })))
-      .exists();
-    assert
-      .dom(screen.getByText(t('charts.participants-by-status.labels-legend.completed-profile', { count: 1 })))
-      .exists();
     assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared', { count: 1 }))).exists();
   });
 
   test('it should contains tooltips for assessment campaign', async function (assert) {
     this.participantCountByStatus = [
       ['started', 1],
-      ['completed', 1],
       ['shared', 1],
     ];
 
@@ -45,15 +37,12 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
     );
 
     assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.started-tooltip'))).exists();
-    assert
-      .dom(screen.getByText(t('charts.participants-by-status.labels-legend.completed-assessment-tooltip')))
-      .exists();
     assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-tooltip'))).exists();
   });
 
   test('it should display status for profile collection campaign', async function (assert) {
     this.participantCountByStatus = [
-      ['completed', 1],
+      ['started', 1],
       ['shared', 1],
     ];
 
@@ -64,12 +53,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
 />`,
     );
 
-    assert
-      .dom(screen.queryByText(t('charts.participants-by-status.labels-legend.started', { count: 1 })))
-      .doesNotExist();
-    assert
-      .dom(screen.getByText(t('charts.participants-by-status.labels-legend.completed-profile', { count: 1 })))
-      .exists();
+    assert.dom(screen.queryByText(t('charts.participants-by-status.labels-legend.started', { count: 1 }))).exists();
     assert
       .dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-profile', { count: 1 })))
       .exists();
@@ -77,7 +61,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
 
   test('it should contains tooltips for profile collection campaign', async function (assert) {
     this.participantCountByStatus = [
-      ['completed', 1],
+      ['started', 1],
       ['shared', 1],
     ];
 
@@ -88,7 +72,6 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStatus', funct
 />`,
     );
 
-    assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.completed-profile-tooltip'))).exists();
     assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-profile-tooltip'))).exists();
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -182,10 +182,6 @@
         "started": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} in progress"
       },
       "labels-legend": {
-        "completed-assessment": "Pending results ({count})",
-        "completed-assessment-tooltip": "Pending results: These participants have finished their customised test but haven’t submitted their results yet.",
-        "completed-profile": "Pending profiles ({count})",
-        "completed-profile-tooltip": "Pending profiles: These participants haven’t submitted their profiles yet.",
         "shared": "Submitted results ({count})",
         "shared-profile": "Submitted profiles ({count})",
         "shared-profile-tooltip": "Submitted profiles: These participants have submitted their profiles.",
@@ -194,8 +190,6 @@
         "started-tooltip": "In progress: These participants haven’t finished their customised test yet."
       },
       "labels-tooltip": {
-        "completed-assessment": "Pending results: {percentage, number, ::percent .0}",
-        "completed-profile": "Pending profiles: {percentage, number, ::percent .0}",
         "shared": "Submitted results: {percentage, number, ::percent .0}",
         "shared-profile": "Submitted profiles: {percentage, number, ::percent .0}",
         "started": "In progress: {percentage, number, ::percent .0}"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -176,16 +176,11 @@
     "participants-by-status": {
       "a11y-title": "Détail par statut",
       "labels-a11y": {
-        "completed": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en attente d'envoi",
         "shared": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs résultats",
         "shared-profile": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs profils",
         "started": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en cours de test"
       },
       "labels-legend": {
-        "completed-assessment": "En attente d'envoi ({count})",
-        "completed-assessment-tooltip": "En attente d’envoi : Ces participants ont terminé leur parcours mais n’ont pas encore envoyé leurs résultats.",
-        "completed-profile": "En attente d'envoi ({count})",
-        "completed-profile-tooltip": "En attente d’envoi : Ces participants n’ont pas encore envoyé leurs profils.",
         "shared": "Résultats reçus ({count})",
         "shared-profile": "Profils reçus ({count})",
         "shared-profile-tooltip": "Profils reçus : Ces participants ont envoyé leurs profils.",
@@ -194,8 +189,6 @@
         "started-tooltip": "En cours : Ces participants n’ont pas encore terminé leur parcours."
       },
       "labels-tooltip": {
-        "completed-assessment": "En attente d'envoi : {percentage, number, ::percent .0}",
-        "completed-profile": "En attente d'envoi : {percentage, number, ::percent .0}",
         "shared": "Résultats reçus : {percentage, number, ::percent .0}",
         "shared-profile": "Profils reçus : {percentage, number, ::percent .0}",
         "started": "En cours : {percentage, number, ::percent .0}"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -182,10 +182,6 @@
         "started": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count, number} deelnemers}} bezig met test"
       },
       "labels-legend": {
-        "completed-assessment": "In afwachting van verzending ({count})",
-        "completed-assessment-tooltip": "In afwachting van verzending: Deze deelnemers hebben hun test afgerond maar hun resultaten nog niet ingestuurd.",
-        "completed-profile": "In afwachting van verzending ({count})",
-        "completed-profile-tooltip": "In afwachting van verzending: Deze deelnemers hebben hun profiel nog niet ingestuurd.",
         "shared": "Ontvangen resultaten ({count})",
         "shared-profile": "Ontvangen profielen ({count})",
         "shared-profile-tooltip": "Ontvangen profielen: Deze deelnemers hebben hun profiel ingestuurd.",
@@ -194,8 +190,6 @@
         "started-tooltip": "Bezig: Deze deelnemers hebben hun test nog niet voltooid."
       },
       "labels-tooltip": {
-        "completed-assessment": "In afwachting van verzending: {percentage, number, ::percent .0}",
-        "completed-profile": "In afwachting van verzending: {percentage, number, ::percent .0}",
         "shared": "Ontvangen resultaten: {percentage, number, ::percent .0}",
         "shared-profile": "Ontvangen profielen: {percentage, number, ::percent .0}",
         "started": "Bezig: {percentage, number, ::procent .0}"


### PR DESCRIPTION
## 🔆 Problème

Nous souhaitons abandonner le statut "TO_SHARE" pour les participations de campagne. Pour ce faire nous allons progressivement arrêter de traiter ce statut. 

## ⛱️ Proposition

Modifier ce graphique sur PixOrga pour ne plus afficher le statut "En attente d'envoi"
<img width="345" height="460" alt="image" src="https://github.com/user-attachments/assets/82cf9272-666a-476d-8d39-19e33b60ab8b" />

## 🏄 Pour tester
Acceder a un resultat de campagne.