### PR TITLE
[TECH] Utiliser le champ isDisabled de PixIconButton sur les contrôles du stepper (PIX-19399)

### DIFF
--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -134,7 +134,7 @@ export default class ModulixStepper extends Component {
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
             @iconName="chevronLeft"
-            aria-disabled="{{this.isPreviousButtonControlDisabled}}"
+            @isDisabled={{this.isPreviousButtonControlDisabled}}
             @triggerAction={{this.displayPreviousStep}}
             aria-controls={{this.id}}
           />
@@ -151,7 +151,7 @@ export default class ModulixStepper extends Component {
           <PixIconButton
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.next.ariaLabel"}}
             @iconName="chevronRight"
-            aria-disabled="{{this.isNextButtonControlDisabled}}"
+            @isDisabled={{this.isNextButtonControlDisabled}}
             @triggerAction={{this.goBackToNextStep}}
             aria-controls={{this.id}}
           />

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1419,7 +1419,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           // then
           assert
             .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
-            .hasAria('disabled', 'false');
+            .doesNotHaveAria('disabled');
         });
 
         module('when user clicks the controls previous button', function () {
@@ -1518,7 +1518,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             // then
             assert
               .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
-              .hasAria('disabled', 'false');
+              .doesNotHaveAria('disabled');
           });
 
           module('when user clicks the controls next button', function () {


### PR DESCRIPTION
## 🔆 Problème

Le composant `PixIconButton` a maintenant un attribut `@isDisabled`.

## ⛱️ Proposition

L'utiliser pour les contrôles précédent/suivant du stepper.

## 🌊 Remarques

- Pix UI était déjà à jour.
- Je n'ai pas trouvé d'autres utilisations de PixIconButton dans notre scope qui pourraient bénéficier de ce nouveau paramètre.
- J'ai dû changer la façon dont on teste parce qu'avant on passait `false` à `aria-disabled` et maintenant l'attribut n'apparaît plus du tout. Ce n'est pas idéal parce que le test dépend de l'implémentation mais avec l'assertion `isDisabled` j'avais un faux positif.

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13430.review.pix.fr/modules/bac-a-sable).
2. Aller jusqu'au stepper horizontal
3. Constater que les boutons de contrôle sont bien désactivés.
4. Répondre à la première question, aller à la suivante, constater que le bouton précédent est activé.
5. Revenir à la première question, constater que le bouton précédent est désactivé et le bouton suivant est activé.