### PR TITLE
[BUGFIX] Réparer l'affichage du pendant des places disponibles lors d'un changement d'organisation (PIX-19380)

### DIFF
--- a/orga/app/components/banner/maximum-places-exceeded.gjs
+++ b/orga/app/components/banner/maximum-places-exceeded.gjs
@@ -4,15 +4,14 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class MaximumPlacesExceeded extends Component {
-  @service store;
+  @service currentUser;
 
-  get displayMaximumPlacesExceededBanner() {
-    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachedMaximumPlacesLimit;
+  get displayMaximumPlacesLimitBanner() {
+    return this.currentUser.placeStatistics?.hasReachedMaximumPlacesLimit;
   }
 
   <template>
-    {{#if this.displayMaximumPlacesExceededBanner}}
+    {{#if this.displayMaximumPlacesLimitBanner}}
       <PixBannerAlert @type="error">
         {{t
           "banners.maximum-places-exceeded.message"

--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -16,10 +16,10 @@ export default class CampaignTabs extends Component {
   @service session;
   @service pixMetrics;
   @service store;
+  @service currentUser;
 
   get hasReachedPlacesLimit() {
-    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachedMaximumPlacesLimit;
+    return this.currentUser.placeStatistics?.hasReachedMaximumPlacesLimit;
   }
 
   @action

--- a/orga/app/components/campaign/list-header.gjs
+++ b/orga/app/components/campaign/list-header.gjs
@@ -8,11 +8,10 @@ import { t } from 'ember-intl';
 import PageTitle from '../ui/page-title';
 
 export default class List extends Component {
-  @service store;
+  @service currentUser;
 
   get hasReachedPlacesLimit() {
-    const statistics = this.store.peekAll('organization-place-statistic')?.[0];
-    return statistics?.hasReachedMaximumPlacesLimit;
+    return this.currentUser.placeStatistics?.hasReachedMaximumPlacesLimit;
   }
 
   get campaignCreationRoute() {

--- a/orga/app/components/layout/user-logged-menu.gjs
+++ b/orga/app/components/layout/user-logged-menu.gjs
@@ -55,9 +55,7 @@ export default class UserLoggedMenu extends Component {
     userOrgaSettings.organization = selectedOrganization;
     await userOrgaSettings.save({ adapterOptions: { userId: prescriber.id } });
 
-    const queryParams = {};
-    Object.keys(this.router.currentRoute.queryParams).forEach((key) => (queryParams[key] = undefined));
-    this.router.replaceWith('authenticated', { queryParams });
+    this.router.replaceWith('authenticated.index');
 
     await this.currentUser.load();
   }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -64,6 +64,8 @@ export default class CurrentUserService extends Service {
       this.organizationPlaceStatistics = await this.store.queryRecord('organization-place-statistic', {
         organizationId: this.organization.id,
       });
+    } else {
+      this.organizationPlaceStatistics = null;
     }
   }
 

--- a/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
+++ b/orga/tests/integration/components/banner/maximum-places-exceeded-test.gjs
@@ -1,16 +1,15 @@
 import { render } from '@1024pix/ember-testing-library';
 import MaximumPlacesExceeded from 'pix-orga/components/banner/maximum-places-exceeded';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Banner | Maximum places exceeded', function (hooks) {
   setupIntlRenderingTest(hooks);
-
-  let store;
-
+  let currentUser;
   hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
+    currentUser = this.owner.lookup('service:current-user');
     this.intl = this.owner.lookup('service:intl');
   });
 
@@ -28,7 +27,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
     module('when maximum places is not reached', function () {
       test('it should not display a banner', async function (assert) {
         // given
-        store.createRecord('organization-place-statistic', { hasReachedMaximumPlacesLimit: false });
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: false });
 
         // when
         const screen = await render(<template><MaximumPlacesExceeded /></template>);
@@ -41,7 +40,7 @@ module('Integration | Component | Banner | Maximum places exceeded', function (h
     module('when maximum places is reached', function () {
       test('it should display a banner', async function (assert) {
         // given
-        store.createRecord('organization-place-statistic', { hasReachedMaximumPlacesLimit: true });
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: true });
 
         // when
         const screen = await render(<template><MaximumPlacesExceeded /></template>);

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -19,9 +19,10 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
     ENV.APP.API_HOST = originalAppHost;
   });
 
-  let store, screen, fileSaver, notifications, access_token;
+  let store, screen, fileSaver, notifications, access_token, currentUser;
 
   hooks.beforeEach(function () {
+    currentUser = this.owner.lookup('service:current-user');
     class sessionService extends Service {
       isAuthenticated = true;
       data = {
@@ -38,7 +39,6 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
     ENV.APP.API_HOST = 'https://myapp.com';
     access_token = Symbol('ACCESS_TOKEN');
     store = this.owner.lookup('service:store');
-    this.owner.lookup('service:current-user');
     fileSaver = this.owner.lookup('service:file-saver');
     notifications = this.owner.lookup('service:notifications');
     this.owner.setupRouter();
@@ -116,9 +116,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
 
     module('when has reached maximum places limit is true', function (hooks) {
       hooks.beforeEach(function () {
-        const storeService = this.owner.lookup('service:store');
-        sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: true });
       });
 
       test('it should display disabled evaluation results item', async function (assert) {
@@ -195,9 +193,7 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
 
     module('when has reach maximum places is true', function (hooks) {
       hooks.beforeEach(function () {
-        const storeService = this.owner.lookup('service:store');
-        sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: true });
       });
 
       test('it should display disabled profile results item', async function (assert) {

--- a/orga/tests/integration/components/campaign/list-header-test.gjs
+++ b/orga/tests/integration/components/campaign/list-header-test.gjs
@@ -28,10 +28,8 @@ module('Integration | Component | Campaign | ListHeader', function (hooks) {
     module('when places limit is not reached', function () {
       test('it displays a create link', async function (assert) {
         // given
-        const storeService = this.owner.lookup('service:store');
-        sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: false }]);
-
+        const currentUser = this.owner.lookup('service:current-user');
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: false });
         // when
         const screen = await render(<template><ListHeader /></template>);
 
@@ -43,9 +41,8 @@ module('Integration | Component | Campaign | ListHeader', function (hooks) {
     module('when places limit is reached', function () {
       test('it displays a disabled link', async function (assert) {
         // given
-        const storeService = this.owner.lookup('service:store');
-        sinon.stub(storeService, 'peekAll');
-        storeService.peekAll.returns([{ hasReachedMaximumPlacesLimit: true }]);
+        const currentUser = this.owner.lookup('service:current-user');
+        sinon.stub(currentUser, 'organizationPlaceStatistics').value({ hasReachedMaximumPlacesLimit: true });
 
         // when
         const screen = await render(<template><ListHeader /></template>);

--- a/orga/tests/integration/components/layout/user-logged-menu-test.gjs
+++ b/orga/tests/integration/components/layout/user-logged-menu-test.gjs
@@ -1,14 +1,13 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import Object from '@ember/object';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
+import UserLoggedMenu from 'pix-orga/components/layout/user-logged-menu';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | Layout::UserLoggedMenu', function () {
+module('Integration | Component | UserLoggedMenu', function () {
   module('When user belongs to several organizations', function (hooks) {
     setupIntlRenderingTest(hooks);
 
@@ -42,7 +41,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function () {
 
     test("should display user's firstName and lastName", async function (assert) {
       // when
-      const screen = await render(hbs`<Layout::UserLoggedMenu />`);
+      const screen = await render(<template><UserLoggedMenu /></template>);
 
       // then
       assert.ok(screen.getByText(`${prescriber.firstName} ${prescriber.lastName}`));
@@ -50,7 +49,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function () {
 
     test('should display the user current organization name and externalId', async function (assert) {
       // when
-      const screen = await render(hbs`<Layout::UserLoggedMenu />`);
+      const screen = await render(<template><UserLoggedMenu /></template>);
       const currentOrganizationText = screen.getByText(`${organization.name} (${organization.externalId})`, {
         selector: 'p',
       });
@@ -61,7 +60,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function () {
 
     test('should display the disconnect link when menu is open', async function (assert) {
       // when
-      const screen = await render(hbs`<Layout::UserLoggedMenu />`);
+      const screen = await render(<template><UserLoggedMenu /></template>);
       await clickByName("Changer d'organisation");
 
       // then
@@ -70,36 +69,12 @@ module('Integration | Component | Layout::UserLoggedMenu', function () {
 
     test('should display the organizations name when menu is open', async function (assert) {
       // when
-      const screen = await render(hbs`<Layout::UserLoggedMenu />`);
+      const screen = await render(<template><UserLoggedMenu /></template>);
       await clickByName("Changer d'organisation");
 
       // then
       assert.ok(await screen.findByRole('option', { name: `${organization2.name} (${organization2.externalId})` }));
       assert.ok(await screen.findByRole('option', { name: `${organization3.name}` }));
-    });
-
-    test('should redirect to authenticated route before reload the current user', async function (assert) {
-      const replaceWithStub = sinon.stub();
-
-      class RouterStub extends Service {
-        replaceWith = replaceWithStub;
-        currentRoute = { queryParams: [] };
-      }
-
-      class StoreStub extends Service {
-        peekRecord() {
-          return { save() {} };
-        }
-      }
-      this.owner.register('service:router', RouterStub);
-      this.owner.register('service:store', StoreStub);
-
-      const screen = await render(hbs`<Layout::UserLoggedMenu @onChangeOrganization={{this.onChangeOrganization}} />`);
-      await clickByName("Changer d'organisation");
-      await click(await screen.findByRole('option', { name: `${organization2.name} (${organization2.externalId})` }));
-
-      sinon.assert.callOrder(replaceWithStub, loadStub);
-      assert.ok(true);
     });
   });
   module('When user belongs to only one organization', function (hooks) {
@@ -126,9 +101,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function () {
       }
       this.owner.register('service:current-user', CurrentUserStub);
       test('should not display organization switcher when user belongs to only one organization', async function (assert) {
-        const screen = await render(
-          hbs`<Layout::UserLoggedMenu @onChangeOrganization={{this.onChangeOrganization}} />`,
-        );
+        const screen = await render(<template><UserLoggedMenu /></template>);
         assert.notOk(screen.getByRole('button', { name: "Changer d'organisation" }));
       });
     });


### PR DESCRIPTION
## 🔆 Problème

Le bandeau des places disponible ne s'affiche pas correctemetn au changement d'orga<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On utilise les données provenant du service plutot que d'un model provenant d'un store qui ne se mettez pas à jour
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Aller sur l'orga proclassic
- voir le bandeau de limite de places 
- voir le bouton d'export des résultats bloqué
- voir le bouton de création de campagne bloqué
- changer d'orga
- ne plus voir le bandeau
- voir le bouton d'export des résultats actif
- voir le bouton de création de campagne actif

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
