### PR TITLE
[BUGFIX] Attendre l'instanciation du LearningContentRepository pour les certifs Pix+ (PIX-19410).

### DIFF
--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -168,8 +168,10 @@ async function _findChallengesForComplementaryCertification({ complementaryCerti
     return knex.whereIn('id', complementaryCertificationChallengesIds).orderBy('id');
   };
 
+  const challengeDtos = await getInstance().find(cacheKey, findCallback);
+
   return decorateWithCertificationCalibration({
-    challengeDtos: await getInstance().find(cacheKey, findCallback),
+    challengeDtos,
     complementaryCertificationChallenges,
   });
 }


### PR DESCRIPTION
## 🔆 Problème

Lorsque l'on arrive sur la première question d'une certification complémentaire, l'instanciation du LearningContentRepository ne semble pas complétée lors de l'appel à la la méthode `decorateWithCertificationCalibration`, créant une erreur puisqu'aucun challenge n'est remonté au candidat.

## ⛱️ Proposition

Evaluer l'instanciation du repository en amont de l'appel à la fonction

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Créer une session (certif-prescriptor@example.net) et y inscrire un candidat en certification complémentaire Pix+ Droit
- Rentrer en certification et vérifier qu'une question est présentée au candidat
