### PR TITLE
[FEATURE] Ajout du bouton "Reprendre mon parcours" sur les parcours combinés (PIX-19017)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -19,8 +19,10 @@ import {
 import { QUEST_OFFSET, TARGET_PROFILE_BADGES_STAGES_ID, TARGET_PROFILE_NO_BADGES_NO_STAGES_ID } from './constants.js';
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
-const firstTrainingId = QUEST_OFFSET + 1;
-const secondTrainingId = QUEST_OFFSET + 2;
+const firstTrainingfrFRId = QUEST_OFFSET + 1;
+const secondTrainingfrFRId = QUEST_OFFSET + 2;
+const firstTrainingFRId = QUEST_OFFSET + 3;
+const secondTrainingFRId = QUEST_OFFSET + 4;
 
 function buildCombinedCourseQuest(databaseBuilder, organizationId) {
   const targetProfile = buildTargetProfile(databaseBuilder, { id: organizationId }, 0, TARGET_PROFILE_TUBES[0]);
@@ -39,18 +41,36 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
     }),
   );
   databaseBuilder.factory.buildTraining({
-    id: firstTrainingId,
+    id: firstTrainingfrFRId,
     type: 'modulix',
     title: 'Demo combinix 1',
     link: '/modules/demo-combinix-1',
     locale: 'fr-fr',
   });
   databaseBuilder.factory.buildTraining({
-    id: secondTrainingId,
+    id: secondTrainingfrFRId,
     type: 'modulix',
     title: 'Demo combinix 2',
     link: '/modules/demo-combinix-2',
     locale: 'fr-fr',
+  });
+
+  // For now, we make doubles of the previous trainings because training does not accept multiple locales
+  // The behaviour is the same in production
+
+  databaseBuilder.factory.buildTraining({
+    id: firstTrainingFRId,
+    type: 'modulix',
+    title: 'Demo combinix 1',
+    link: '/modules/demo-combinix-1',
+    locale: 'fr',
+  });
+  databaseBuilder.factory.buildTraining({
+    id: secondTrainingFRId,
+    type: 'modulix',
+    title: 'Demo combinix 2',
+    link: '/modules/demo-combinix-2',
+    locale: 'fr',
   });
 
   databaseBuilder.factory.buildQuestForCombinedCourse({
@@ -120,12 +140,30 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
     ],
   });
   const trainingTriggerIds = [
-    databaseBuilder.factory.buildTrainingTrigger({ trainingId: firstTrainingId, threshold: 0, type: 'prerequisite' })
-      .id,
-    databaseBuilder.factory.buildTrainingTrigger({ trainingId: firstTrainingId, threshold: 50, type: 'goal' }).id,
-    databaseBuilder.factory.buildTrainingTrigger({ trainingId: secondTrainingId, threshold: 50, type: 'prerequisite' })
-      .id,
-    databaseBuilder.factory.buildTrainingTrigger({ trainingId: secondTrainingId, threshold: 100, type: 'goal' }).id,
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: firstTrainingfrFRId,
+      threshold: 0,
+      type: 'prerequisite',
+    }).id,
+    databaseBuilder.factory.buildTrainingTrigger({ trainingId: firstTrainingfrFRId, threshold: 50, type: 'goal' }).id,
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: secondTrainingfrFRId,
+      threshold: 50,
+      type: 'prerequisite',
+    }).id,
+    databaseBuilder.factory.buildTrainingTrigger({ trainingId: secondTrainingfrFRId, threshold: 100, type: 'goal' }).id,
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: firstTrainingFRId,
+      threshold: 0,
+      type: 'prerequisite',
+    }).id,
+    databaseBuilder.factory.buildTrainingTrigger({ trainingId: firstTrainingFRId, threshold: 50, type: 'goal' }).id,
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: secondTrainingFRId,
+      threshold: 51,
+      type: 'prerequisite',
+    }).id,
+    databaseBuilder.factory.buildTrainingTrigger({ trainingId: secondTrainingFRId, threshold: 100, type: 'goal' }).id,
   ];
   trainingTriggerIds.forEach((trainingTriggerId) =>
     TARGET_PROFILE_TUBES[0].map((tube) =>
@@ -386,11 +424,19 @@ const buildTargetProfile = (databaseBuilder, organization, index, tubes) => {
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     targetProfileId: targetProfile.id,
-    trainingId: firstTrainingId,
+    trainingId: firstTrainingfrFRId,
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     targetProfileId: targetProfile.id,
-    trainingId: secondTrainingId,
+    trainingId: secondTrainingfrFRId,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: targetProfile.id,
+    trainingId: firstTrainingFRId,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    targetProfileId: targetProfile.id,
+    trainingId: secondTrainingFRId,
   });
 
   tubes.map(({ id, level }) =>

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -17,25 +17,25 @@ test('pass a combined course as sco user and see the final result', async ({ pag
 
   await test.step('Start combined course', async function () {
     await page.getByRole('button', { name: 'Commencer mon parcours' }).click();
-    await page.getByRole('link', { name: 'campagne diag' }).click();
   });
 
   await test.step('Run campaign', async function () {
     await page.getByRole('button', { name: 'Je commence' }).click();
     await page.getByRole('button', { name: 'Ignorer' }).click();
     await page.getByRole('button', { name: 'Je passe et je vais à la' }).click();
-    //Le bouton "Voir mes résultats" existe deux fois à ce moment, on doit donc faire autrement en attendant de corriger cette page
-    await page.locator('#ember138').click();
+    await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
     await page.getByRole('button', { name: "J'envoie mes résultats" }).click();
     await page.getByRole('link', { name: 'Continuer' }).click();
   });
 
+  await test.step('Resume combined course', async function () {
+    await page.getByRole('button', { name: 'Reprendre mon parcours' }).click();
+  });
+
   await test.step('Run module', async function () {
-    await page.getByRole('link', { name: 'Demo combinix' }).click();
     await page.getByRole('button', { name: 'Commencer le module' }).click();
     await page.getByRole('button', { name: 'Terminer' }).click();
-    //Sera enlevé au prochain ticket pour passer l'url en relative, on aura plus les problèmes liés à l'host
-    await page.goto('http://localhost:4200/parcours/COMBINIX1/');
+    await page.getByRole('link', { name: 'Continuer' }).click();
   });
 
   await test.step('End of combined course', async function () {

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -33,6 +33,11 @@ export default class CombinedCourses extends Component {
           @size="large"
         >{{t "pages.combined-courses.content.start-button"}}
         </PixButton>
+      {{else if (eq @combinedCourse.status "STARTED")}}
+        <PixButton @type="submit" @triggerAction={{this.goToNextItem}} @loading-color="white" @size="large">{{t
+            "pages.combined-courses.content.resume-button"
+          }}
+        </PixButton>
       {{/if}}
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}
@@ -46,11 +51,18 @@ export default class CombinedCourses extends Component {
   @service featureToggles;
   @service intl;
   @service store;
+  @service router;
 
   @action
   async startQuestParticipation() {
     const combinedCourseAdapter = this.store.adapterFor('combined-course');
     await combinedCourseAdapter.start(this.args.combinedCourse.code);
-    this.args.combinedCourse.reload();
+    this.goToNextItem();
+  }
+
+  @action
+  goToNextItem() {
+    const item = this.args.combinedCourse.nextCombinedCourseItem;
+    this.router.transitionTo(item.route, item.reference, { queryParams: { redirection: item.redirection } });
   }
 }

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -1,5 +1,11 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
+export const CombinedCourseStatuses = {
+  NOT_STARTED: 'NOT_STARTED',
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED',
+};
+
 export default class CombinedCourse extends Model {
   @attr('string') name;
   @attr('string') code;

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -7,4 +7,10 @@ export default class CombinedCourse extends Model {
   @attr('string') status;
 
   @hasMany('combined-course-item', { async: false, inverse: 'combinedCourse' }) items;
+
+  get nextCombinedCourseItem() {
+    return this.hasMany('items')
+      .value()
+      .find((item) => !item.isCompleted);
+  }
 }

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { CombinedCourseStatuses } from '../../../../models/combined-course.js';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering.js';
 
 module('Integration | Component | combined course', function (hooks) {
@@ -44,7 +45,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'NOT_STARTED',
+        status: CombinedCourseStatuses.NOT_STARTED,
         code: 'COMBINIX9',
       });
 
@@ -66,7 +67,11 @@ module('Integration | Component | combined course', function (hooks) {
     test('should display start button', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'NOT_STARTED', code: 'COMBINIX9' });
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.NOT_STARTED,
+        code: 'COMBINIX9',
+      });
 
       this.setProperties({ combinedCourse });
 
@@ -83,7 +88,11 @@ module('Integration | Component | combined course', function (hooks) {
       const store = this.owner.lookup('service:store');
       const router = this.owner.lookup('service:router');
 
-      const combinedCourse = store.createRecord('combined-course', { id: 1, status: 'NOT_STARTED', code: 'COMBINIX9' });
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.NOT_STARTED,
+        code: 'COMBINIX9',
+      });
       const combinedCourseItem = store.createRecord('combined-course-item', {
         id: 1,
         reference: 'CAMPAIGN1',
@@ -122,7 +131,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'NOT_STARTED',
+        status: CombinedCourseStatuses.NOT_STARTED,
         code: 'COMBINIX9',
       });
 
@@ -151,7 +160,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'NOT_STARTED',
+        status: CombinedCourseStatuses.NOT_STARTED,
         code: 'COMBINIX9',
       });
 
@@ -184,7 +193,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'STARTED',
+        status: CombinedCourseStatuses.STARTED,
         code: 'COMBINIX9',
       });
 
@@ -218,7 +227,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'STARTED',
+        status: CombinedCourseStatuses.STARTED,
         code: 'COMBINIX9',
       });
 
@@ -260,7 +269,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       const combinedCourse = store.createRecord('combined-course', {
         id: 1,
-        status: 'STARTED',
+        status: CombinedCourseStatuses.STARTED,
         code: 'COMBINIX9',
       });
 
@@ -301,7 +310,7 @@ module('Integration | Component | combined course', function (hooks) {
 
     const combinedCourse = store.createRecord('combined-course', {
       id: 1,
-      status: 'STARTED',
+      status: CombinedCourseStatuses.STARTED,
       code: 'COMBINIX9',
     });
 
@@ -319,26 +328,25 @@ module('Integration | Component | combined course', function (hooks) {
       router.transitionTo.calledWith('module', 'mon-module', { queryParams: { redirection: 'une+url+chiffree' } }),
     );
   });
-});
+  module('when participation is completed', function () {
+    test('should display that combined course is finished', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
 
-module('when participation is completed', function () {
-  test('should display that combined course is finished', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+      });
 
-    const combinedCourse = store.createRecord('combined-course', {
-      id: 1,
-      status: 'COMPLETED',
-      code: 'COMBINIX9',
-    });
+      this.setProperties({ combinedCourse });
 
-    this.setProperties({ combinedCourse });
-
-    // when
-    const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
         <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
-    // then
-    assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.completed.title') }));
+      // then
+      assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.completed.title') }));
+    });
   });
 });

--- a/mon-pix/tests/unit/models/combined-course-test.js
+++ b/mon-pix/tests/unit/models/combined-course-test.js
@@ -41,18 +41,5 @@ module('Unit | Model | Combined Course', function (hooks) {
       combinedCourse.items = [combinedCourseItem, secondCombinedCourseItem];
       assert.strictEqual(combinedCourse.nextCombinedCourseItem, secondCombinedCourseItem);
     });
-    test('when there are several items to complete', function (assert) {
-      const firstCombinedCourseItem = store.createRecord('combined-course-item', {
-        isCompleted: false,
-        redirection: '/modules/demo-combinix-1',
-      });
-      const secondCombinedCourseItem = store.createRecord('combined-course-item', {
-        isCompleted: false,
-        redirection: '/campagnes/CODE123',
-      });
-      const combinedCourse = store.createRecord('combined-course');
-      combinedCourse.items = [firstCombinedCourseItem, secondCombinedCourseItem];
-      assert.strictEqual(combinedCourse.nextCombinedCourseItem, firstCombinedCourseItem);
-    });
   });
 });

--- a/mon-pix/tests/unit/models/combined-course-test.js
+++ b/mon-pix/tests/unit/models/combined-course-test.js
@@ -1,0 +1,58 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | Combined Course', function (hooks) {
+  setupTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+  module('#nextCombinedCourseItemLink', function () {
+    test('when user has not completed any item', function (assert) {
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        redirection: '/campagnes/CODE123',
+      });
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [combinedCourseItem];
+      assert.strictEqual(combinedCourse.nextCombinedCourseItem, combinedCourseItem);
+    });
+    test('when all items are completed', function (assert) {
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: true,
+        redirection: '/campagnes/CODE123',
+      });
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [combinedCourseItem];
+      assert.strictEqual(combinedCourse.nextCombinedCourseItem, undefined);
+    });
+    test('when one item is completed and the other is not', function (assert) {
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: true,
+        redirection: '/modules/demo-combinix-1',
+      });
+      const secondCombinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        redirection: '/campagnes/CODE123',
+      });
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [combinedCourseItem, secondCombinedCourseItem];
+      assert.strictEqual(combinedCourse.nextCombinedCourseItem, secondCombinedCourseItem);
+    });
+    test('when there are several items to complete', function (assert) {
+      const firstCombinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        redirection: '/modules/demo-combinix-1',
+      });
+      const secondCombinedCourseItem = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        redirection: '/campagnes/CODE123',
+      });
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [firstCombinedCourseItem, secondCombinedCourseItem];
+      assert.strictEqual(combinedCourse.nextCombinedCourseItem, firstCombinedCourseItem);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1195,6 +1195,7 @@
         "title": "Congratulations! You're done!"
       },
       "content": {
+        "resume-button": "Resume course",
         "start-button": "Start course"
       },
       "items": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1186,7 +1186,8 @@
     },
     "combined-courses": {
       "content": {
-        "start-button": "Iniciar el curso"
+        "start-button": "Iniciar el curso",
+        "resume-course": "Reanudar mi curso"
       },
       "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1195,6 +1195,7 @@
         "title": "Félicitations ! Vous avez terminé !"
       },
       "content": {
+        "resume-button": "Reprendre mon parcours",
         "start-button": "Commencer mon parcours"
       },
       "items": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1190,7 +1190,8 @@
     },
     "combined-courses": {
       "content": {
-        "start-button": "Cursus starten"
+        "start-button": "Cursus starten",
+        "resume-button": "Cursus hervatten"
       },
       "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",


### PR DESCRIPTION
## 🔆 Problème
Lorsque l'utilisateur accède à un parcours combiné pour la première fois, il voit le bouton "Commencer mon parcours" tout en haut de la liste d'items.
Ce bouton disparaît à la reprise du parcours.
Or, à ce moment-là, on veut voir un bouton "Reprendre mon parcours".

## ⛱️ Proposition
On ajoute un getter getNextCombinedCourseItem pour retrouver l'item qui sera lié au bouton "Reprendre mon parcours".

## 🏄 Pour tester
Lancer un parcours combiné. Cliquer sur le bouton "commencer mon parcours" et vérifier qu'il pointe bien vers la campagne de diag. 
Aller au bout de la campagne de diagnostic.
Voir le bouton "Reprendre mon parcours" qui doit mener sur le module demo-combinix-1.