### PR TITLE
[BUGFIX] Corrige le mapping de la colonne PIX_PLUS_EDU_CPE dans l'import ODS candidats (PIX-19377)

### DIFF
--- a/api/src/certification/enrolment/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/src/certification/enrolment/infrastructure/files/candidates-import/CandidateData.js
@@ -86,6 +86,10 @@ class CandidateData {
       complementaryCertification,
       ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
     );
+    this.pixPlusEduCPE = this._displayYesIfCandidateHasComplementaryCertification(
+      complementaryCertification,
+      ComplementaryCertificationKeys.PIX_PLUS_EDU_CPE,
+    );
     this.count = number;
     this._clearBirthInformationDataForExport();
   }

--- a/api/src/certification/enrolment/infrastructure/files/candidates-import/candidates-import-placeholders.js
+++ b/api/src/certification/enrolment/infrastructure/files/candidates-import/candidates-import-placeholders.js
@@ -149,6 +149,10 @@ const IMPORT_CANDIDATES_TEMPLATE_VALUES = [
     placeholder: ComplementaryCertificationKeys.PIX_PLUS_PRO_SANTE,
     propertyName: 'pixPlusProSante',
   },
+  {
+    placeholder: ComplementaryCertificationKeys.PIX_PLUS_EDU_CPE,
+    propertyName: 'pixPlusEduCPE',
+  },
 ];
 
 const EXTRA_EMPTY_CANDIDATE_ROWS = 20;


### PR DESCRIPTION
## 🔆 **Problème**
L'ODS généré pour importer des candidats en certification remplit la colonne "Pix+ CPE" avec la clé `'EDU_CPE'` au lieu d'afficher "Oui" ou de laisser vide selon l'affectation du candidat.

## ⛱️ **Proposition** 
Ajouter la propriété `pixPlusEduCPE` manquante dans `CandidateData.js` et le mapping correspondant dans `candidates-import-placeholders.js` pour suivre le même pattern que les autres certifications complémentaires.

## 🌊 **Remarques**


## 🏄 **Pour tester**
- [Pix Admin] donner l'habilitation Pix+ Edu CPE à un centre
- [Pix Certif] Créer une session sur ce centre, le fichier généré pour l'import ODS n'a pas de valeur dans les lignes d'inscription des candidats
- [Pix Certif] Ajouter des candidats manuellement inscrit ou non en Pix+ edu, générer le fichier ODS, ces candidats s'affichent correctement (Oui/non dans la colonne) puis ajouter des candidats dans l'ODS, importer ce fichier : tout doit bien se passer. 
- Vérifier que la colonne affiche "Oui" pour les candidats concernés et reste vide pour les autres