### PR TITLE
[FEATURE] Rendre le parser CSV résistant aussi aux espaces dans les en-têtes (PIX-19357)

### DIFF
--- a/api/src/shared/infrastructure/serializers/csv/csv-parser.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-parser.js
@@ -76,7 +76,13 @@ class CsvParser {
       const decodedInput = iconv.decode(this._input, encoding);
       const {
         meta: { fields },
-      } = papa.parse(decodedInput, { ...PARSING_OPTIONS, preview: 1 });
+      } = papa.parse(decodedInput, {
+        ...PARSING_OPTIONS,
+        transformHeader: (value) => {
+          return value.trim();
+        },
+        preview: 1,
+      });
       if (fields.some((value) => checkedColumns.includes(value))) {
         inputEncoding = encoding;
         break;
@@ -104,9 +110,10 @@ class CsvParser {
     } = papa.parse(decodedInput, {
       ...PARSING_OPTIONS,
       transformHeader: (value) => {
-        const column = this._columns.find((column) => column.name === value);
+        const trimmedValue = value.trim();
+        const column = this._columns.find((column) => column.name === trimmedValue);
 
-        return column ? column.property : value;
+        return column ? column.property : trimmedValue;
       },
     });
 

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
@@ -45,6 +45,32 @@ describe('Unit | Shared | Infrastructure | Serializer | CsvParser', function () 
     });
   });
 
+  context('when the header has some trailing whitespaces in the column names', function () {
+    it('trims the header column names and then does the standard parsing', async function () {
+      const header = {
+        columns: [
+          new CsvColumn({ property: 'col1', name: 'Column 1' }),
+          new CsvColumn({ property: 'col2', name: 'Column 2' }),
+          new CsvColumn({ property: 'col3', name: 'Column 3' }),
+        ],
+      };
+
+      const column1NameWithWhitespaces = 'Column 1   ';
+      const column2NameWithWhitespaces = '   Column 2';
+      const column3NameWithWhitespaces = '  Column 3  ';
+      const input = `${column1NameWithWhitespaces};${column2NameWithWhitespaces};${column3NameWithWhitespaces}
+      Sylvia;Amelia;Olivia`;
+      const encodedInput = iconv.encode(input, 'utf8');
+
+      const parser = new CsvParser(encodedInput, header);
+      const [result] = parser.parse();
+
+      expect(result.col1).to.equal('Sylvia');
+      expect(result.col2).to.equal('Amelia');
+      expect(result.col3).to.equal('Olivia');
+    });
+  });
+
   context('File does not match requirements', function () {
     let header;
 


### PR DESCRIPTION
## 🔆 Problème

Il arrive qu’en préparant un fichier CSV (par exemple pour un import) on laisse un ou des espaces en fin de la ligne d’en-têtes. Et ces espaces ne se voit pas dans les tableurs ou les éditeurs de texte, ce qui fait qu’il est très facile de faire de préparer des fichiers CSV qui vont être non-valides et que cela soit difficile de comprendre pourquoi.

Le code du `CsvParser` actuel est déjà résistant aux espaces aux extrémités pour les données (c’est à dire pour toutes les autres lignes que la ligne d’en-têtes) mais il n’est pas résistant aux espaces aux extrémités pour les métadonnées (c’est à dire pour la ligne d’en-têtes).

## ⛱️ Proposition

Réaliser des `trim` sur les métadonnées (c’est à dire les en-têtes) avec la fonction `transformHeader` de *papaparse* comme cela est fait sur les données avec la fonction `transform` de *papaparse*.

## 🌊 Remarques

Le besoin d’avoir du `trim` pour les données et les métadonnées est très connu. Cette fonctionnalité est régulièrement demandée par les utilisateurs de *papaparse*, mais pour l’instant cette fonctionnalité n'est pas jugée souhaitable par l’auteur (pour éviter des erreurs dans certains cas selon lui) : https://github.com/mholt/PapaParse/issues/241

## 🏄 Pour tester

Prendre n’importe quelle fonctionnalité de Pix Admin utilisant le `CsvParser`, et utiliser un fichier `.csv` dans lequel on mettra des espaces autour des noms de une ou plusieurs colonnes.

On peut par exemple utiliser l’action _« Ajout de tags en masse sur des organisations »_ : 
1. Se connecter à Pix Admin avec l’utilisateur `superadmin`,
2. Se rendre sur la page `Administration > Déploiement`,
4. Préparer un fichier `CSV` suivant le fichier `.csv` ci-dessous (noter les espaces présents après le nom `Tag name`, mais qu’on ne voit pas) : 
   ```csv
     Organization ID  ,   Tag name   
   123, tag1
   456, tag2
   ```
5. Dans la section `Ajout de tags en masse sur des organisations` téléverser le fichier `.csv` préparé à l’étape précédente.

