### PR TITLE
[FEATURE] Ajouter la durée estimée d'un module au sein d'un parcours combiné (PIX-19027)

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -121,6 +121,7 @@ export class CombinedCourseDetails extends CombinedCourse {
       redirection: encryptedCombinedCourseUrl,
       isCompleted,
       isLocked,
+      duration: module?.duration,
     });
   }
 

--- a/api/src/quest/domain/models/CombinedCourseItem.js
+++ b/api/src/quest/domain/models/CombinedCourseItem.js
@@ -5,7 +5,7 @@ export const ITEM_TYPE = {
 };
 
 export class CombinedCourseItem {
-  constructor({ id, title, reference, type, redirection, isCompleted, isLocked = true }) {
+  constructor({ id, title, reference, type, redirection, isCompleted, duration, isLocked = true }) {
     this.id = id;
     this.title = title;
     this.reference = reference;
@@ -13,5 +13,6 @@ export class CombinedCourseItem {
     this.type = type;
     this.isCompleted = isCompleted;
     this.isLocked = isLocked;
+    this.duration = duration;
   }
 }

--- a/api/src/quest/domain/models/Module.js
+++ b/api/src/quest/domain/models/Module.js
@@ -1,7 +1,8 @@
 export class Module {
-  constructor({ id, title, slug }) {
+  constructor({ id, title, slug, duration }) {
     this.id = id;
     this.title = title;
     this.slug = slug;
+    this.duration = duration;
   }
 }

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -8,7 +8,7 @@ const serialize = function (combinedCourse) {
     items: {
       ref: 'id',
       included: true,
-      attributes: ['title', 'reference', 'type', 'redirection', 'isCompleted', 'isLocked'],
+      attributes: ['title', 'reference', 'type', 'redirection', 'isCompleted', 'isLocked', 'duration'],
     },
     typeForAttribute: (attribute) => {
       if (attribute === 'items') return 'combined-course-items';

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -103,6 +103,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         redirection: 'encryptedUrl',
         isCompleted: false,
         isLocked: true,
+        duration: 5,
       }),
       new CombinedCourseItem({
         id: moduleId2,
@@ -112,6 +113,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         redirection: 'encryptedUrl',
         isCompleted: false,
         isLocked: true,
+        duration: 10,
       }),
     ]);
     expect(result.id).to.equal(questId);
@@ -232,6 +234,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         redirection: 'encryptedUrl',
         isCompleted: true,
         isLocked: false,
+        duration: 5,
       }),
       new CombinedCourseItem({
         id: moduleId3,
@@ -241,6 +244,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
         redirection: 'encryptedUrl',
         isCompleted: false,
         isLocked: false,
+        duration: 10,
       }),
     ]);
     expect(result).to.be.instanceOf(CombinedCourse);

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -805,7 +805,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
             new CombinedCourse({ id, organizationId, name, code }),
             combinedCourseQuestFormat,
           );
-          const module = new Module({ id: 7, title: 'module' });
+          const module = new Module({ id: 7, title: 'module', duration: 10 });
           const dataForQuest = new DataForQuest({
             eligibility: new Eligibility({
               passages: [
@@ -835,6 +835,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               redirection: encryptedCombinedCourseUrl,
               isCompleted: false,
               isLocked: false,
+              duration: 10,
             }),
           ]);
         });

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -42,6 +42,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             redirection: undefined,
             'is-completed': false,
             'is-locked': false,
+            duration: undefined,
           },
         },
         {
@@ -54,6 +55,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
             redirection: 'encryptedCombinedCourseUrl',
             'is-completed': false,
             'is-locked': true,
+            duration: 10,
           },
         },
       ],

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -1,7 +1,7 @@
-import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
 import { CombinedCourse, CombinedCourseDetails } from '../../../../src/quest/domain/models/CombinedCourse.js';
 import { DataForQuest } from '../../../../src/quest/domain/models/DataForQuest.js';
 import { Eligibility } from '../../../../src/quest/domain/models/Eligibility.js';
+import { Module } from '../../../../src/quest/domain/models/Module.js';
 import { Quest } from '../../../../src/quest/domain/models/Quest.js';
 import { domainBuilder } from '../domain-builder.js';
 
@@ -11,9 +11,7 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
     id: 7,
     slug: 'slug',
     title: 'title',
-    isBeta: true,
-    sections: [{ id: 8, type: 'none', grains: [] }],
-    details: '',
+    duration: 10,
     version: '',
   });
   quest =

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -20,6 +20,9 @@ const Content = <template>
           {{yield to="description"}}
         </div>
       </div>
+      <div class="combined-course-item__duration">
+        {{yield to="duration"}}
+      </div>
     </div>
     {{#if @isLocked}}
       <div class="combined-course-item__indicator--locked">
@@ -39,6 +42,13 @@ const Content = <template>
   </div>
 </template>;
 
+const Duration = <template>
+  <PixIcon @name="time" class="combined-course-item__duration__icon" /><span>{{t
+      "pages.combined-courses.items.approximatelySymbol"
+    }}{{@item.duration}}
+    {{t "pages.combined-courses.items.durationUnit"}}</span>
+</template>;
+
 <template>
   {{#if (eq @item.type "FORMATION")}}
     <Content
@@ -53,7 +63,11 @@ const Content = <template>
     </Content>
   {{else}}
     {{#if @isLocked}}
-      <Content @title={{@item.title}} @isLocked={{true}} />
+      <Content @title={{@item.title}} @isLocked={{true}}>
+        <:duration>
+          {{#if @item.duration}}<Duration @item={{@item}} />{{/if}}
+        </:duration>
+      </Content>
     {{else}}
       <LinkTo
         {{on "click" @onClick}}
@@ -63,6 +77,11 @@ const Content = <template>
         disabled
       >
         <Content @title={{@item.title}} @isCompleted={{@item.isCompleted}}>
+          <:duration>
+            {{#if @item.duration}}
+              <Duration @item={{@item}} />
+            {{/if}}
+          </:duration>
           <:blockEnd>
             {{#if @isNextItemToComplete}}
               <PixTag @color="purple-light" class="combined-course-item__current-item-tag">{{t

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -7,6 +7,7 @@ export default class CombinedCourseItem extends Model {
   @attr('string') redirection;
   @attr('boolean') isCompleted;
   @attr('boolean') isLocked;
+  @attr('number') duration;
 
   get route() {
     return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -120,4 +120,18 @@
   background: var(--pix-tertiary-100);
   border-radius: 50px;
   }
+
+  &__duration {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    align-self: center;
+    color: var(--pix-neutral-500);
+    font-size: 13px;
+    line-height: 18px;
+
+      &__icon {
+      width: 16px;
+      height: 16px;
+  }
+  }
 }

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -32,6 +32,62 @@ module('Integration | Component | combined course', function (hooks) {
       // then
       assert.ok(screen.getByRole('heading', { name: 'Combinix' }));
     });
+    test('should display duration on item if exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+        isLocked: false,
+        duration: 10,
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.NOT_STARTED,
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      //then
+      assert.ok(screen.getByText(/10 min/));
+    });
+    test('should not display duration on item if it does not exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+      });
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.NOT_STARTED,
+        code: 'COMBINIX9',
+      });
+
+      combinedCourse.items.push(combinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      //then
+      assert.notOk(screen.queryByText(t('pages.combined-courses.items.durationUnit')));
+    });
   });
   module('when there is a formation item', function () {
     test('should display formation item', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1199,7 +1199,9 @@
         "start-button": "Start course"
       },
       "items": {
+        "approximatelySymbol": "≈",
         "completed": "Completed!",
+        "durationUnit": "min",
         "formation": {
           "description": "Complete your test and unlock customised training modules! The number of modules will depend on your results.",
           "title": "I am training myself"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1199,7 +1199,9 @@
           "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados."
         },
         "completed": "¡Completado!",
-        "tagText": "¡Ya estás ahí!"
+        "tagText": "¡Ya estás ahí!",
+        "durationUnit": "min",
+        "approximatelySymbol": "≈"
       }
     },
     "comparison-window": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1199,7 +1199,9 @@
         "start-button": "Commencer mon parcours"
       },
       "items": {
+        "approximatelySymbol": "≈",
         "completed": "Complété !",
+        "durationUnit": "min",
         "formation": {
           "description": "Terminez votre test et débloquez des modules de formation sur mesure ! Leur nombre dépendra de vos résultats.",
           "title": "Je me forme"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1203,7 +1203,9 @@
           "description": "Voltooi uw test en ontgrendel op maat gemaakte trainingsmodules! Het aantal modules hangt af van uw resultaten."
         },
         "completed": "Voltooid!",
-        "tagText": "U bent er nu!"
+        "tagText": "U bent er nu!",
+        "durationUnit": "min",
+        "approximatelySymbol": "≈"
       }
     },
     "comparison-window": {


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir afficher la durée estimée d'un module au sein d'un parcours combiné.

## ⛱️ Proposition
On fait remonter la donnée depuis le back (generateItems). Deux models ont dû être modifiés : ModuleStatus et Module (domaine "quest").
 
## 🏄 Pour tester
Commencer le parcours combiné ; après avoir passé la campagne de diagnostic, vérifier que la donnée attendue s'affiche bien.