### PR TITLE
[TECH] Supprimer les anciennes tables de configurations de certification (PIX-19068)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,5 @@ high-level-tests/e2e/cypress/snapshots/actual/**
 # Docker-compose config
 docker/data/
 
-# Claude Code local development guidance
+# Claude Code documentation
 CLAUDE.md

--- a/api/db/migrations/20250902152814_remove-obsolete-certification-configuration-tables.js
+++ b/api/db/migrations/20250902152814_remove-obsolete-certification-configuration-tables.js
@@ -1,0 +1,46 @@
+// Remove obsolete certification configuration tables
+// These tables were consolidated into the new `certification-configurations` table
+// in migration 20250807134527_copy-flash-configurations-to-new-table.js
+// All data has been migrated and these tables are now unused.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable('certification-scoring-configurations');
+  await knex.schema.dropTable('competence-scoring-configurations');
+  await knex.schema.dropTable('flash-algorithm-configurations');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.createTable('certification-scoring-configurations', function (table) {
+    table.integer('id').primary();
+    table.jsonb('configuration').notNullable();
+    table.timestamp('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.bigInteger('createdByUserId').index().references('users.id');
+  });
+
+  await knex.schema.createTable('competence-scoring-configurations', function (table) {
+    table.integer('id').primary();
+    table.jsonb('configuration').notNullable();
+    table.timestamp('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.bigInteger('createdByUserId').references('users.id');
+  });
+
+  await knex.schema.createTable('flash-algorithm-configurations', function (table) {
+    table.integer('id').primary();
+    table.integer('maximumAssessmentLength').nullable();
+    table.integer('challengesBetweenSameCompetence').nullable();
+    table.boolean('limitToOneQuestionPerTube').nullable();
+    table.boolean('enablePassageByAllCompetences').nullable();
+    table.float('variationPercent').nullable();
+    table.timestamp('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
🔆 Problème
Les tables `certification-scoring-configurations`, `competence-scoring-configurations` et `flash-algorithm-configurations` sont devenues obsolètes depuis la consolidation dans la table `certification-configurations` (migration du 7 août 2025). Ces tables sont vides et ne sont plus utilisées par le code.

⛱️ Proposition
Créer une migration pour supprimer définitivement ces 3 tables obsolètes de la base de données.

🌊 Remarques
- Les données ont été migrées vers `certification-configurations` en août 2025
- Toutes les tables sont vides (0 lignes)
- Le code utilise uniquement la nouvelle table consolidée
- Migration testée avec rollback fonctionnel

🏄 Pour tester

**Tests techniques :**
- Vérifier que les tables n'existent plus après migration :
  ```sql
  \dt certification-scoring-configurations
  \dt competence-scoring-configurations  
  \dt flash-algorithm-configurations
  ```
- Confirmer que la table `certification-configurations` existe et contient les données
- Tester le rollback si nécessaire : `npm run db:rollback:latest`

**Test fonctionnel - Passation d'une certification :**
1. Se connecter en tant que candidat à la certification
2. Effectuer une session de certification complète :
   - Démarrer une certification
   - Répondre aux questions de l'évaluation flash
   - Terminer la certification
3. Vérifier que :
   - L'algorithme de sélection des questions fonctionne correctement
   - Le scoring de certification s'applique normalement
   - Les résultats sont générés sans erreur
4. Vérifier dans Pix Admin que les résultats de certification s'affichent correctement