### PR TITLE
[FEATURE] Animation des feedbacks (PIX-19326)

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -1,8 +1,8 @@
 .feedback {
   position: relative;
+  height: 100%;
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   border-radius: var(--pix-spacing-4x);
-
 
   &--success {
     --modulix-feedback-state-color: var(--pix-success-700);
@@ -19,5 +19,29 @@
   &__state {
     color: var(--modulix-feedback-state-color);
     font-weight: var(--pix-font-bold);
+  }
+
+  @media (not (prefers-reduced-motion: reduce)) {
+    animation:
+      0.4s slide-in ease-in-out,
+      0.5s fade-in ease-in-out;
+
+    @keyframes slide-in {
+      0% {
+        height: 0;
+        max-height: 0;
+        padding: 0 var(--pix-spacing-6x);
+        overflow: hidden;
+      }
+
+      60% {
+        max-height: 100%;
+        padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+      }
+
+      100% {
+        max-height: 100%;
+      }
+    }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -14,6 +14,15 @@
 
   &__proposals {
     margin: var(--pix-spacing-4x) 0;
+
+    @media (not (prefers-reduced-motion: reduce)) {
+      .pix-label-wrapped--state-success,
+      .pix-label-wrapped--state-error {
+        transition:
+          border 0.25s 0.25s,
+          color 0.25s 0.25s;
+      }
+    }
   }
 
   &__required-field-missing {

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -82,7 +82,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
 
-    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
+    assert.dom(await screen.findByText("Bravo ! C'est la bonne réponse.")).exists();
     const continueButton = screen.getByRole('button', { name: 'Continuer' });
     await click(continueButton);
 

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -75,14 +75,14 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     await click(wrongAnswerRadio);
     await click(firstQcuVerifyButton);
 
-    assert.dom(screen.getByRole('status')).exists();
+    const feedback = await screen.findByRole('status');
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.strictEqual(feedback.innerText, '');
     assert.false(firstQcuForm.disabled);
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);
@@ -90,7 +90,8 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     const firstQcuVerifyButtonCameBack = await screen.findByRole('button', { name: 'Vérifier ma réponse' });
     await click(wrongAnswerRadio);
     await click(firstQcuVerifyButtonCameBack);
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+
+    await within(feedback).findByText('Faux');
   });
 
   test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
@@ -168,14 +169,14 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
     await click(wrongAnswerRadio);
     await click(firstQcuVerifyButton);
 
-    assert.dom(screen.getByRole('status')).exists();
+    const feedback = await screen.findByRole('status');
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.strictEqual(feedback.innerText, '');
     assert.false(firstQcuForm.disabled);
     assert.false(wrongAnswerRadio.checked);
     assert.false(rightAnswerRadio.checked);

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -68,13 +68,13 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
     await click(firstQcuVerifyButton);
 
     // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+    assert.dom(await screen.findByText("Bravo ! C'est la bonne réponse.")).exists();
 
     // when
     await click(screen.getByLabelText('Faux'));
     await click(nextQcuVerifyButton);
 
     // then
-    assert.dom(screen.getByText('Pas ouf')).exists();
+    assert.dom(await screen.findByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -3,6 +3,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click, find, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -634,7 +635,16 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when onElementRetry is called', function () {
+  module('when onElementRetry is called', function (hooks) {
+    let clock;
+
+    hooks.beforeEach(function () {
+      clock = sinon.useFakeTimers();
+    });
+
+    hooks.afterEach(function () {
+      clock.restore();
+    });
     test('should call onElementRetry pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -676,7 +686,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
       await click(screen.getByLabelText('I am the wrong answer!'));
       const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
       await click(verifyButton);
-      await clickByName(t('pages.modulix.buttons.activity.retry'));
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+      const retryButton = screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') });
+      await click(retryButton);
 
       // then
       sinon.assert.calledOnce(onElementRetryStub);
@@ -889,7 +901,17 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module('When we retry an answerable element', function () {
+    module('When we retry an answerable element', function (hooks) {
+      let clock;
+
+      hooks.beforeEach(function () {
+        clock = sinon.useFakeTimers();
+      });
+
+      hooks.afterEach(function () {
+        clock.restore();
+      });
+
       test('should call the onElementRetry action', async function (assert) {
         // given
         const passageEvents = this.owner.lookup('service:passage-events');
@@ -947,7 +969,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         await clickByName('radio1');
         const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
         await click(verifyButton);
-        await clickByName(t('pages.modulix.buttons.activity.retry'));
+        await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+        await click(screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') }));
         sinon.assert.calledOnce(onElementRetryStub);
         assert.ok(true);
       });

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -2,7 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcu from 'mon-pix/components/module/element/qcu';
+import ModulixQcu, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -11,14 +11,18 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | QCU', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let passageEventService, passageEventRecordStub;
+  let clock;
+  let passageEventService;
+  let passageEventRecordStub;
 
   hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers();
     passageEventService = this.owner.lookup('service:passageEvents');
     passageEventRecordStub = sinon.stub(passageEventService, 'record');
   });
 
   hooks.afterEach(function () {
+    clock.restore();
     passageEventRecordStub.restore();
   });
 
@@ -113,6 +117,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     assert.dom(screen.getByText('Correct!')).exists();
     assert.dom(screen.getByText('Good job!')).exists();
     assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
@@ -131,6 +136,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     assert.dom(screen.getByText('Wrong!')).exists();
     assert.dom(screen.getByText('Try again!')).exists();
     assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
@@ -149,7 +155,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+    assert.dom(screen.getByRole('button', { name: 'Réessayer' })).exists();
   });
 
   test('should be able to focus back to proposals when feedback appears', async function (assert) {

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -106,6 +106,35 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
 
+  test('should disable proposals during validation', async function (assert) {
+    // given
+    const onAnswerSpy = sinon.spy();
+    const qcuElement = _getQcuElement();
+
+    // when
+    const screen = await render(<template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    await click(screen.getByRole('radio', { name: 'radio1' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
+
+    // then
+    assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+    assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
+  });
+
+  test('should disable verification button during validation', async function (assert) {
+    // given
+    const onAnswerSpy = sinon.spy();
+    const qcuElement = _getQcuElement();
+
+    // when
+    const screen = await render(<template><ModulixQcu @element={{qcuElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    await click(screen.getByRole('radio', { name: 'radio1' }));
+    await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
+
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier ma réponse' })).doesNotExist();
+  });
+
   test('should display an ok feedback when exists', async function (assert) {
     // given
     const onAnswerSpy = sinon.spy();
@@ -117,6 +146,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
+    assert.dom(screen.queryByText('Correct!')).doesNotExist();
+    assert.dom(screen.queryByText('Good job!')).doesNotExist();
+
     await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     assert.dom(screen.getByText('Correct!')).exists();
     assert.dom(screen.getByText('Good job!')).exists();
@@ -136,6 +168,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
 
     // then
+    assert.dom(screen.queryByText('Wrong!')).doesNotExist();
+    assert.dom(screen.queryByText('Try again!')).doesNotExist();
+
     await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     assert.dom(screen.getByText('Wrong!')).exists();
     assert.dom(screen.getByText('Try again!')).exists();

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -4,6 +4,7 @@ import Service from '@ember/service';
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixStepper from 'mon-pix/components/module/component/stepper';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -75,7 +76,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
-      module('When step contains answerable elements', function () {
+      module('When step contains answerable elements', function (hooks) {
+        let clock;
+
+        hooks.beforeEach(function () {
+          clock = sinon.useFakeTimers();
+        });
+
+        hooks.afterEach(function () {
+          clock.restore();
+        });
         module('When the only answerable element is unanswered', function () {
           test('should not display the Next button', async function (assert) {
             // given
@@ -249,7 +259,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             await clickByName('radio2');
             const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
             await click(verifyButton);
-            await clickByName(t('pages.modulix.buttons.activity.retry'));
+            await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+            const retryButton = screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') });
+            await click(retryButton);
             sinon.assert.calledOnce(onElementRetryStub);
             assert.ok(true);
           });
@@ -896,7 +908,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           });
         });
 
-        module('When we retry an answerable element', function () {
+        module('When we retry an answerable element', function (hooks) {
+          let clock;
+
+          hooks.beforeEach(function () {
+            clock = sinon.useFakeTimers();
+          });
+
+          hooks.afterEach(function () {
+            clock.restore();
+          });
           test('should call the onElementRetry action', async function (assert) {
             // given
             const passageEventService = this.owner.lookup('service:passage-events');
@@ -957,7 +978,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             await clickByName('radio2');
             const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
             await click(verifyButton);
-            await clickByName(t('pages.modulix.buttons.activity.retry'));
+            await clock.tickAsync(VERIFY_RESPONSE_DELAY);
+            const retryButton = screen.getByRole('button', { name: t('pages.modulix.buttons.activity.retry') });
+            await click(retryButton);
             sinon.assert.calledOnce(onElementRetryStub);
             assert.ok(true);
           });


### PR DESCRIPTION
## ⛱️ Proposition

On souhaite différer les feedbacks avant leur apparition. On a mis en place une simulation de 500ms de délai avant de déclencher l'apparition, qui elle même prends quelques centaines de millisecondes pour animer l'apparition des différents morceaux du feedback.

Le feedback de diag/constat étant commun aux QCU/QCM/QROCM, ces 3 types d'éléments bénéficient de l'animation.

## 🌊 Remarques

Dans le code du QCU.gjs, on combat vraiment `ModuleElement` qu'on est sensé étendre. Il faudrait prévoir une phase de refacto pour mettre en commun ce qui sera utile sur les autres modalités.

## 🏄 Pour tester
Sur [la galerie](https://app-pr13351.review.pix.fr/modules/galerie/passage),
- Tester un QCU :
  * S'assurer que le feedback n'est pas instantané.
  * S'assurer que les animations sont propres,
  * S'assurer qu'il n'y a pas d'animation lorsqu'on réessaie,
  * S'assurer qu'une 2ème vérification fonctionne.
- Tester un QCM :
   * S'assurer que les animations sont propres.
- Tester un QROCM :
   * S'assurer que les animations sont propres.

