### PR TITLE
[FEATURE] Améliorer accessibilité du Stepper et de la Step (PIX-19415)

### DIFF
--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -23,6 +23,7 @@ export default class ModulixStep extends Component {
     return this.args.currentStep === this.args.totalSteps;
   }
 
+
   @action
   focusAndScroll(htmlElement) {
     if (!this.args.isActive) {
@@ -40,10 +41,9 @@ export default class ModulixStep extends Component {
         {{didInsert this.focusAndScroll}}
         inert={{if @isHidden true}}
         aria-hidden={{if @isHidden "true"}}
+        aria-roledescription={{t "pages.modulix.stepper.step.aria-role-description"}}
+        aria-label={{t "pages.modulix.stepper.step.aria-label" currentStep=@currentStep totalSteps=@totalSteps}}
       >
-        <h4 class="stepper__step__position screen-reader-only">
-          {{t "pages.modulix.stepper.step.position" currentStep=@currentStep totalSteps=@totalSteps}}
-        </h4>
         {{#each this.displayableElements as |element|}}
           <div class="grain-card-content__element">
             <Element

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -23,10 +23,9 @@ export default class ModulixStep extends Component {
     return this.args.currentStep === this.args.totalSteps;
   }
 
-
   @action
   focusAndScroll(htmlElement) {
-    if (!this.args.isActive) {
+    if (!this.args.isActive || this.args.preventScrollAndFocus) {
       return;
     }
 

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -30,6 +30,9 @@ export default class ModulixStepper extends Component {
 
   @tracked displayedStepIndex = 0;
 
+  @tracked
+  preventScrollAndFocus = false;
+
   @action
   stepIsActive(index) {
     return this.displayedStepIndex === index;
@@ -55,6 +58,7 @@ export default class ModulixStepper extends Component {
     }
 
     this.displayedStepIndex -= 1;
+    this.preventScrollAndFocus = true;
   }
 
   @action
@@ -69,6 +73,7 @@ export default class ModulixStepper extends Component {
 
     this.args.onStepperNextStep(currentStepPosition);
     this.displayedStepIndex = currentStepPosition;
+    this.preventScrollAndFocus = false;
   }
 
   @action
@@ -78,6 +83,7 @@ export default class ModulixStepper extends Component {
     }
 
     this.displayedStepIndex++;
+    this.preventScrollAndFocus = true;
   }
 
   get lastDisplayedStepIndex() {
@@ -180,6 +186,7 @@ export default class ModulixStepper extends Component {
                 @onExpandToggle={{@onExpandToggle}}
                 @onNextButtonClick={{this.displayNextStep}}
                 @shouldDisplayNextButton={{this.shouldDisplayNextButton}}
+                @preventScrollAndFocus={{this.preventScrollAndFocus}}
               />
             {{/each}}
           {{/if}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -49,7 +49,7 @@ export default class ModulixStepper extends Component {
   }
 
   @action
-  displayPreviousStep() {
+  goBackToPreviousStep() {
     if (this.displayedStepIndex === 0) {
       return;
     }
@@ -123,8 +123,6 @@ export default class ModulixStepper extends Component {
     return this.args.id || `pix-tabs-${guidFor(this)}`;
   }
 
-
-
   <template>
     <div
       class="stepper stepper--{{@direction}}"
@@ -138,7 +136,7 @@ export default class ModulixStepper extends Component {
             @ariaLabel={{t "pages.modulix.buttons.stepper.controls.previous.ariaLabel"}}
             @iconName="chevronLeft"
             @isDisabled={{this.isPreviousButtonControlDisabled}}
-            @triggerAction={{this.displayPreviousStep}}
+            @triggerAction={{this.goBackToPreviousStep}}
             aria-controls={{this.id}}
           />
           <p

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -123,10 +123,13 @@ export default class ModulixStepper extends Component {
     return this.args.id || `pix-tabs-${guidFor(this)}`;
   }
 
+
+
   <template>
     <div
       class="stepper stepper--{{@direction}}"
-      aria-live="assertive"
+      aria-live="polite"
+      aria-roledescription="{{t 'pages.modulix.stepper.aria-role-description'}}"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
       {{#if this.isHorizontalDirection}}

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -29,7 +29,7 @@ module('Integration | Component | Module | Step', function (hooks) {
 
       // then
       assert.dom(screen.getByText(element.content)).exists();
-      assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 4 })).exists();
+      assert.strictEqual(screen.getAllByLabelText('1 sur 4').length, 1);
     });
 
     test('should display a step with a qcu element', async function (assert) {
@@ -132,7 +132,7 @@ module('Integration | Component | Module | Step', function (hooks) {
           );
 
           // then
-          assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 3', level: 4 })).exists();
+          assert.strictEqual(screen.getAllByLabelText('1 sur 3').length, 1);
           assert.dom(screen.getByRole('button', { name: "Aller à l'étape suivante" })).exists();
 
           //when
@@ -194,7 +194,7 @@ module('Integration | Component | Module | Step', function (hooks) {
         // then
         assert.dom(screen.getByText(textElement.content)).exists();
         assert.dom(screen.queryByText(unknownElement.content)).doesNotExist();
-        assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 4 })).exists();
+        assert.strictEqual(screen.getAllByLabelText('1 sur 4').length, 1);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -71,8 +71,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
-        assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+        assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -440,8 +439,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).exists();
+            assert.strictEqual(screen.getAllByLabelText('1 sur 1').length, 1)
+
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -489,8 +488,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.queryAllByRole('heading', { level: 4 }).length, 0);
-            assert.dom(screen.queryByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).doesNotExist();
+            assert.dom(screen.queryByLabelText('1 sur 1')).doesNotExist()
           });
         });
       });
@@ -538,7 +536,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {
@@ -619,9 +618,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
-          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
-          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+
         });
 
         module('when has unsupported elements', function () {
@@ -664,9 +663,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
           });
         });
       });
@@ -675,36 +673,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
   module('When stepper is horizontal', function () {
     module('A Stepper with 2 steps', function () {
-      test('it should set horizontal class', async function (assert) {
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
-
-        // when
-        await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
-
-        // then
-        assert.dom(find('.stepper--horizontal')).exists();
-      });
-
-      test('it should set accessible control buttons', async function (assert) {
+      test('it should set accessible stepper', async function (assert) {
         const steps = [
           {
             elements: [
@@ -739,6 +708,12 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert
           .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
           .hasAria('controls', 'stepper-container-id-1');
+        assert
+          .dom(find('.stepper--horizontal'))
+          .hasAria('roleDescription', t('pages.modulix.stepper.aria-role-description'));
+        assert
+          .dom(screen.getByLabelText('1 sur 2'))
+          .hasAria('roleDescription', t('pages.modulix.stepper.step.aria-role-description'));
       });
 
       test('it should display current step number', async function (assert) {
@@ -827,8 +802,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
-        assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+        assert.dom(screen.getByLabelText('1 sur 2'))
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -1273,8 +1247,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).exists();
+            assert.dom(screen.getByLabelText('1 sur 1'));
+            assert
+              .dom(screen.getByLabelText('1 sur 1'))
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -1322,8 +1297,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.queryAllByRole('heading', { level: 4 }).length, 0);
-            assert.dom(screen.queryByRole('heading', { level: 4, name: 'Étape 1 sur 1' })).doesNotExist();
+            assert.dom(screen.queryByLabelText('1 sur 1')).doesNotExist();
           });
         });
       });
@@ -1371,8 +1345,9 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 4, disabled: true }).length, 1);
-          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 1);
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2', { disabled: true }).length, 1)
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+        });
         });
 
         test('should enable the controls previous button', async function (assert) {
@@ -1468,7 +1443,10 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
+            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+            assert
+              .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+              .isFocused();
           });
 
           test('should enable next button', async function (assert) {
@@ -1570,7 +1548,10 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               );
 
               // then
-              assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+              assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
+              assert
+                .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+                .isFocused();
             });
           });
         });
@@ -1653,9 +1634,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
-          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
-          assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
         });
 
         module('when has unsupported elements', function () {
@@ -1700,9 +1680,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByRole('heading', { level: 4 }).length, 2);
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 1 sur 2' })).exists();
-            assert.dom(screen.getByRole('heading', { level: 4, name: 'Étape 2 sur 2' })).exists();
+            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
           });
         });
       });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -71,7 +71,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
         // then
-        assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
+        assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -114,6 +114,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -233,6 +234,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             const store = this.owner.lookup('service:store');
             const passage = store.createRecord('passage');
             sinon.stub(passageEventService, 'record');
+
             function getLastCorrectionForElementStub(element) {
               if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
                 return {};
@@ -305,6 +307,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub(element) {
               if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
                 return Symbol('Correction');
@@ -365,6 +368,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -421,6 +425,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -439,7 +444,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByLabelText('1 sur 1').length, 1)
+            assert.strictEqual(screen.getAllByLabelText('1 sur 1').length, 1);
 
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
@@ -470,6 +475,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -488,7 +494,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.dom(screen.queryByLabelText('1 sur 1')).doesNotExist()
+            assert.dom(screen.queryByLabelText('1 sur 1')).doesNotExist();
           });
         });
       });
@@ -536,8 +542,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {
@@ -609,18 +615,19 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               ],
             },
           ];
+
           class PreviewModeServiceStub extends Service {
             isEnabled = true;
           }
+
           this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
           // when
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
-
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
         });
 
         module('when has unsupported elements', function () {
@@ -654,17 +661,19 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             class PreviewModeServiceStub extends Service {
               isEnabled = true;
             }
+
             this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
             // when
             const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
 
             // then
-            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
-            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
           });
         });
       });
@@ -738,6 +747,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             ],
           },
         ];
+
         function stepperIsFinished() {}
 
         function onStepperNextStepStub() {}
@@ -802,7 +812,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
         // then
-        assert.dom(screen.getByLabelText('1 sur 2'))
+        assert.dom(screen.getByLabelText('1 sur 2'));
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -913,6 +923,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -1041,6 +1052,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             const store = this.owner.lookup('service:store');
             const passage = store.createRecord('passage');
             sinon.stub(passageEventService, 'record');
+
             function getLastCorrectionForElementStub(element) {
               if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
                 return {};
@@ -1113,6 +1125,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub(element) {
               if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
                 return Symbol('Correction');
@@ -1173,6 +1186,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -1229,6 +1243,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
@@ -1247,9 +1262,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.dom(screen.getByLabelText('1 sur 1'));
-            assert
-              .dom(screen.getByLabelText('1 sur 1'))
+            assert.dom(screen.getByLabelText('1 sur 1')).exists();
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -1258,7 +1271,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
         module('When there are no supported elements at all', function () {
           test('should not display the Stepper', async function (assert) {
-            // given
             const steps = [
               {
                 elements: [
@@ -1279,11 +1291,11 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             function getLastCorrectionForElementStub() {}
 
             const store = this.owner.lookup('service:store');
             const passage = store.createRecord('passage');
-
             // when
             const screen = await render(
               <template>
@@ -1304,7 +1316,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
       module('When user clicks on the Next button', function () {
         test('should display the next step', async function (assert) {
-          // given
           const steps = [
             {
               elements: [
@@ -1345,13 +1356,12 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
           // then
-          assert.strictEqual(screen.getAllByLabelText('1 sur 2', { disabled: true }).length, 1)
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
-        });
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2', { disabled: true }).length, 1);
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
+          assert.dom(screen.getByLabelText('2 sur 2')).isFocused();
         });
 
         test('should enable the controls previous button', async function (assert) {
-          // given
           const steps = [
             {
               elements: [
@@ -1390,7 +1400,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
-
           // then
           assert
             .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
@@ -1399,7 +1408,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
         module('when user clicks the controls previous button', function () {
           test('should go back to previous step', async function (assert) {
-            // given
             const steps = [
               {
                 elements: [
@@ -1440,17 +1448,15 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
             await click(
               screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
-            );
-
-            // then
-            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+            ),
+              // then
+              assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
             assert
               .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
               .isFocused();
           });
 
           test('should enable next button', async function (assert) {
-            // given
             const steps = [
               {
                 elements: [
@@ -1501,7 +1507,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
           module('when user clicks the controls next button', function () {
             test('should go back to next step', async function (assert) {
-              // given
               const steps = [
                 {
                   elements: [
@@ -1557,7 +1562,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         });
 
         test('should not display the Next button when there are no steps left', async function (assert) {
-          // given
           const steps = [
             {
               elements: [
@@ -1596,6 +1600,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
           // when
           await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
+
+          //then
           assert
             .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
             .doesNotExist();
@@ -1604,7 +1610,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
       module('when preview mode is enabled', function () {
         test('should display all the steps', async function (assert) {
-          // given
           const steps = [
             {
               elements: [
@@ -1625,22 +1630,22 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               ],
             },
           ];
+
           class PreviewModeServiceStub extends Service {
             isEnabled = true;
           }
-          this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
+          this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
           // when
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
         });
 
         module('when has unsupported elements', function () {
           test('should display all the steps but filter out unsupported element', async function (assert) {
-            // given
             const steps = [
               {
                 elements: [
@@ -1669,9 +1674,11 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 ],
               },
             ];
+
             class PreviewModeServiceStub extends Service {
               isEnabled = true;
             }
+
             this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
 
             // when
@@ -1680,8 +1687,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1)
-            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1)
+            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
           });
         });
       });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1807,8 +1807,10 @@
         "button": "Display the steps of the module"
       },
       "stepper": {
+        "aria-role-description": "stepper",
         "step": {
-          "position": "Step {currentStep} of {totalSteps}"
+          "aria-label": "{currentStep} of {totalSteps}",
+          "aria-role-description": "step"
         }
       },
       "verification-precondition-failed-alert": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1793,8 +1793,10 @@
         "button": "Visualizar los pasos del módulo"
       },
       "stepper": {
+        "aria-role-description": "Secuencia de etapas",
         "step": {
-          "position": "{currentStep} Paso a paso {totalSteps}"
+          "aria-role-description": "etapa",
+          "aria-label": "{currentStep} de {totalSteps}"
         }
       },
       "verification-precondition-failed-alert": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1807,8 +1807,10 @@
         "button": "Afficher les étapes du module"
       },
       "stepper": {
+        "aria-role-description": "suite d'étapes",
         "step": {
-          "position": "Étape {currentStep} sur {totalSteps}"
+          "aria-label": "{currentStep} sur {totalSteps}",
+          "aria-role-description": "étape"
         }
       },
       "verification-precondition-failed-alert": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1797,8 +1797,10 @@
         "button": "De modulestappen weergeven"
       },
       "stepper": {
+        "aria-role-description": "reeks stappen",
         "step": {
-          "position": "{currentStep} Stap op {totalSteps}"
+          "aria-role-description": "stap",
+          "aria-label": "{currentStep} op {totalSteps}"
         }
       },
       "verification-precondition-failed-alert": {


### PR DESCRIPTION
## 🔆 Problème

Le stepper et la step manquent certains éléments de a11y.

## ⛱️ Proposition

- Ajouter les attributs aria nécessaires sur Stepper et Step, en s'appuyant sur la documentation W3C du Caroussel : 
- Maintenir le focus sur les boutons de contrôle des étapes pour le Stepper horizontal

## 🌊 Remarques

- On a renommé une fonction pour harmoniser les noms
- Gros gros soucis avec le lint, il y a sûrement des commits à refaire

## 🏄 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr13470.review.pix.fr/modules/bac-a-sable)
- Afficher le stepper horizontal
- Vérifier qu'on peut naviguer entre les étapes sans problème
- Vérifier les aria présents sur le step et stepper
- Vérifier que le focus reste sur les boutons de contrôle après qu'on les ait utilisés
- Vérifier que le focus va bien sur l'étape d'après quand on utilise le bouton "Suivant"
