### PR TITLE
[FEATURE] Abaisser les niveaux de titre des modules (PIX-19233)(PIX-18992)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -393,7 +393,7 @@
               "element": {
                 "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><ul><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>L’adresse IP publique donne une information sur la zone géographique de connexion : le pays, voire la ville.</li></ul>"
+                "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h4><ul><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>L’adresse IP publique donne une information sur la zone géographique de connexion : le pays, voire la ville.</li></ul>"
               }
             }
           ]
@@ -525,7 +525,7 @@
                     {
                       "id": "9bc62c21-dfd4-40a8-9497-680a7e1c13d9",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">🕹️</span> À vous de jouer !</h3><p>À l'aide du schéma ci-dessus, trouvez pour chaque question si elle correspond à une IP privée ou à une IP publique.</p>"
+                      "content": "<h4><span aria-hidden=\"true\">🕹️</span> À vous de jouer !</h4><p>À l'aide du schéma ci-dessus, trouvez pour chaque question si elle correspond à une IP privée ou à une IP publique.</p>"
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -14,7 +14,7 @@
   "sections": [
     {
       "id": "cfaefec9-e185-43b8-8258-e8beff6dd56b",
-      "type": "blank",
+      "type": "question-yourself",
       "grains": [
         {
           "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
@@ -174,13 +174,7 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": "47d5fdea-8141-4184-a78e-c7f871de71fc",
-      "type": "question-yourself",
-      "grains": [
+        },
         {
           "id": "cef7d350-008b-410b-8a6a-39b56efdbe8d",
           "type": "discovery",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -475,7 +475,7 @@
               "element": {
                 "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
                 "type": "text",
-                "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
+                "content": "<h4>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h4><p>Des noms d'artistes de musique très sympas:</p><ol class=\"modulix-two-columns\"> <li>Dylan</li> <li>The Beatles</li> <li>The Who</li><li>Blondie</li><li>Joan Baez</li><li>Supertramp</li><li>Kraftwerk</li> <li>Queen</li><li>David Bowie</li><li>Céline Dion</li></ol>"
               }
             },
             {
@@ -483,7 +483,7 @@
               "element": {
                 "id": "84726001-1665-457d-8f13-4a74dc4768ea",
                 "type": "text",
-                "content": "<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>"
+                "content": "<h4>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h4>"
               }
             },
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -149,7 +149,7 @@
                     {
                       "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
                       "type": "text",
-                      "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
+                      "content": "<h4 class=\"screen-reader-only\">L'identifiant</h4><h5><u>Partie 1&nbsp;: l’identifiant</u>. Cette partie est choisie par Mickaël.</h5><p>Tous les identifiants sont possibles, ou presque.</p><p><span aria-hidden=\"true\">✔️</span> Par exemple&nbsp;: <code>mickael.aubert123</code> ou <code>mika671</code> ou <code>g3odu671</code></p><p><span aria-hidden=\"true\">✖️</span> Certains caractères sont interdits (<code>&amp;</code> <code>@</code>  <code>$</code> <code>*</code> <code>€</code>) ou à éviter (accents, majuscules).</p><p><br><span aria-hidden=\"true\">📖</span> Un conseil : si vous voulez envoyer des mails importants, il vaut mieux créer une adresse mail avec un identifiant classique, par exemple <code>prenom.nom</code>.</p>"
                     }
                   ]
                 },
@@ -165,7 +165,7 @@
                     {
                       "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
                       "type": "text",
-                      "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h4><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
+                      "content": "<h4 class=\"screen-reader-only\">L'arobase</h4><h5><u>Au centre, l’arobase</u> (@) sépare l’identifiant du fournisseur d’adresse mail.</h5><p>En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><br><span aria-hidden=\"true\">💡</span> L'arobase est un symbole qui était utilisé avant l’informatique. En 1970, il a été choisi pour écrire les adresses mail car il était très peu utilisé et facile à repérer.</p>"
                     }
                   ]
                 },
@@ -181,7 +181,7 @@
                     {
                       "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
                       "type": "text",
-                      "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
+                      "content": "<h4 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h4><h5><u>Partie 2&nbsp;: le fournisseur d’adresse mail</u>. Cette partie de l’adresse est donnée par le fournisseur.</h5><p><span aria-hidden=\"true\">✔️</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul><p><br>Quand vous écrivez une adresse mail, soyez attentifs à l'extension (<code>.fr</code>, <code>.com</code>, etc.). C'est important pour que le mail soit envoyé à la bonne adresse. <span aria-hidden=\"true\">🧐</span></p>"
                     }
                   ]
                 }
@@ -477,7 +477,7 @@
               "element": {
                 "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+                "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h4><ul><li>C'est l'<strong>utilisateur qui choisit son identifiant</strong> d'adresse mail. Il peut utiliser des <strong>chiffres</strong> ou des <strong>majuscules</strong>.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: <code>mickael.aubert123</code> ; <code>M3g4Cool1415</code>, etc.<br></li><li>Il y a une <strong>arobase</strong> (@) dans une adresse mail. Elle permet de <strong>séparer l’identifiant et le fournisseur</strong> d’adresse mail.<br></li><li>Après l'arobase, les adresses mail <strong>se terminent de différentes manières</strong>, selon le <strong>fournisseur d’adresse</strong> mail.<br><span aria-hidden=\"true\">✔️</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -213,7 +213,7 @@
                     {
                       "id": "be70c1be-d6d1-4b6e-bcee-de1ab8859ee0",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer</h3><p>Vous allez maintenant devoir analyser trois situations avec des résultats visiblement biaisés.</p><p>Pour chaque situation, trouvez la cause principale des résultats biaisés.<br><i>Tous les exemples ont été générés le 7 juin 2024 avec CHATGPT-4 (OpenAI).</i></p>"
+                      "content": "<h4><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer</h4><p>Vous allez maintenant devoir analyser trois situations avec des résultats visiblement biaisés.</p><p>Pour chaque situation, trouvez la cause principale des résultats biaisés.<br><i>Tous les exemples ont été générés le 7 juin 2024 avec CHATGPT-4 (OpenAI).</i></p>"
                     }
                   ]
                 },
@@ -375,7 +375,7 @@
               "element": {
                 "id": "d7c949fb-9fac-400d-990a-a6cb8144c653",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h3><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
+                "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite</h4><p>Les biais dans les LLM peuvent avoir différentes origines&nbsp;:</p><ul><li>Les <strong>données d'entraînement</strong> comportent déjà des stéréotypes et des biais, qui se retrouvent par la suite dans les modèles.</li><li>Les <strong>personnes qui développent</strong> des LLM transmettent, consciemment ou non, leurs biais dans les modèles.</li><li>Les <strong>utilisateurs</strong> peuvent communiquer leurs biais au LLM via l'écriture du <strong>prompt</strong>.</li></ul>"
               }
             }
           ]
@@ -408,7 +408,7 @@
                     {
                       "id": "4c5bad43-7a4b-4535-8951-dc2b98e1de54",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">🔧&nbsp;</span>Et si on essayait ?</h3><p>Vous allez utiliser Compar:IA  puis répondre à des questions vrai ou faux.</p>"
+                      "content": "<h4><span aria-hidden=\"true\">🔧&nbsp;</span>Et si on essayait ?</h4><p>Vous allez utiliser Compar:IA  puis répondre à des questions vrai ou faux.</p>"
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -317,7 +317,7 @@
               "element": {
                 "id": "97e1108c-34ef-4772-a3ca-e385d6319bc6",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h3><p>Pour envoyer un mail, il faut remplir ses différents champs avec les bonnes informations :</p>"
+                "content": "<h4><span aria-hidden=\"true\">📌</span> Résumons avant de passer à la suite :</h4><p>Pour envoyer un mail, il faut remplir ses différents champs avec les bonnes informations :</p>"
               }
             },
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -42,7 +42,7 @@
                 "url": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.mp4",
                 "poster": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.jpg",
                 "subtitles": "https://assets.pix.org/modules/decouverte-ent/intro_conversation.vtt",
-                "transcription": "<p></p><h3>Des devoirs en ligne ?</h3><p></p><p>Conversation entre Martin et sa fille Ava&nbsp;:&nbsp;</p><p>Martin&nbsp;: Alors Ava, cette journée ?<br>Ava&nbsp;: Super, papa ! Mais je suis quand même contente d’être en week-end.<br>Martin&nbsp;: Tu as des devoirs pour la semaine prochaine ?<br>Ava&nbsp;: Oui, le prof a mis des devoirs en ligne.<br>Martin&nbsp;: En ligne ?</p>"
+                "transcription": "<p></p><h4>Des devoirs en ligne ?</h4><p></p><p>Conversation entre Martin et sa fille Ava&nbsp;:&nbsp;</p><p>Martin&nbsp;: Alors Ava, cette journée ?<br>Ava&nbsp;: Super, papa ! Mais je suis quand même contente d’être en week-end.<br>Martin&nbsp;: Tu as des devoirs pour la semaine prochaine ?<br>Ava&nbsp;: Oui, le prof a mis des devoirs en ligne.<br>Martin&nbsp;: En ligne ?</p>"
               }
             }
           ]
@@ -138,7 +138,7 @@
                     {
                       "id": "90c81b47-b175-4f42-b5aa-914ec83025b8",
                       "type": "text",
-                      "content": "<h3>L’espace numérique de travail (ENT) est le service en ligne proposé par l’établissement scolaire.</h3>\n<p><br>L’ENT est utilisé par les élèves, les enseignants, les parents et les personnels d’éducation (CPE, principal...).</p>\n<p>Il est accessible sur ordinateur, smartphone et tablette.</p>\n<p><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT est sécurisé et il protège l’accès aux données personnelles des parents et des enfants.</p>"
+                      "content": "<h4>L’espace numérique de travail (ENT) est le service en ligne proposé par l’établissement scolaire.</h4>\n<p><br>L’ENT est utilisé par les élèves, les enseignants, les parents et les personnels d’éducation (CPE, principal...).</p>\n<p>Il est accessible sur ordinateur, smartphone et tablette.</p>\n<p><strong><span aria-hidden=\"true\">💡</span>&nbsp;Bon à savoir</strong> <br>L’ENT est sécurisé et il protège l’accès aux données personnelles des parents et des enfants.</p>"
                     }
                   ]
                 },
@@ -147,7 +147,7 @@
                     {
                       "id": "52089ff2-4c01-4047-a188-dbd5537caf18",
                       "type": "text",
-                      "content": "<h3>La plupart des collèges et des lycées et certaines écoles primaire ont un ENT mais ce n'est pas obligatoire.</h3>\n<p>Les ENT peuvent être différents d’un département ou d’une région à l’autre.</p>\n<p><span aria-hidden=\"true\">✔️</span> Par exemple, en Corse les élèves utilisent l’ENT Leia et, en Occitanie, les élèves utilisent MonENTOccitanie.</p>"
+                      "content": "<h4>La plupart des collèges et des lycées et certaines écoles primaire ont un ENT mais ce n'est pas obligatoire.</h4>\n<p>Les ENT peuvent être différents d’un département ou d’une région à l’autre.</p>\n<p><span aria-hidden=\"true\">✔️</span> Par exemple, en Corse les élèves utilisent l’ENT Leia et, en Occitanie, les élèves utilisent MonENTOccitanie.</p>"
                     }
                   ]
                 }
@@ -217,7 +217,7 @@
               "element": {
                 "id": "63803887-ac1c-4385-b9bc-65877d649134",
                 "type": "text",
-                "content": "<h3>L’ENT permet aux parents de suivre au quotidien la scolarité de leurs enfants&nbsp;:</h3>\n<ul>\n    <li>voir l’emploi du temps</li>\n    <li>communiquer avec l’établissement scolaire</li>\n    <li>consulter le cahier de textes numérique</li>\n</ul>\n<p><span aria-hidden=\"true\">👉</span> En début d’année, l’établissement scolaire donne les informations pour se connecter à l’ENT&nbsp;: le lien vers l’ENT, un identifiant et un mot de passe. Il faut conserver ces informations tout au long de l'année.<br>Souvent, le compte Educonnect permet de se connecter à l'ENT.</p>"
+                "content": "<h4>L’ENT permet aux parents de suivre au quotidien la scolarité de leurs enfants&nbsp;:</h4>\n<ul>\n    <li>voir l’emploi du temps</li>\n    <li>communiquer avec l’établissement scolaire</li>\n    <li>consulter le cahier de textes numérique</li>\n</ul>\n<p><span aria-hidden=\"true\">👉</span> En début d’année, l’établissement scolaire donne les informations pour se connecter à l’ENT&nbsp;: le lien vers l’ENT, un identifiant et un mot de passe. Il faut conserver ces informations tout au long de l'année.<br>Souvent, le compte Educonnect permet de se connecter à l'ENT.</p>"
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -48,7 +48,7 @@
                     {
                       "id": "7254a4fe-b11d-492f-985c-20a94f454a4d",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">🎮</span> Commençons par un jeu</h3><p>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est <strong>plutôt vraie</strong> ou <strong>plutôt fausse</strong>.<br>Bonne chance&#8239;!</p>"
+                      "content": "<h4><span aria-hidden=\"true\">🎮</span> Commençons par un jeu</h4><p>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est <strong>plutôt vraie</strong> ou <strong>plutôt fausse</strong>.<br>Bonne chance&#8239;!</p>"
                     }
                   ]
                 },
@@ -216,7 +216,7 @@
                     {
                       "id": "5c6ec12a-f5b4-4683-ae7a-11b79fddd0a5",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer !</h3>Dans chacune des situations suivantes, trouvez s'il s'agit d'une opinion, d'une rumeur, d'une anecdote ou d'une information."
+                      "content": "<h4><span aria-hidden=\"true\">&nbsp;🕹️</span> À vous de jouer !</h4>Dans chacune des situations suivantes, trouvez s'il s'agit d'une opinion, d'une rumeur, d'une anecdote ou d'une information."
                     }
                   ]
                 },
@@ -428,7 +428,7 @@
                     {
                       "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
                       "type": "text",
-                      "content": "<h3>Question n°1&nbsp;: <i>qui</i> est la personne qui partage cette information&#8239;?&nbsp;<span aria-hidden=\"true\">💬</span></h3><p>Demandez-vous si vous connaissez cette personne, si elle est reconnue ou encore si elle a un intérêt particulier à ce que cette information circule.</p>"
+                      "content": "<h4>Question n°1&nbsp;: <i>qui</i> est la personne qui partage cette information&#8239;?&nbsp;<span aria-hidden=\"true\">💬</span></h4><p>Demandez-vous si vous connaissez cette personne, si elle est reconnue ou encore si elle a un intérêt particulier à ce que cette information circule.</p>"
                     }
                   ]
                 },
@@ -437,7 +437,7 @@
                     {
                       "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
                       "type": "text",
-                      "content": "<h3>Question n°2&nbsp;: de <i>quand</i> date l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+                      "content": "<h4>Question n°2&nbsp;: de <i>quand</i> date l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h4><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
                     }
                   ]
                 },
@@ -446,7 +446,7 @@
                     {
                       "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
                       "type": "text",
-                      "content": "<h3>Question n°3&nbsp;: <i>d’où</i> provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🤔</span></h3><p>Cherchez à connaître l’origine de cette information, c’est-à-dire sa source : un témoignage direct, le résultat d'expériences scientifiques ou l'enquête d'un journal, etc.<br>Regardez également si l’auteur a partagé ses sources et si vous pouvez vérifier cette information par vous-même, en cherchant d’autres sources pour les comparer.</p>"
+                      "content": "<h4>Question n°3&nbsp;: <i>d’où</i> provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🤔</span></h4><p>Cherchez à connaître l’origine de cette information, c’est-à-dire sa source : un témoignage direct, le résultat d'expériences scientifiques ou l'enquête d'un journal, etc.<br>Regardez également si l’auteur a partagé ses sources et si vous pouvez vérifier cette information par vous-même, en cherchant d’autres sources pour les comparer.</p>"
                     }
                   ]
                 },
@@ -539,7 +539,7 @@
                     {
                       "id": "613bd45d-8e88-4ca5-bfa0-368be2336027",
                       "type": "text",
-                      "content": "<h3><span aria-hidden=\"true\">🔎</span> C'est l'heure d'utiliser le « Qui ? Quand ? D'où ? »</h3><p>Dans les exemples suivants, les informations publiées sont sûrement fausses.<br>En effet, une des réponses au « Qui ? Quand ? D'où ? » présente un problème.<br>Trouvez dans chaque exemple où se situe ce problème.</p>"
+                      "content": "<h4><span aria-hidden=\"true\">🔎</span> C'est l'heure d'utiliser le « Qui ? Quand ? D'où ? »</h4><p>Dans les exemples suivants, les informations publiées sont sûrement fausses.<br>En effet, une des réponses au « Qui ? Quand ? D'où ? » présente un problème.<br>Trouvez dans chaque exemple où se situe ce problème.</p>"
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -14,7 +14,7 @@
   "sections": [
     {
       "id": "06f70348-a80b-4ae5-9b04-5efd55f770cd",
-      "type": "blank",
+      "type": "question-yourself",
       "grains": [
         {
           "id": "9f7af22d-8cd2-45e0-b2d0-611e9903300e",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -490,7 +490,7 @@
                     {
                       "id": "05a30b10-ac62-40a5-961b-9f3f3e831da0",
                       "type": "qcu",
-                      "instruction": "<h4>🗣️ 🎤 Une application retrouve le titre d'une musique que vous lui chantez.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "instruction": "<h5>🗣️ 🎤 Une application retrouve le titre d'une musique que vous lui chantez.</h5><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
                       "proposals": [
                         {
                           "id": "1",
@@ -534,7 +534,7 @@
                     {
                       "id": "d6644a42-0b76-4e9c-8595-43c2da89cb9b",
                       "type": "qcu",
-                      "instruction": "<h4>🎬 ▶️ Un site vous propose de nouveaux contenus suite au visionnage d’une vidéo.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "instruction": "<h5>🎬 ▶️ Un site vous propose de nouveaux contenus suite au visionnage d’une vidéo.</h5><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
                       "proposals": [
                         {
                           "id": "1",
@@ -578,7 +578,7 @@
                     {
                       "id": "e67d64c3-9912-4046-9f03-46059c51247c",
                       "type": "qcu",
-                      "instruction": "<h4>📷 🏷️ Un logiciel ajoute automatiquement des mots clés à des photographies.</h4><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
+                      "instruction": "<h5>📷 🏷️ Un logiciel ajoute automatiquement des mots clés à des photographies.</h5><p><br>Dans quel type de tâche est spécialisée l'IA utilisée ?</p>",
                       "proposals": [
                         {
                           "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -540,7 +540,7 @@
                     {
                       "id": "d85a05a1-0c9d-4ce7-ad25-9333eb3a75c3",
                       "type": "text",
-                      "content": "<h3>Quels sont les risques des discussions en ligne ?</h3><p>Il est impossible de savoir qui se trouve réellement de l’autre côté de l’écran. Les personnes avec de mauvaises intentions cherchent souvent à&nbsp;: </p><ul><li>manipuler les autres joueurs</li><li>proposer des rencontres dans la vraie vie</li><li>pousser à partager des photos ou des informations personnelles</li></ul><p>⚠️ <strong>Attention</strong><br>Même avec un jeu qui ne permet pas de discuter avec d’autres joueurs, ce risque n’est pas écarté. En effet, certaines consoles permettent de discuter en ligne, tout comme les ordinateurs et les smartphones.</p>"
+                      "content": "<h4>Quels sont les risques des discussions en ligne ?</h4><p>Il est impossible de savoir qui se trouve réellement de l’autre côté de l’écran. Les personnes avec de mauvaises intentions cherchent souvent à&nbsp;: </p><ul><li>manipuler les autres joueurs</li><li>proposer des rencontres dans la vraie vie</li><li>pousser à partager des photos ou des informations personnelles</li></ul><p>⚠️ <strong>Attention</strong><br>Même avec un jeu qui ne permet pas de discuter avec d’autres joueurs, ce risque n’est pas écarté. En effet, certaines consoles permettent de discuter en ligne, tout comme les ordinateurs et les smartphones.</p>"
                     }
                   ]
                 },
@@ -549,7 +549,7 @@
                     {
                       "id": "6b8112ec-45ab-4665-b690-9adf0b6e93ac",
                       "type": "text",
-                      "content": "<h3>Comment se protéger ?</h3><p>🔎 D’abord, il faut être attentif lors du choix d’un jeu vidéo. Sur les boîtes ou les pages en ligne des jeux, la mention d’interaction entre joueurs peut prendre différentes formes&nbsp;: «&nbsp;<strong>les utilisateurs interagissent</strong>&nbsp;», «&nbsp;<strong>interaction entre les joueurs</strong>&nbsp;», «&nbsp;<strong>interactivité des utilisateurs</strong>&nbsp;»...</p>"
+                      "content": "<h4>Comment se protéger ?</h4><p>🔎 D’abord, il faut être attentif lors du choix d’un jeu vidéo. Sur les boîtes ou les pages en ligne des jeux, la mention d’interaction entre joueurs peut prendre différentes formes&nbsp;: «&nbsp;<strong>les utilisateurs interagissent</strong>&nbsp;», «&nbsp;<strong>interaction entre les joueurs</strong>&nbsp;», «&nbsp;<strong>interactivité des utilisateurs</strong>&nbsp;»...</p>"
                     },
                     {
                       "id": "9e9b11ab-0ffb-4dc9-917a-f5e336300ce5",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -124,7 +124,7 @@
               "element": {
                 "id": "826281e7-865f-462d-abc0-77537c42a2b4",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">🧑‍💻&nbsp;🔮&nbsp;</span>Une personne peut deviner votre mot de passe.</h3><p>Si vous utilisez des informations privées dans votre mot de passe, il est possible qu’une personne de votre entourage le devine facilement.</p><p><span aria-hidden=\"true\">⚠️</span> Elle pourra alors accéder à vos données personnelles et privées. Et ce n’est peut-être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.</p>"
+                "content": "<h4><span aria-hidden=\"true\">🧑‍💻&nbsp;🔮&nbsp;</span>Une personne peut deviner votre mot de passe.</h4><p>Si vous utilisez des informations privées dans votre mot de passe, il est possible qu’une personne de votre entourage le devine facilement.</p><p><span aria-hidden=\"true\">⚠️</span> Elle pourra alors accéder à vos données personnelles et privées. Et ce n’est peut-être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.</p>"
               }
             },
             {
@@ -140,7 +140,7 @@
               "element": {
                 "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">🤖&nbsp;🏴‍☠️&nbsp;</span>Un logiciel informatique peut pirater votre mot de passe.</h3><p>Les ordinateurs sont capables de trouver des mots de passe en testant très rapidement différentes combinaisons possibles.<br>En 2023, un mot de passe court comme <code>$0Leil@?</code> peut être piraté en 5 minutes seulement. Mais avec un mot de passe plus long, comme <code>$0Leil@1504</code>, cette durée passe à 226 ans.</p> <p><span aria-hidden=\"true\">⚠️</span> En général, le pirate ne vous connaît pas. Il cherche certainement à revendre vos informations ou à vous voler de l’argent.</p>"
+                "content": "<h4><span aria-hidden=\"true\">🤖&nbsp;🏴‍☠️&nbsp;</span>Un logiciel informatique peut pirater votre mot de passe.</h4><p>Les ordinateurs sont capables de trouver des mots de passe en testant très rapidement différentes combinaisons possibles.<br>En 2023, un mot de passe court comme <code>$0Leil@?</code> peut être piraté en 5 minutes seulement. Mais avec un mot de passe plus long, comme <code>$0Leil@1504</code>, cette durée passe à 226 ans.</p> <p><span aria-hidden=\"true\">⚠️</span> En général, le pirate ne vous connaît pas. Il cherche certainement à revendre vos informations ou à vous voler de l’argent.</p>"
               }
             }
           ]
@@ -281,7 +281,7 @@
               "element": {
                 "id": "02bb0017-a74d-4c78-8502-3c57d9f12209",
                 "type": "text",
-                "content": "<h3>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h3><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
+                "content": "<h4>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h4><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
               }
             },
             {
@@ -297,7 +297,7 @@
               "element": {
                 "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
                 "type": "text",
-                "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
+                "content": "<h4>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h4><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
               }
             },
             {
@@ -313,7 +313,7 @@
               "element": {
                 "id": "c4505a09-864c-48f8-8077-013fae2db291",
                 "type": "text",
-                "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
+                "content": "<h4>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h4><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
               }
             }
           ]
@@ -462,7 +462,7 @@
               "element": {
                 "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
                 "type": "text",
-                "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
+                "content": "<h4>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h4><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
               }
             },
             {
@@ -478,7 +478,7 @@
               "element": {
                 "id": "f6edeae6-fbfb-4dce-b556-1bb7928d5ff5",
                 "type": "text",
-                "content": "<h3>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h3><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
+                "content": "<h4>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h4><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
               }
             },
             {
@@ -494,7 +494,7 @@
               "element": {
                 "id": "dadd152e-350c-4710-8609-af5f92e69b2c",
                 "type": "text",
-                "content": "<h3>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h3><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
+                "content": "<h4>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h4><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
               }
             }
           ]
@@ -583,7 +583,7 @@
               "element": {
                 "id": "2e695244-52c5-4277-8414-d18777d0d242",
                 "type": "text",
-                "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
+                "content": "<h4>Ce qu’il faut retenir</h4><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -391,14 +391,14 @@
                     {
                       "id": "fdbfa739-e38f-41d6-ba98-6660fe729e16",
                       "type": "text",
-                      "content": "<h3>Une clé USB ou un clavier sans-fil (avec récepteur USB)</h3>"
+                      "content": "<h4>Une clé USB ou un clavier sans-fil (avec récepteur USB)</h4>"
                     },
                     {
                       "id": "34aee94d-4bdb-4923-8111-69a46ce158dd",
                       "type": "image",
                       "url": "https://assets.pix.org/draft/modules/JUTKL4Q.jpeg",
                       "alt": "Photographie d'une clé USB et d'un clavier sans-fil et son récepteur USB",
-                      "alternativeText": "<h3>Une clé USB</h3><p>La clé USB comporte une prise USB. Elle se branche toute entière à l'ordinateur, sans besoin de cable.</p><h3>Un clavier sans-fil (avec récepteur USB)&nbsp;</h3>\n<p>Le clavier se branche à l'ordinateur grâce au récepteur USB. C'est une petite prise USB qui n'est pas reliée par un fil au clavier.</p>"
+                      "alternativeText": "<h4>Une clé USB</h4><p>La clé USB comporte une prise USB. Elle se branche toute entière à l'ordinateur, sans besoin de cable.</p><h4>Un clavier sans-fil (avec récepteur USB)&nbsp;</h4>\n<p>Le clavier se branche à l'ordinateur grâce au récepteur USB. C'est une petite prise USB qui n'est pas reliée par un fil au clavier.</p>"
                     }
                   ]
                 },
@@ -407,14 +407,14 @@
                     {
                       "id": "b91728f4-a8f2-403b-81bc-520db8b8cbf0",
                       "type": "text",
-                      "content": "\n<h3>Une souris filaire ou une manette de jeux vidéos</h3>"
+                      "content": "\n<h4>Une souris filaire ou une manette de jeux vidéos</h4>"
                     },
                     {
                       "id": "b7f8feb2-b355-4fbd-99ec-48511303536f",
                       "type": "image",
                       "url": "https://assets.pix.org/draft/modules/SAWzPl8.jpeg",
                       "alt": "Photo d'une souris filaire et d'une manette de jeu vidéo à connexion USB",
-                      "alternativeText": "<h3>Une souris filaire </h3><p>La souris est reliée à un cable, au bout de celui-ci on voit une prise USB.</p><h3>Une manette de jeux vidéos </h3><p>La manette est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
+                      "alternativeText": "<h4>Une souris filaire </h4><p>La souris est reliée à un cable, au bout de celui-ci on voit une prise USB.</p><h4>Une manette de jeux vidéos </h4><p>La manette est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
                     }
                   ]
                 },
@@ -423,14 +423,14 @@
                     {
                       "id": "07bc0dd7-c121-4f6d-8e3a-ba45faffc93c",
                       "type": "text",
-                      "content": "<h3>Un cable de chargeur de téléphone portable ou une webcam</h3>"
+                      "content": "<h4>Un cable de chargeur de téléphone portable ou une webcam</h4>"
                     },
                     {
                       "id": "06160ea0-d7dd-41ba-b455-c3078de15be6",
                       "type": "image",
                       "url": "https://assets.pix.org/draft/modules/EJKVD5d.jpeg",
                       "alt": "Photo d'un câble de chargeur de téléphone portable à connexion USB, et d'une webcam à connexion USB",
-                      "alternativeText": "<h3>Un câble de téléphone portable </h3>\n<p>Le cable de chargeur de téléphone portable est muni d'une prise USB (pour le port de l'ordinateur), et d'une prise USB-C (pour le port du téléphone).</p><h3>Une webcam</h3><p>La webcam est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
+                      "alternativeText": "<h4>Un câble de téléphone portable </h4>\n<p>Le cable de chargeur de téléphone portable est muni d'une prise USB (pour le port de l'ordinateur), et d'une prise USB-C (pour le port du téléphone).</p><h4>Une webcam</h4><p>La webcam est reliée à un cable, au bout de celui-ci on voit une prise USB.</p>"
                     }
                   ]
                 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -122,7 +122,7 @@
               "element": {
                 "id": "afc8b60f-c2c1-405b-a6a4-a0e08e23ccc3",
                 "type": "text",
-                "content": "<h3>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h3><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
+                "content": "<h4>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h4><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
               }
             },
             {
@@ -138,7 +138,7 @@
               "element": {
                 "id": "81710de7-1311-4980-81f5-87944e56de28",
                 "type": "text",
-                "content": "<h3>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h3><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
+                "content": "<h4>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h4><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
               }
             },
             {
@@ -154,7 +154,7 @@
               "element": {
                 "id": "78385472-07b0-4229-bfb8-a10636690300",
                 "type": "text",
-                "content": "<h3>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h3><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
+                "content": "<h4>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h4><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
               }
             },
             {
@@ -170,7 +170,7 @@
               "element": {
                 "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
                 "type": "text",
-                "content": "<h3>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h3><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
+                "content": "<h4>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h4><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
               }
             },
             {
@@ -186,7 +186,7 @@
               "element": {
                 "id": "ca62ac2d-950d-4c00-b14d-2ac9e7d509f2",
                 "type": "text",
-                "content": "<h3>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h3><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
+                "content": "<h4>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h4><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
               }
             }
           ]
@@ -427,7 +427,7 @@
               "element": {
                 "id": "01eb319e-8219-425a-b66f-00f8f73a4842",
                 "type": "text",
-                "content": "<h3>Répondez aux questions ci-dessous en naviguant dans  <a href=\"https://fr.wikipedia.org/wiki/Inca_(Majorque)\" target=\"blank\">l'article Wikipédia de la commune d'Inca.</a></h3>"
+                "content": "<h4>Répondez aux questions ci-dessous en naviguant dans  <a href=\"https://fr.wikipedia.org/wiki/Inca_(Majorque)\" target=\"blank\">l'article Wikipédia de la commune d'Inca.</a></h4>"
               }
             },
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -146,7 +146,7 @@
               "element": {
                 "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
                 "type": "text",
-                "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
+                "content": "<h4>C'est quoi une source d'information&#8239;?</h4><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
               }
             },
             {
@@ -162,7 +162,7 @@
               "element": {
                 "id": "e3ebd36a-c8b9-4990-af63-061329824708",
                 "type": "text",
-                "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
+                "content": "<h4>Comment savoir si on peut croire une source&#8239;?</h4><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
               }
             }
           ]
@@ -349,7 +349,7 @@
               "element": {
                 "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
                 "type": "text",
-                "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
+                "content": "<h4>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h4><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
               }
             },
             {
@@ -365,7 +365,7 @@
               "element": {
                 "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
                 "type": "text",
-                "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
+                "content": "<h4>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h4><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
               }
             },
             {
@@ -381,7 +381,7 @@
               "element": {
                 "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
                 "type": "text",
-                "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
+                "content": "<h4>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h4><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -63,7 +63,7 @@
               "element": {
                 "id": "c785bfd1-e8b8-42a0-8354-333d5acf6555",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">🔎</span> Observez : votre souris a-t-elle un fil ?</h3>"
+                "content": "<h4><span aria-hidden=\"true\">🔎</span> Observez : votre souris a-t-elle un fil ?</h4>"
               }
             }
           ]
@@ -135,7 +135,7 @@
               "element": {
                 "id": "6b6eeef4-bb9b-4769-906d-47e72db93543",
                 "type": "text",
-                "content": "<p>Pour l'instant, regardez votre souris. Ne regardez pas ce qu'il se passe à l'écran.<br></p><h3><span aria-hidden=\"true\">👉</span> Déplacez votre souris, en suivant ces étapes :</h3><ul><li>Étape 1 : Posez votre main confortablement sur la souris.</li><li>Étape 2 : Faites glissez la souris doucement sur la table.</li></ul>"
+                "content": "<p>Pour l'instant, regardez votre souris. Ne regardez pas ce qu'il se passe à l'écran.<br></p><h4><span aria-hidden=\"true\">👉</span> Déplacez votre souris, en suivant ces étapes :</h4><ul><li>Étape 1 : Posez votre main confortablement sur la souris.</li><li>Étape 2 : Faites glissez la souris doucement sur la table.</li></ul>"
               }
             },
             {
@@ -222,7 +222,7 @@
               "element": {
                 "id": "0dc90047-776b-48cd-944e-72ca51c69cfc",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur de votre souris.</h3><p>Pour découvrir l'image cachée, passez le pointeur de votre souris dans toute la zone.</p>"
+                "content": "<h4><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur de votre souris.</h4><p>Pour découvrir l'image cachée, passez le pointeur de votre souris dans toute la zone.</p>"
               }
             },
             {
@@ -264,7 +264,7 @@
               "element": {
                 "id": "a33ac061-ab23-4e94-b60e-904e701e7d76",
                 "type": "text",
-                "content": "<h3><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur sur chacun des éléments qui apparaissent. </h3><p>Vous pouvez essayer autant de fois que vous voulez.</p>"
+                "content": "<h4><span aria-hidden=\"true\">👉</span> Dans la zone ci-dessous, déplacez le pointeur sur chacun des éléments qui apparaissent. </h4><p>Vous pouvez essayer autant de fois que vous voulez.</p>"
               }
             },
             {
@@ -283,7 +283,7 @@
               "element": {
                 "id": "9c1c4342-96a6-4c14-a5b0-5ed0d202fb8f",
                 "type": "text",
-                "content": "<h3> <span aria-hidden=\"true\">💡</span> Astuce si vous ne voyez plus le pointeur sur votre écran :&nbsp;</h3> <p> Bougez de gauche à droite votre souris doucement sur la table.<br> Vous verrez le pointeur bouger à l'écran.</p>"
+                "content": "<h4> <span aria-hidden=\"true\">💡</span> Astuce si vous ne voyez plus le pointeur sur votre écran :&nbsp;</h4> <p> Bougez de gauche à droite votre souris doucement sur la table.<br> Vous verrez le pointeur bouger à l'écran.</p>"
               }
             }
           ]
@@ -369,7 +369,7 @@
               "element": {
                 "id": "e45a32cf-2ab9-4464-85d0-ae4f0ca897cb",
                 "type": "text",
-                "content": "<h3>D'abord, pourquoi est-ce qu'on dit «&nbsp;<strong>clic&nbsp;</strong>»&nbsp;?</h3><p>C'est le bruit que fait une souris d'ordinateur quand on appuie sur un de ses boutons.</p>"
+                "content": "<h4>D'abord, pourquoi est-ce qu'on dit «&nbsp;<strong>clic&nbsp;</strong>»&nbsp;?</h4><p>C'est le bruit que fait une souris d'ordinateur quand on appuie sur un de ses boutons.</p>"
               }
             },
             {
@@ -549,7 +549,7 @@
                     {
                       "id": "734ef21d-3850-40db-840e-e16253d8817b",
                       "type": "text",
-                      "content": "<h3>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h3><br><p> Ce clic gauche va faire démarrer la vidéo.</p>"
+                      "content": "<h4>Faites un clic gauche sur «&nbsp;Play&nbsp;» <span aria-hidden=\"true\">▶️</span> au centre de l'image ci-dessous.</h4><br><p> Ce clic gauche va faire démarrer la vidéo.</p>"
                     },
                     {
                       "id": "b0f296c2-a295-4424-8eb1-76e3fbcc1ebb",
@@ -631,7 +631,7 @@
               "element": {
                 "id": "72a98ef7-1052-4f70-bfe8-a77ff4279f61",
                 "type": "text",
-                "content": "<h3>Les 5 points à retenir <span aria-hidden=\"true\">📌</span></h3>"
+                "content": "<h4>Les 5 points à retenir <span aria-hidden=\"true\">📌</span></h4>"
               }
             },
             {

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -94,7 +94,7 @@
               "element": {
                 "id": "e9aef60c-f18a-471e-85c7-e50b4731b86b",
                 "type": "text",
-                "content": "<h3>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h3>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>"
+                "content": "<h4>Pour afficher mon texte sur plusieurs colonnes, je peux utiliser la classe <em>modulix-two-columns</em>.</h4>\n <p>Des noms d'artistes de musique très sympas:</p>\n<ol class=\"modulix-two-columns\">\n    <li>Dylan</li>\n    <li>The Beatles</li>\n    <li>The Who</li>\n    <li>Blondie</li>\n    <li>Joan Baez</li>\n    <li>Supertramp</li>\n    <li>Kraftwerk</li>\n    <li>Queen</li>\n    <li>David Bowie</li>\n    <li>Céline Dion</li>\n</ol>"
               }
             },
             {
@@ -120,7 +120,7 @@
                 "id": "84726001-1665-457d-8f13-4a74dc4768ea",
                 "type": "expand",
                 "title": "Mon titre expand",
-                "content": "<h3>On commence avec les leçons</h3>"
+                "content": "<h4>On commence avec les leçons</h4>"
               }
             }
           ]
@@ -263,7 +263,6 @@
                           "id": "2",
                           "content": "Faux",
                           "feedback": { "diagnosis": "Mauvaise réponse !" }
-
                         }
                       ]
                     }

--- a/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
@@ -62,7 +62,7 @@ describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
                     id: '84726001-1665-457d-8f13-4a74dc4768ea',
                     type: 'text',
                     content:
-                      '<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>',
+                      '<h4>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h4>',
                   },
                 },
                 {

--- a/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
@@ -61,7 +61,7 @@ describe('Acceptance | Script | Helper | Get grains', function () {
                     id: '84726001-1665-457d-8f13-4a74dc4768ea',
                     type: 'text',
                     content:
-                      '<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>',
+                      '<h4>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h4>',
                   },
                 },
                 {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -47,7 +47,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
                       content:
-                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
                   },
                 ],
@@ -86,7 +86,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
                       content:
-                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
                   },
                 ],
@@ -255,7 +255,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
                       content:
-                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
                   },
                 ],
@@ -369,7 +369,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
                       content:
-                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
                   },
                 ],
@@ -517,7 +517,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                       id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                       type: 'text',
                       content:
-                        "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                        "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
                     },
                   },
                 ],

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
@@ -37,7 +37,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
                 id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                 type: 'text',
                 content:
-                  "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                  "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
               },
             },
           ],
@@ -70,7 +70,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
                 id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                 type: 'text',
                 content:
-                  "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                  "<h4 class='screen-reader-only'>L'arobase</h4><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
               },
             },
           ],

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -639,7 +639,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
                     element: {
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
-                      content: '<h3>Content.</h3>',
+                      content: '<h4>Content.</h4>',
                     },
                   },
                 ],

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -535,7 +535,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                       element: {
                         id: '84726001-1665-457d-8f13-4a74dc4768ea',
                         type: 'text',
-                        content: '<h3>Content</h3>',
+                        content: '<h4>Content</h4>',
                       },
                     },
                   ],
@@ -2242,7 +2242,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                     element: {
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
-                      content: '<h3>Content</h3>',
+                      content: '<h4>Content</h4>',
                     },
                   },
                   {
@@ -2250,7 +2250,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                     unknown: {
                       id: '16ad694a-848f-456d-95a6-c488350c3ed7',
                       type: 'text',
-                      content: '<h3>Content</h3>',
+                      content: '<h4>Content</h4>',
                     },
                   },
                 ],
@@ -2300,7 +2300,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                     element: {
                       id: '84726001-1665-457d-8f13-4a74dc4768ea',
                       type: 'text',
-                      content: '<h3>Content</h3>',
+                      content: '<h4>Content</h4>',
                     },
                   },
                   {

--- a/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
@@ -14,7 +14,7 @@ describe('Unit | Scripts | Get Modules as CSV', function () {
                 id: '84726001-1665-457d-8f13-4a74dc4768ea',
                 type: 'text',
                 content:
-                  '<h3>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h3>',
+                  '<h4>On commence avec les leçons.<br>Les leçons sont des textes, des images ou des vidéos. Les leçons sont là pour vous expliquer des concepts ou des méthodes.</h4>',
               },
             },
             {

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -42,9 +42,9 @@ export default class ModulixStep extends Component {
         inert={{if @isHidden true}}
         aria-hidden={{if @isHidden "true"}}
       >
-        <h3 class="stepper__step__position screen-reader-only">
+        <h4 class="stepper__step__position screen-reader-only">
           {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}
-        </h3>
+        </h4>
         {{#each this.displayableElements as |element|}}
           <div class="grain-card-content__element">
             <Element

--- a/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
@@ -17,7 +17,7 @@
   box-shadow: 0 12px 24px 0 rgb(7 20 46 / 12%);
 }
 
-/* To get higher specifity than `.modulix-passage h3` we double classes usage */
+/* To get higher specifity than `.modulix-passage h4` we double classes usage */
 .element-flashcards-intro-card {
   .element-flashcards-intro-card {
     &__title {

--- a/mon-pix/app/components/module/element/flashcards/flashcards-intro-card.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards-intro-card.gjs
@@ -9,7 +9,7 @@ import { t } from 'ember-intl';
       </div>
     {{/if}}
 
-    <h3 class="element-flashcards-intro-card__title">{{@title}}</h3>
+    <h4 class="element-flashcards-intro-card__title">{{@title}}</h4>
 
     <div class="element-flashcards-intro-card__footer">
       <PixButton @triggerAction={{@onStart}} @variant="primary" @size="small">

--- a/mon-pix/app/components/module/element/qab/qab-score-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-score-card.gjs
@@ -3,12 +3,12 @@ import { t } from 'ember-intl';
 <template>
   <div class="qab-card qab-score-card">
     <div class="qab-card__container">
-      <h1 class="qab-score-card__title">
+      <h4 class="qab-score-card__title">
         {{t "pages.modulix.qab.score.title"}}
-      </h1>
-      <h2 class="qab-score-card__subtitle">
+      </h4>
+      <p class="qab-score-card__subtitle">
         {{t "pages.modulix.qab.score.yourScore" score=@score total=@total}}
-      </h2>
+      </p>
     </div>
   </div>
 </template>

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -249,11 +249,11 @@ export default class ModuleGrain extends Component {
       tabindex="-1"
       {{didInsert this.focusAndScroll}}
     >
-      <h2 class="screen-reader-only">{{t
+      <h3 class="screen-reader-only">{{t
           "pages.modulix.flashcards.navigation.longCurrentStep"
           current=@currentStep
           total=@totalSteps
-        }}</h2>
+        }}</h3>
       <div class="grain__card grain-card--{{this.grainType}}">
         {{#if this.isGrainTypeWithTag}}
           <PixTag class="grain-card-tag" @color="grey">
@@ -261,8 +261,8 @@ export default class ModuleGrain extends Component {
           </PixTag>
         {{/if}}
         {{#if this.isGrainTypeWithTitle}}
-          <h2 class="grain-card-title">
-            {{this.grainTitle}}</h2>
+          <h3 class="grain-card-title">
+            {{this.grainTitle}}</h3>
         {{/if}}
         <div class="grain-card__content">
           <!-- eslint-disable-next-line no-unused-vars -->

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -49,7 +49,7 @@ export default class ModulixPreview extends Component {
             "element": {
               "id": "2222222a-2222-2bcd-e222-2f2222gh2222",
               "type": "text",
-              "content": "<h3>Voici une leçon</h3>"
+              "content": "<h4>Voici une leçon</h4>"
             }
           },
           {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -56,7 +56,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         await clickByName('Continuer');
 
         // then
-        assert.dom(screen.getByRole('heading', { name: 'Étape 2 sur 3', level: 2 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Étape 2 sur 3', level: 3 })).exists();
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
       });
     });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       const text = {
         id: '84726001-1665-457d-8f13-4a74dc4768ea',
         type: 'text',
-        content: '<h3>content</h3>',
+        content: '<h4>content</h4>',
       };
       user = server.create('user', 'withEmail');
 

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -39,7 +39,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     const screen = await render(<template><ModulixFlashcards @flashcards={{flashcards}} /></template>);
 
     // then
-    assert.ok(screen.getByRole('heading', { name: "Introduction à l'adresse e-mail" }));
+    assert.ok(screen.getByRole('heading', { name: "Introduction à l'adresse e-mail", level: 4 }));
     assert.strictEqual(
       screen.getByRole('presentation').getAttribute('src'),
       'https://images.pix.fr/modulix/flashcards-intro.png',

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -25,7 +25,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
     );
 
     // then
-    assert.ok(screen.getByRole('heading', { name: `Étape ${currentStep} sur ${totalSteps}`, level: 2 }));
+    assert.ok(screen.getByRole('heading', { name: `Étape ${currentStep} sur ${totalSteps}`, level: 3 }));
     assert.dom('.grain').hasAttribute('id', 'grain_12345-abcdef');
   });
 

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -137,7 +137,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     test('should not display the non existing elements but display the existing ones', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const existingElement = { content: '<h3>existing element content</h3>', type: 'text' };
+      const existingElement = { content: '<h4>existing element content</h4>', type: 'text' };
       const nonExistingElement1 = { type: 'non-existing-element-type' };
       const nonExistingElement2 = {
         type: 'non-existing-element-type',
@@ -169,7 +169,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // when
       const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
       // then
-      assert.ok(screen.queryByRole('heading', { name: 'existing element content', level: 3 }));
+      assert.ok(screen.queryByRole('heading', { name: 'existing element content', level: 4 }));
       assert.dom('.grain-card-content__element').exists({ count: 1 });
     });
   });

--- a/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-score-card_test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | Module | QabScoreCard', function (hooks) {
     const screen = await render(<template><QabScoreCard @score={{score}} @total={{total}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('heading', { name: 'Série terminée' })).exists();
-    assert.dom(screen.getByRole('heading', { name: 'Votre score : 4/5' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Série terminée', level: 4 })).exists();
+    assert.dom(screen.getByText('Votre score : 4/5')).exists();
   });
 });

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -28,7 +28,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
       // then
       assert.dom(screen.getByText(element.content)).exists();
-      assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 4 })).exists();
     });
 
     test('should display a step with a qcu element', async function (assert) {
@@ -123,7 +123,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
         // then
         assert.dom(screen.queryByText(element.content)).doesNotExist();
-        assert.dom(screen.queryByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).doesNotExist();
+        assert.dom(screen.queryByRole('heading', { name: 'Étape 1 sur 4', level: 4 })).doesNotExist();
       });
     });
 
@@ -152,7 +152,7 @@ module('Integration | Component | Module | Step', function (hooks) {
         // then
         assert.dom(screen.getByText(textElement.content)).exists();
         assert.dom(screen.queryByText(unknownElement.content)).doesNotExist();
-        assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 4 })).exists();
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -71,8 +71,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+        assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -440,8 +440,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
+            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).exists();
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -489,8 +489,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
-            assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
+            assert.strictEqual(screen.queryAllByRole('heading', { level: 4 }).length, 0);
+            assert.dom(screen.queryByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).doesNotExist();
           });
         });
       });
@@ -538,7 +538,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {
@@ -619,9 +619,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
+          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
         });
 
         module('when has unsupported elements', function () {
@@ -664,9 +664,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
           });
         });
       });
@@ -790,8 +790,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-        assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+        assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
+        assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -1159,8 +1159,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
+            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).exists();
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -1208,8 +1208,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
-            assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
+            assert.strictEqual(screen.queryAllByRole('heading', { level: 4 }).length, 0);
+            assert.dom(screen.queryByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).doesNotExist();
           });
         });
       });
@@ -1257,8 +1257,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3, disabled: true }).length, 1);
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+          assert.strictEqual(screen.getAllByRole('heading', { level: 4, disabled: true }).length, 1);
+          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {
@@ -1339,9 +1339,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
+          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
         });
 
         module('when has unsupported elements', function () {
@@ -1386,9 +1386,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-            assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
+            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
           });
         });
       });


### PR DESCRIPTION
## 🔆 Problème

Depuis la mise en place des sections #13319, les niveaux de titres ne sont plus cohérents.

## ⛱️ Proposition

Abaisser tous les niveaux de titre d'un niveau.

## 🌊 Remarques

Le WYSIWYG de Modulix Editor a aussi été impacté https://github.com/1024pix/modulix-editor/commit/654ce089bef1f21d6b245326137485a87951e7cb

## 🏄 Pour tester

Dans [la prévisualisation d'un module existant](https://app-pr13364.review.pix.fr/modules/preview/bac-a-sable), s'assurer avec Wave que la cohérence des niveaux de titre est respectée.

S'assurer qu'il n'y a pas de régression de design dans les modalités :
- QAB (affichage des scores)
- Flashcard
- Stepper