### PR TITLE
[FEATURE] Gérer le bouton suivant dans le stepper horizontal (PIX-19388)

### DIFF
--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -1,3 +1,4 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -58,6 +59,14 @@ export default class ModulixStep extends Component {
             />
           </div>
         {{/each}}
+        {{#if @shouldDisplayNextButton}}
+          <PixButton
+            aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
+            @variant="primary"
+            @triggerAction={{@onNextButtonClick}}
+            class="stepper__next-button"
+          >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+        {{/if}}
       </section>
     {{/if}}
   </template>

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -177,19 +177,12 @@ export default class ModulixStepper extends Component {
                 @onVideoPlay={{@onVideoPlay}}
                 @onFileDownload={{@onFileDownload}}
                 @onExpandToggle={{@onExpandToggle}}
+                @onNextButtonClick={{this.displayNextStep}}
+                @shouldDisplayNextButton={{this.shouldDisplayNextButton}}
               />
             {{/each}}
-
           {{/if}}
         </div>
-        {{#if this.shouldDisplayNextButton}}
-          <PixButton
-            aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
-            @variant="primary"
-            @triggerAction={{this.displayNextStep}}
-            class="stepper__next-button"
-          >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
-        {{/if}}
       {{else}}
         {{#if this.hasDisplayableSteps}}
           {{#each this.stepsToDisplay as |step index|}}

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -1,8 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
-import { find } from '@ember/test-helpers';
+import { click, find } from '@ember/test-helpers';
 import ModulixStep from 'mon-pix/components/module/component/step';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -99,6 +100,47 @@ module('Integration | Component | Module | Step', function (hooks) {
         const stepElement = find('.stepper__step');
         assert.dom(stepElement).exists();
         assert.dom(stepElement).hasAttribute('aria-hidden', 'true');
+      });
+    });
+
+    module('when shouldDisplayNextButton attribute is true', function () {
+      module('when user clicks on next button', function () {
+        test('should call the method onNextButtonClick', async function (assert) {
+          // given
+          const onNextButtonClickSpy = sinon.stub();
+          const element = {
+            id: 'd0690f26-978c-41c3-9a21-da931857739c',
+            content: '<button type="button">Mon bouton</button>',
+            type: 'text',
+          };
+          const step = {
+            elements: [element],
+          };
+
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStep
+                @isHidden={{false}}
+                @currentStep={{1}}
+                @totalSteps={{3}}
+                @step={{step}}
+                @shouldDisplayNextButton={{true}}
+                @onNextButtonClick={{onNextButtonClickSpy}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 3', level: 4 })).exists();
+          assert.dom(screen.getByRole('button', { name: "Aller à l'étape suivante" })).exists();
+
+          //when
+          await click(screen.getByRole('button', { name: "Aller à l'étape suivante" }));
+
+          // then
+          assert.true(onNextButtonClickSpy.calledOnce);
+        });
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème

Pour un Stepper horizontal, le bouton suivant apparaît en dehors du cadre, ce qui n'est pas beau.

## ⛱️ Proposition

Vu avec Pierre : mettre le bouton Suivant dans le cadre de la Step. 
Le bouton a été déplacé dans le template de Step pour le Stepper horizontal

## 🌊 Remarques

Le bouton reste au niveau du Stepper pour le cas où celui-ci est vertical.

## 🏄 Pour tester
- Aller sur le [bac-a-sable](https://app-pr13441.review.pix.fr/modules/bac-a-sable)
- Afficher un stepper horizontal
- Vérifier que le bouton suivant est dans les étapes et qu'il fonctionne toujours
- Afficher un stepper vertical
- Vérifier que le bouton suivant en dehors des étapes et qu'il fonctionne toujours