### PR TITLE
[TECH] Corriger une erreur d'accessibilité Cypress

### DIFF
--- a/mon-pix/app/templates/error.gjs
+++ b/mon-pix/app/templates/error.gjs
@@ -6,7 +6,7 @@ import pageTitle from 'ember-page-title/helpers/page-title';
 <template>
   {{pageTitle (t "navigation.error")}}
 
-  <div class="error-page">
+  <main class="error-page">
     <PixBlock class="error-page__body-section">
       <div class="error-page__main-content">
         <h1 class="error-page__main-content__title">{{t "pages.error.first-title"}}</h1>
@@ -27,5 +27,5 @@ import pageTitle from 'ember-page-title/helpers/page-title';
         <p>{{@controller.errorMessage}}</p>
       </div>
     </PixBlock>
-  </div>
+  </main>
 </template>


### PR DESCRIPTION
## 🔆 Problème

Des erreurs d'accessibilité via Cypress Axe surviennent à chaque run de la CI.

## ⛱️ Proposition

Traiter une de ces erreurs sur la page d'erreur de PixApp via [la mise en place d'un `main`](https://dequeuniversity.com/rules/axe/4.9/landmark-one-main\?application\=axeAPI)

## 🌊 Remarques

Je ne sais pas trop comment corriger les autres problèmes

## 🏄 Pour tester

Vérifier que cette erreur n'apparait plus dans les runs CircleCI e2e_test_mon_pix : 

```
{
    id: 'landmark-one-main',
    impact: 'moderate',
    description: 'Ensures the document has a main landmark',
    help: 'Document should have one main landmark',
    helpUrl: 'https://dequeuniversity.com/rules/axe/4.9/landmark-one-main?application=axeAPI',
    nodes: 'html'
}
```
