### PR TITLE
[FEATURE] Désactiver les propositions des QCM lors de la vérification des réponses (PIX-18932)

### DIFF
--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -5,6 +5,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
@@ -15,6 +16,8 @@ export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcm extends ModuleElement {
   @service passageEvents;
+
+  @tracked isAnswering = false;
 
   selectedAnswerIds = new Set();
 
@@ -27,7 +30,7 @@ export default class ModuleQcm extends ModuleElement {
   }
 
   get disableInput() {
-    return super.disableInput ? true : null;
+    return super.disableInput || this.isAnswering;
   }
 
   resetAnswers() {
@@ -58,11 +61,13 @@ export default class ModuleQcm extends ModuleElement {
 
   @action
   async onAnswer(event) {
+    this.isAnswering = true;
     event.preventDefault();
     await this.waitFor(VERIFY_RESPONSE_DELAY);
     await super.onAnswer(event);
+    this.isAnswering = false;
 
-    const status = this.answerIsValid ? "ok" : "ko";
+    const status = this.answerIsValid ? 'ok' : 'ko';
     this.passageEvents.record({
       type: 'QCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -11,6 +11,8 @@ import ModulixFeedback from 'mon-pix/components/module/feedback';
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import ModuleElement from './module-element';
 
+export const VERIFY_RESPONSE_DELAY = 500;
+
 export default class ModuleQcm extends ModuleElement {
   @service passageEvents;
 
@@ -56,13 +58,19 @@ export default class ModuleQcm extends ModuleElement {
 
   @action
   async onAnswer(event) {
+    event.preventDefault();
+    await this.waitFor(VERIFY_RESPONSE_DELAY);
     await super.onAnswer(event);
 
-    const status = this.answerIsValid ? 'ok' : 'ko';
+    const status = this.answerIsValid ? "ok" : "ko";
     this.passageEvents.record({
       type: 'QCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
+  }
+
+  waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
   <template>

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -63,10 +63,10 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     await click(wrongAnswerCheckbox);
     await click(qcmVerifyButton);
 
-    assert.dom(screen.getByRole('status')).exists();
+    const feedback = await screen.findByRole('status');
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
@@ -79,7 +79,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     await click(wrongAnswerCheckbox);
     await click(rightAnswerCheckbox);
     await click(qcmVerifyButtonCameBack);
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    await within(feedback).findByText('Faux');
   });
 
   test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
@@ -116,7 +116,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      isBeta: true,
+      isBeta: false,
       sections: [section],
     });
 
@@ -141,7 +141,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
     assert.dom(screen.getByRole('status')).exists();
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
@@ -152,8 +152,7 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(qcmVerifyButtonCameBack);
-    const validationAlert = screen.queryAllByRole('alert')[1];
-
+    const validationAlert = await screen.findByRole('alert');
     assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -85,7 +85,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
     await click(firstQcmVerifyButton);
 
     // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+    assert.dom(await screen.findByText("Bravo ! C'est la bonne réponse.")).exists();
 
     // when
     await click(screen.getByLabelText('I am the first wrong answer!'));
@@ -93,6 +93,6 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
     await click(nextQcmVerifyButton);
 
     // then
-    assert.dom(screen.getByText('Pas ouf')).exists();
+    assert.dom(await screen.findByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -2,7 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcm from 'mon-pix/components/module/element/qcm';
+import ModulixQcm, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcm';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -13,12 +13,16 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
   let passageEventService, passageEventRecordStub;
 
+  let clock;
+
   hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers();
     passageEventService = this.owner.lookup('service:passageEvents');
     passageEventRecordStub = sinon.stub(passageEventService, 'record');
   });
 
   hooks.afterEach(function () {
+    clock.restore();
     passageEventRecordStub.restore();
   });
 
@@ -80,6 +84,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
 
     // then
     sinon.assert.calledWith(onAnswerSpy, { userResponse, element: qcmElement });
@@ -112,6 +117,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     // when
     await click(screen.getByLabelText('checkbox1'));
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
 
     // then
     assert.dom(screen.getByRole('alert')).exists();
@@ -135,8 +141,10 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     await click(screen.getByLabelText('checkbox1'));
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
 
     // then
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -58,7 +58,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.dom(verifyButton).exists();
   });
 
-  test('should call action and send an event when verify button is clicked', async function (assert) {
+  test('should disable interaction, call action and send an event when verify button is clicked', async function (assert) {
     // given
     const answeredProposal = [
       { id: '1', content: 'select1' },
@@ -79,14 +79,20 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
     // when
     const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
-    await click(screen.getByLabelText(answeredProposal[0].content));
-    await click(screen.getByLabelText(answeredProposal[1].content));
+    const proposal1Element = screen.getByLabelText(qcmElement.proposals[0].content);
+    const proposal2Element = screen.getByLabelText(qcmElement.proposals[1].content);
+    const proposal3Element = screen.getByLabelText(qcmElement.proposals[2].content);
+    await click(proposal1Element);
+    await click(proposal2Element);
 
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     await click(verifyButton);
-    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
 
     // then
+    assert.dom(proposal1Element).hasAria('disabled', 'true');
+    assert.dom(proposal2Element).hasAria('disabled', 'true');
+    assert.dom(proposal3Element).hasAria('disabled', 'true');
+    await clock.tickAsync(VERIFY_RESPONSE_DELAY);
     sinon.assert.calledWith(onAnswerSpy, { userResponse, element: qcmElement });
     sinon.assert.calledWithExactly(passageEventRecordStub, {
       type: 'QCM_ANSWERED',


### PR DESCRIPTION
## 🔆 Problème

Après que l'utilisateur ait répondu et avant que la réponse du serveur soit reçu, il reste possible de changer sa réponse aux élément QCM et QROCM.

## ⛱️ Proposition

- [x] Désactiver les inputs de l'élément QCM dès la réponse de l'utilisateur

## 🌊 Remarques

- La désactivation des boutons d'envoi était déjà gérée
- Comme le temps de réponse du serveur est très court (même en simulant une mauvaise connexion) j'ai aussi ajouté un délai de 500 ms comme cela a déjà été fait pour les QCU.

## 🏄 Pour tester

1. Se rendre sur le module bac-a-sable
2. Répondre à un QCM et constater que les cases à cocher sont désactivées immédiatement
