### PR TITLE
[FEATURE] Ajouter une api pour les parcours combinés (PIX-19311)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -159,6 +159,7 @@
     "doc:api:prescription": "node scripts/generate-api-documentation.js src/prescription > src/prescription/API.md",
     "doc:api:team": "node scripts/generate-api-documentation.js src/team > src/team/API.md",
     "doc:api:organizational-entities": "node scripts/generate-api-documentation.js src/organizational-entities > src/organizational-entities/API.md",
+    "doc:api:quest": "node scripts/generate-api-documentation.js src/quest > src/quest/API.md",
     "lint": "run-p --continue-on-error 'lint:!(ci|database|fix)'",
     "lint:ci": "run-p --continue-on-error 'lint:!(ci|fix)'",
     "lint:fix": "run-p --continue-on-error lint:*:fix",

--- a/api/src/quest/API.md
+++ b/api/src/quest/API.md
@@ -1,0 +1,49 @@
+This doc has been generated on 01/09/2025 08:49:28 with `scripts/generate-api-documentation.js`. See package.json.
+
+---
+## Modules
+
+<dl>
+<dt><a href="#module_CombinedCourseApi">CombinedCourseApi</a></dt>
+<dd></dd>
+</dl>
+
+## Classes
+
+<dl>
+<dt><a href="#CombinedCourse">CombinedCourse</a></dt>
+<dd><p>exposed CombinedCourse object from api</p>
+</dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#CombinedCourseArgs">CombinedCourseArgs</a> : <code>object</code></dt>
+<dd></dd>
+</dl>
+
+<a name="module_CombinedCourseApi"></a>
+
+## CombinedCourseApi
+<a name="module_CombinedCourseApi..getByCampaignId"></a>
+
+### CombinedCourseApi~getByCampaignId(campaignId) ⇒ [<code>Promise.&lt;CombinedCourse&gt;</code>](#CombinedCourse)
+**Kind**: inner method of [<code>CombinedCourseApi</code>](#module_CombinedCourseApi)  
+
+| Param | Type |
+| --- | --- |
+| campaignId | <code>number</code> | 
+
+<a name="CombinedCourseArgs"></a>
+
+## CombinedCourseArgs : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| name | <code>string</code> | 
+
+

--- a/api/src/quest/application/api/CombinedCourse.model.js
+++ b/api/src/quest/application/api/CombinedCourse.model.js
@@ -1,0 +1,20 @@
+/**
+ * Constructor wraps a quest CombinedCourse object
+ * @class
+ * @classdesc exposed CombinedCourse object from api
+ */
+export class CombinedCourse {
+  /**
+   * @typedef {object} CombinedCourseArgs
+   * @property {number} id
+   * @property {string} name
+   */
+
+  /**
+   * @param {CombinedCourseArgs} args
+   */
+  constructor({ id, name }) {
+    this.id = id;
+    this.name = name;
+  }
+}

--- a/api/src/quest/application/api/combined-course-api.js
+++ b/api/src/quest/application/api/combined-course-api.js
@@ -1,0 +1,26 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { CombinedCourse } from './CombinedCourse.model.js';
+import { MultipleQuestFoundError } from './errors.js';
+
+/**
+ * @module CombinedCourseApi
+ */
+
+/**
+ * @function
+ * @name getByCampaignId
+ *
+ * @param {number} campaignId
+ * @returns {Promise<CombinedCourse>}
+ */
+export const getByCampaignId = async (campaignId) => {
+  const courses = await usecases.findCombinedCourseByCampaignId({ campaignId });
+
+  if (courses.length === 0) {
+    return null;
+  }
+  if (courses.length > 1) {
+    throw new MultipleQuestFoundError('Campaign is referenced in multiple Combined courses');
+  }
+  return new CombinedCourse(courses[0]);
+};

--- a/api/src/quest/application/api/errors.js
+++ b/api/src/quest/application/api/errors.js
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/domain/errors.js';
+
+export class MultipleQuestFoundError extends DomainError {
+  constructor({ campaignId }) {
+    super(`Found multiple quests using campaignId ${campaignId}`, 'MULTIPLE_QUEST_FOUND');
+  }
+}

--- a/api/src/quest/domain/usecases/get-combined-course-by-campaign-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-campaign-id.js
@@ -1,0 +1,3 @@
+export async function findCombinedCourseByCampaignId({ campaignId, combinedCourseRepository }) {
+  return combinedCourseRepository.findByCampaignId({ campaignId });
+}

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -24,6 +24,7 @@ const dependencies = {
 import { checkUserQuest } from './check-user-quest-success.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
+import { findCombinedCourseByCampaignId } from './get-combined-course-by-campaign-id.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
 import { getVerifiedCode } from './get-verified-code.js';
@@ -34,6 +35,7 @@ import { updateCombinedCourse } from './update-combined-course.js';
 const usecasesWithoutInjectedDependencies = {
   checkUserQuest,
   createOrUpdateQuestsInBatch,
+  findCombinedCourseByCampaignId,
   getCombinedCourseByCode,
   getQuestResultsForCampaignParticipation,
   getVerifiedCode,

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -13,6 +13,16 @@ const getByCode = async ({ code }) => {
   return new CombinedCourse(quest);
 };
 
+const findByCampaignId = async ({ campaignId }) => {
+  const knexConn = DomainTransaction.getConnection();
+  const quests = await knexConn('quests')
+    .select('id', 'organizationId', 'code', 'name')
+    .whereNotNull('code')
+    .whereJsonSupersetOf('successRequirements', [{ data: { campaignId: { data: campaignId } } }]);
+
+  return quests.map((quest) => new CombinedCourse(quest));
+};
+
 const saveInBatch = async ({ combinedCourses }) => {
   const knexConn = DomainTransaction.getConnection();
   const combinedCoursesToSave = combinedCourses.map(_toDTO);
@@ -32,4 +42,4 @@ const _toDTO = (combinedCourse) => {
   };
 };
 
-export { getByCode, saveInBatch };
+export { findByCampaignId, getByCode, saveInBatch };

--- a/api/tests/quest/acceptance/application/api/combined-course-api_test.js
+++ b/api/tests/quest/acceptance/application/api/combined-course-api_test.js
@@ -1,0 +1,95 @@
+import * as combinedCourseApi from '../../../../../src/quest/application/api/combined-course-api.js';
+import { CombinedCourse } from '../../../../../src/quest/application/api/CombinedCourse.model.js';
+import { MultipleQuestFoundError } from '../../../../../src/quest/application/api/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Acceptance | Quest | Application | combined-course-api', function () {
+  let organizationId, campaignId, combinedCourseId, combinedCourseName;
+  beforeEach(async function () {
+    //given
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    combinedCourseName = 'Mon parcours Combiné';
+    combinedCourseId = databaseBuilder.factory.buildQuestForCombinedCourse({
+      code: 'ABCDE1234',
+      name: combinedCourseName,
+      organizationId,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaignId,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    }).id;
+    await databaseBuilder.commit();
+  });
+
+  it('should return combined courses by campaignId', async function () {
+    // when
+    const result = await combinedCourseApi.getByCampaignId(campaignId);
+
+    // then
+    expect(result).to.be.instanceOf(CombinedCourse);
+    expect(result.id).to.equal(combinedCourseId);
+    expect(result.name).to.equal(combinedCourseName);
+  });
+
+  it('should return null if no combined courses found', async function () {
+    //given
+    const campaignNotInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await combinedCourseApi.getByCampaignId(campaignNotInQuest.id);
+
+    // then
+    expect(result).null;
+  });
+
+  it('should throw an error if multiple combined courses found', async function () {
+    //given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    databaseBuilder.factory.buildQuestForCombinedCourse({
+      code: 'QWERTY123',
+      name: combinedCourseName,
+      organizationId,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaignId,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+      rewardId: null,
+      rewardType: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(combinedCourseApi.getByCampaignId)(campaignId);
+
+    // then
+    expect(error).instanceOf(MultipleQuestFoundError);
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-campaign-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-campaign-id_test.js
@@ -1,0 +1,60 @@
+import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Quest | Domain | UseCases | get-combined-course-by-campaign-id', function () {
+  let courseId, organizationId, campaignId;
+
+  beforeEach(async function () {
+    //given
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    const code = 'ABCDE1234';
+    const name = 'Mon parcours Combiné';
+    courseId = databaseBuilder.factory.buildQuestForCombinedCourse({
+      code,
+      name,
+      organizationId,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaignId,
+              comparison: 'equal',
+            },
+            status: {
+              data: 'SHARED',
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    }).id;
+    await databaseBuilder.commit();
+  });
+
+  it('should return a combined course', async function () {
+    // when
+    const result = await usecases.findCombinedCourseByCampaignId({ campaignId });
+
+    // then
+    expect(result).lengthOf(1);
+    expect(result[0]).instanceOf(CombinedCourse);
+    expect(result[0].id).equal(courseId);
+  });
+
+  it('should return an empty array if no quest match', async function () {
+    //given
+    const campaigNotInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.findCombinedCourseByCampaignId({ campaignId: campaigNotInQuest.id });
+
+    // then
+    expect(result).deep.equal([]);
+  });
+});


### PR DESCRIPTION

## 🔆 Problème
On souhaite pouvoir savoir si une campagne appartient à un parcours combiné afin de pouvoir adapté certains affichage dans orga
Or il n'existe pas encore d'api pour intérroger les parcours combinés
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition
On crée une api pour intérroger les parcours combiné. 
La première api permet de récupérer un parcours combiné à partir d'un id de campagne
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Pour l'instant seul un test d'acceptance permet de valider la fonctionnalité
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
