### PR TITLE
[TECH] Mise à jour du package epreuves-components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
       "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -876,6 +876,36 @@
               }
             }
           ]
+        },
+        {
+          "id": "27ab0dd6-61d7-4cd9-8f43-f5e4c13f7f30",
+          "type": "lesson",
+          "title": "qcm-deepfake",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "af0aa765-13d3-4a18-8dd2-e78028ebbde4",
+                "type": "text",
+                "content": "<p>qcm-deepfake</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "d58e3796-5c02-4587-9d19-39f7b808a82f",
+                "type": "custom",
+                "tagName": "qcm-deepfake",
+                "props": {
+                  "titleLevel": 2,
+                  "successImage": "https://epreuves.pix.fr/images/camtasia.png",
+                  "failImage": "https://epreuves.pix.fr/images/icones/actu.jpg",
+                  "infoImage": "https://epreuves.pix.fr/images/icones/avg.png",
+                  "searchImage": "https://epreuves.pix.fr/images/icones/avira.svg"
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -102,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
       "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -78,6 +78,8 @@ export class NormalizedProps {
         return this.normalizeImageQuizProps(props);
       case 'image-quizzes':
         return this.normalizeImageQuizzesProps(props);
+      case 'qcm-deepfake':
+        return this.normalizeQcmDeepfakeProps(props);
       default:
         return props;
     }
@@ -93,6 +95,13 @@ export class NormalizedProps {
         displayHeight: NormalizedProps.unsetNumber(slide.displayHeight),
         license: NormalizedProps.unsetObject(slide.license),
       })),
+    };
+  }
+
+  normalizeQcmDeepfakeProps(props) {
+    return {
+      ...props,
+      titleLevel: NormalizedProps.unsetNumber(props.titleLevel),
     };
   }
 

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -809,7 +809,6 @@
       "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
       "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }


### PR DESCRIPTION
## 🔆 Problème
Il faut rendre disponible le nouveau poi `qcm-deepfake`

## ⛱️ Proposition
Rendre disponible le poi en question

## 🌊 Remarques
RAS

## 🏄 Pour tester
Voir sur la page de démo des modulix.