### PR TITLE
[BUGFIX] Rattrapage des lieux de naissance absents des certificats PDF pour certains candidats inscrits par INSEE code (PIX-19191)

### DIFF
--- a/api/scripts/certification/fix-birth-place-from-insee-code.js
+++ b/api/scripts/certification/fix-birth-place-from-insee-code.js
@@ -1,0 +1,105 @@
+import { knex } from '../../db/knex-database-connection.js';
+import * as certificationCpfCityRepository from '../../src/certification/enrolment/infrastructure/repositories/certification-cpf-city-repository.js';
+import * as certificationCpfCountryRepository from '../../src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js';
+import { getBirthInformation } from '../../src/certification/shared/domain/services/certification-cpf-service.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const excludedINSEECode = '99999';
+
+export class FixBirthPlaceFromInseeCode extends Script {
+  constructor() {
+    super({
+      description: 'Fix missing birth places from INSEE code',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit the UPDATE or not',
+          demandOption: true,
+        },
+        batchSize: {
+          type: 'number',
+          describe: 'Number of rows to update at once',
+          demandOption: false,
+          default: 1000,
+        },
+        delayBetweenBatch: {
+          type: 'number',
+          describe: 'In ms, force a pause between COMMIT',
+          demandOption: false,
+          default: 1000,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    this.logger = logger;
+    const dryRun = options.dryRun;
+    const batchSize = options.batchSize;
+    const delayInMs = options.delayBetweenBatch;
+
+    this.logger.info({ dryRun, batchSize, delayInMs });
+
+    let hasNext = true;
+    let cursorId = 0;
+
+    do {
+      await await knex.transaction(async (transaction) => {
+        try {
+          const candidatesWithoutBirthCity = await this.#getCandidatesToUpdate({ cursorId, batchSize, transaction });
+
+          for (const candidate of candidatesWithoutBirthCity) {
+            const birthInformation = await getBirthInformation({
+              birthCountry: candidate.birthCountry,
+              birthINSEECode: candidate.birthINSEECode,
+              birthCity: null,
+              birthPostalCode: null,
+              certificationCpfCountryRepository,
+              certificationCpfCityRepository,
+            });
+
+            const birthCity = birthInformation.birthCity;
+
+            await transaction('certification-candidates').update({ birthCity }).where({ id: candidate.id });
+          }
+
+          if (dryRun) {
+            this.logger.info('Rollback !');
+            await transaction.rollback();
+          } else {
+            this.logger.info('Commit !');
+            await transaction.commit();
+          }
+          // Prepare for next batch
+          hasNext = candidatesWithoutBirthCity.length > 0;
+          cursorId = candidatesWithoutBirthCity.at(-1)?.id;
+          await this.delay(delayInMs);
+        } catch (error) {
+          await transaction.rollback();
+          throw error;
+        }
+      });
+    } while (hasNext);
+  }
+
+  #getCandidatesToUpdate({ cursorId, batchSize, transaction }) {
+    this.logger.debug({ cursorId, batchSize });
+    return transaction
+      .select(['id', 'birthCountry', 'birthINSEECode'])
+      .from('certification-candidates')
+      .whereNull('birthCity')
+      .whereNotNull('birthINSEECode')
+      .where('birthINSEECode', '<>', excludedINSEECode)
+      .where('id', '>', cursorId)
+      .orderBy('id')
+      .limit(batchSize);
+  }
+
+  async delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, FixBirthPlaceFromInseeCode);

--- a/api/tests/integration/scripts/certification/fix-birth-place-from-insee-code_test.js
+++ b/api/tests/integration/scripts/certification/fix-birth-place-from-insee-code_test.js
@@ -5,6 +5,7 @@ import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
 describe('Integration | Scripts | Certification | fix-birth-place-from-insee-code', function () {
   it('should update all candidates with birthCityCode but without birthcity but with birtCityCode', async function () {
     const excludedINSEECode = '99999';
+    const nonExistingINSEECode = '75000';
 
     // given
     const options = {
@@ -15,6 +16,7 @@ describe('Integration | Scripts | Certification | fix-birth-place-from-insee-cod
     const logger = {
       info: sinon.stub(),
       debug: sinon.stub(),
+      warn: sinon.stub(),
     };
 
     databaseBuilder.factory.buildCertificationCandidate({ birthCity: 'Paris' });
@@ -25,6 +27,10 @@ describe('Integration | Scripts | Certification | fix-birth-place-from-insee-cod
     databaseBuilder.factory.buildCertificationCandidate({
       birthCity: null,
       birthINSEECode: null,
+    });
+    databaseBuilder.factory.buildCertificationCandidate({
+      birthCity: null,
+      birthINSEECode: nonExistingINSEECode,
     });
     databaseBuilder.factory.buildCertificationCandidate({
       birthCity: null,

--- a/api/tests/integration/scripts/certification/fix-birth-place-from-insee-code_test.js
+++ b/api/tests/integration/scripts/certification/fix-birth-place-from-insee-code_test.js
@@ -1,0 +1,58 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { FixBirthPlaceFromInseeCode } from '../../../../scripts/certification/fix-birth-place-from-insee-code.js';
+import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | fix-birth-place-from-insee-code', function () {
+  it('should update all candidates with birthCityCode but without birthcity but with birtCityCode', async function () {
+    const excludedINSEECode = '99999';
+
+    // given
+    const options = {
+      dryRun: false,
+      batchSize: 10,
+      delayBetweenBatch: 10,
+    };
+    const logger = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    };
+
+    databaseBuilder.factory.buildCertificationCandidate({ birthCity: 'Paris' });
+    const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+      birthCity: null,
+      birthINSEECode: '75115',
+    }).id;
+    databaseBuilder.factory.buildCertificationCandidate({
+      birthCity: null,
+      birthINSEECode: null,
+    });
+    databaseBuilder.factory.buildCertificationCandidate({
+      birthCity: null,
+      birthINSEECode: excludedINSEECode,
+    });
+    databaseBuilder.factory.buildCertificationCpfCountry({
+      code: '99100',
+      commonName: 'FRANCE',
+      originalName: 'FRANCE',
+    });
+    databaseBuilder.factory.buildCertificationCpfCity({
+      name: 'PARIS 15',
+      postalCode: '75015',
+      INSEECode: '75115',
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const fixBirthPlaceFromInseeCode = new FixBirthPlaceFromInseeCode();
+    await fixBirthPlaceFromInseeCode.handle({ options, logger });
+
+    // then
+    const updatedCandidate = await knex('certification-candidates').where({ id: candidateId }).first();
+    expect(updatedCandidate.birthCity).to.equal('PARIS 15');
+    const candidatesWithoutBirthCity = await knex('certification-candidates')
+      .where('birthCity', '=', null)
+      .where('birthINSEECode', '<>', excludedINSEECode);
+    expect(candidatesWithoutBirthCity).to.be.empty;
+  });
+});


### PR DESCRIPTION
d## 🔆 Problème

Les lieux de naissance d'élèves importés via un fichier SIECLE avec un code Insee (et non une commune de naissance) ne s’affichaient pas sur leur certificat. 

Un bugfix a été déployé pour convertir un Insee code en commune de naissance au moment de l’inscription en session d’un élève concerné (et donc que son lieu de naissance s’affiche bien sur son certificat).

## ⛱️ Proposition

Ajout d'un script qui update les candidats n'ayant actuellement pas de birthCity à partir de leur birthINSEECode

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Supprimer le champ birthCity de candidat et leur mettre un champ birthINSEECode

Lancer le script à l'aide de la commande suivante :

```
scalingo -a "pix-api-review-pr13349" run "LOG_LEVEL=info node scripts/certification/fix-birth-place-from-insee-code.js --batchSize=1000 --delayBetweenBatch=1000 --dryRun=true" 2>&1

 DEBUG=knex:* LOG_LEVEL=debug node  scripts/certification/fix-birth-place-from-insee-code.js --dryRun=false --batchSize=2 --delayBetweenBatch=200
``` 

Vérifier que ces candidats ont bien à nouveau une valeur dans le champ birthCity