### PR TITLE
[FEATURE] Modifie le wording des statuts de participation (PIX-19368)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -85,7 +85,7 @@ test('Assessment campaign', async ({ page }) => {
     await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
     await page.getByRole('link', { name: 'campagne pro', exact: true }).click();
     await expect(
-      page.getByRole('region').filter({ hasText: 'Résultats reçus Retrouvez ici' }).getByRole('definition'),
+      page.getByRole('region').filter({ hasText: 'Participations terminées Retrouvez ici' }).getByRole('definition'),
     ).toBeVisible();
     await expect(
       page.getByRole('region').filter({ hasText: 'Total de participants' }).getByRole('definition'),

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { or } from 'ember-truth-helpers';
 import sumBy from 'lodash/sumBy';
 
 import ParticipantsCount from '../cards/participants-count';
@@ -43,7 +42,6 @@ export default class Dashboard extends Component {
         <ParticipantsByDay
           @campaignId={{@campaign.id}}
           @totalParticipations={{@totalParticipations}}
-          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
           class="activity-dashboard__participations-by-day"
         />
         <ParticipantsByStatus

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -37,11 +37,7 @@ export default class Dashboard extends Component {
           @isLoading={{this.participantsByStatusLoading}}
           class="activity-dashboard__total-participants-card"
         />
-        <SharedCount
-          @value={{this.shared}}
-          @isLoading={{this.participantsByStatusLoading}}
-          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
-        />
+        <SharedCount @value={{this.shared}} @isLoading={{this.participantsByStatusLoading}} />
       </div>
       <div class="activity-dashboard__row">
         <ParticipantsByDay

--- a/orga/app/components/campaign/activity/dashboard.gjs
+++ b/orga/app/components/campaign/activity/dashboard.gjs
@@ -49,7 +49,6 @@ export default class Dashboard extends Component {
         <ParticipantsByStatus
           @loading={{this.participantsByStatusLoading}}
           @participantCountByStatus={{this.participantCountByStatus}}
-          @shouldDisplayAssessmentLabels={{or @campaign.isTypeAssessment @campaign.isTypeExam}}
           class="activity-dashboard__participations-by-status"
         />
       </div>

--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -121,7 +121,7 @@ export default class ParticipantsList extends Component {
             {{t "pages.campaign-activity.table.column.status"}}
           </:header>
           <:cell>
-            <ParticipationStatus @status={{participation.status}} @campaignType={{@campaign.type}} />
+            <ParticipationStatus @status={{participation.status}} />
           </:cell>
         </PixTableColumn>
 

--- a/orga/app/components/campaign/cards/shared-count.gjs
+++ b/orga/app/components/campaign/cards/shared-count.gjs
@@ -3,14 +3,9 @@ import { t } from 'ember-intl';
 
 <template>
   <PixIndicatorCard
-    @title={{if
-      @shouldDisplayAssessmentLabels
-      (t "cards.submitted-count.title")
-      (t "cards.submitted-count.title-profiles")
-    }}
+    @title={{t "cards.submitted-count.title"}}
     @iconName="inboxIn"
     @color="green"
-    @info={{t "cards.submitted-count.information"}}
     @loadingMessage={{t "cards.submitted-count.loader"}}
     @isLoading={{@isLoading}}
     ...attributes

--- a/orga/app/components/campaign/charts/participants-by-day.gjs
+++ b/orga/app/components/campaign/charts/participants-by-day.gjs
@@ -57,15 +57,11 @@ export default class ParticipantsByDay extends Component {
     return { startedDatasets, sharedDatasets };
   }
 
-  get labels() {
-    return this.args.shouldDisplayAssessmentLabels ? LABELS_ASSESSMENT : LABELS_PROFILE_COLLECTIONS;
-  }
-
   get data() {
     return {
       datasets: [
         {
-          label: this.intl.t(this.labels.started.legend),
+          label: this.intl.t(LABELS.started.legend),
           data: this.startedDatasets,
           borderColor: '#613fdd',
           backgroundColor: '#613fdd',
@@ -74,7 +70,7 @@ export default class ParticipantsByDay extends Component {
           order: 2,
         },
         {
-          label: this.intl.t(this.labels.shared.legend),
+          label: this.intl.t(LABELS.shared.legend),
           data: this.sharedDatasets,
           borderColor: '#038a25',
           backgroundColor: '#038a25',
@@ -139,17 +135,10 @@ export default class ParticipantsByDay extends Component {
     let startedCaption = '';
     let sharedCaption = '';
 
-    if (this.args.shouldDisplayAssessmentLabels) {
-      startedCaption = LABELS_ASSESSMENT.started.caption;
-      startedLabel = LABELS_ASSESSMENT.started.a11y;
-      sharedCaption = LABELS_ASSESSMENT.shared.caption;
-      sharedLabel = LABELS_ASSESSMENT.shared.a11y;
-    } else {
-      startedCaption = LABELS_PROFILE_COLLECTIONS.started.caption;
-      startedLabel = LABELS_PROFILE_COLLECTIONS.started.a11y;
-      sharedCaption = LABELS_PROFILE_COLLECTIONS.shared.caption;
-      sharedLabel = LABELS_PROFILE_COLLECTIONS.shared.a11y;
-    }
+    startedCaption = LABELS.started.caption;
+    startedLabel = LABELS.started.a11y;
+    sharedCaption = LABELS.shared.caption;
+    sharedLabel = LABELS.shared.a11y;
 
     return [
       { caption: startedCaption, entries: this.startedDatasets, countLabel: startedLabel },
@@ -194,7 +183,7 @@ export default class ParticipantsByDay extends Component {
   </template>
 }
 
-const LABELS_ASSESSMENT = {
+const LABELS = {
   started: {
     caption: 'charts.participants-by-day.captions.started',
     legend: 'charts.participants-by-day.labels-legend.started',
@@ -204,19 +193,6 @@ const LABELS_ASSESSMENT = {
     caption: 'charts.participants-by-day.captions.shared',
     legend: 'charts.participants-by-day.labels-legend.shared',
     a11y: 'charts.participants-by-day.labels-a11y.shared',
-  },
-};
-
-const LABELS_PROFILE_COLLECTIONS = {
-  started: {
-    caption: 'charts.participants-by-day.captions.started',
-    legend: 'charts.participants-by-day.labels-legend.started',
-    a11y: 'charts.participants-by-day.labels-a11y.started',
-  },
-  shared: {
-    caption: 'charts.participants-by-day.captions.shared-profile',
-    legend: 'charts.participants-by-day.labels-legend.shared-profile',
-    a11y: 'charts.participants-by-day.labels-a11y.shared-profile',
   },
 };
 

--- a/orga/app/components/campaign/charts/participants-by-status-legend.gjs
+++ b/orga/app/components/campaign/charts/participants-by-status-legend.gjs
@@ -1,5 +1,3 @@
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { guidFor } from '@ember/object/internals';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -23,19 +21,5 @@ export default class ParticipantsByStatusLegend extends Component {
   <template>
     <canvas id={{this.canvasId}} class="participants-by-status__legend-view" />
     <span>{{@dataset.legend}}</span>
-    <PixTooltip @id="legend-tooltip-{{@dataset.key}}" @isWide="true" @position="top-left">
-      <:triggerElement>
-        <PixIcon
-          @name="help"
-          @plainIcon={{true}}
-          class="participants-by-status__legend-tooltip"
-          tabindex="0"
-          aria-describedby="legend-tooltip-{{@dataset.key}}"
-        />
-      </:triggerElement>
-      <:tooltip>
-        {{@dataset.legendTooltip}}
-      </:tooltip>
-    </PixTooltip>
   </template>
 }

--- a/orga/app/components/campaign/charts/participants-by-status.gjs
+++ b/orga/app/components/campaign/charts/participants-by-status.gjs
@@ -57,15 +57,15 @@ export default class ParticipantsByStatus extends Component {
         legend: false,
         tooltip: {
           ...TOOLTIP_CONFIG,
-          callbacks: { label: (data) => data.label },
+          callbacks: { label: () => '' },
         },
       },
       borderWidth: 0,
     };
   }
 
-  getDatasetLabels(key, count, shouldDisplayAssessmentLabels) {
-    const datasetLabels = shouldDisplayAssessmentLabels ? LABELS_ASSESSMENT[key] : LABELS_PROFILE_COLLECTIONS[key];
+  getDatasetLabels(key, count) {
+    const datasetLabels = LABELS_ASSESSMENT[key];
     const percentage = this.total !== 0 ? count / this.total : 0;
     const canvas = pattern.draw(datasetLabels.shape, datasetLabels.color);
 
@@ -123,25 +123,6 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.shared',
     legendTooltip: 'charts.participants-by-status.labels-legend.shared-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared',
-    color: '#1c825d',
-    shape: 'weave',
-  },
-};
-
-const LABELS_PROFILE_COLLECTIONS = {
-  started: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.started',
-    legend: 'charts.participants-by-status.labels-legend.started',
-    legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
-    a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#ffcb33',
-    shape: 'diamond-box',
-  },
-  shared: {
-    tooltip: 'charts.participants-by-status.labels-tooltip.shared-profile',
-    legend: 'charts.participants-by-status.labels-legend.shared-profile',
-    legendTooltip: 'charts.participants-by-status.labels-legend.shared-profile-tooltip',
-    a11y: 'charts.participants-by-status.labels-a11y.shared-profile',
     color: '#1c825d',
     shape: 'weave',
   },

--- a/orga/app/components/campaign/results/assessment-cards.gjs
+++ b/orga/app/components/campaign/results/assessment-cards.gjs
@@ -15,6 +15,6 @@ import CampaignStageAverage from '../cards/stage-average';
       <CampaignResultAverage @value={{@averageResult}} class="assessment-cards__average-card" />
     {{/if}}
 
-    <CampaignSharedCount @value={{@sharedParticipationsCount}} @shouldDisplayAssessmentLabels={{true}} />
+    <CampaignSharedCount @value={{@sharedParticipationsCount}} />
   </div>
 </template>

--- a/orga/app/components/organization-learner/activity/participation-row.gjs
+++ b/orga/app/components/organization-learner/activity/participation-row.gjs
@@ -58,7 +58,7 @@ export default class ParticipationRow extends Component {
         {{t "pages.organization-learner.activity.participation-list.table.column.status"}}
       </:header>
       <:cell>
-        <ParticipationStatus @status={{@participation.status}} @campaignType={{@participation.campaignType}} />
+        <ParticipationStatus @status={{@participation.status}} />
       </:cell>
     </PixTableColumn>
 

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -11,10 +11,8 @@ export default class ParticipationStatus extends Component {
   }
 
   get label() {
-    const { status, campaignType } = this.args;
-    return this.intl.t(
-      `components.participation-status.${status}-${campaignType === 'EXAM' ? 'ASSESSMENT' : campaignType}`,
-    );
+    const { status } = this.args;
+    return this.intl.t(`components.participation-status.${status}`);
   }
 
   <template>
@@ -26,6 +24,5 @@ export default class ParticipationStatus extends Component {
 
 const COLORS = {
   STARTED: 'yellow-light',
-  TO_SHARE: 'purple-light',
   SHARED: 'green-light',
 };

--- a/orga/tests/integration/components/campaign/activity/participants-list-test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       {
         firstName: 'Joe',
         lastName: 'La frite',
-        status: 'TO_SHARE',
+        status: 'STARTED',
         participantExternalId: 'patate',
       },
     ]);
@@ -47,7 +47,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     assert.ok(screen.getByText('Joe'));
     assert.ok(screen.getByText('La frite'));
     assert.ok(screen.getByText('patate'));
-    assert.ok(screen.getAllByText("En attente d'envoi"));
+    assert.ok(screen.getAllByText(t('components.participation-status.STARTED')));
   });
 
   test('it should display pagination in correct language', async function (assert) {

--- a/orga/tests/integration/components/campaign/cards/shared-count-test.js
+++ b/orga/tests/integration/components/campaign/cards/shared-count-test.js
@@ -8,29 +8,12 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Campaign::Cards::SharedCount', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('When shouldDisplayAssessmentLabels is true', () => {
-    test('it should display shared participations count card', async function (assert) {
-      this.sharedCount = 10;
+  test('it should display shared count card', async function (assert) {
+    this.sharedCount = 10;
 
-      const screen = await render(
-        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @shouldDisplayAssessmentLabels={{true}} />`,
-      );
+    const screen = await render(hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} />`);
 
-      assert.dom(screen.getByText(t('cards.submitted-count.title'))).exists();
-      assert.dom(screen.getByText('10')).exists();
-    });
-  });
-
-  module('When shouldDisplayAssessmentLabels is false', () => {
-    test('it should display shared profiles count card', async function (assert) {
-      this.sharedCount = 10;
-
-      const screen = await render(
-        hbs`<Campaign::Cards::SharedCount @value={{this.sharedCount}} @shouldDisplayAssessmentLabels={{false}} />`,
-      );
-
-      assert.dom(screen.getByText(t('cards.submitted-count.title-profiles'))).exists();
-      assert.dom(screen.getByText('10'));
-    });
+    assert.dom(screen.getByText(t('cards.submitted-count.title'))).exists();
+    assert.dom(screen.getByText('10')).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-day-test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
     dataFetcher = sinon.stub(adapter, 'getParticipationsByDay');
   });
 
-  test('it should display status for assessment campaign', async function (assert) {
+  test('it should display statuses', async function (assert) {
     // given
     dataFetcher.withArgs(campaignId).resolves({
       data: {
@@ -36,30 +36,9 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
       hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{true}} />`,
     );
 
-    assert.strictEqual(screen.getAllByText('Date').length, 2);
-    assert.ok(screen.getByText('Total des participants'));
-    assert.ok(screen.getByText('Total des participants ayant envoyé leurs résultats'));
-  });
-
-  test('it should display status for profile collection campaign', async function (assert) {
-    // given
-    dataFetcher.withArgs(campaignId).resolves({
-      data: {
-        attributes: {
-          'started-participations': [],
-          'shared-participations': [],
-        },
-      },
-    });
-
-    // when
-    const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @shouldDisplayAssessmentLabels={{false}} />`,
-    );
-
-    assert.strictEqual(screen.getAllByText('Date').length, 2);
-    assert.ok(screen.getByText('Total des participants'));
-    assert.ok(screen.getByText('Total des participants ayant envoyé leurs profils'));
+    assert.strictEqual(screen.getAllByText(t('charts.participants-by-day.labels-a11y.date')).length, 2);
+    assert.ok(screen.getByText(t('charts.participants-by-day.labels-a11y.started')));
+    assert.ok(screen.getByText(t('charts.participants-by-day.labels-a11y.shared')));
   });
 
   test('it should display participants by day', async function (assert) {

--- a/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-status-test.js
@@ -8,70 +8,16 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Campaign::Charts::ParticipantsByStatus', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display status for assessment campaign', async function (assert) {
+  test('it should display statuses', async function (assert) {
     this.participantCountByStatus = [
       ['started', 1],
       ['shared', 1],
     ];
 
     const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByStatus
-  @participantCountByStatus={{this.participantCountByStatus}}
-  @shouldDisplayAssessmentLabels={{true}}
-/>`,
+      hbs`<Campaign::Charts::ParticipantsByStatus @participantCountByStatus={{this.participantCountByStatus}} />`,
     );
     assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared', { count: 1 }))).exists();
-  });
-
-  test('it should contains tooltips for assessment campaign', async function (assert) {
-    this.participantCountByStatus = [
-      ['started', 1],
-      ['shared', 1],
-    ];
-
-    const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByStatus
-  @participantCountByStatus={{this.participantCountByStatus}}
-  @shouldDisplayAssessmentLabels={{true}}
-/>`,
-    );
-
-    assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.started-tooltip'))).exists();
-    assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-tooltip'))).exists();
-  });
-
-  test('it should display status for profile collection campaign', async function (assert) {
-    this.participantCountByStatus = [
-      ['started', 1],
-      ['shared', 1],
-    ];
-
-    const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByStatus
-  @participantCountByStatus={{this.participantCountByStatus}}
-  @shouldDisplayAssessmentLabels={{false}}
-/>`,
-    );
-
-    assert.dom(screen.queryByText(t('charts.participants-by-status.labels-legend.started', { count: 1 }))).exists();
-    assert
-      .dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-profile', { count: 1 })))
-      .exists();
-  });
-
-  test('it should contains tooltips for profile collection campaign', async function (assert) {
-    this.participantCountByStatus = [
-      ['started', 1],
-      ['shared', 1],
-    ];
-
-    const screen = await render(
-      hbs`<Campaign::Charts::ParticipantsByStatus
-  @participantCountByStatus={{this.participantCountByStatus}}
-  @shouldDisplayAssessmentLabels={{false}}
-/>`,
-    );
-
-    assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.shared-profile-tooltip'))).exists();
+    assert.dom(screen.getByText(t('charts.participants-by-status.labels-legend.started', { count: 1 }))).exists();
   });
 });

--- a/orga/tests/integration/components/organization-learner/activity/participation-list-test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-list-test.js
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -29,7 +30,7 @@ module('Integration | Component | OrganizationLearner::Activity::ParticipationLi
     assert.ok(screen.getByText('Évaluation'));
     assert.ok(screen.getByText('12/12/2022'));
     assert.ok(screen.getByText('25/12/2022'));
-    assert.ok(screen.getByText('Résultats reçus'));
+    assert.ok(screen.getByText(t('components.participation-status.SHARED')));
     assert.ok(screen.getByText('2'));
   });
 
@@ -53,7 +54,7 @@ module('Integration | Component | OrganizationLearner::Activity::ParticipationLi
     assert.ok(screen.getByText('Collecte de profil'));
     assert.ok(screen.getByText('12/12/2022'));
     assert.ok(screen.getByText('25/12/2022'));
-    assert.ok(screen.getByText('Profil reçu'));
+    assert.ok(screen.getByText(t('components.participation-status.SHARED')));
     assert.ok(screen.getByText('1'));
   });
 

--- a/orga/tests/integration/components/ui/participation-status-test.js
+++ b/orga/tests/integration/components/ui/participation-status-test.js
@@ -11,7 +11,6 @@ module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
   module('label', function () {
     test('it should display formatted label', async function (assert) {
       this.set('status', 'SHARED');
-      this.set('campaignType', 'ASSESSMENT');
 
       // when
       const screen = await render(
@@ -19,7 +18,7 @@ module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
       );
 
       // then
-      assert.ok(screen.getByText(t('components.participation-status.SHARED-ASSESSMENT')));
+      assert.ok(screen.getByText(t('components.participation-status.SHARED')));
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -138,19 +138,16 @@
   "charts": {
     "participants-by-day": {
       "captions": {
-        "shared": "Submitted results by day",
-        "shared-profile": "Submitted profiles by day",
+        "shared": "Completed participations by day",
         "started": "Total participants by day"
       },
       "labels-a11y": {
         "date": "Date",
-        "shared": "Submitted results",
-        "shared-profile": "Submitted profiles",
+        "shared": "Completed participations",
         "started": "Total participants"
       },
       "labels-legend": {
-        "shared": "Submitted results",
-        "shared-profile": "Submitted profiles",
+        "shared": "Completed participations",
         "started": "Total participants"
       },
       "loader": "Loading participant's activity",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -408,12 +408,8 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participation-status": {
-      "SHARED-ASSESSMENT": "Submitted results",
-      "SHARED-PROFILES_COLLECTION": "Submitted profile",
-      "STARTED-ASSESSMENT": "In progress",
-      "STARTED-PROFILES_COLLECTION": "Pending results",
-      "TO_SHARE-ASSESSMENT": "Pending results",
-      "TO_SHARE-PROFILES_COLLECTION": "Pending profile"
+      "SHARED": "Completed",
+      "STARTED": "In progress"
     },
     "terms-of-service": {
       "actions": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -131,10 +131,8 @@
       }
     },
     "submitted-count": {
-      "information": "Find here the results submitted by your participants. This includes all the participants who have finished and clicked on the button \"Submit my results\" or \"Submit my profile\".",
       "loader": "Loading submitted results or profiles",
-      "title": "Submitted results",
-      "title-profiles": "Submitted profiles"
+      "title": "Completed participations"
     }
   },
   "charts": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -174,22 +174,15 @@
     "participants-by-status": {
       "a11y-title": "Detail by participation status",
       "labels-a11y": {
-        "completed": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with pending results",
         "shared": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with submitted results",
-        "shared-profile": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} with submitted profiles",
         "started": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count, number} participants}} in progress"
       },
       "labels-legend": {
-        "shared": "Submitted results ({count})",
-        "shared-profile": "Submitted profiles ({count})",
-        "shared-profile-tooltip": "Submitted profiles: These participants have submitted their profiles.",
-        "shared-tooltip": "Submitted results: These participants have finished their customised test and submitted their results.",
-        "started": "In progress ({count})",
-        "started-tooltip": "In progress: These participants haven’t finished their customised test yet."
+        "shared": "Completed participations ({count})",
+        "started": "In progress ({count})"
       },
       "labels-tooltip": {
-        "shared": "Submitted results: {percentage, number, ::percent .0}",
-        "shared-profile": "Submitted profiles: {percentage, number, ::percent .0}",
+        "shared": "Completed participations: {percentage, number, ::percent .0}",
         "started": "In progress: {percentage, number, ::percent .0}"
       },
       "loader": "Loading statuses distribution",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -138,19 +138,16 @@
   "charts": {
     "participants-by-day": {
       "captions": {
-        "shared": "Total de participants par jour ayant envoyé leurs résultats par jour",
-        "shared-profile": "Total de participants ayant envoyé leurs profils par jour",
+        "shared": "Participations terminées par jour",
         "started": "Total de participants par jour"
       },
       "labels-a11y": {
         "date": "Date",
-        "shared": "Total des participants ayant envoyé leurs résultats",
-        "shared-profile": "Total des participants ayant envoyé leurs profils",
+        "shared": "Participations terminées",
         "started": "Total des participants"
       },
       "labels-legend": {
-        "shared": "Résultats reçus",
-        "shared-profile": "Profils reçus",
+        "shared": "Participations terminées",
         "started": "Total des participants"
       },
       "loader": "Chargement de l'activité des participants",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -131,10 +131,8 @@
       }
     },
     "submitted-count": {
-      "information": "Retrouvez ici les résultats envoyés par vos participants. Ce nombre comprend l’ensemble des participants ayant terminé et cliqué sur le bouton \"J'envoie mes résultats\" ou \"J'envoie mon profil\".",
       "loader": "Chargement des résultats ou profils reçus",
-      "title": "Résultats reçus",
-      "title-profiles": "Profils reçus"
+      "title": "Paticipations terminées"
     }
   },
   "charts": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -408,12 +408,8 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participation-status": {
-      "SHARED-ASSESSMENT": "Résultats reçus",
-      "SHARED-PROFILES_COLLECTION": "Profil reçu",
-      "STARTED-ASSESSMENT": "En cours",
-      "STARTED-PROFILES_COLLECTION": "En attente d'envoi",
-      "TO_SHARE-ASSESSMENT": "En attente d'envoi",
-      "TO_SHARE-PROFILES_COLLECTION": "En attente d'envoi"
+      "SHARED": "Terminé",
+      "STARTED": "En cours"
     },
     "terms-of-service": {
       "actions": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -175,20 +175,14 @@
       "a11y-title": "Détail par statut",
       "labels-a11y": {
         "shared": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs résultats",
-        "shared-profile": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} ayant envoyés leurs profils",
         "started": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count, number} participants}} en cours de test"
       },
       "labels-legend": {
-        "shared": "Résultats reçus ({count})",
-        "shared-profile": "Profils reçus ({count})",
-        "shared-profile-tooltip": "Profils reçus : Ces participants ont envoyé leurs profils.",
-        "shared-tooltip": "Résultats reçus : Ces participants ont terminé leur parcours et envoyé leurs résultats.",
-        "started": "En cours ({count})",
-        "started-tooltip": "En cours : Ces participants n’ont pas encore terminé leur parcours."
+        "shared": "Participations terminées ({count})",
+        "started": "En cours ({count})"
       },
       "labels-tooltip": {
-        "shared": "Résultats reçus : {percentage, number, ::percent .0}",
-        "shared-profile": "Profils reçus : {percentage, number, ::percent .0}",
+        "shared": "Participations terminées : {percentage, number, ::percent .0}",
         "started": "En cours : {percentage, number, ::percent .0}"
       },
       "loader": "Chargement des proportions par statut",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -408,12 +408,8 @@
       "title": "{count, plural, =0 {Deelnemer} =1 {Deelnemer ({count})} other {Deelnemers ({count})}}"
     },
     "participation-status": {
-      "SHARED-ASSESSMENT": "Ontvangen resultaten",
-      "SHARED-PROFILES_COLLECTION": "Profiel ontvangen",
-      "STARTED-ASSESSMENT": "Bezig",
-      "STARTED-PROFILES_COLLECTION": "In afwachting van verzending",
-      "TO_SHARE-ASSESSMENT": "In afwachting van verzending",
-      "TO_SHARE-PROFILES_COLLECTION": "In afwachting van verzending"
+      "SHARED": "Voltooid",
+      "STARTED": "Bezig"
     },
     "terms-of-service": {
       "actions": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -131,10 +131,8 @@
       }
     },
     "submitted-count": {
-      "information": "Hier vind je de resultaten die door je deelnemers zijn verzonden. Dit aantal omvat alle deelnemers die klaar zijn en op de knop \"Ik verstuur mijn resultaten\" of \"Ik verstuur mijn profiel\" hebben geklikt.",
       "loader": "Ontvangen resultaten of profielen laden",
-      "title": "Ontvangen resultaten",
-      "title-profiles": "Ontvangen profielen"
+      "title": "Patcipaties voltooid"
     }
   },
   "charts": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -174,23 +174,16 @@
     "participants-by-status": {
       "a11y-title": "Detail per status",
       "labels-a11y": {
-        "completed": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count, number} deelnemers}} in afwachting van insturen",
         "shared": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count, number} deelnemers}} die hun resultaten hebben ingestuurd",
-        "shared-profile": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count, number} deelnemers}} die hun profiel hebben ingestuurd",
         "started": "{count, plural, =0 {0 deelnemer} =1 {1 deelnemer} other {{count, number} deelnemers}} bezig met test"
       },
       "labels-legend": {
-        "shared": "Ontvangen resultaten ({count})",
-        "shared-profile": "Ontvangen profielen ({count})",
-        "shared-profile-tooltip": "Ontvangen profielen: Deze deelnemers hebben hun profiel ingestuurd.",
-        "shared-tooltip": "Resultaten ontvangen: Deze deelnemers hebben hun test afgerond en hun resultaten ingestuurd.",
-        "started": "Bezig ({count})",
-        "started-tooltip": "Bezig: Deze deelnemers hebben hun test nog niet voltooid."
+        "shared": "Deelnames voltooid ({count})",
+        "started": "Bezig ({count})"
       },
       "labels-tooltip": {
-        "shared": "Ontvangen resultaten: {percentage, number, ::percent .0}",
-        "shared-profile": "Ontvangen profielen: {percentage, number, ::percent .0}",
-        "started": "Bezig: {percentage, number, ::procent .0}"
+        "shared": "Deelnames voltooid: {percentage, number, ::percent .0}",
+        "started": "Bezig: {percentage, number, ::percent .0}"
       },
       "loader": "Laden verhoudingen per status",
       "title": "Statussen"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -138,19 +138,16 @@
   "charts": {
     "participants-by-day": {
       "captions": {
-        "shared": "Totaal aantal deelnemers per dag die hun resultaten instuurden",
-        "shared-profile": "Totaal aantal deelnemers dat per dag hun profiel instuurde",
+        "shared": "Voltooide deelnames per dag",
         "started": "Totaal aantal deelnemers per dag"
       },
       "labels-a11y": {
         "date": "Datum",
-        "shared": "Totaal aantal deelnemers die hun resultaten hebben ingestuurd",
-        "shared-profile": "Totaal aantal deelnemers die hun profiel hebben ingestuurd",
+        "shared": "Voltooide deelnames",
         "started": "Totaal aantal deelnemers"
       },
       "labels-legend": {
-        "shared": "Ontvangen resultaten",
-        "shared-profile": "Ontvangen profielen",
+        "shared": "Voltooide deelnames",
         "started": "Totaal aantal deelnemers"
       },
       "loader": "Deelnemersactiviteit laden",


### PR DESCRIPTION
## 🔆 Problème
On veut simplifier les libellés des statuts de participation dans Pix Orga.

## ⛱️ Proposition
- Mise à jour des traductions fr.json, en.json et nl.json
- Simplification de l'affichage des statuts de participation

## 🏄 Pour tester
- [x] Vérifier l'affichage des statuts dans le graphique par jour
- [x] Vérifier l'affichage des statuts dans le graphique par statut
- [x] Vérifier l'affichage des statuts de participation dans les listes de participants
- [x] Tester avec différents types de campagnes (évaluation, collecte de profils)
- [x] S'assurer que les traductions s'affichent correctement dans toutes les langues