### PR TITLE
[BUGFIX] Résolution du problème pour l'affichage des cartes mission (PIX-19413)

### DIFF
--- a/junior/app/styles/components/mission-card/card.scss
+++ b/junior/app/styles/components/mission-card/card.scss
@@ -48,7 +48,7 @@
     .area-code-5 {
       color: var(--pix-environnementnum-dark);
 
-      svg .background {
+      .background {
         fill: var(--pix-environnementnum-light);
       }
     }


### PR DESCRIPTION
## 🔆 Problème

<img width="476" height="720" alt="image" src="https://github.com/user-attachments/assets/aa68a520-a7d2-4cad-9a02-f8d0d9f6ca06" />

## ⛱️ Proposition

Fix tout ça :) 

## 🌊 Remarques

RAS
## 🏄 Pour tester

Afficher les missions expérimentales : 
* lancer `scalingo -a pix-api-review-pr13443 run npm run toggles -- --key=showExperimentalMissions --value=true`
* redémarrer 
La carte mission "Découvrir la souris" est en violet.
