### PR TITLE
[TECH] Améliorer les espacements entre les élements du composant PageTitle (PIX-19386).

### DIFF
--- a/orga/app/components/index/classic.gjs
+++ b/orga/app/components/index/classic.gjs
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import ScoBanner from 'pix-orga/components/banner/sco-banner';
 import ActionCardsList from 'pix-orga/components/index/action-cards-list';
 import ActionCardsListItem from 'pix-orga/components/index/action-cards-list-item';
 import OrganizationInfo from 'pix-orga/components/index/organization-information';
@@ -29,11 +28,11 @@ export default class IndexClassic extends Component {
   }
 
   <template>
-    <Welcome @firstName={{this.currentUser.prescriber.firstName}} @description={{this.description}} />
-
-    {{#if this.currentUser.isSCOManagingStudents}}
-      <ScoBanner />
-    {{/if}}
+    <Welcome
+      @firstName={{this.currentUser.prescriber.firstName}}
+      @description={{this.description}}
+      @displayScoBanner={{this.currentUser.isSCOManagingStudents}}
+    />
 
     <OrganizationInfo @organizationName={{this.currentUser.organization.name}} />
 

--- a/orga/app/components/index/welcome.gjs
+++ b/orga/app/components/index/welcome.gjs
@@ -1,13 +1,19 @@
 import { t } from 'ember-intl';
+import ScoBanner from 'pix-orga/components/banner/sco-banner';
 import PageTitle from 'pix-orga/components/ui/page-title';
 
 <template>
-  <PageTitle class="welcome__title">
+  <PageTitle class="welcome__title" @displayNotificationAlert={{@displayScoBanner}}>
     <:title>
       {{t "components.index.welcome.title" name=@firstName}}
     </:title>
+
     <:subtitle>
       {{@description}}
     </:subtitle>
+
+    <:notificationAlert>
+      <ScoBanner />
+    </:notificationAlert>
   </PageTitle>
 </template>

--- a/orga/app/components/places/title.gjs
+++ b/orga/app/components/places/title.gjs
@@ -10,7 +10,7 @@ function todayDate() {
 }
 
 <template>
-  <PageTitle @spaceBetweenTools={{true}}>
+  <PageTitle @spaceBetweenTools={{true}} @displayNotificationAlert={{true}}>
     <:title>
       {{t "pages.places.title"}}
     </:title>

--- a/orga/app/components/ui/page-title.gjs
+++ b/orga/app/components/ui/page-title.gjs
@@ -1,3 +1,5 @@
+import { and } from 'ember-truth-helpers';
+
 function setTitleClasses(spaceBetweenTools, centerTitle) {
   const classes = ['page-title__main'];
 
@@ -19,15 +21,15 @@ function setTitleClasses(spaceBetweenTools, centerTitle) {
       {{/if}}
     </div>
 
-    {{#if (has-block "notificationAlert")}}
-      <div class="page-title__notification-alert">
-        {{yield to="notificationAlert"}}
+    {{#if (has-block "subtitle")}}
+      <div>
+        {{yield to="subtitle"}}
       </div>
     {{/if}}
 
-    {{#if (has-block "subtitle")}}
-      <div class="page-title__sub-title">
-        {{yield to="subtitle"}}
+    {{#if (and (has-block "notificationAlert") @displayNotificationAlert)}}
+      <div class="page-title__notification-alert">
+        {{yield to="notificationAlert"}}
       </div>
     {{/if}}
 

--- a/orga/app/styles/components/index/organization-information.scss
+++ b/orga/app/styles/components/index/organization-information.scss
@@ -4,6 +4,6 @@
   &__title {
     @extend %pix-title-xs;
 
-    margin: var(--pix-spacing-8x) 0 var(--pix-spacing-4x);
+    margin-bottom: var(--pix-spacing-4x);
   }
 }

--- a/orga/app/styles/components/ui/page-title.scss
+++ b/orga/app/styles/components/ui/page-title.scss
@@ -2,7 +2,12 @@
 @use 'pix-design-tokens/breakpoints';
 
 .page-title {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-3x);
   width: 100%;
+  margin-bottom: var(--pix-spacing-8x);
+
 
   &--center {
     @include breakpoints.device-is('mobile') {
@@ -14,7 +19,7 @@
     display: flex;
     gap: var(--pix-spacing-2x);
     justify-content: space-between;
-    margin-bottom: var(--pix-spacing-8x);
+
 
     &--center {
       justify-content: center;
@@ -33,10 +38,6 @@
     text-overflow: ellipsis;
   }
 
-  &__sub-title {
-    margin-bottom: var(--pix-spacing-6x);
-  }
-
   &__title {
     @extend %pix-title-m;
 
@@ -53,7 +54,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--pix-spacing-2x);
-    margin-bottom: var(--pix-spacing-6x);
   }
 }
 

--- a/orga/app/styles/pages/authenticated/attestations.scss
+++ b/orga/app/styles/pages/authenticated/attestations.scss
@@ -1,9 +1,7 @@
 @use 'pix-design-tokens/typography';
 
 .attestations-page {
-  display: flex;
-  flex-direction: column;
-  padding: var(--pix-spacing-8x) 0;
+  margin-bottom: var(--pix-spacing-8x) 0;
 
   &__title {
     @extend %pix-title-m;


### PR DESCRIPTION
## 🔆 Problème

Les espacements sont chelou

## ⛱️ Proposition

Rendre ça plus harmonieux sur les PageTitle

## 🌊 Remarques

RAS

## 🏄 Pour tester

Aller sur PixOrga et regarder ça.