### PR TITLE
[FEATURE] Supprimer le statut TO_SHARE dans le détail de l'activité d'un participant (PIX-19325)

### DIFF
--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerActivity.js
@@ -18,20 +18,13 @@ class OrganizationLearnerActivity {
 
     const { SHARED = 0, TO_SHARE = 0, STARTED = 0 } = countBy(participationsForCampaignType, 'status');
 
-    const statisticForCampaignType = {
+    return {
       campaignType,
       shared: SHARED,
-      to_share: TO_SHARE,
+      // TODO Remove TO_SHARE status once not used anymore
+      started: TO_SHARE + STARTED,
       total: participationsForCampaignType.length,
     };
-
-    if (campaignType === CampaignTypes.ASSESSMENT) {
-      return {
-        ...statisticForCampaignType,
-        started: STARTED,
-      };
-    }
-    return statisticForCampaignType;
   }
 
   #statistics(participations) {

--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js
@@ -1,3 +1,5 @@
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+
 class OrganizationLearnerParticipation {
   constructor({
     id,
@@ -15,7 +17,8 @@ class OrganizationLearnerParticipation {
     this.campaignName = campaignName;
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
-    this.status = status;
+    // TODO Remove TO_SHARE status once not used anymore
+    this.status = status === CampaignParticipationStatuses.TO_SHARE ? CampaignParticipationStatuses.STARTED : status;
     this.campaignId = campaignId;
     this.participationCount = participationCount;
     this.lastCampaignParticipationId = lastCampaignParticipationId || id;

--- a/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerActivity_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerActivity_test.js
@@ -33,14 +33,13 @@ describe('Unit | Domain | Read-Models | OrganizationLearnerActivity', function (
     const expectedStatistics = [
       {
         campaignType: CampaignTypes.ASSESSMENT,
-        started: 1,
-        to_share: 1,
+        started: 2,
         shared: 1,
         total: 3,
       },
       {
         campaignType: CampaignTypes.PROFILES_COLLECTION,
-        to_share: 1,
+        started: 1,
         shared: 1,
         total: 2,
       },
@@ -71,13 +70,12 @@ describe('Unit | Domain | Read-Models | OrganizationLearnerActivity', function (
       {
         campaignType: CampaignTypes.ASSESSMENT,
         started: 3,
-        to_share: 0,
         shared: 0,
         total: 3,
       },
       {
         campaignType: CampaignTypes.PROFILES_COLLECTION,
-        to_share: 0,
+        started: 0,
         shared: 0,
         total: 0,
       },

--- a/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerParticipation_test.js
@@ -1,7 +1,7 @@
 import { OrganizationLearnerParticipation } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../test-helper.js';
-const { SHARED } = CampaignParticipationStatuses;
+const { SHARED, STARTED, TO_SHARE } = CampaignParticipationStatuses;
 
 describe('Unit | Domain | Read-Models | OrganizationLearner | OrganizationLearnerParticipation', function () {
   describe('constructor', function () {
@@ -13,7 +13,7 @@ describe('Unit | Domain | Read-Models | OrganizationLearner | OrganizationLearne
         campaignName: 'Hulk',
         createdAt: new Date('2000-01-03'),
         sharedAt: new Date('2000-12-12'),
-        status: SHARED,
+        status: TO_SHARE,
         campaignId: 404,
         participationCount: 1,
         lastCampaignParticipationId: 202,
@@ -25,7 +25,7 @@ describe('Unit | Domain | Read-Models | OrganizationLearner | OrganizationLearne
         campaignName: 'Hulk',
         createdAt: new Date('2000-01-03'),
         sharedAt: new Date('2000-12-12'),
-        status: 'SHARED',
+        status: STARTED,
         campaignId: 404,
         participationCount: 1,
         lastCampaignParticipationId: 202,

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
@@ -120,7 +120,6 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             type: 'organizationLearnerStatistics',
             attributes: {
               shared: 0,
-              'to-share': 0,
               total: 1,
               started: 1,
             },
@@ -130,7 +129,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             type: 'organizationLearnerStatistics',
             attributes: {
               shared: 1,
-              'to-share': 0,
+              started: 0,
               total: 1,
             },
           },

--- a/orga/app/components/organization-learner/activity.gjs
+++ b/orga/app/components/organization-learner/activity.gjs
@@ -41,10 +41,6 @@ export default class Activity extends Component {
                     "pages.organization-learner.activity.cards.started"
                     count=this.assessmentStatistics.started
                   }}</li>
-                <li>{{t
-                    "pages.organization-learner.activity.cards.to-share"
-                    count=this.assessmentStatistics.to_share
-                  }}</li>
                 <li>{{t "pages.organization-learner.activity.cards.shared" count=this.assessmentStatistics.shared}}</li>
               </ul>
             </:sub>
@@ -60,14 +56,18 @@ export default class Activity extends Component {
             <:default>{{this.profileCollectionsStatistics.total}}</:default>
             <:sub>
               <ul class="cards__stats">
-                <li>{{t
-                    "pages.organization-learner.activity.cards.to-share"
-                    count=this.profileCollectionsStatistics.to_share
-                  }}</li>
-                <li>{{t
+                <li>
+                  {{t
+                    "pages.organization-learner.activity.cards.started"
+                    count=this.profileCollectionsStatistics.started
+                  }}
+                </li>
+                <li>
+                  {{t
                     "pages.organization-learner.activity.cards.shared"
                     count=this.profileCollectionsStatistics.shared
-                  }}</li>
+                  }}
+                </li>
               </ul>
             </:sub>
           </PixIndicatorCard>

--- a/orga/app/models/organization-learner-statistic.js
+++ b/orga/app/models/organization-learner-statistic.js
@@ -3,7 +3,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class OrganizationLearnerStatistic extends Model {
   @attr('number') shared;
   @attr('number') started;
-  @attr('number') to_share;
   @attr('number') total;
 
   @belongsTo('organization-learner-activity', { async: true, inverse: 'organizationLearnerStatistics' })

--- a/orga/tests/integration/components/organization-learner/activity-test.js
+++ b/orga/tests/integration/components/organization-learner/activity-test.js
@@ -39,139 +39,131 @@ module('Integration | Component | OrganizationLearner::Activity', function (hook
         )
         .exists();
     });
+  });
 
-    test('it should not display the empty state when there is participations', async function (assert) {
-      // given
-      const participations = [
-        {
-          campaignType: 'ASSESSMENT',
-          campaignName: 'Ma 1ère campagne',
-          createdAt: '2022-12-12',
-          sharedAt: '2022-12-25',
-          status: 'SHARED',
-        },
-      ];
-      const statistics = [];
-      this.set('participations', participations);
-      this.set('statistics', statistics);
-      this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
+  test('it should not display the empty state when there is participations', async function (assert) {
+    // given
+    const participations = [
+      {
+        campaignType: 'ASSESSMENT',
+        campaignName: 'Ma 1ère campagne',
+        createdAt: '2022-12-12',
+        sharedAt: '2022-12-25',
+        status: 'SHARED',
+      },
+    ];
+    const statistics = [];
+    this.set('participations', participations);
+    this.set('statistics', statistics);
+    this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
 
-      // when
-      const screen = await render(
-        hbs`<OrganizationLearner::Activity
+    // when
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity
   @participations={{this.participations}}
   @statistics={{this.statistics}}
   @learner={{this.learner}}
 />`,
-      );
+    );
 
-      // then
-      assert
-        .dom(
-          screen.queryByText(
-            t('pages.organization-learner.activity.empty-state', {
-              organizationLearnerFirstName: 'Bob',
-              organizationLearnerLastName: 'Dylan',
-            }),
-          ),
-        )
-        .doesNotExist();
-    });
-    test('it should display assessement participations statistics when there is participations', async function (assert) {
-      // given
-      const participations = [
-        {
-          campaignType: 'ASSESSMENT',
-          campaignName: 'Ma 1ère campagne',
-          createdAt: '2022-12-12',
-          sharedAt: '2022-12-25',
-          status: 'SHARED',
-        },
-      ];
-      const statistics = [
-        {
-          id: 'ASSESSMENT',
-          shared: 1,
-          started: 2,
-          to_share: 3,
-          total: 6,
-        },
-      ];
-      this.set('participations', participations);
-      this.set('statistics', statistics);
-      this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
+    // then
+    assert
+      .dom(
+        screen.queryByText(
+          t('pages.organization-learner.activity.empty-state', {
+            organizationLearnerFirstName: 'Bob',
+            organizationLearnerLastName: 'Dylan',
+          }),
+        ),
+      )
+      .doesNotExist();
+  });
+  test('it should display assessment participations statistics when there are participations', async function (assert) {
+    // given
+    const participations = [
+      {
+        campaignType: 'ASSESSMENT',
+        campaignName: 'Ma 1ère campagne',
+        createdAt: '2022-12-12',
+        sharedAt: '2022-12-25',
+        status: 'SHARED',
+      },
+    ];
+    const statistics = [
+      {
+        id: 'ASSESSMENT',
+        shared: 1,
+        started: 2,
+        total: 3,
+      },
+    ];
+    this.set('participations', participations);
+    this.set('statistics', statistics);
+    this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
 
-      // when
-      const screen = await render(
-        hbs`<OrganizationLearner::Activity
+    // when
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity
   @participations={{this.participations}}
   @statistics={{this.statistics}}
   @learner={{this.learner}}
 />`,
-      );
+    );
 
-      // then
-      const assessmentCard = within(
-        screen.getByRole('heading', {
-          name: t('pages.organization-learner.activity.assessment-summary'),
-        }).parentElement,
-      );
-      assert.dom(assessmentCard.getByRole('definition')).containsText('6');
-      assert
-        .dom(assessmentCard.getByText(t('pages.organization-learner.activity.cards.started', { count: 2 })))
-        .exists();
-      assert
-        .dom(assessmentCard.getByText(t('pages.organization-learner.activity.cards.to-share', { count: 3 })))
-        .exists();
-      assert
-        .dom(assessmentCard.getByText(t('pages.organization-learner.activity.cards.shared', { count: 1 })))
-        .exists();
-    });
-    test('it should display profile collection participations statistics when there is participations', async function (assert) {
-      // given
-      const participations = [
-        {
-          campaignType: 'PROFILES_COLLECTION',
-          campaignName: 'Ma 1ère campagne',
-          createdAt: '2022-12-12',
-          sharedAt: '2022-12-25',
-          status: 'SHARED',
-        },
-      ];
-      const statistics = [
-        {
-          id: 'PROFILES_COLLECTION',
-          to_share: 3,
-          shared: 1,
-          total: 4,
-        },
-      ];
-      this.set('participations', participations);
-      this.set('statistics', statistics);
-      this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
+    // then
+    const assessmentCard = within(
+      screen.getByRole('heading', {
+        name: t('pages.organization-learner.activity.assessment-summary'),
+      }).parentElement,
+    );
+    assert.dom(assessmentCard.getByRole('definition')).containsText('3');
+    assert.dom(assessmentCard.getByText(t('pages.organization-learner.activity.cards.started', { count: 2 }))).exists();
+    assert.dom(assessmentCard.getByText(t('pages.organization-learner.activity.cards.shared', { count: 1 }))).exists();
+  });
+  test('it should display profile collection participations statistics when there is participations', async function (assert) {
+    // given
+    const participations = [
+      {
+        campaignType: 'PROFILES_COLLECTION',
+        campaignName: 'Ma 1ère campagne',
+        createdAt: '2022-12-12',
+        sharedAt: '2022-12-25',
+        status: 'SHARED',
+      },
+    ];
+    const statistics = [
+      {
+        id: 'PROFILES_COLLECTION',
+        started: 3,
+        shared: 1,
+        total: 4,
+      },
+    ];
+    this.set('participations', participations);
+    this.set('statistics', statistics);
+    this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
 
-      // when
-      const screen = await render(
-        hbs`<OrganizationLearner::Activity
+    // when
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity
   @participations={{this.participations}}
   @statistics={{this.statistics}}
   @learner={{this.learner}}
 />`,
-      );
+    );
 
-      // then
-      const profileCollectionCard = within(
-        screen.getByRole('heading', {
-          name: t('pages.organization-learner.activity.profile-collection-summary'),
-        }).parentElement,
-      );
-      assert.dom(profileCollectionCard.getByRole('definition')).containsText('4');
-      assert
-        .dom(profileCollectionCard.getByText(t('pages.organization-learner.activity.cards.to-share', { count: 3 })))
-        .exists();
-      assert
-        .dom(profileCollectionCard.getByText(t('pages.organization-learner.activity.cards.shared', { count: 1 })))
-        .exists();
-    });
+    // then
+    const profileCollectionCard = within(
+      screen.getByRole('heading', {
+        name: t('pages.organization-learner.activity.profile-collection-summary'),
+      }).parentElement,
+    );
+    assert.dom(profileCollectionCard.getByRole('definition')).containsText('4');
+    assert
+      .dom(profileCollectionCard.getByText(t('pages.organization-learner.activity.cards.started', { count: 3 })))
+      .exists();
+    assert
+      .dom(profileCollectionCard.getByText(t('pages.organization-learner.activity.cards.shared', { count: 1 })))
+      .exists();
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -424,6 +424,7 @@
       "SHARED-ASSESSMENT": "Submitted results",
       "SHARED-PROFILES_COLLECTION": "Submitted profile",
       "STARTED-ASSESSMENT": "In progress",
+      "STARTED-PROFILES_COLLECTION": "Pending profile",
       "TO_SHARE-ASSESSMENT": "Pending results",
       "TO_SHARE-PROFILES_COLLECTION": "Pending profile"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -423,6 +423,7 @@
       "SHARED-ASSESSMENT": "Résultats reçus",
       "SHARED-PROFILES_COLLECTION": "Profil reçu",
       "STARTED-ASSESSMENT": "En cours",
+      "STARTED-PROFILES_COLLECTION": "En attente d'envoi",
       "TO_SHARE-ASSESSMENT": "En attente d'envoi",
       "TO_SHARE-PROFILES_COLLECTION": "En attente d'envoi"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -424,6 +424,7 @@
       "SHARED-ASSESSMENT": "Ontvangen resultaten",
       "SHARED-PROFILES_COLLECTION": "Profiel ontvangen",
       "STARTED-ASSESSMENT": "Bezig",
+      "STARTED-PROFILES_COLLECTION": "In afwachting van verzending",
       "TO_SHARE-ASSESSMENT": "In afwachting van verzending",
       "TO_SHARE-PROFILES_COLLECTION": "In afwachting van verzending"
     },


### PR DESCRIPTION
## 🔆 Problème
Nous souhaitons rendre progressivement obsolète l'utilisation du statut `TO_SHARE` dans le cadre de la simplification des statuts de participation.

## ⛱️ Proposition
- Supprimer le statut `TO_SHARE` du détail d'activité des participants sur PixOrga
- Mettre à jour la route API pour ne plus retourner ce statut dans les statistiques
- Adapter les composants frontend pour ne plus afficher ce statut
- Nettoyer les tests obsolètes liés à ce statut

## 🌊 Remarques 
- Les traductions pour le statut `TO_SHARE` dans `components.participation-status` n'ont pas été supprimées car le composant est utilisé ailleurs. Elles seront supprimées dans une PR ultérieure.
- Utiliser `hide whitespaces` pour la review : certains tests ont été sortis de contextes où ils n'avaient pas leur place.

## 🏄 Pour tester
 Accéder à la page de détail d'activité d'un participant