### PR TITLE
[BUGFIX] Recharger les statistiques de participation de la page d'accueil (PIX-19350)

### DIFF
--- a/orga/app/components/index/classic.gjs
+++ b/orga/app/components/index/classic.gjs
@@ -37,7 +37,7 @@ export default class IndexClassic extends Component {
 
     <OrganizationInfo @organizationName={{this.currentUser.organization.name}} />
 
-    <ParticipationStatistics @participationStatistics={{@participationStatistics}} />
+    <ParticipationStatistics @participationStatistics={{this.currentUser.participationStatistics}} />
 
     <ActionCardsList>
 

--- a/orga/app/routes/authenticated/index.js
+++ b/orga/app/routes/authenticated/index.js
@@ -16,9 +16,4 @@ export default class IndexRoute extends Route {
     }
     return this.router.replaceWith(this.currentUser.homePage);
   }
-
-  async model() {
-    const organization = this.currentUser.organization;
-    return await organization.participationStatistics;
-  }
 }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -14,6 +14,7 @@ export default class CurrentUserService extends Service {
   @tracked isAgriculture;
   @tracked isGarAuthenticationMethod;
   @tracked organizationPlaceStatistics;
+  @tracked participationStatistics;
 
   get homePage() {
     if (this.canAccessMissionsPage) {
@@ -73,6 +74,10 @@ export default class CurrentUserService extends Service {
     }
   }
 
+  async loadParticipationStatistics() {
+    this.participationStatistics = await this.organization.participationStatistics;
+  }
+
   async load() {
     if (this.session.isAuthenticated) {
       try {
@@ -119,5 +124,6 @@ export default class CurrentUserService extends Service {
     this.isAgriculture = organization.isAgriculture;
     this.organization = organization;
     await this.loadPlaceStatistics();
+    await this.loadParticipationStatistics();
   }
 }

--- a/orga/app/templates/authenticated/index.gjs
+++ b/orga/app/templates/authenticated/index.gjs
@@ -8,6 +8,6 @@ import IndexMissions from 'pix-orga/components/index/missions';
   {{#if @controller.canAccessMissionsPage}}
     <IndexMissions />
   {{else}}
-    <IndexClassic @participationStatistics={{@model}} />
+    <IndexClassic />
   {{/if}}
 </template>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -639,4 +639,18 @@ function routes() {
     const organizationId = request.params.organizationId;
     return schema.organizationPlaceStatistics.find(organizationId);
   });
+
+  this.get('/organizations/:organizationId/participation-statistics', function (schema, request) {
+    const organizationId = request.params.organizationId;
+    const data = schema.participationStatistics.find(organizationId);
+
+    if (data === null) {
+      return schema.participationStatistics.create({
+        totalParticipationCount: 0,
+        sharedParticipationCountLastThirtyDays: 0,
+        completedParticipationCount: 0,
+      });
+    }
+    return data;
+  });
 }

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -26,6 +26,9 @@ export default ApplicationSerializer.extend({
       divisions: {
         related: divisionUrl,
       },
+      participationStatistics: {
+        related: `/api/organizations/${organization.id}/participation-statistics`,
+      },
     };
   },
 });

--- a/orga/tests/acceptance/homepage-test.js
+++ b/orga/tests/acceptance/homepage-test.js
@@ -1,0 +1,91 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import authenticateSession from '../helpers/authenticate-session';
+import { createPrescriberByUser } from '../helpers/test-init';
+
+module('Acceptance | Home page', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user belongs to multiple organization', function (hooks) {
+    let firstOrganization, secondOrganization, user;
+
+    hooks.beforeEach(async function () {
+      user = server.create('user', {
+        firstName: 'Harry',
+        lastName: 'Cover',
+        email: 'harry@cover.com',
+        lang: 'fr',
+        pixOrgaTermsOfServiceStatus: 'accepted',
+      });
+
+      firstOrganization = server.create('organization', {
+        name: 'First',
+      });
+
+      secondOrganization = server.create('organization', {
+        name: 'Second',
+      });
+
+      const firstMembership = server.create('membership', {
+        organizationId: firstOrganization.id,
+        userId: user.id,
+      });
+
+      const secondMembership = server.create('membership', {
+        organizationId: secondOrganization.id,
+        userId: user.id,
+      });
+
+      user.memberships = [firstMembership, secondMembership];
+      user.userOrgaSettings = server.create('user-orga-setting', { organization: firstOrganization, user });
+      createPrescriberByUser({
+        user,
+      });
+      await authenticateSession(user.id);
+    });
+
+    test('it should display participation statistics for current organization', async function (assert) {
+      // given
+      server.create('participation-statistic', {
+        id: firstOrganization.id,
+        totalParticipationCount: 15,
+        completedParticipationCount: 12,
+        sharedParticipationCountLastThirtyDays: 8,
+      });
+      server.create('participation-statistic', {
+        id: secondOrganization.id,
+        totalParticipationCount: 0,
+        completedParticipationCount: 0,
+        sharedParticipationCountLastThirtyDays: 0,
+      });
+
+      // when
+      const screen = await visit('/?preview=true');
+      assert.ok(screen.getByText('80%'));
+      assert.ok(
+        screen.getByText(
+          t('components.index.participation-statistics.completion-rate.description', { completed: 12, started: 15 }),
+        ),
+        'erreur completion rate',
+      );
+      assert.ok(screen.getByText('8'));
+
+      const button = screen.getByRole('button', { name: "Changer d'organisation" });
+      await click(button);
+      await click(screen.getByText('Second'));
+
+      assert.ok(screen.getByText(t('components.index.participation-statistics.completion-rate.no-activity')));
+      assert.ok(
+        screen.getByText(
+          t('components.index.participation-statistics.completed-participations.no-completed-participations'),
+        ),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Les statistiques de la page d'accueil ne se recharge pas

## ⛱️ Proposition

Afficher les bonnes infos de participations sur la page d'accueil

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Se connecter sur l'orga pro classic 
- Aller sur la page d'accueil `/?preview=true`
- Changer pour l'orga SCO managing
- voir les stat qui changent