### PR TITLE
[TECH] Injection des challenges calibrés dans les référentiels cadres (PIX-19298).

### DIFF
--- a/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
+++ b/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
@@ -1,0 +1,139 @@
+import Joi from 'joi';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { csvFileParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const columnSchemas = [
+  { name: 'challengeId', schema: Joi.string().required() },
+  { name: 'complementaryCertificationKey', schema: Joi.string().required() },
+  { name: 'alpha', schema: Joi.number().required() },
+  { name: 'delta', schema: Joi.number().required() },
+  { name: 'calibrationId', schema: Joi.number().required() },
+];
+
+export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script {
+  constructor() {
+    super({
+      description: 'update certification-frameworks-challenges alpha and deltas columns from CSV file',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe:
+            'CSV File with challengeId, complementaryCertificationKey, alpha (discriminant), delta (difficulty), and calibrationId columns',
+          demandOption: true,
+          coerce: csvFileParser(columnSchemas),
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { file: csvData, dryRun } = options;
+
+    logger.info(`Processing ${csvData.length} records from CSV file`);
+
+    if (csvData.length === 0) {
+      logger.info('No records to process');
+      return { processed: 0, updated: 0 };
+    }
+
+    // Extract data for PostgreSQL unnest approach - we need to handle the composite key
+    const challengeIds = csvData.map((row) => row.challengeId);
+    const complementaryCertificationKeys = csvData.map((row) => row.complementaryCertificationKey);
+    const discriminantValues = csvData.map((row) => row.alpha);
+    const difficultyValues = csvData.map((row) => row.delta);
+    const calibrationIds = csvData.map((row) => row.calibrationId);
+
+    const trx = await knex.transaction();
+
+    try {
+      // First, verify that the complementaryCertificationKey + challengeId combinations exist
+      const existingRecords = await trx('certification-frameworks-challenges')
+        .select('challengeId', 'complementaryCertificationKey')
+        .whereIn(
+          ['complementaryCertificationKey', 'challengeId'],
+          csvData.map((row) => [row.complementaryCertificationKey, row.challengeId]),
+        );
+
+      const existingKeys = existingRecords.map((r) => `${r.complementaryCertificationKey}:${r.challengeId}`);
+      const requestedKeys = csvData.map((row) => `${row.complementaryCertificationKey}:${row.challengeId}`);
+      const missingKeys = requestedKeys.filter((key) => !existingKeys.includes(key));
+
+      if (missingKeys.length > 0) {
+        logger.warn(
+          `Warning: ${missingKeys.length} complementaryCertificationKey-challengeId combinations not found in database:`,
+        );
+        missingKeys.forEach((key) => {
+          const [certKey, challengeId] = key.split(':');
+          logger.warn(`  - ${certKey} : ${challengeId}`);
+        });
+        throw new Error('Some challenges are missing');
+      }
+
+      // Perform batch update using PostgreSQL unnest for efficient bulk operations
+      // We update based on both complementaryCertificationKey and challengeId
+      // eslint-disable-next-line knex/avoid-injections
+      const updateResult = await trx.raw(
+        `
+        UPDATE "certification-frameworks-challenges"
+        SET discriminant = data.discriminant,
+            difficulty = data.difficulty,
+            "calibrationId" = data."calibrationId"
+        FROM (
+          SELECT
+        unnest(ARRAY[${challengeIds.map(() => '?').join(',')}]::text[]) as "challengeId",
+        unnest(ARRAY[${complementaryCertificationKeys.map(() => '?').join(',')}]::text[]) as "complementaryCertificationKey",
+        unnest(ARRAY[${discriminantValues.map(() => '?').join(',')}]::numeric[]) as discriminant,
+        unnest(ARRAY[${difficultyValues.map(() => '?').join(',')}]::numeric[]) as difficulty,
+        unnest(ARRAY[${calibrationIds.map(() => '?').join(',')}]::integer[]) as "calibrationId"
+        ) as data
+        WHERE "certification-frameworks-challenges"."challengeId" = data."challengeId"
+        AND "certification-frameworks-challenges"."complementaryCertificationKey" = data."complementaryCertificationKey"
+      `,
+        [
+          ...challengeIds,
+          ...complementaryCertificationKeys,
+          ...discriminantValues,
+          ...difficultyValues,
+          ...calibrationIds,
+        ],
+      );
+
+      const updatedCount = updateResult.rowCount || 0;
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`Dry run: ${updatedCount} records would be updated`);
+        logger.info(`Records found in database: ${existingRecords.length}/${csvData.length}`);
+
+        return { processed: csvData.length, updated: 0, found: existingRecords.length };
+      }
+
+      await trx.commit();
+      logger.info(`Successfully updated ${updatedCount} certification-frameworks-challenges records`);
+      logger.info(`Records processed: ${csvData.length}`);
+      logger.info(`Records found in database: ${existingRecords.length}`);
+
+      return {
+        processed: csvData.length,
+        updated: updatedCount,
+        found: existingRecords.length,
+        missing: missingKeys.length,
+      };
+    } catch (error) {
+      await trx.rollback();
+      logger.error('Error during batch update:', error.message);
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, BatchUpdateCertificationFrameworksChallengesFromCsv);

--- a/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
+++ b/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
@@ -16,7 +16,7 @@ const columnSchemas = [
 export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script {
   constructor() {
     super({
-      description: 'update certification-frameworks-challenges alpha and deltas columns from CSV file',
+      description: 'updates certification-frameworks-challenges discriminant and difficulty columns from a CSV file',
       permanent: false,
       options: {
         file: {
@@ -29,7 +29,7 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
         dryRun: {
           type: 'boolean',
           describe: 'Run the script without making any database changes',
-          default: false,
+          default: true,
         },
       },
     });
@@ -45,27 +45,48 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
       return { processed: 0, updated: 0 };
     }
 
+    const complementaryCertificationKey = csvData[0].complementaryCertificationKey;
+    const fileContainsOnlyOneCalibration = csvData.every(
+      (row) => row.complementaryCertificationKey === complementaryCertificationKey,
+    );
+
+    if (!fileContainsOnlyOneCalibration) {
+      throw new Error('The CSV file must contain only one complementary certification calibration');
+    }
+
     const trx = await knex.transaction();
 
     try {
-      const existingRecords = await trx('certification-frameworks-challenges')
-        .select('challengeId', 'complementaryCertificationKey')
-        .whereIn(
-          ['complementaryCertificationKey', 'challengeId'],
-          csvData.map((row) => [row.complementaryCertificationKey, row.challengeId]),
-        );
+      const row = await trx('certification-frameworks-challenges')
+        .select('version')
+        .where({ complementaryCertificationKey })
+        .andWhere('discriminant', null)
+        .andWhere('difficulty', null)
+        .orderBy('version', 'desc')
+        .first();
 
-      const existingKeys = existingRecords.map((r) => `${r.complementaryCertificationKey}:${r.challengeId}`);
-      const requestedKeys = csvData.map((row) => `${row.complementaryCertificationKey}:${row.challengeId}`);
-      const missingKeys = requestedKeys.filter((key) => !existingKeys.includes(key));
-
-      if (missingKeys.length > 0) {
-        logger.warn(
-          `Warning: ${missingKeys.length} complementaryCertificationKey-challengeId combinations not found in database`,
+      if (!row) {
+        throw new Error(
+          `No challenges to calibrate were found for the complementary certification key: ${complementaryCertificationKey}`,
         );
-        missingKeys.forEach((key) => {
-          const [certKey, challengeId] = key.split(':');
-          logger.warn(`  - ${certKey} : ${challengeId}`);
+      }
+
+      const { version } = row;
+
+      const frameworkChallengesToCalibrate = await trx('certification-frameworks-challenges')
+        .select('challengeId', 'complementaryCertificationKey', 'version')
+        .where({ version, complementaryCertificationKey });
+
+      const challengeIdsToCalibrate = frameworkChallengesToCalibrate.map(
+        (frameworkChallenge) => `${frameworkChallenge.challengeId}`,
+      );
+      const requestedChallengeIds = csvData.map((row) => row.challengeId);
+      const missingChallengeIds = requestedChallengeIds.filter((key) => !challengeIdsToCalibrate.includes(key));
+
+      if (missingChallengeIds.length > 0) {
+        logger.warn(`Warning: ${missingChallengeIds.length} challenge(s) not found in database`);
+        missingChallengeIds.forEach((key) => {
+          logger.warn(`${key}`);
         });
         throw new Error('Some challenges are missing');
       }
@@ -77,6 +98,7 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
           .where({
             challengeId: row.challengeId,
             complementaryCertificationKey: row.complementaryCertificationKey,
+            version: frameworkChallengesToCalibrate[0].version,
           })
           .update({
             discriminant: row.alpha,
@@ -90,21 +112,21 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
       if (dryRun) {
         await trx.rollback();
         logger.info(`Dry run: ${updatedCount} records would be updated`);
-        logger.info(`Records found in database: ${existingRecords.length}/${csvData.length}`);
+        logger.info(`Records found in database: ${frameworkChallengesToCalibrate.length}/${csvData.length}`);
 
-        return { processed: csvData.length, updated: 0, found: existingRecords.length };
+        return { processed: csvData.length, updated: 0, found: frameworkChallengesToCalibrate.length };
       }
 
       await trx.commit();
       logger.info(`Successfully updated ${updatedCount} certification-frameworks-challenges records`);
       logger.info(`Records processed: ${csvData.length}`);
-      logger.info(`Records found in database: ${existingRecords.length}`);
+      logger.info(`Records found in database: ${frameworkChallengesToCalibrate.length}`);
 
       return {
         processed: csvData.length,
         updated: updatedCount,
-        found: existingRecords.length,
-        missing: missingKeys.length,
+        found: frameworkChallengesToCalibrate.length,
+        missing: missingChallengeIds.length,
       };
     } catch (error) {
       await trx.rollback();

--- a/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
+++ b/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
@@ -45,13 +45,6 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
       return { processed: 0, updated: 0 };
     }
 
-    // Extract data for PostgreSQL unnest approach - we need to handle the composite key
-    const challengeIds = csvData.map((row) => row.challengeId);
-    const complementaryCertificationKeys = csvData.map((row) => row.complementaryCertificationKey);
-    const discriminantValues = csvData.map((row) => row.alpha);
-    const difficultyValues = csvData.map((row) => row.delta);
-    const calibrationIds = csvData.map((row) => row.calibrationId);
-
     const trx = await knex.transaction();
 
     try {
@@ -78,36 +71,24 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
         throw new Error('Some challenges are missing');
       }
 
-      // Perform batch update using PostgreSQL unnest for efficient bulk operations
-      // We update based on both complementaryCertificationKey and challengeId
-      // eslint-disable-next-line knex/avoid-injections
-      const updateResult = await trx.raw(
-        `
-        UPDATE "certification-frameworks-challenges"
-        SET discriminant = data.discriminant,
-            difficulty = data.difficulty,
-            "calibrationId" = data."calibrationId"
-        FROM (
-          SELECT
-        unnest(ARRAY[${challengeIds.map(() => '?').join(',')}]::text[]) as "challengeId",
-        unnest(ARRAY[${complementaryCertificationKeys.map(() => '?').join(',')}]::text[]) as "complementaryCertificationKey",
-        unnest(ARRAY[${discriminantValues.map(() => '?').join(',')}]::numeric[]) as discriminant,
-        unnest(ARRAY[${difficultyValues.map(() => '?').join(',')}]::numeric[]) as difficulty,
-        unnest(ARRAY[${calibrationIds.map(() => '?').join(',')}]::integer[]) as "calibrationId"
-        ) as data
-        WHERE "certification-frameworks-challenges"."challengeId" = data."challengeId"
-        AND "certification-frameworks-challenges"."complementaryCertificationKey" = data."complementaryCertificationKey"
-      `,
-        [
-          ...challengeIds,
-          ...complementaryCertificationKeys,
-          ...discriminantValues,
-          ...difficultyValues,
-          ...calibrationIds,
-        ],
-      );
+      // Perform batch update using individual update queries in transaction
+      // This is more readable and maintainable than complex unnest operations
+      let updatedCount = 0;
 
-      const updatedCount = updateResult.rowCount || 0;
+      for (const row of csvData) {
+        const updateResult = await trx('certification-frameworks-challenges')
+          .where({
+            challengeId: row.challengeId,
+            complementaryCertificationKey: row.complementaryCertificationKey,
+          })
+          .update({
+            discriminant: row.alpha,
+            difficulty: row.delta,
+            calibrationId: row.calibrationId,
+          });
+
+        updatedCount += updateResult;
+      }
 
       if (dryRun) {
         await trx.rollback();

--- a/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
+++ b/api/scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js
@@ -48,7 +48,6 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
     const trx = await knex.transaction();
 
     try {
-      // First, verify that the complementaryCertificationKey + challengeId combinations exist
       const existingRecords = await trx('certification-frameworks-challenges')
         .select('challengeId', 'complementaryCertificationKey')
         .whereIn(
@@ -62,7 +61,7 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
 
       if (missingKeys.length > 0) {
         logger.warn(
-          `Warning: ${missingKeys.length} complementaryCertificationKey-challengeId combinations not found in database:`,
+          `Warning: ${missingKeys.length} complementaryCertificationKey-challengeId combinations not found in database`,
         );
         missingKeys.forEach((key) => {
           const [certKey, challengeId] = key.split(':');
@@ -71,8 +70,6 @@ export class BatchUpdateCertificationFrameworksChallengesFromCsv extends Script 
         throw new Error('Some challenges are missing');
       }
 
-      // Perform batch update using individual update queries in transaction
-      // This is more readable and maintainable than complex unnest operations
       let updatedCount = 0;
 
       for (const row of csvData) {

--- a/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
@@ -7,7 +7,6 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
   let challenge1, challenge2, challenge3;
 
   beforeEach(async function () {
-    // Create test data
     complementaryCertificationKey1 = databaseBuilder.factory.buildComplementaryCertification({
       key: 'DROIT',
     }).key;
@@ -19,29 +18,28 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
     challenge2 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec456DEF' });
     challenge3 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec789GHI' });
 
-    // Create existing certification-frameworks-challenges records
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
       challengeId: challenge1.id,
       complementaryCertificationKey: complementaryCertificationKey1,
-      discriminant: 1.0,
-      difficulty: 0.5,
-      calibrationId: 1,
+      discriminant: null,
+      difficulty: null,
+      calibrationId: null,
     });
 
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
       challengeId: challenge2.id,
       complementaryCertificationKey: complementaryCertificationKey1,
-      discriminant: 0.8,
-      difficulty: -0.3,
-      calibrationId: 2,
+      discriminant: null,
+      difficulty: null,
+      calibrationId: null,
     });
 
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
       challengeId: challenge3.id,
       complementaryCertificationKey: complementaryCertificationKey2,
-      discriminant: 1.2,
-      difficulty: 1.1,
-      calibrationId: 3,
+      discriminant: null,
+      difficulty: null,
+      calibrationId: null,
     });
 
     await databaseBuilder.commit();
@@ -106,146 +104,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
   });
 
   describe('#handle', function () {
-    it('should update certification-frameworks-challenges with new discriminant and difficulty values', async function () {
-      // given
-      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
-      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
-      const file = [
-        {
-          challengeId: challenge1.id,
-          complementaryCertificationKey: complementaryCertificationKey1,
-          alpha: 0.85,
-          delta: 1.25,
-          calibrationId: 1001,
-        },
-        {
-          challengeId: challenge2.id,
-          complementaryCertificationKey: complementaryCertificationKey1,
-          alpha: 1.12,
-          delta: -0.75,
-          calibrationId: 1001,
-        },
-      ];
-
-      // when
-      const result = await script.handle({ logger, options: { file, dryRun: false } });
-
-      // then
-      expect(result.processed).to.equal(2);
-      expect(result.updated).to.equal(2);
-      expect(result.found).to.equal(2);
-
-      // Check that the values were actually updated in the database
-      const updatedRecords = await knex('certification-frameworks-challenges')
-        .whereIn('challengeId', [challenge1.id, challenge2.id])
-        .where('complementaryCertificationKey', complementaryCertificationKey1)
-        .select('challengeId', 'discriminant', 'difficulty', 'calibrationId');
-
-      const record1 = updatedRecords.find((r) => r.challengeId === challenge1.id);
-      const record2 = updatedRecords.find((r) => r.challengeId === challenge2.id);
-
-      expect(record1.discriminant).to.equal(0.85);
-      expect(record1.difficulty).to.equal(1.25);
-      expect(record1.calibrationId).to.equal(1001);
-
-      expect(record2.discriminant).to.equal(1.12);
-      expect(record2.difficulty).to.equal(-0.75);
-      expect(record2.calibrationId).to.equal(1001);
-    });
-
-    it('should handle null calibrationId values correctly', async function () {
-      // given
-      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
-      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
-      const file = [
-        {
-          challengeId: challenge3.id,
-          complementaryCertificationKey: complementaryCertificationKey2,
-          alpha: 0.95,
-          delta: 0.5,
-          calibrationId: null,
-        },
-      ];
-
-      // when
-      await script.handle({ logger, options: { file, dryRun: false } });
-
-      // then
-      const updatedRecord = await knex('certification-frameworks-challenges')
-        .where('challengeId', challenge3.id)
-        .where('complementaryCertificationKey', complementaryCertificationKey2)
-        .first();
-
-      expect(updatedRecord.discriminant).to.equal(0.95);
-      expect(updatedRecord.difficulty).to.equal(0.5);
-      expect(updatedRecord.calibrationId).to.be.null;
-    });
-
-    it('should run in dry-run mode without making changes', async function () {
-      // given
-      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
-      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
-      const file = [
-        {
-          challengeId: challenge1.id,
-          complementaryCertificationKey: complementaryCertificationKey1,
-          alpha: 0.85,
-          delta: 1.25,
-          calibrationId: 1001,
-        },
-      ];
-
-      // Store original values
-      const originalRecord = await knex('certification-frameworks-challenges')
-        .where('challengeId', challenge1.id)
-        .where('complementaryCertificationKey', complementaryCertificationKey1)
-        .first();
-
-      // when
-      const result = await script.handle({ logger, options: { file, dryRun: true } });
-
-      // then
-      expect(result.processed).to.equal(1);
-      expect(result.updated).to.equal(0);
-      expect(result.found).to.equal(1);
-
-      // Verify no changes were made
-      const unchangedRecord = await knex('certification-frameworks-challenges')
-        .where('challengeId', challenge1.id)
-        .where('complementaryCertificationKey', complementaryCertificationKey1)
-        .first();
-
-      expect(unchangedRecord.discriminant).to.equal(originalRecord.discriminant);
-      expect(unchangedRecord.difficulty).to.equal(originalRecord.difficulty);
-      expect(unchangedRecord.calibrationId).to.equal(originalRecord.calibrationId);
-    });
-
-    it('should throw error when trying to update non-existent challenge combinations', async function () {
-      // given
-      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
-      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
-      const file = [
-        {
-          challengeId: 'recNONEXISTENT',
-          complementaryCertificationKey: complementaryCertificationKey1,
-          alpha: 0.85,
-          delta: 1.25,
-          calibrationId: 1001,
-        },
-      ];
-
-      // when/then
-      await expect(script.handle({ logger, options: { file, dryRun: false } })).to.be.rejectedWith(
-        'Some challenges are missing',
-      );
-
-      expect(logger.warn).to.have.been.calledWith(
-        'Warning: 1 complementaryCertificationKey-challengeId combinations not found in database:',
-      );
-      expect(logger.warn).to.have.been.calledWith(`  - ${complementaryCertificationKey1} : recNONEXISTENT`);
-    });
-
-    it('should handle empty CSV file gracefully', async function () {
+    it('handles empty CSV file', async function () {
       // given
       const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
       const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
@@ -260,7 +119,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
       expect(logger.info).to.have.been.calledWith('No records to process');
     });
 
-    it('should update multiple records efficiently using batch operation', async function () {
+    it('runs in dry-run mode without making changes', async function () {
       // given
       const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
       const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
@@ -272,48 +131,93 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
           delta: 1.25,
           calibrationId: 1001,
         },
+      ];
+
+      // when
+      const result = await script.handle({ logger, options: { file, dryRun: true } });
+
+      // then
+      expect(result.processed).to.equal(1);
+      expect(result.updated).to.equal(0);
+      expect(result.found).to.equal(1);
+
+      const unchangedRecord = await knex('certification-frameworks-challenges')
+        .where('challengeId', challenge1.id)
+        .where('complementaryCertificationKey', complementaryCertificationKey1)
+        .first();
+
+      expect(unchangedRecord.discriminant).to.be.null;
+      expect(unchangedRecord.difficulty).to.be.null;
+      expect(unchangedRecord.calibrationId).to.be.null;
+    });
+
+    it('throws an error when trying to update non-existent challenge combinations', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
         {
-          challengeId: challenge2.id,
+          challengeId: 'recNONEXISTENT',
           complementaryCertificationKey: complementaryCertificationKey1,
-          alpha: 1.12,
-          delta: -0.75,
-          calibrationId: 1002,
-        },
-        {
-          challengeId: challenge3.id,
-          complementaryCertificationKey: complementaryCertificationKey2,
-          alpha: 0.95,
-          delta: 0.5,
-          calibrationId: 1003,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
         },
       ];
+
+      // when
+      await expect(script.handle({ logger, options: { file, dryRun: false } })).to.be.rejectedWith(
+        'Some challenges are missing',
+      );
+
+      // then
+      expect(logger.warn).to.have.been.calledWith(
+        'Warning: 1 complementaryCertificationKey-challengeId combinations not found in database',
+      );
+      expect(logger.warn).to.have.been.calledWith(`  - ${complementaryCertificationKey1} : recNONEXISTENT`);
+    });
+
+    it('updates certification-frameworks-challenges with new discriminant, difficulty and calibrationId values', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const challenge1Update = {
+        challengeId: challenge1.id,
+        complementaryCertificationKey: complementaryCertificationKey1,
+        alpha: 0.85,
+        delta: 1.25,
+        calibrationId: 1001,
+      };
+      const challenge2Update = {
+        challengeId: challenge2.id,
+        complementaryCertificationKey: complementaryCertificationKey1,
+        alpha: 1.12,
+        delta: -0.75,
+        calibrationId: 1001,
+      };
+      const file = [challenge1Update, challenge2Update];
 
       // when
       const result = await script.handle({ logger, options: { file, dryRun: false } });
 
       // then
-      expect(result.processed).to.equal(3);
-      expect(result.updated).to.equal(3);
-      expect(result.found).to.equal(3);
+      expect(result.processed).to.equal(2);
+      expect(result.updated).to.equal(2);
+      expect(result.found).to.equal(2);
 
-      // Verify all records were updated
-      const allUpdatedRecords = await knex('certification-frameworks-challenges')
-        .whereIn('challengeId', [challenge1.id, challenge2.id, challenge3.id])
-        .select('challengeId', 'complementaryCertificationKey', 'discriminant', 'difficulty', 'calibrationId');
+      const updatedRecords = await knex('certification-frameworks-challenges')
+        .whereIn('challengeId', [challenge1.id, challenge2.id])
+        .where('complementaryCertificationKey', complementaryCertificationKey1)
+        .select('challengeId', 'discriminant', 'difficulty', 'calibrationId')
+        .orderBy('challengeId');
 
-      expect(allUpdatedRecords).to.have.length(3);
+      expect(updatedRecords[0].discriminant).to.equal(challenge1Update.alpha);
+      expect(updatedRecords[0].difficulty).to.equal(challenge1Update.delta);
+      expect(updatedRecords[0].calibrationId).to.equal(challenge1Update.calibrationId);
 
-      const record1 = allUpdatedRecords.find((r) => r.challengeId === challenge1.id);
-      expect(record1.discriminant).to.equal(0.85);
-      expect(record1.calibrationId).to.equal(1001);
-
-      const record2 = allUpdatedRecords.find((r) => r.challengeId === challenge2.id);
-      expect(record2.discriminant).to.equal(1.12);
-      expect(record2.calibrationId).to.equal(1002);
-
-      const record3 = allUpdatedRecords.find((r) => r.challengeId === challenge3.id);
-      expect(record3.discriminant).to.equal(0.95);
-      expect(record3.calibrationId).to.equal(1003);
+      expect(updatedRecords[1].discriminant).to.equal(challenge2Update.alpha);
+      expect(updatedRecords[1].difficulty).to.equal(challenge2Update.delta);
+      expect(updatedRecords[1].calibrationId).to.equal(challenge2Update.calibrationId);
     });
   });
 });

--- a/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
@@ -1,0 +1,319 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { BatchUpdateCertificationFrameworksChallengesFromCsv } from '../../../../scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js';
+import { createTempFile, databaseBuilder, expect, sinon } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | batch-update-certification-frameworks-challenges-from-csv', function () {
+  let complementaryCertificationKey1, complementaryCertificationKey2;
+  let challenge1, challenge2, challenge3;
+
+  beforeEach(async function () {
+    // Create test data
+    complementaryCertificationKey1 = databaseBuilder.factory.buildComplementaryCertification({
+      key: 'DROIT',
+    }).key;
+    complementaryCertificationKey2 = databaseBuilder.factory.buildComplementaryCertification({
+      key: 'EDU_1ER_DEGRE',
+    }).key;
+
+    challenge1 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec123ABC' });
+    challenge2 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec456DEF' });
+    challenge3 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec789GHI' });
+
+    // Create existing certification-frameworks-challenges records
+    databaseBuilder.factory.buildCertificationFrameworksChallenge({
+      challengeId: challenge1.id,
+      complementaryCertificationKey: complementaryCertificationKey1,
+      discriminant: 1.0,
+      difficulty: 0.5,
+      calibrationId: 1,
+    });
+
+    databaseBuilder.factory.buildCertificationFrameworksChallenge({
+      challengeId: challenge2.id,
+      complementaryCertificationKey: complementaryCertificationKey1,
+      discriminant: 0.8,
+      difficulty: -0.3,
+      calibrationId: 2,
+    });
+
+    databaseBuilder.factory.buildCertificationFrameworksChallenge({
+      challengeId: challenge3.id,
+      complementaryCertificationKey: complementaryCertificationKey2,
+      discriminant: 1.2,
+      difficulty: 1.1,
+      calibrationId: 3,
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  describe('#parse', function () {
+    it('parses CSV input file with all required columns', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const options = script.metaInfo.options;
+      const file = 'certification-frameworks-challenges-update.csv';
+      const csvData = [
+        'challengeId,complementaryCertificationKey,alpha,delta,calibrationId',
+        `${challenge1.id},${complementaryCertificationKey1},0.85,1.25,1001`,
+        `${challenge2.id},${complementaryCertificationKey1},1.12,-0.75,1001`,
+        `${challenge3.id},${complementaryCertificationKey2},0.95,0.50,1002`,
+      ].join('\n');
+
+      const csvFilePath = await createTempFile(file, csvData);
+
+      // when
+      const parsedData = await options.file.coerce(csvFilePath);
+
+      // then
+      expect(parsedData).to.deep.equal([
+        {
+          challengeId: challenge1.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+        {
+          challengeId: challenge2.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 1.12,
+          delta: -0.75,
+          calibrationId: 1001,
+        },
+        {
+          challengeId: challenge3.id,
+          complementaryCertificationKey: complementaryCertificationKey2,
+          alpha: 0.95,
+          delta: 0.5,
+          calibrationId: 1002,
+        },
+      ]);
+    });
+
+    it('should fail when required columns are missing', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const options = script.metaInfo.options;
+      const file = 'invalid-certification-frameworks-challenges.csv';
+      const csvData = ['challengeId,alpha,delta', `${challenge1.id},0.85,1.25`].join('\\n');
+
+      const csvFilePath = await createTempFile(file, csvData);
+
+      // when/then
+      await expect(options.file.coerce(csvFilePath)).to.be.rejected;
+    });
+  });
+
+  describe('#handle', function () {
+    it('should update certification-frameworks-challenges with new discriminant and difficulty values', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: challenge1.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+        {
+          challengeId: challenge2.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 1.12,
+          delta: -0.75,
+          calibrationId: 1001,
+        },
+      ];
+
+      // when
+      const result = await script.handle({ logger, options: { file, dryRun: false } });
+
+      // then
+      expect(result.processed).to.equal(2);
+      expect(result.updated).to.equal(2);
+      expect(result.found).to.equal(2);
+
+      // Check that the values were actually updated in the database
+      const updatedRecords = await knex('certification-frameworks-challenges')
+        .whereIn('challengeId', [challenge1.id, challenge2.id])
+        .where('complementaryCertificationKey', complementaryCertificationKey1)
+        .select('challengeId', 'discriminant', 'difficulty', 'calibrationId');
+
+      const record1 = updatedRecords.find((r) => r.challengeId === challenge1.id);
+      const record2 = updatedRecords.find((r) => r.challengeId === challenge2.id);
+
+      expect(record1.discriminant).to.equal(0.85);
+      expect(record1.difficulty).to.equal(1.25);
+      expect(record1.calibrationId).to.equal(1001);
+
+      expect(record2.discriminant).to.equal(1.12);
+      expect(record2.difficulty).to.equal(-0.75);
+      expect(record2.calibrationId).to.equal(1001);
+    });
+
+    it('should handle null calibrationId values correctly', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: challenge3.id,
+          complementaryCertificationKey: complementaryCertificationKey2,
+          alpha: 0.95,
+          delta: 0.5,
+          calibrationId: null,
+        },
+      ];
+
+      // when
+      await script.handle({ logger, options: { file, dryRun: false } });
+
+      // then
+      const updatedRecord = await knex('certification-frameworks-challenges')
+        .where('challengeId', challenge3.id)
+        .where('complementaryCertificationKey', complementaryCertificationKey2)
+        .first();
+
+      expect(updatedRecord.discriminant).to.equal(0.95);
+      expect(updatedRecord.difficulty).to.equal(0.5);
+      expect(updatedRecord.calibrationId).to.be.null;
+    });
+
+    it('should run in dry-run mode without making changes', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: challenge1.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+      ];
+
+      // Store original values
+      const originalRecord = await knex('certification-frameworks-challenges')
+        .where('challengeId', challenge1.id)
+        .where('complementaryCertificationKey', complementaryCertificationKey1)
+        .first();
+
+      // when
+      const result = await script.handle({ logger, options: { file, dryRun: true } });
+
+      // then
+      expect(result.processed).to.equal(1);
+      expect(result.updated).to.equal(0);
+      expect(result.found).to.equal(1);
+
+      // Verify no changes were made
+      const unchangedRecord = await knex('certification-frameworks-challenges')
+        .where('challengeId', challenge1.id)
+        .where('complementaryCertificationKey', complementaryCertificationKey1)
+        .first();
+
+      expect(unchangedRecord.discriminant).to.equal(originalRecord.discriminant);
+      expect(unchangedRecord.difficulty).to.equal(originalRecord.difficulty);
+      expect(unchangedRecord.calibrationId).to.equal(originalRecord.calibrationId);
+    });
+
+    it('should throw error when trying to update non-existent challenge combinations', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: 'recNONEXISTENT',
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+      ];
+
+      // when/then
+      await expect(script.handle({ logger, options: { file, dryRun: false } })).to.be.rejectedWith(
+        'Some challenges are missing',
+      );
+
+      expect(logger.warn).to.have.been.calledWith(
+        'Warning: 1 complementaryCertificationKey-challengeId combinations not found in database:',
+      );
+      expect(logger.warn).to.have.been.calledWith(`  - ${complementaryCertificationKey1} : recNONEXISTENT`);
+    });
+
+    it('should handle empty CSV file gracefully', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [];
+
+      // when
+      const result = await script.handle({ logger, options: { file, dryRun: false } });
+
+      // then
+      expect(result.processed).to.equal(0);
+      expect(result.updated).to.equal(0);
+      expect(logger.info).to.have.been.calledWith('No records to process');
+    });
+
+    it('should update multiple records efficiently using batch operation', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: challenge1.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+        {
+          challengeId: challenge2.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 1.12,
+          delta: -0.75,
+          calibrationId: 1002,
+        },
+        {
+          challengeId: challenge3.id,
+          complementaryCertificationKey: complementaryCertificationKey2,
+          alpha: 0.95,
+          delta: 0.5,
+          calibrationId: 1003,
+        },
+      ];
+
+      // when
+      const result = await script.handle({ logger, options: { file, dryRun: false } });
+
+      // then
+      expect(result.processed).to.equal(3);
+      expect(result.updated).to.equal(3);
+      expect(result.found).to.equal(3);
+
+      // Verify all records were updated
+      const allUpdatedRecords = await knex('certification-frameworks-challenges')
+        .whereIn('challengeId', [challenge1.id, challenge2.id, challenge3.id])
+        .select('challengeId', 'complementaryCertificationKey', 'discriminant', 'difficulty', 'calibrationId');
+
+      expect(allUpdatedRecords).to.have.length(3);
+
+      const record1 = allUpdatedRecords.find((r) => r.challengeId === challenge1.id);
+      expect(record1.discriminant).to.equal(0.85);
+      expect(record1.calibrationId).to.equal(1001);
+
+      const record2 = allUpdatedRecords.find((r) => r.challengeId === challenge2.id);
+      expect(record2.discriminant).to.equal(1.12);
+      expect(record2.calibrationId).to.equal(1002);
+
+      const record3 = allUpdatedRecords.find((r) => r.challengeId === challenge3.id);
+      expect(record3.discriminant).to.equal(0.95);
+      expect(record3.calibrationId).to.equal(1003);
+    });
+  });
+});

--- a/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/batch-update-certification-frameworks-challenges-from-csv_test.js
@@ -4,7 +4,7 @@ import { createTempFile, databaseBuilder, expect, sinon } from '../../../test-he
 
 describe('Integration | Scripts | Certification | batch-update-certification-frameworks-challenges-from-csv', function () {
   let complementaryCertificationKey1, complementaryCertificationKey2;
-  let challenge1, challenge2, challenge3;
+  let challenge1, challenge2, challenge3, challenge4;
 
   beforeEach(async function () {
     complementaryCertificationKey1 = databaseBuilder.factory.buildComplementaryCertification({
@@ -17,6 +17,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
     challenge1 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec123ABC' });
     challenge2 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec456DEF' });
     challenge3 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec789GHI' });
+    challenge4 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'rec012JKL' });
 
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
       challengeId: challenge1.id,
@@ -24,6 +25,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
       discriminant: null,
       difficulty: null,
       calibrationId: null,
+      createdAt: new Date('2021-01-01'),
     });
 
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
@@ -31,15 +33,25 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
       complementaryCertificationKey: complementaryCertificationKey1,
       discriminant: null,
       difficulty: null,
-      calibrationId: null,
+      createdAt: new Date('2021-01-01'),
     });
 
     databaseBuilder.factory.buildCertificationFrameworksChallenge({
       challengeId: challenge3.id,
+      complementaryCertificationKey: complementaryCertificationKey1,
+      discriminant: 0.5,
+      difficulty: 1.89,
+      calibrationId: 1000,
+      createdAt: new Date('2020-01-01'),
+    });
+
+    databaseBuilder.factory.buildCertificationFrameworksChallenge({
+      challengeId: challenge4.id,
       complementaryCertificationKey: complementaryCertificationKey2,
-      discriminant: null,
-      difficulty: null,
-      calibrationId: null,
+      discriminant: 1.25,
+      difficulty: 3.91,
+      calibrationId: 1000,
+      createdAt: new Date('2021-01-01'),
     });
 
     await databaseBuilder.commit();
@@ -55,7 +67,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
         'challengeId,complementaryCertificationKey,alpha,delta,calibrationId',
         `${challenge1.id},${complementaryCertificationKey1},0.85,1.25,1001`,
         `${challenge2.id},${complementaryCertificationKey1},1.12,-0.75,1001`,
-        `${challenge3.id},${complementaryCertificationKey2},0.95,0.50,1002`,
+        `${challenge3.id},${complementaryCertificationKey1},0.95,0.50,1002`,
       ].join('\n');
 
       const csvFilePath = await createTempFile(file, csvData);
@@ -81,7 +93,7 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
         },
         {
           challengeId: challenge3.id,
-          complementaryCertificationKey: complementaryCertificationKey2,
+          complementaryCertificationKey: complementaryCertificationKey1,
           alpha: 0.95,
           delta: 0.5,
           calibrationId: 1002,
@@ -119,6 +131,53 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
       expect(logger.info).to.have.been.calledWith('No records to process');
     });
 
+    it('throws an error if there are multiple complementary certifications keys', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: 'recSOMETHING_1',
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+        {
+          challengeId: 'recSOMETHING_2',
+          complementaryCertificationKey: complementaryCertificationKey2,
+          alpha: 0.58,
+          delta: 2.15,
+          calibrationId: 1001,
+        },
+      ];
+
+      // when // then
+      await expect(script.handle({ logger, options: { file, dryRun: false } })).to.be.rejectedWith(
+        'The CSV file must contain only one complementary certification calibration',
+      );
+    });
+
+    it('throws an error if there are no found challenges in the database', async function () {
+      // given
+      const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
+      const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+      const file = [
+        {
+          challengeId: 'recSOMETHING_1',
+          complementaryCertificationKey: complementaryCertificationKey2,
+          alpha: 0.85,
+          delta: 1.25,
+          calibrationId: 1001,
+        },
+      ];
+
+      // when // then
+      await expect(script.handle({ logger, options: { file, dryRun: false } })).to.be.rejectedWith(
+        `No challenges to calibrate were found for the complementary certification key: ${complementaryCertificationKey2}`,
+      );
+    });
+
     it('runs in dry-run mode without making changes', async function () {
       // given
       const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
@@ -131,27 +190,33 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
           delta: 1.25,
           calibrationId: 1001,
         },
+        {
+          challengeId: challenge2.id,
+          complementaryCertificationKey: complementaryCertificationKey1,
+          alpha: 1.58,
+          delta: 2.15,
+          calibrationId: 1001,
+        },
       ];
 
       // when
       const result = await script.handle({ logger, options: { file, dryRun: true } });
 
       // then
-      expect(result.processed).to.equal(1);
+      expect(result.processed).to.equal(2);
       expect(result.updated).to.equal(0);
-      expect(result.found).to.equal(1);
+      expect(result.found).to.equal(2);
 
-      const unchangedRecord = await knex('certification-frameworks-challenges')
-        .where('challengeId', challenge1.id)
+      const unchangedRecords = await knex('certification-frameworks-challenges')
         .where('complementaryCertificationKey', complementaryCertificationKey1)
-        .first();
+        .andWhere('difficulty', null)
+        .andWhere('discriminant', null)
+        .andWhere('calibrationId', null);
 
-      expect(unchangedRecord.discriminant).to.be.null;
-      expect(unchangedRecord.difficulty).to.be.null;
-      expect(unchangedRecord.calibrationId).to.be.null;
+      expect(unchangedRecords).to.have.length(2);
     });
 
-    it('throws an error when trying to update non-existent challenge combinations', async function () {
+    it('throws an error when trying to update challenges not found in the database', async function () {
       // given
       const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
       const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
@@ -171,13 +236,11 @@ describe('Integration | Scripts | Certification | batch-update-certification-fra
       );
 
       // then
-      expect(logger.warn).to.have.been.calledWith(
-        'Warning: 1 complementaryCertificationKey-challengeId combinations not found in database',
-      );
-      expect(logger.warn).to.have.been.calledWith(`  - ${complementaryCertificationKey1} : recNONEXISTENT`);
+      expect(logger.warn).to.have.been.calledWith('Warning: 1 challenge(s) not found in database');
+      expect(logger.warn).to.have.been.calledWith(`recNONEXISTENT`);
     });
 
-    it('updates certification-frameworks-challenges with new discriminant, difficulty and calibrationId values', async function () {
+    it('updates the latest version of certification-frameworks-challenges with new discriminant, difficulty and calibrationId values', async function () {
       // given
       const script = new BatchUpdateCertificationFrameworksChallengesFromCsv();
       const logger = { info: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };


### PR DESCRIPTION
## 🔆 Problème

Les référentiels cadres des certifications complémentaires créés jusqu'à maintenant ne sont pas calibrés.
Cette étape est indispensable pour pouvoir qu'ils soient utilisables en simulation ou certification.

## ⛱️ Proposition

Création d'un script d'injection des calibrations via CSV

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Enregister le fichier suivant pour l'import : 
[calibration_frameworks.csv](https://github.com/user-attachments/files/22214422/calibration_frameworks.csv)

Exécuter le script avec la commande suivante : 

```
scalingo -a pix-api-review-pr13462 run --file="<FILE_PATH>" "node scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js --dryRun=true --file=/tmp/uploads/<FILE_NAME>"
```

Constater qu'une erreur survient car le CSV contient plusieurs clés de complémentaire
Retirer la ligne de la complémentaire en trop
Ré-exécuter le script ci-dessus

Si pas de problème, ré-exécuter la commande avec le dryRun à false: 
```
scalingo -a pix-api-review-pr13462 run --file="<FILE_PATH>" "node scripts/certification/batch-update-certification-frameworks-challenges-from-csv.js --dryRun=false --file=/tmp/uploads/<FILE_NAME>"
```

Vérifier que les challenges présents dans le fichier CSV ont été calibrés dans la table `certification-frameworks-challenges`
