### PR TITLE
[FEATURE] Afficher les cadenas sur les items bloqués sur un parcours combiné (PIX-19020)

### DIFF
--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -5,12 +5,13 @@ export const ITEM_TYPE = {
 };
 
 export class CombinedCourseItem {
-  constructor({ id, title, reference, type, redirection, isCompleted }) {
+  constructor({ id, title, reference, type, redirection, isCompleted, isLocked = true }) {
     this.id = id;
     this.title = title;
     this.reference = reference;
     this.redirection = redirection;
     this.type = type;
     this.isCompleted = isCompleted;
+    this.isLocked = isLocked;
   }
 }

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (combinedCourse) {
     items: {
       ref: 'id',
       included: true,
-      attributes: ['title', 'reference', 'type', 'redirection', 'isCompleted'],
+      attributes: ['title', 'reference', 'type', 'redirection', 'isCompleted', 'isLocked'],
     },
     typeForAttribute: (attribute) => {
       if (attribute === 'items') return 'combined-course-items';

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -93,6 +93,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: campaign.name,
         type: ITEM_TYPE.CAMPAIGN,
         isCompleted: false,
+        isLocked: false,
       }),
       new CombinedCourseItem({
         id: moduleId1,
@@ -101,6 +102,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
         isCompleted: false,
+        isLocked: true,
       }),
       new CombinedCourseItem({
         id: moduleId2,
@@ -109,6 +111,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
         isCompleted: false,
+        isLocked: true,
       }),
     ]);
     expect(result.id).to.equal(questId);
@@ -219,6 +222,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         title: campaign.name,
         type: ITEM_TYPE.CAMPAIGN,
         isCompleted: true,
+        isLocked: false,
       }),
       new CombinedCourseItem({
         id: moduleId1,
@@ -227,6 +231,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
         isCompleted: true,
+        isLocked: false,
       }),
       new CombinedCourseItem({
         id: moduleId3,
@@ -235,6 +240,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         type: ITEM_TYPE.MODULE,
         redirection: 'encryptedUrl',
         isCompleted: false,
+        isLocked: false,
       }),
     ]);
     expect(result).to.be.instanceOf(CombinedCourse);

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -733,6 +733,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             title: campaign.name,
             type: ITEM_TYPE.CAMPAIGN,
             isCompleted: true,
+            isLocked: false,
           }),
         ]);
       });
@@ -774,6 +775,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             type: ITEM_TYPE.CAMPAIGN,
             redirection: undefined,
             isCompleted: true,
+            isLocked: false,
           }),
         ]);
       });
@@ -832,6 +834,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               type: ITEM_TYPE.MODULE,
               redirection: encryptedCombinedCourseUrl,
               isCompleted: false,
+              isLocked: false,
             }),
           ]);
         });
@@ -899,6 +902,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               title: campaign.name,
               type: ITEM_TYPE.CAMPAIGN,
               isCompleted: true,
+              isLocked: false,
             }),
           ]);
         });
@@ -968,6 +972,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               title: campaign.name,
               type: ITEM_TYPE.CAMPAIGN,
               isCompleted: true,
+              isLocked: false,
             }),
             new CombinedCourseItem({
               id: module.id,
@@ -976,6 +981,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               type: ITEM_TYPE.MODULE,
               redirection: encryptedCombinedCourseUrl,
               isCompleted: false,
+              isLocked: false,
             }),
           ]);
         });
@@ -1067,11 +1073,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
                 title: campaign.name,
                 type: ITEM_TYPE.CAMPAIGN,
                 isCompleted: false,
+                isLocked: false,
               }),
               new CombinedCourseItem({
                 id: 'formation_' + combinedCourse.quest.id + '_' + campaign.targetProfileId,
                 reference: campaign.targetProfileId,
                 type: ITEM_TYPE.FORMATION,
+                isLocked: true,
               }),
             ]);
           });
@@ -1173,11 +1181,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
                 title: campaign.name,
                 type: ITEM_TYPE.CAMPAIGN,
                 isCompleted: false,
+                isLocked: false,
               }),
               new CombinedCourseItem({
                 id: 'formation_' + combinedCourse.quest.id + '_' + campaign.targetProfileId,
                 reference: campaign.targetProfileId,
                 type: ITEM_TYPE.FORMATION,
+                isLocked: true,
               }),
               new CombinedCourseItem({
                 id: secondCampaign.id,
@@ -1185,11 +1195,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
                 title: secondCampaign.name,
                 type: ITEM_TYPE.CAMPAIGN,
                 isCompleted: false,
+                isLocked: true,
               }),
               new CombinedCourseItem({
                 id: 'formation_' + combinedCourse.quest.id + '_' + secondCampaign.targetProfileId,
                 reference: secondCampaign.targetProfileId,
                 type: ITEM_TYPE.FORMATION,
+                isLocked: true,
               }),
             ]);
           });
@@ -1277,11 +1289,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
                 title: campaign.name,
                 type: ITEM_TYPE.CAMPAIGN,
                 isCompleted: false,
+                isLocked: false,
               }),
               new CombinedCourseItem({
                 id: 'formation_' + combinedCourse.quest.id + '_' + campaign.targetProfileId,
                 reference: campaign.targetProfileId,
                 type: ITEM_TYPE.FORMATION,
+                isLocked: true,
               }),
               new CombinedCourseItem({
                 id: moduleFromQuest.id,
@@ -1290,6 +1304,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
                 type: ITEM_TYPE.MODULE,
                 redirection: encryptedCombinedCourseUrl,
                 isCompleted: false,
+                isLocked: true,
               }),
             ]);
           });
@@ -1337,6 +1352,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             title: campaign1.name,
             type: ITEM_TYPE.CAMPAIGN,
             isCompleted: false,
+            isLocked: false,
           }),
         ]);
       });
@@ -1388,7 +1404,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
         );
         const dataForQuest = new DataForQuest({
           eligibility: new Eligibility({
-            campaignParticipations: [{ campaignId: campaign1.id, status: 'STARTED' }],
+            campaignParticipations: [
+              { campaignId: campaign1.id, status: 'STARTED' },
+              { campaignId: campaign2.id, status: 'SHARED' },
+            ],
             passages: [],
           }),
         });
@@ -1408,7 +1427,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             reference: campaign2.code,
             title: campaign2.name,
             type: ITEM_TYPE.CAMPAIGN,
-            isCompleted: false,
+            isCompleted: true,
+            isLocked: false,
           }),
           new CombinedCourseItem({
             id: campaign1.id,
@@ -1416,6 +1436,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             title: campaign1.name,
             type: ITEM_TYPE.CAMPAIGN,
             isCompleted: false,
+            isLocked: false,
           }),
           new CombinedCourseItem({
             id: module.id,
@@ -1424,6 +1445,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             type: ITEM_TYPE.MODULE,
             redirection: redirectionUrl,
             isCompleted: false,
+            isLocked: true,
           }),
         ]);
       });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -41,6 +41,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             type: ITEM_TYPE.CAMPAIGN,
             redirection: undefined,
             'is-completed': false,
+            'is-locked': false,
           },
         },
         {
@@ -52,6 +53,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             type: ITEM_TYPE.MODULE,
             redirection: 'encryptedCombinedCourseUrl',
             'is-completed': false,
+            'is-locked': true,
           },
         },
       ],

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -1,5 +1,6 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { hash } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
@@ -48,7 +49,13 @@ const Content = <template>
     {{#if @isLocked}}
       <Content @title={{@item.title}} @isLocked={{true}} />
     {{else}}
-      <LinkTo @route={{@item.route}} @model={{@item.reference}} @query={{hash redirection=@item.redirection}} disabled>
+      <LinkTo
+        {{on "click" @onClick}}
+        @route={{@item.route}}
+        @model={{@item.reference}}
+        @query={{hash redirection=@item.redirection}}
+        disabled
+      >
         <Content @title={{@item.title}} @isCompleted={{@item.isCompleted}} />
       </LinkTo>
     {{/if}}

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -41,7 +41,11 @@ export default class CombinedCourses extends Component {
       {{/if}}
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}
-        <CombinedCourseItem @item={{item}} @isLocked={{eq @combinedCourse.status "NOT_STARTED"}} />
+        <CombinedCourseItem
+          @item={{item}}
+          @isLocked={{item.isLocked}}
+          @onClick={{if (eq @combinedCourse.status "NOT_STARTED") this.startQuestParticipation noop}}
+        />
       {{/each}}
     </div>
   </template>
@@ -54,7 +58,8 @@ export default class CombinedCourses extends Component {
   @service router;
 
   @action
-  async startQuestParticipation() {
+  async startQuestParticipation(e) {
+    e.preventDefault();
     const combinedCourseAdapter = this.store.adapterFor('combined-course');
     await combinedCourseAdapter.start(this.args.combinedCourse.code);
     this.goToNextItem();
@@ -66,3 +71,4 @@ export default class CombinedCourses extends Component {
     this.router.transitionTo(item.route, item.reference, { queryParams: { redirection: item.redirection } });
   }
 }
+function noop() {}

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -6,6 +6,7 @@ export default class CombinedCourseItem extends Model {
   @attr('string') type;
   @attr('string') redirection;
   @attr('boolean') isCompleted;
+  @attr('boolean') isLocked;
 
   get route() {
     return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir inciter l'utilisateur d'un parcours combiné à suivre les items de formation dans un ordre précis. Pour ce faire, on enlève les liens des boutons des items non débloqués par l'utilisateur et on affiche un cadenas.

## ⛱️ Proposition
On ajoute de la logique côté back, sur le model Combined Course Item, pour lui ajouter un attribut "isLocked". Le front gère l'affichage en fonction de cette variable.

## 🌊 Remarques
De manière un peu annexe, on a changé un comportement : le premier item (en général pour septembre, une campagne de diag) sera automatiquement débloqué, pour pouvoir coller à la maquette et anticiper l'indicaiton "Vous en êtes là" :
<img width="761" height="697" alt="Capture d’écran 2025-09-04 à 10 07 35" src="https://github.com/user-attachments/assets/03b6f286-3a2b-4cde-a4b8-aeaa2baf78dc" />
On a donc dû modifier le comportement d'un test en conséquence : 'should display campaign with no link' devient 'should display campaign with link'.

## 🏄 Pour tester
Aller sur le parcours combiné, vérifier l'affichage des cadenas du début à la fin du parcours.