### PR TITLE
[FEATURE] Supprimer le statut "TO_SHARE" dans l'activite d'une campagne (PIX-19324)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,8 +1,8 @@
 import stream from 'node:stream';
 
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
-import { getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import { escapeFileName } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { escapeFileName, getChallengeLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { CampaignParticipationStatuses } from '../../shared/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignDetailsManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
 import * as campaignParticipantsActivitySerializer from '../infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js';
@@ -10,6 +10,7 @@ import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi
 import * as campaignToJoinSerializer from '../infrastructure/serializers/jsonapi/campaign-to-join-serializer.js';
 import * as targetProfileSerializer from '../infrastructure/serializers/jsonapi/target-profile-serializer.js';
 
+const { TO_SHARE, STARTED, SHARED } = CampaignParticipationStatuses;
 const { PassThrough } = stream;
 
 const getByCode = async function (
@@ -132,6 +133,10 @@ const findParticipantsActivity = async function (
   }
   if (filters.groups && !Array.isArray(filters.groups)) {
     filters.groups = [filters.groups];
+  }
+  // TODO Remove TO_SHARE status once it's no longer used
+  if (filters.status) {
+    filters.status = filters.status === STARTED ? [STARTED, TO_SHARE] : [SHARED];
   }
 
   const { userId } = request.auth.credentials;

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
@@ -1,3 +1,5 @@
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
+
 class CampaignParticipantActivity {
   constructor({
     campaignParticipationId,
@@ -16,7 +18,8 @@ class CampaignParticipantActivity {
     this.lastName = lastName;
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
-    this.status = status;
+    // TODO Remove TO_SHARE status once it's no longer used
+    this.status = status === CampaignParticipationStatuses.TO_SHARE ? CampaignParticipationStatuses.STARTED : status;
     this.lastCampaignParticipationId = lastCampaignParticipationId || campaignParticipationId;
     this.participationCount = participationCount || 0;
   }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -94,7 +94,7 @@ function _filterByDivisions(queryBuilder, filters) {
 
 function _filterByStatus(queryBuilder, filters) {
   if (filters.status) {
-    queryBuilder.where('campaign-participations.status', filters.status);
+    queryBuilder.whereIn('campaign-participations.status', filters.status);
   }
 }
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -437,7 +437,6 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
           sharedAt: new Date('2024-01-02'),
           status: CampaignParticipationStatuses.SHARED,
         });
-
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -196,7 +196,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
       });
 
       context('when the participation is not shared', function () {
-        it('should return status to share', async function () {
+        it('should return status started', async function () {
           // given
           campaign = databaseBuilder.factory.buildCampaign();
           databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, status: TO_SHARE });
@@ -207,7 +207,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
             await campaignParticipantActivityRepository.findPaginatedByCampaignId({ campaignId: campaign.id });
 
           // then
-          expect(campaignParticipantsActivities[0].status).to.equal(TO_SHARE);
+          expect(campaignParticipantsActivities[0].status).to.equal(STARTED);
         });
       });
 
@@ -324,7 +324,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         const { campaignParticipantsActivities, pagination } =
           await campaignParticipantActivityRepository.findPaginatedByCampaignId({
             campaignId: campaign.id,
-            filters: { status: STARTED },
+            filters: { status: [STARTED] },
           });
 
         const participantExternalIds = campaignParticipantsActivities.map((result) => result.participantExternalId);

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -331,7 +331,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
   describe('#findParticipantsActivity', function () {
     let serializedParticipantsActivities;
     let participantsActivities;
-    const filters = { status: 'SHARED', groups: ['L1'], search: 'Choupette' };
+    const filters = { status: ['SHARED'], groups: ['L1'], search: 'Choupette' };
 
     const campaignId = 1;
     const userId = 1;

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignParticipantAct
         userId: 123,
         participantExternalId: 'Alba67',
         sharedAt,
-        status: CampaignParticipationStatuses.SHARED,
+        status: CampaignParticipationStatuses.TO_SHARE,
         lastCampaignParticipationId: null,
         participationCount: null,
       });
@@ -26,7 +26,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignParticipantAct
         userId: 123,
         participantExternalId: 'Alba67',
         sharedAt,
-        status: CampaignParticipationStatuses.SHARED,
+        status: CampaignParticipationStatuses.STARTED,
         lastCampaignParticipationId: 45,
         participationCount: 0,
       });

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -123,10 +123,9 @@ export default class ParticipationFilters extends Component {
   }
 
   get statusOptions() {
-    const { isTypeAssessment, isTypeExam, type } = this.args.campaign;
+    const { type } = this.args.campaign;
 
-    const statuses = isTypeAssessment || isTypeExam ? ['STARTED', 'TO_SHARE', 'SHARED'] : ['TO_SHARE', 'SHARED'];
-
+    const statuses = ['STARTED', 'SHARED'];
     const finalType = type === 'EXAM' ? 'ASSESSMENT' : type;
     return statuses.map((status) => {
       const label = this.intl.t(`components.participation-status.${status}-${finalType}`);

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -889,36 +889,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         .exists();
     });
 
-    test('it should display 3 statuses for exam campaign', async function (assert) {
-      // given
-      const campaign = store.createRecord('campaign', {
-        id: campaignId,
-        name: 'campagne 1',
-        type: 'EXAM',
-        targetProfileHasStage: false,
-        stages: [],
-      });
-
-      // when
-      const screen = await render(
-        <template><ParticipationFilters @campaign={{campaign}} @onFilter={{noop}} /></template>,
-      );
-
-      // then
-      await click(screen.getByLabelText(t('pages.campaign-results.filters.type.status.title')));
-      const options = await screen.findAllByRole('option');
-      assert.deepEqual(
-        options.map((option) => option.innerText),
-        [
-          t('pages.campaign-results.filters.type.status.empty'),
-          t('components.participation-status.STARTED-ASSESSMENT'),
-          t('components.participation-status.TO_SHARE-ASSESSMENT'),
-          t('components.participation-status.SHARED-ASSESSMENT'),
-        ],
-      );
-    });
-
-    test('it should display 3 statuses for assessment campaign', async function (assert) {
+    test('it should display statuses', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
         id: campaignId,
@@ -941,36 +912,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         [
           t('pages.campaign-results.filters.type.status.empty'),
           t('components.participation-status.STARTED-ASSESSMENT'),
-          t('components.participation-status.TO_SHARE-ASSESSMENT'),
           t('components.participation-status.SHARED-ASSESSMENT'),
-        ],
-      );
-    });
-
-    test('it should display 2 statuses for profiles collection campaign', async function (assert) {
-      // given
-      const campaign = store.createRecord('campaign', {
-        id: '1',
-        name: 'campagne 1',
-        type: 'PROFILES_COLLECTION',
-        targetProfileHasStage: false,
-        stages: [],
-      });
-
-      // when
-      const screen = await render(
-        <template><ParticipationFilters @campaign={{campaign}} @onFilter={{noop}} /></template>,
-      );
-
-      // then
-      await click(screen.getByLabelText(t('pages.campaign-results.filters.type.status.title')));
-      const options = await screen.findAllByRole('option');
-      assert.deepEqual(
-        options.map((option) => option.innerText),
-        [
-          t('pages.campaign-results.filters.type.status.empty'),
-          t('components.participation-status.TO_SHARE-PROFILES_COLLECTION'),
-          t('components.participation-status.SHARED-PROFILES_COLLECTION'),
         ],
       );
     });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -424,7 +424,7 @@
       "SHARED-ASSESSMENT": "Submitted results",
       "SHARED-PROFILES_COLLECTION": "Submitted profile",
       "STARTED-ASSESSMENT": "In progress",
-      "STARTED-PROFILES_COLLECTION": "Pending profile",
+      "STARTED-PROFILES_COLLECTION": "Pending results",
       "TO_SHARE-ASSESSMENT": "Pending results",
       "TO_SHARE-PROFILES_COLLECTION": "Pending profile"
     },


### PR DESCRIPTION
## 🔆 Problème
Nous devons gérer la transition du statut `TO_SHARE` qui devient obsolète

## ⛱️ Proposition
Masquer  le statut `TO_SHARE` dans l'activité d'une campagne tout en maintenant la compatibilité avec les données existantes 

## 🌊 Remarques 

## 🏄 Pour tester
1. Accéder à une campagne avec des participations ayant différents statuts
2. Vérifier que les filtres ne montrent que `STARTED` et `SHARED`
3. Filtrer par `STARTED` et s'assurer que les participations avec statut `TO_SHARE` en base apparaissent