### PR TITLE
[BUGFIX] Dans le QCU déclaratif, aligner les phrases longues à gauche (PIX-19371)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -334,7 +334,7 @@
                   },
                   {
                     "id": "3",
-                    "content": "Pendant que le dentifrice est mis",
+                    "content": "Pendant que le dentifrice est mis, parce que j'aime les défis et que je suis multitâche et que j'aime les phrases interminables.",
                     "feedback": {
                       "diagnosis": "<p>Digne des plus grands acrobates !</p>"
                     }

--- a/mon-pix/app/components/module/component/_proposal-button.scss
+++ b/mon-pix/app/components/module/component/_proposal-button.scss
@@ -3,10 +3,9 @@
 .proposal-button {
   @extend %pix-body-m;
 
-  display: flex;
-  align-items: center;
   width: 100%;
   padding: var(--pix-spacing-3x) var(--pix-spacing-4x);
+  text-align: left;
   background: var(--pix-neutral-0);
   border: 1px solid var(--pix-neutral-500);
   border-radius: 8px;


### PR DESCRIPTION
## 🔆 Problème

Dans le QCU déclaratif, les phrases courtes sont alignées à gauche mais les phrases de plus d’une ligne sont centrées

## ⛱️ Proposition

Toujours aligner à gauche.

## 🌊 Remarques

Je ne sais pas pourquoi on avait mis `display: flex;` et `align-items: center` sur ces éléments, peut-être un copier-coller malheureux, mais retirer ces propriétés permet de corriger le problème.

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13384.review.pix.fr/modules/preview/bac-a-sable)
2. Scroller jusqu'à l'exemple de [QCU Déclaratif](https://app-pr13384.review.pix.fr/modules/preview/bac-a-sable#instruction-6a6944be-a8a3-4138-b5dc-af664cf40b07) (<- ou cliquer ici 🪄)
3. Constater que toutes les propositions, y compris la longue, sont alignées à gauche