### PR TITLE
[FEATURE] Afficher le titre du Combinix

### DIFF
--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -17,6 +17,9 @@ const CompletedText = <template>
 export default class CombinedCourses extends Component {
   <template>
     <div class="combined-course">
+      <div class="combined-course__header">
+        <h1>{{@combinedCourse.name}} </h1>
+      </div>
       {{#if (eq @combinedCourse.status "COMPLETED")}}
         <section class="combined-course-completed">
           <img src="/images/illustrations/combined-course/completed.svg" />

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -25,6 +25,7 @@
       &__description {
         @extend %pix-body-m;
       }
+
     }
   }
 
@@ -32,6 +33,20 @@
     margin: var(--pix-spacing-6x) 0;
     border-top: 1px solid var(--pix-neutral-100);
   }
+
+  &__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-2x);
+  align-items: flex-start;
+  align-self: stretch;
+  padding: var(--pix-spacing-10x) 0 var(--pix-spacing-6x) 0;
+
+    h1 {
+      @extend %pix-title-m;
+  }
+  }
+
 }
 
 .combined-course-item {

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -10,6 +10,28 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering.js';
 module('Integration | Component | combined course', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  module('in all cases', function () {
+    test('should display Combinix title', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'NOT_STARTED',
+        code: 'COMBINIX9',
+        name: 'Combinix',
+      });
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.ok(screen.getByRole('heading', { name: 'Combinix' }));
+    });
+  });
   module('when there is a formation item', function () {
     test('should display formation item', async function (assert) {
       // given


### PR DESCRIPTION
## 🔆 Problème
En arrivant sur un parcours combiné, on veut pouvoir afficher son nom.

## ⛱️ Proposition
On ajoute une balise h1 à l'intérieur de la div combined-course du composant gjs combined-courses. On modifie les tests pour prendre compte le nouvel affichage.

## 🏄 Pour tester
On lance un parcours combiné et on constate l'existence du titre. 