### PR TITLE
[BUGFIX] Afficher la modale de confirmation en néerlandais si l'invitation à une organisation est en néerlandais (PIX-19395)

### DIFF
--- a/orga/app/components/team/invite-form.gjs
+++ b/orga/app/components/team/invite-form.gjs
@@ -77,7 +77,7 @@ export default class InviteForm extends Component {
       >
         <:content>
           <p>{{t "pages.team-new.invite-form-modal.warning"}}</p>
-          <p>{{t "pages.team-new.invite-form-modal.question"}}</p>
+          <p class="invite-form__question">{{t "pages.team-new.invite-form-modal.question"}}</p>
         </:content>
 
         <:footer>

--- a/orga/app/styles/components/team/invite-form.scss
+++ b/orga/app/styles/components/team/invite-form.scss
@@ -1,6 +1,9 @@
 @use 'pix-design-tokens/typography';
 
 .invite-form {
+  &__question {
+    margin-top: var(--pix-spacing-2x);;
+  }
 
   &__email-field {
     min-height: 70px;

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1856,10 +1856,10 @@
         }
       },
       "invite-form-modal": {
-        "confirm": "Confirm",
-        "question": "Do you want to continue? ",
-        "title": "Confirm the addition of new team members",
-        "warning": "Members you add will have access to participant results and campaign analytics."
+        "confirm": "Bevestigen",
+        "question": "Wilt u doorgaan?",
+        "title": "Bevestig de toevoeging van nieuwe teamleden",
+        "warning": "Leden die u toevoegt, krijgen toegang tot de resultaten van deelnemers en campagneanalyses."
       },
       "invited-members": "Als gasten de e-mail ontvangen, kunnen ze kiezen of ze een Pix-account willen aanmaken of willen inloggen met een bestaand Pix-account.",
       "several-email-requirement": "Je kunt meerdere leden uitnodigen door e-mailadressen te scheiden met komma's.",


### PR DESCRIPTION
## 🔆 Problème

Problème 

En NL sur Pix Orga : Team > Uitnodigingen > Een lid uitnodigen 

Je renseigne les adresses e-mail puis je clique sur “Uitnodigen”

Alors une modale de confirmation d’envoi s’affiche et celle-ci est en anglais. 


## ⛱️ Proposition

Traduire le contenu de l’EN en NL. 


## 🌊 Remarques

Nous avons ajouté une ligne entre le paragraphe descriptif et la question.

## 🏄 Pour tester

- Se connecter sur Pix Orga (domaine org, en néerlandais) en tant qu'administrateur d'une organisation (ex : allorga@example.net)
- inviter un membre
- constater que la modale de confirmation de l'envoi de l'email d'invitation est en néerlandais
