### PR TITLE
[BUGFIX] Suppression de la propriété `has-complementary-referential` dans l'update d'une certif. complémentaire (PIX-19411).

### DIFF
--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -18,6 +18,7 @@ export default class ComplementaryCertificationAdapter extends ApplicationAdapte
       delete payload.data.attributes['label'];
       delete payload.data.attributes['has-external-jury'];
       delete payload.data.attributes['target-profiles-history'];
+      delete payload.data.attributes['has-complementary-referential'];
 
       const { targetProfileId, notifyOrganizations } = snapshot.adapterOptions;
       payload.data.attributes['target-profile-id'] = targetProfileId;


### PR DESCRIPTION
## 🔆 Problème

Une propriété `hasComplementaryReferential` a été ajoutée au modèle `ComplementaryCertification`. Cette propriété se trouve initialisée et envoyée lors de la mise à jour d'une certification complémentaire (ex: versioning de CLEA) alors qu'elle n'est pas désirée.

## ⛱️ Proposition

Suppression de cette propriété dans l'objet lors de l'update

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Mettre à jour la certification complémentaire CLEA dans pix-admin (superadmin@example.net) et vérifier qu'il n'y ait pas d'erreur
