### PR TITLE
[TECH] Upgrade du package pour ajouter nouveau POI calcul-impact

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -82,7 +82,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.1.0",
+        "@1024pix/epreuves-components": "^1.2.0",
         "@1024pix/eslint-plugin": "^2.1.8",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -123,10 +123,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
-      "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.0.tgz",
+      "integrity": "sha512-a7ZfKebCupx4wgO9IQ65z3MtjpBilU2PdUz+0vmfG8g5W4ddgxj4yNEJahKkXlOJVZnCDGBPgLH5taqkJId/zg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.1.0",
+    "@1024pix/epreuves-components": "^1.2.0",
     "@1024pix/eslint-plugin": "^2.1.8",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -17,6 +17,32 @@
       "type": "blank",
       "grains": [
         {
+          "id": "5161dd9c-0ed3-43a8-b550-ced9e2c539ba",
+          "type": "lesson",
+          "title": "calcul-impact",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "db7caf2c-1e0f-4748-85d9-e33be7cbeb73",
+                "type": "text",
+                "content": "<p>calcul-impact</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "6251f379-2a39-4731-a19a-fde17151c889",
+                "type": "custom",
+                "tagName": "calcul-impact",
+                "props": {
+                  "titleLevel": 2
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "208deb8a-4580-4a33-8ca5-32205f5f07dd",
           "type": "lesson",
           "title": "complete-phrase",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^1.1.0",
+        "@1024pix/epreuves-components": "^1.2.0",
         "@1024pix/eslint-plugin": "^2.1.8",
         "@1024pix/pix-ui": "^55.25.3",
         "@1024pix/stylelint-config": "^5.1.35",
@@ -98,10 +98,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
-      "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.0.tgz",
+      "integrity": "sha512-a7ZfKebCupx4wgO9IQ65z3MtjpBilU2PdUz+0vmfG8g5W4ddgxj4yNEJahKkXlOJVZnCDGBPgLH5taqkJId/zg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^1.1.0",
+    "@1024pix/epreuves-components": "^1.2.0",
     "@1024pix/eslint-plugin": "^2.1.8",
     "@1024pix/pix-ui": "^55.25.3",
     "@1024pix/stylelint-config": "^5.1.35",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.6",
-        "@1024pix/epreuves-components": "^1.1.0",
+        "@1024pix/epreuves-components": "^1.2.0",
         "@1024pix/eslint-plugin": "^2.1.8",
         "@1024pix/pix-ui": "^55.25.3",
         "@1024pix/stylelint-config": "^5.1.35",
@@ -805,10 +805,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.1.0.tgz",
-      "integrity": "sha512-jZbIyPjcoHRYlakCS3aCgJZx+6h62hE9TIddRVmbkDfSPLTfNumKFRmLUaSysER/m0IfvmI+b78n2HML56exYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.0.tgz",
+      "integrity": "sha512-a7ZfKebCupx4wgO9IQ65z3MtjpBilU2PdUz+0vmfG8g5W4ddgxj4yNEJahKkXlOJVZnCDGBPgLH5taqkJId/zg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.6",
-    "@1024pix/epreuves-components": "^1.1.0",
+    "@1024pix/epreuves-components": "^1.2.0",
     "@1024pix/eslint-plugin": "^2.1.8",
     "@1024pix/pix-ui": "^55.25.3",
     "@1024pix/stylelint-config": "^5.1.35",


### PR DESCRIPTION
## 🔆 Problème
Il faut rendre disponible le nouveau POI calcul-impact

## ⛱️ Proposition
Rendre disponible le POI calcul-impact via une mise à jour du package correspondant

## 🌊 Remarques
RAS

## 🏄 Pour tester
Voir la page de démo modulix et s'assurer qu'il s'affiche bien en premier.