### PR TITLE
[FEATURE] Ajouter un pre-handler pour limiter l'accès des campagne de parcours combiné (PIX-19315).

### DIFF
--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -77,7 +77,13 @@ const register = async function (server) {
       method: 'PUT',
       path: '/api/campaigns/{campaignId}/archive',
       config: {
-        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
+        pre: [
+          { method: securityPreHandlers.checkAuthorizationToManageCampaign },
+          {
+            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            assign: 'campaignBelongsToCombinedCourse',
+          },
+        ],
         validate: {
           params: Joi.object({
             campaignId: identifiersType.campaignId,

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -40,6 +40,10 @@ const register = async function (server) {
             method: securityPreHandlers.checkAuthorizationToManageCampaign,
             assign: 'isAdminOrCreatorFromTheCampaign',
           },
+          {
+            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+            assign: 'campaignBelongsToCombinedCourse',
+          },
         ],
         validate: {
           params: Joi.object({

--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -1,5 +1,6 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import {
+  CampaignBelongsToCombinedCourseError,
   CampaignCodeFormatError,
   CampaignParticipationDoesNotBelongToUser,
   CampaignUniqueCodeError,
@@ -54,6 +55,10 @@ const campaignDomainErrorMappingConfiguration = [
   {
     name: OrganizationNotAuthorizedToCreateCampaignError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message),
+  },
+  {
+    name: CampaignBelongsToCombinedCourseError.name,
+    httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
   },
 ];
 

--- a/api/src/prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js
+++ b/api/src/prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js
@@ -1,0 +1,11 @@
+// LionelB: on appelle l'api directement plutot que depuis le repo campaign pour éviter une dépendance cyclique
+import * as combinedCourseApi from '../../../../quest/application/api/combined-course-api.js';
+import { CampaignBelongsToCombinedCourseError } from '../../domain/errors.js';
+
+const execute = async function ({ campaignId, dependencies = { combinedCourseApi } }) {
+  if ((await dependencies.combinedCourseApi.getByCampaignId(campaignId)) !== null) {
+    throw new CampaignBelongsToCombinedCourseError();
+  }
+};
+
+export { execute };

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -85,8 +85,18 @@ class CampaignTypeError extends DomainError {
   }
 }
 
+class CampaignBelongsToCombinedCourseError extends DomainError {
+  constructor() {
+    super(
+      'This campaign belongs to a combined course. Some operations are blocked',
+      'CAMPAIGN_BELONGS_TO_COMBINED_COURSE',
+    );
+  }
+}
+
 export {
   ArchivedCampaignError,
+  CampaignBelongsToCombinedCourseError,
   CampaignCodeFormatError,
   CampaignParticipationDoesNotBelongToUser,
   CampaignTypeError,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -5,6 +5,7 @@ import { PIX_ADMIN } from '../../authorization/domain/constants.js';
 import * as checkUserIsCandidateUseCase from '../../certification/enrolment/application/usecases/check-user-is-candidate.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
+import * as checkCampaignBelongsToCombinedCourseUsecase from '../../prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js';
 import * as checkCampaignParticipationBelongsToUserUsecase from '../../prescription/campaign/application/usecases/checkCampaignParticipationBelongsToUser.js';
 import * as checkAuthorizationToAccessCombinedCourseUsecase from '../../quest/application/usecases/check-authorization-to-access-combined-course.js';
 import * as isSchoolSessionActive from '../../school/application/usecases/is-school-session-active.js';
@@ -876,6 +877,17 @@ async function checkOrganizationLearnerBelongsToOrganization(
   }
 }
 
+async function checkCampaignBelongsToCombinedCourse(
+  request,
+  h,
+  dependencies = { checkCampaignBelongsToCombinedCourseUsecase },
+) {
+  const campaignId = parseInt(request.params.campaignId);
+
+  await dependencies.checkCampaignBelongsToCombinedCourseUsecase.execute({ campaignId });
+  return h.response(true);
+}
+
 function _noOrganizationFound(error) {
   return error instanceof NotFoundError;
 }
@@ -890,6 +902,7 @@ const securityPreHandlers = {
   checkAuthorizationToManageCampaign,
   checkAuthorizationToAccessCampaign,
   checkAuthorizationToAccessCombinedCourse,
+  checkCampaignBelongsToCombinedCourse,
   checkCertificationCenterIsNotScoManagingStudents,
   checkIfUserIsBlocked,
   checkOrganizationHasFeature,

--- a/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
+++ b/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
@@ -1,0 +1,39 @@
+import * as checkAuthorizationToAccessCombinedCourse from '../../../../../../src/prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js';
+import { CampaignBelongsToCombinedCourseError } from '../../../../../../src/prescription/campaign/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Campaign | Application | Usecases | checkCampaignBelongsToCombinedCourse', function () {
+  it('should throw if a campaign belongs to combined course', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    databaseBuilder.factory.buildQuestForCombinedCourse({
+      code: 'ABCDE1234',
+      name: 'Mon parcours Combiné',
+      organizationId,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaignId,
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(checkAuthorizationToAccessCombinedCourse.execute)({ campaignId });
+
+    // then
+    expect(error).instanceOf(CampaignBelongsToCombinedCourseError);
+  });
+
+  // it('should not throw if campaign does not belongs to combined course', async function () {
+
+  // });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -398,6 +398,21 @@ describe('Unit | Application | Router | campaign-administration-router', functio
     });
   });
 
+  it('should call checkCampaignBelongsToCombinedCourse pre-handler', async function () {
+    // given
+    sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
+    sinon.stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse').callsFake((request, h) => h.response(true));
+
+    const httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+
+    // when
+    await httpTestServer.request('PUT', '/api/campaigns/123/archive');
+
+    // then
+    expect(securityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
+  });
+
   describe('DELETE /api/campaigns/{campaignId}/archive', function () {
     it('should return 400 with an invalid campaign id', async function () {
       // given

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -9,7 +9,7 @@ import {
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Application | Router | campaign-administration-router ', function () {
+describe('Unit | Application | Router | campaign-administration-router', function () {
   describe('POST /api/campaigns', function () {
     it('should not call controller method when security prehandler failed', async function () {
       // given
@@ -37,6 +37,24 @@ describe('Unit | Application | Router | campaign-administration-router ', functi
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+    it('should call checkCampaignBelongsToCombinedCourse pre-handler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToManageCampaign').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkCampaignBelongsToCombinedCourse')
+        .callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('PATCH', '/api/campaigns/1234', {
+        data: { attributes: { name: 'io', title: 'io', 'custom-landing-page-text': null, 'owner-id': 12 } },
+      });
+
+      // then
+      expect(securityPreHandlers.checkCampaignBelongsToCombinedCourse).called;
     });
   });
 

--- a/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
@@ -1,7 +1,7 @@
 import * as checkAuthorizationToAccessCombinedCourse from '../../../../../src/quest/application/usecases/check-authorization-to-access-combined-course.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
-describe('Unit | Application | Usecases | checkAuthorizationToAccessCombinedCourse', function () {
+describe('Integration | Application | Usecases | checkAuthorizationToAccessCombinedCourse', function () {
   it('should return true if user belongs to combined course organization', async function () {
     // given
     const code = 'COMBINIX1';

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -1,9 +1,54 @@
+import { CampaignBelongsToCombinedCourseError } from '../../../../src/prescription/campaign/domain/errors.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
-import { domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
+import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Shared | Unit | Application | SecurityPreHandlers', function () {
+  describe('#checkCampaignBelongsToCombinedCourse', function () {
+    context('Successful case', function () {
+      it('should authorize access when campaign does not belongs to a combined course', async function () {
+        // given
+        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
+          execute: sinon.stub().resolves(),
+        };
+
+        // when
+        const response = await securityPreHandlers.checkCampaignBelongsToCombinedCourse(
+          { params: { campaignId: '123' } },
+          hFake,
+          {
+            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
+          },
+        );
+
+        // then
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid access when the user is not the certificartion candidate', async function () {
+        // given
+        const checkCampaignBelongsToCombinedCourseUsecaseStub = {
+          execute: sinon.stub().rejects(new CampaignBelongsToCombinedCourseError()),
+        };
+
+        // when
+        const error = await catchErr(securityPreHandlers.checkCampaignBelongsToCombinedCourse)(
+          { params: { campaignId: '123' } },
+          hFake,
+          {
+            checkCampaignBelongsToCombinedCourseUsecase: checkCampaignBelongsToCombinedCourseUsecaseStub,
+          },
+        );
+
+        // then
+        expect(error).instanceOf(CampaignBelongsToCombinedCourseError);
+      });
+    });
+  });
+
   describe('#checkAdminMemberHasRoleSuperAdmin', function () {
     let request;
 


### PR DESCRIPTION
## 🔆 Problème

Avec l'arrivée des parcours combiné, on souhaite restreindre certaines actions pour les campagnes incluses

## ⛱️ Proposition

Ajouter un pré-handler qui vérifie qu'une campagne ne fait pas partie d'un parcours combiné

## 🌊 Remarques


## 🏄 Pour tester

- afficher les paramêtres d'une campagne d'un parcours combiné 
- cliquer sur modifier et enregistrer
- cliquer sur archiver
- (voir des toast d'erreur) ?
