### PR TITLE
[FEATURE] Changement de couleur des cartes mission pour le domaine 5 (PIX-19431)

### DIFF
--- a/junior/app/styles/globals/_colors.scss
+++ b/junior/app/styles/globals/_colors.scss
@@ -12,7 +12,7 @@
   --pix-contenu-dark: rgb(var(--pix-contenu-dark-inline));
   --pix-contenu-light-inline:63,125,216;
   --pix-contenu-light: rgb(var(--pix-contenu-light-inline));
-  --pix-environnementnum-dark-inline:54,39,113;
+  --pix-environnementnum-dark-inline:133,133,249;
   --pix-environnementnum-dark: rgb(var(--pix-environnementnum-dark-inline));
   --pix-environnementnum-light-inline:99,70,206;
   --pix-environnementnum-light: rgb(var(--pix-environnementnum-light-inline));


### PR DESCRIPTION
## 🔆 Problème

La courleur est trop foncé pour le domaine 5

## ⛱️ Proposition

Utiliser la couleur rgb 133,133,249

## 🌊 Remarques

ras

## 🏄 Pour tester

Check que les couleur du domaine 5 sont bien 133,133,249 ou #8585F9 dans le dom (il est possible de changer une classe en area-5 pour le voir)