### PR TITLE
[FEATURE] Ajouter les contrôles précédent/suivant au stepper horizontal (PIX-19293)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -104,38 +104,6 @@
   }
 }
 
-.stepper--vertical {
-  display: flex;
-  flex-direction: column;
-
-  /* stylelint-disable-next-line no-descending-specificity */
-  .stepper__step {
-    margin-bottom: var(--pix-spacing-6x);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    &--active {
-      @extend .auto-scroll;
-
-      outline: none;
-    }
-
-    &__position {
-      display: inline-block;
-
-      @extend %pix-body-m;
-
-      margin: var(--pix-spacing-1x) 0 var(--pix-spacing-4x) 0;
-      padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
-      color: var(--pix-neutral-800);
-      background: var(--pix-neutral-20);
-      border-radius: var(--modulix-radius-l);
-    }
-  }
-}
-
 .stepper__next-button {
   justify-self: start;
   width: fit-content;

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -6,7 +6,6 @@
   &__controls {
     @extend %pix-cta-s;
 
-    display: flex;
     display: inline-flex;
     gap: var(--pix-spacing-2x);
     align-items: center;
@@ -21,59 +20,85 @@
   }
 
   &__steps {
-    display: grid;
-    grid-template-rows: auto auto;
-    gap: 8px;
+    display: flex;
+  }
+}
 
-    .stepper__step {
-      --previous-slide-visible-width: 10px;
+.stepper--vertical {
+  display: flex;
+  flex-direction: column;
 
-      grid-row: 1 / 1;
-      grid-column: 1 / 1;
-      align-items: center;
-      padding: var(--pix-spacing-4x);
-      border: 1px solid var(--pix-neutral-100);
-      border-radius: 8px;
+  .stepper__step {
+    margin-bottom: var(--pix-spacing-6x);
 
-      &:not(.stepper-step__active) {
-        position: relative;
-        transform: translateX(calc((-50vw - 50%) + var(--previous-slide-visible-width)));
-        pointer-events: none;
+    &:last-child {
+      margin-bottom: 0;
+    }
 
-        &::after {
-          position: absolute;
-          top: 50%;
-          left: calc(100% + 4px);
-          width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
-          border-bottom: 1px solid var(--pix-neutral-500);
-          opacity: 0.3;
-          content: '';
-        }
+    &--active {
+      @extend .auto-scroll;
+
+      outline: none;
+    }
+
+    &__position {
+      display: inline-block;
+
+      @extend %pix-body-m;
+
+      margin: var(--pix-spacing-1x) 0 var(--pix-spacing-4x) 0;
+      padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+      color: var(--pix-neutral-800);
+      background: var(--pix-neutral-20);
+      border-radius: var(--modulix-radius-l);
+    }
+  }
+}
+
+.stepper--horizontal {
+  /* stylelint-disable-next-line no-descending-specificity */
+  .stepper__step {
+    --stepper-previous-slide-visible-width: 10px;
+    --stepper-gap-between-steps: calc(50vw - 50% - var(--stepper-previous-slide-visible-width));
+    --stepper-gap-between-steps-with-step-width: calc(var(--stepper-gap-between-steps) + 100%);
+    --stepper-gap-between-line-and-step: 4px;
+
+    flex: 0 0 100%;
+    align-items: center;
+    margin-right: var(--stepper-gap-between-steps);
+    padding: var(--pix-spacing-4x);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: 8px;
+    transform: translateX(calc(-1 * var(--stepper-gap-between-steps-with-step-width) * var(--current-step-index)));
+
+    /* Line between steps */
+    &:not(.stepper-step--last-step) {
+      position: relative;
+
+      &::after {
+        position: absolute;
+        top: 50%;
+        left: calc(100% + var(--stepper-gap-between-line-and-step));
+        width: calc(var(--stepper-gap-between-steps) - (2 * var(--stepper-gap-between-line-and-step)));
+        border-bottom: 1px solid var(--pix-neutral-500);
+        opacity: 0.3;
+        content: '';
       }
+    }
 
-      &.stepper-step__active:not(.stepper-step--last-step) {
-        position: relative;
+    /* Fake empty step at the end */
+    &:last-child:not(.stepper-step--last-step) {
+      position: relative;
 
-        &::after {
-          position: absolute;
-          top: 50%;
-          left: calc(100% + 4px);
-          width: calc(50vw - 50% - var(--previous-slide-visible-width) - 8px);
-          border-bottom: 1px solid var(--pix-neutral-500);
-          opacity: 0.3;
-          content: '';
-        }
-
-        &::before {
-          position: absolute;
-          top: 0;
-          left: calc((50vw + 50%) - var(--previous-slide-visible-width));
-          width: 100%;
-          height: 100%;
-          border: 1px solid var(--pix-neutral-100);
-          border-radius: 8px;
-          content: '';
-        }
+      &::before {
+        position: absolute;
+        top: 0;
+        left: var(--stepper-gap-between-steps-with-step-width);
+        width: 100%;
+        height: 100%;
+        border: 1px solid var(--pix-neutral-100);
+        border-radius: 8px;
+        content: '';
       }
     }
   }
@@ -120,7 +145,7 @@
 @include breakpoints.device-is('tablet') {
   .stepper--horizontal {
     .stepper__step {
-      --previous-slide-visible-width: 20px;
+      --stepper-previous-slide-visible-width: 20px;
     }
   }
 }
@@ -128,7 +153,7 @@
 @include breakpoints.device-is('desktop') {
   .stepper--horizontal {
     .stepper__step {
-      --previous-slide-visible-width: 100px;
+      --stepper-previous-slide-visible-width: 100px;
     }
   }
 }

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -34,9 +34,7 @@ export default class ModulixStep extends Component {
   <template>
     {{#if this.hasDisplayableElements}}
       <section
-        class="stepper__step
-          {{if @hasJustAppeared 'stepper-step__active'}}
-          {{if this.isLastStep 'stepper-step--last-step'}}"
+        class="stepper__step {{if this.isLastStep 'stepper-step--last-step'}}"
         tabindex="-1"
         {{didInsert this.focusAndScroll}}
         inert={{if @isHidden true}}

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -24,7 +24,7 @@ export default class ModulixStep extends Component {
 
   @action
   focusAndScroll(htmlElement) {
-    if (!this.args.hasJustAppeared) {
+    if (!this.args.isActive) {
       return;
     }
 

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -48,7 +48,7 @@ export default class ModulixStepper extends Component {
 
   @action
   displayNextStep() {
-    const currentStepPosition = this.currentStepIndex + 1;
+    const currentStepPosition = this.lastDisplayedStepIndex + 1;
     const nextStep = this.displayableSteps[currentStepPosition];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
 
@@ -60,7 +60,7 @@ export default class ModulixStepper extends Component {
     this.displayedStepIndex = currentStepPosition;
   }
 
-  get currentStepIndex() {
+  get lastDisplayedStepIndex() {
     return this.stepsToDisplay.length - 1;
   }
 

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -31,8 +31,8 @@ export default class ModulixStepper extends Component {
   @tracked displayedStepIndex = 0;
 
   @action
-  hasStepJustAppeared(index) {
-    return this.lastDisplayedStepIndex === index;
+  stepIsActive(index) {
+    return this.displayedStepIndex === index;
   }
 
   @action
@@ -41,7 +41,7 @@ export default class ModulixStepper extends Component {
       return false;
     }
 
-    return !this.hasStepJustAppeared(index);
+    return !this.stepIsActive(index);
   }
 
   get hasDisplayableSteps() {
@@ -170,6 +170,7 @@ export default class ModulixStepper extends Component {
                 @onElementAnswer={{@onElementAnswer}}
                 @onElementRetry={{@onElementRetry}}
                 @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+                @isActive={{this.stepIsActive index}}
                 @isHidden={{this.stepIsHidden index}}
                 @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                 @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
@@ -199,7 +200,7 @@ export default class ModulixStepper extends Component {
               @onElementAnswer={{@onElementAnswer}}
               @onElementRetry={{@onElementRetry}}
               @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-              @hasJustAppeared={{this.hasStepJustAppeared index}}
+              @isActive={{this.stepIsActive index}}
               @isHidden={{false}}
               @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -47,6 +47,11 @@ export default class ModulixStepper extends Component {
   }
 
   @action
+  displayPreviousStep() {
+    this.displayedStepIndex -= 1;
+  }
+
+  @action
   displayNextStep() {
     const currentStepPosition = this.lastDisplayedStepIndex + 1;
     const nextStep = this.displayableSteps[currentStepPosition];
@@ -107,6 +112,7 @@ export default class ModulixStepper extends Component {
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
             @iconName="chevronLeft"
             aria-disabled="{{this.isPreviousButtonDisabled}}"
+            @triggerAction={{this.displayPreviousStep}}
           />
           <p
             class="stepper-controls__position"

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import { concat } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -90,6 +91,10 @@ export default class ModulixStepper extends Component {
     return this.args.direction === 'horizontal';
   }
 
+  get isPreviousButtonDisabled() {
+    return this.displayedStepIndex === 0;
+  }
+
   <template>
     <div
       class="stepper stepper--{{@direction}}"
@@ -101,7 +106,7 @@ export default class ModulixStepper extends Component {
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
             @iconName="chevronLeft"
-            aria-disabled="true"
+            aria-disabled="{{this.isPreviousButtonDisabled}}"
           />
           <p
             class="stepper-controls__position"

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -97,6 +98,11 @@ export default class ModulixStepper extends Component {
     >
       {{#if this.isHorizontalDirection}}
         <div class="stepper__controls">
+          <PixIconButton
+            @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
+            @iconName="chevronLeft"
+            aria-disabled="true"
+          />
           <p
             class="stepper-controls__position"
             aria-label="{{t
@@ -107,6 +113,11 @@ export default class ModulixStepper extends Component {
           >
             {{inc this.displayedStepIndex}}/{{this.totalSteps}}
           </p>
+          <PixIconButton
+            @ariaLabel={{t "pages.modulix.buttons.stepper.controls.next.ariaLabel"}}
+            @iconName="chevronRight"
+            aria-disabled="true"
+          />
         </div>
         <div class="stepper__steps">
           {{#if this.hasDisplayableSteps}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -2,14 +2,15 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import Step from 'mon-pix/components/module/component/step';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import { inc } from 'mon-pix/helpers/inc';
-import { guidFor } from '@ember/object/internals';
 
 import didInsert from '../../../modifiers/modifier-did-insert';
 
@@ -31,7 +32,7 @@ export default class ModulixStepper extends Component {
 
   @action
   hasStepJustAppeared(index) {
-    return this.stepsToDisplay.length - 1 === index;
+    return this.lastDisplayedStepIndex === index;
   }
 
   @action
@@ -88,7 +89,7 @@ export default class ModulixStepper extends Component {
   }
 
   get answerableElementsInCurrentStep() {
-    const currentStep = this.stepsToDisplay[this.stepsToDisplay.length - 1];
+    const currentStep = this.stepsToDisplay[this.lastDisplayedStepIndex];
     return currentStep.elements.filter((element) => element.isAnswerable);
   }
 
@@ -115,7 +116,7 @@ export default class ModulixStepper extends Component {
   }
 
   get isNextButtonControlDisabled() {
-   return this.displayedStepIndex === this.stepsToDisplay.length - 1;
+    return this.displayedStepIndex === this.lastDisplayedStepIndex;
   }
 
   get id() {
@@ -155,7 +156,11 @@ export default class ModulixStepper extends Component {
             aria-controls={{this.id}}
           />
         </div>
-        <div id={{this.id}} class="stepper__steps">
+        <div
+          id={{this.id}}
+          class="stepper__steps"
+          style={{htmlUnsafe (concat "--current-step-index:" this.displayedStepIndex)}}
+        >
           {{#if this.hasDisplayableSteps}}
             {{#each this.stepsToDisplay as |step index|}}
               <Step
@@ -165,7 +170,6 @@ export default class ModulixStepper extends Component {
                 @onElementAnswer={{@onElementAnswer}}
                 @onElementRetry={{@onElementRetry}}
                 @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-                @hasJustAppeared={{this.hasStepJustAppeared index}}
                 @isHidden={{this.stepIsHidden index}}
                 @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                 @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
@@ -174,16 +178,17 @@ export default class ModulixStepper extends Component {
                 @onExpandToggle={{@onExpandToggle}}
               />
             {{/each}}
-            {{#if this.shouldDisplayNextButton}}
-              <PixButton
-                aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
-                @variant="primary"
-                @triggerAction={{this.displayNextStep}}
-                class="stepper__next-button"
-              >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
-            {{/if}}
+
           {{/if}}
         </div>
+        {{#if this.shouldDisplayNextButton}}
+          <PixButton
+            aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
+            @variant="primary"
+            @triggerAction={{this.displayNextStep}}
+            class="stepper__next-button"
+          >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+        {{/if}}
       {{else}}
         {{#if this.hasDisplayableSteps}}
           {{#each this.stepsToDisplay as |step index|}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -9,6 +9,7 @@ import { t } from 'ember-intl';
 import Step from 'mon-pix/components/module/component/step';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import { inc } from 'mon-pix/helpers/inc';
+import { guidFor } from '@ember/object/internals';
 
 import didInsert from '../../../modifiers/modifier-did-insert';
 
@@ -117,6 +118,10 @@ export default class ModulixStepper extends Component {
    return this.displayedStepIndex === this.stepsToDisplay.length - 1;
   }
 
+  get id() {
+    return this.args.id || `pix-tabs-${guidFor(this)}`;
+  }
+
   <template>
     <div
       class="stepper stepper--{{@direction}}"
@@ -130,6 +135,7 @@ export default class ModulixStepper extends Component {
             @iconName="chevronLeft"
             aria-disabled="{{this.isPreviousButtonControlDisabled}}"
             @triggerAction={{this.displayPreviousStep}}
+            aria-controls={{this.id}}
           />
           <p
             class="stepper-controls__position"
@@ -146,9 +152,10 @@ export default class ModulixStepper extends Component {
             @iconName="chevronRight"
             aria-disabled="{{this.isNextButtonControlDisabled}}"
             @triggerAction={{this.goBackToNextStep}}
+            aria-controls={{this.id}}
           />
         </div>
-        <div class="stepper__steps">
+        <div id={{this.id}} class="stepper__steps">
           {{#if this.hasDisplayableSteps}}
             {{#each this.stepsToDisplay as |step index|}}
               <Step

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -69,6 +69,15 @@ export default class ModulixStepper extends Component {
     this.displayedStepIndex = currentStepPosition;
   }
 
+  @action
+  goBackToNextStep() {
+    if (this.isNextButtonControlDisabled) {
+      return;
+    }
+
+    this.displayedStepIndex++;
+  }
+
   get lastDisplayedStepIndex() {
     return this.stepsToDisplay.length - 1;
   }
@@ -136,6 +145,7 @@ export default class ModulixStepper extends Component {
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.next.ariaLabel"}}
             @iconName="chevronRight"
             aria-disabled="{{this.isNextButtonControlDisabled}}"
+            @triggerAction={{this.goBackToNextStep}}
           />
         </div>
         <div class="stepper__steps">

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -48,6 +48,10 @@ export default class ModulixStepper extends Component {
 
   @action
   displayPreviousStep() {
+    if (this.displayedStepIndex === 0) {
+      return;
+    }
+
     this.displayedStepIndex -= 1;
   }
 

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -100,8 +100,12 @@ export default class ModulixStepper extends Component {
     return this.args.direction === 'horizontal';
   }
 
-  get isPreviousButtonDisabled() {
+  get isPreviousButtonControlDisabled() {
     return this.displayedStepIndex === 0;
+  }
+
+  get isNextButtonControlDisabled() {
+   return this.displayedStepIndex === this.stepsToDisplay.length - 1;
   }
 
   <template>
@@ -115,7 +119,7 @@ export default class ModulixStepper extends Component {
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
             @iconName="chevronLeft"
-            aria-disabled="{{this.isPreviousButtonDisabled}}"
+            aria-disabled="{{this.isPreviousButtonControlDisabled}}"
             @triggerAction={{this.displayPreviousStep}}
           />
           <p
@@ -131,7 +135,7 @@ export default class ModulixStepper extends Component {
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.next.ariaLabel"}}
             @iconName="chevronRight"
-            aria-disabled="true"
+            aria-disabled="{{this.isNextButtonControlDisabled}}"
           />
         </div>
         <div class="stepper__steps">

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1343,6 +1343,54 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             .hasAria('disabled', 'false');
         });
 
+        module('when user clicks the controls previous button', function() {
+          test('should go back to previous step', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                    type: 'text',
+                    content: '<p>Text 1</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+            ];
+
+            function stepperIsFinished() {}
+
+            function onStepperNextStepStub() {}
+
+            const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+            );
+
+            // when
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
+
+            // then
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+          });
+        });
+
         test('should not display the Next button when there are no steps left', async function (assert) {
           // given
           const steps = [

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -704,6 +704,37 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert.dom(find('.stepper--horizontal')).exists();
       });
 
+      test('it should set accessible control buttons', async function (assert) {
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>);
+
+        // then
+        assert.dom(find('#stepper-container-id-1')).exists();
+        assert.dom(screen.getByRole('button', {name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel')})).hasAria('controls', 'stepper-container-id-1');
+        assert.dom(screen.getByRole('button', {name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('controls', 'stepper-container-id-1');
+      });
+
       test('it should display current step number', async function (assert) {
         // given
         const steps = [
@@ -1476,7 +1507,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
             // then
             assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('disabled', 'false')
-
           });
 
           module('when user clicks the controls next button', function() {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1478,6 +1478,56 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('disabled', 'false')
 
           });
+
+          module('when user clicks the controls next button', function() {
+            test('should go back to next step', async function (assert) {
+              // given
+              const steps = [
+                {
+                  elements: [
+                    {
+                      id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                      type: 'text',
+                      content: '<p>Text 1</p>',
+                    },
+                  ],
+                },
+                {
+                  elements: [
+                    {
+                      id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                      type: 'text',
+                      content: '<p>Text 2</p>',
+                    },
+                  ],
+                },
+              ];
+
+              function stepperIsFinished() {}
+
+              function onStepperNextStepStub() {}
+
+              const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @steps={{steps}}
+                  @stepperIsFinished={{stepperIsFinished}}
+                  @onStepperNextStep={{onStepperNextStepStub}}
+                />
+              </template>,
+              );
+
+              // when
+              await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+              await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
+              await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }));
+
+              // then
+              assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+            });
+
+          });
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -727,12 +727,18 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         ];
 
         // when
-        const screen = await render(<template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>);
+        const screen = await render(
+          <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
+        );
 
         // then
         assert.dom(find('#stepper-container-id-1')).exists();
-        assert.dom(screen.getByRole('button', {name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel')})).hasAria('controls', 'stepper-container-id-1');
-        assert.dom(screen.getByRole('button', {name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('controls', 'stepper-container-id-1');
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+          .hasAria('controls', 'stepper-container-id-1');
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+          .hasAria('controls', 'stepper-container-id-1');
       });
 
       test('it should display current step number', async function (assert) {
@@ -1416,7 +1422,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             .hasAria('disabled', 'false');
         });
 
-        module('when user clicks the controls previous button', function() {
+        module('when user clicks the controls previous button', function () {
           test('should go back to previous step', async function (assert) {
             // given
             const steps = [
@@ -1445,19 +1451,21 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             function onStepperNextStepStub() {}
 
             const screen = await render(
-            <template>
-              <ModulixStepper
-                @direction="horizontal"
-                @steps={{steps}}
-                @stepperIsFinished={{stepperIsFinished}}
-                @onStepperNextStep={{onStepperNextStepStub}}
-              />
-            </template>,
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @steps={{steps}}
+                  @stepperIsFinished={{stepperIsFinished}}
+                  @onStepperNextStep={{onStepperNextStepStub}}
+                />
+              </template>,
             );
 
             // when
             await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
-            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
+            await click(
+              screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+            );
 
             // then
             assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
@@ -1491,25 +1499,29 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             function onStepperNextStepStub() {}
 
             const screen = await render(
-            <template>
-              <ModulixStepper
-                @direction="horizontal"
-                @steps={{steps}}
-                @stepperIsFinished={{stepperIsFinished}}
-                @onStepperNextStep={{onStepperNextStepStub}}
-              />
-            </template>,
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @steps={{steps}}
+                  @stepperIsFinished={{stepperIsFinished}}
+                  @onStepperNextStep={{onStepperNextStepStub}}
+                />
+              </template>,
             );
 
             // when
             await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
-            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
+            await click(
+              screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+            );
 
             // then
-            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('disabled', 'false')
+            assert
+              .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+              .hasAria('disabled', 'false');
           });
 
-          module('when user clicks the controls next button', function() {
+          module('when user clicks the controls next button', function () {
             test('should go back to next step', async function (assert) {
               // given
               const steps = [
@@ -1538,25 +1550,28 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               function onStepperNextStepStub() {}
 
               const screen = await render(
-              <template>
-                <ModulixStepper
-                  @direction="horizontal"
-                  @steps={{steps}}
-                  @stepperIsFinished={{stepperIsFinished}}
-                  @onStepperNextStep={{onStepperNextStepStub}}
-                />
-              </template>,
+                <template>
+                  <ModulixStepper
+                    @direction="horizontal"
+                    @steps={{steps}}
+                    @stepperIsFinished={{stepperIsFinished}}
+                    @onStepperNextStep={{onStepperNextStepStub}}
+                  />
+                </template>,
               );
 
               // when
               await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
-              await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
-              await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }));
+              await click(
+                screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+              );
+              await click(
+                screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }),
+              );
 
               // then
               assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
             });
-
           });
         });
 

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -830,6 +830,48 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           .hasAria('disabled', 'true');
       });
 
+      test('should not be able to navigate to negative step', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+        // then
+        await click(
+          screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+        );
+        assert
+          .dom(
+            screen.getByLabelText(
+              t('pages.modulix.stepper.step.position', {
+                currentStep: 1,
+                totalSteps: 2,
+              }),
+            ),
+          )
+          .exists();
+      });
+
       module('When step contains answerable elements', function () {
         module('When the only answerable element is unanswered', function () {
           test('should not display the Next button', async function (assert) {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1431,6 +1431,53 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             // then
             assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
           });
+
+          test('should enable next button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                    type: 'text',
+                    content: '<p>Text 1</p>',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                  },
+                ],
+              },
+            ];
+
+            function stepperIsFinished() {}
+
+            function onStepperNextStepStub() {}
+
+            const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+            );
+
+            // when
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }));
+
+            // then
+            assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel')})).hasAria('disabled', 'false')
+
+          });
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -795,6 +795,41 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
+      test('should display disabled controls buttons', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+        // then
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+          .hasAria('disabled', 'true');
+        assert
+          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+          .hasAria('disabled', 'true');
+      });
+
       module('When step contains answerable elements', function () {
         module('When the only answerable element is unanswered', function () {
           test('should not display the Next button', async function (assert) {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1296,6 +1296,53 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
         });
 
+        test('should enable the controls previous button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          function stepperIsFinished() {}
+
+          function onStepperNextStepStub() {}
+
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
+
+          // when
+          await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+            .hasAria('disabled', 'false');
+        });
+
         test('should not display the Next button when there are no steps left', async function (assert) {
           // given
           const steps = [

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1680,6 +1680,14 @@
           }
         },
         "stepper": {
+          "controls": {
+            "next": {
+              "ariaLabel": "Next step"
+            },
+            "previous": {
+              "ariaLabel": "Previous step"
+            }
+          },
           "next": {
             "ariaLabel": "Go to the next step",
             "name": "Next"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1669,6 +1669,14 @@
           "next": {
             "ariaLabel": "Ir al paso siguiente",
             "name": "Siguiente"
+          },
+          "controls": {
+            "next": {
+              "ariaLabel": "Paso siguiente"
+            },
+            "previous": {
+              "ariaLabel": "Paso anterior"
+            }
           }
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1680,6 +1680,14 @@
           }
         },
         "stepper": {
+          "controls": {
+            "next": {
+              "ariaLabel": "Étape suivante"
+            },
+            "previous": {
+              "ariaLabel": "Étape précédente"
+            }
+          },
           "next": {
             "ariaLabel": "Aller à l'étape suivante",
             "name": "Suivant"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1673,6 +1673,14 @@
           "next": {
             "ariaLabel": "Ga naar de volgende stap",
             "name": "Volgende"
+          },
+          "controls": {
+            "next": {
+              "ariaLabel": "Volgende stap"
+            },
+            "previous": {
+              "ariaLabel": "Vorige stap"
+            }
           }
         }
       },


### PR DESCRIPTION
## 🔆 Problème

Le stepper horizontal n'a pas de boutons pour revenir en arrière ou retourner vers l'avant.

## ⛱️ Proposition

Ajouter des boutons "précédent" et "suivant".

## 🌊 Remarques

Pour rendre possible la navigation dans les étapes, il a fallu changer la logique qui considérait que l'étape affichée était toujours la dernière affichée.

## 🏄 Pour tester

1. Se rendre sur [le module bac à sable](https://app-pr13352.review.pix.fr/modules/bac-a-sable/passage)
2. Aller jusqu'au stepper horizontal
3. Répondre à la première question et aller à l'étape 2
4. Cliquer sur le bouton précédent dans les contrôles
5. Constater qu'on retourne à l'étape 1
6. Cliquer sur le bouton suivant dans les contrôles
7. Constater qu'on est revenu à l'étape 2
