### PR TITLE
[TECH] Supprimer le feature toggle Use Locale dans les applications front (PIX-19273).

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -2,5 +2,4 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isFilteringRecommendedTrainingByOrganizationsEnabled;
-  @attr('boolean') useLocale;
 }

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -35,47 +35,26 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('currentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('returns the intl locale', function (assert) {
+    module('when current locale is not set', function () {
+      test('returns the default locale', function (assert) {
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr');
+      });
+    });
+
+    module('when current locale is set', function () {
+      test('returns the current locale', function (assert) {
         // given
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+        localeService.setCurrentLocale('fr-BE');
 
         // when
         const currentLocale = localeService.currentLocale;
 
         // then
         assert.strictEqual(currentLocale, 'fr-BE');
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      module('when current locale is not set', function () {
-        test('returns the default locale', function (assert) {
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr');
-        });
-      });
-
-      module('when current locale is set', function () {
-        test('returns the current locale', function (assert) {
-          // given
-          localeService.setCurrentLocale('fr-BE');
-
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr-BE');
-        });
       });
     });
   });
@@ -185,327 +164,141 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('set app locale', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const locale = DEFAULT_LOCALE;
+    test('set app locale in the cookies', function (assert) {
+      // given
+      const dayjsService = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjsService, 'setLocale');
+      const intlService = this.owner.lookup('service:intl');
+      sinon.stub(intlService, 'setLocale');
+      const cookiesService = this.owner.lookup('service:cookies');
+      sinon.stub(cookiesService, 'write');
+      const locale = 'nl-BE';
 
-        // when
-        localeService.setCurrentLocale(locale);
+      // when
+      localeService.setCurrentLocale(locale);
 
-        // then
-        sinon.assert.calledWith(intlService.setLocale, locale);
-        sinon.assert.calledWith(dayjsService.setLocale, locale);
-        assert.strictEqual(metricsService.context.locale, locale);
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      test('set app locale in the cookies', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const cookiesService = this.owner.lookup('service:cookies');
-        sinon.stub(cookiesService, 'write');
-        const locale = 'nl-BE';
-
-        // when
-        localeService.setCurrentLocale(locale);
-
-        // then
-        const currentLocale = localeService.currentLocale;
-        assert.strictEqual(currentLocale, 'nl-BE');
-        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
-        sinon.assert.calledWith(intlService.setLocale, 'nl');
-        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-        assert.strictEqual(metricsService.context.locale, 'nl-BE');
-      });
+      // then
+      const currentLocale = localeService.currentLocale;
+      assert.strictEqual(currentLocale, 'nl-BE');
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+      sinon.assert.calledWith(intlService.setLocale, 'nl');
+      sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+      assert.strictEqual(metricsService.context.locale, 'nl-BE');
     });
   });
 
   module('setBestLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      module('when the current domain is "fr"', function () {
-        test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
-          // given
-          const dayjsService = this.owner.lookup('service:dayjs');
-          sinon.stub(dayjsService, 'setLocale');
-          const intlService = this.owner.lookup('service:intl');
-          sinon.stub(intlService, 'setLocale');
-          const cookiesService = this.owner.lookup('service:cookies');
-          sinon.stub(cookiesService, 'write');
-          sinon.stub(cookiesService, 'exists').returns(false);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.setBestLocale({ queryParams: null, user: null });
-
-          // then
-          sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
+    module('when the current domain extension is "fr"', function (hooks) {
+      hooks.beforeEach(function () {
+        currentDomainService.getExtension.returns('fr');
       });
 
-      module('when the current domain extension is "org"', function () {
-        module('when no current user', function () {
-          module('when there is no overriding language', function () {
-            test('sets the the default locale', async function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
+      test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', 'nl');
+        sinon.stub(cookiesService, 'write');
 
-              // when
-              localeService.setBestLocale({ queryParams: null, user: null });
+        // when
+        localeService.setBestLocale({ queryParams: null });
 
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-
-          module('when the overriding language is supported', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-
-          module('when the overriding language is not supported', function () {
-            test('sets the default locale', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'xxx' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-        });
-
-        module('when user is loaded', function () {
-          module('when there is no overriding language', function () {
-            module('when the user language is supported', function () {
-              test('sets the locale with the user language', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'nl' };
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, 'nl');
-                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-                assert.strictEqual(metricsService.context.locale, 'nl');
-              });
-            });
-
-            module('when the user language is not supported', function () {
-              test('sets the default locale', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'tlh' }; // tlh: Klingon locale
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-              });
-            });
-          });
-
-          module('when the overriding language is given', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-        });
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'fr-FR');
       });
     });
 
-    module('when useLocale feature toggle is enabled', function (hooks) {
+    module('when the current domain extension is "org"', function (hooks) {
       hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+        currentDomainService.getExtension.returns('org');
       });
 
-      module('when the current domain extension is "fr"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('fr');
-        });
+      test('sets the default locale', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', '');
+        sinon.stub(cookiesService, 'write');
 
-        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // when
+        localeService.setBestLocale({ queryParams: null });
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+      });
+
+      module('when there is query param "lang"', function () {
+        test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', 'nl');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is query param "locale"', function () {
+        test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is a cookie', function () {
+        test('sets the locale with the "locale" cookie value', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-BE');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, 'fr-FR');
+          assert.strictEqual(currentLocale, 'fr-BE');
         });
       });
 
-      module('when the current domain extension is "org"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('org');
-        });
-
-        test('sets the default locale', async function (assert) {
+      module('when there is an unsupported cookie', function () {
+        test('sets the nearest supported base language', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', '');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'en-CA');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+          assert.strictEqual(currentLocale, 'en');
         });
+      });
 
-        module('when there is query param "lang"', function () {
-          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
+      module('when the detected locale is fr-FR', function () {
+        test('always returns fr for not France domain', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-FR');
 
-            // when
-            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+          // when
+          localeService.setBestLocale({ queryParams: null });
 
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is query param "locale"', function () {
-          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
-
-            // when
-            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is a cookie', function () {
-          test('sets the locale with the "locale" cookie value', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-BE');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is an unsupported cookie', function () {
-          test('sets the nearest supported base language', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'en-CA');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'en');
-          });
-        });
-
-        module('when the detected locale is fr-FR', function () {
-          test('always returns fr for not France domain', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-FR');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr');
-          });
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr');
         });
       });
     });

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,5 +1,3 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
-export default class FeatureToggle extends Model {
-  @attr('boolean') useLocale;
-}
+export default class FeatureToggle extends Model {}

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -22,14 +22,9 @@ export default class CurrentSessionService extends SessionService {
     await this.currentUser.load();
 
     const queryParams = transition?.to?.queryParams;
-    this.locale.setBestLocale({ user: this.currentUser.certificationPointOfContact, queryParams });
+    this.locale.setBestLocale({ queryParams });
 
-    if (!this.featureToggles.featureToggles?.useLocale && this.currentUser.certificationPointOfContact) {
-      // should not happen with new locale system because we dont rely on user lang anymore.
-      this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.certificationPointOfContact?.lang);
-    } else {
-      this.data.localeNotSupported = false;
-    }
+    this.data.localeNotSupported = false;
   }
 
   handleInvalidation() {

--- a/certif/tests/unit/services/locale-test.js
+++ b/certif/tests/unit/services/locale-test.js
@@ -35,47 +35,26 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('currentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('returns the intl locale', function (assert) {
+    module('when current locale is not set', function () {
+      test('returns the default locale', function (assert) {
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr');
+      });
+    });
+
+    module('when current locale is set', function () {
+      test('returns the current locale', function (assert) {
         // given
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+        localeService.setCurrentLocale('fr-BE');
 
         // when
         const currentLocale = localeService.currentLocale;
 
         // then
         assert.strictEqual(currentLocale, 'fr-BE');
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      module('when current locale is not set', function () {
-        test('returns the default locale', function (assert) {
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr');
-        });
-      });
-
-      module('when current locale is set', function () {
-        test('returns the current locale', function (assert) {
-          // given
-          localeService.setCurrentLocale('fr-BE');
-
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr-BE');
-        });
       });
     });
   });
@@ -185,327 +164,141 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('set app locale', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const locale = DEFAULT_LOCALE;
+    test('set app locale in the cookies', function (assert) {
+      // given
+      const dayjsService = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjsService, 'setLocale');
+      const intlService = this.owner.lookup('service:intl');
+      sinon.stub(intlService, 'setLocale');
+      const cookiesService = this.owner.lookup('service:cookies');
+      sinon.stub(cookiesService, 'write');
+      const locale = 'nl-BE';
 
-        // when
-        localeService.setCurrentLocale(locale);
+      // when
+      localeService.setCurrentLocale(locale);
 
-        // then
-        sinon.assert.calledWith(intlService.setLocale, locale);
-        sinon.assert.calledWith(dayjsService.setLocale, locale);
-        assert.strictEqual(metricsService.context.locale, locale);
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      test('set app locale in the cookies', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const cookiesService = this.owner.lookup('service:cookies');
-        sinon.stub(cookiesService, 'write');
-        const locale = 'nl-BE';
-
-        // when
-        localeService.setCurrentLocale(locale);
-
-        // then
-        const currentLocale = localeService.currentLocale;
-        assert.strictEqual(currentLocale, 'nl-BE');
-        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
-        sinon.assert.calledWith(intlService.setLocale, 'nl');
-        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-        assert.strictEqual(metricsService.context.locale, 'nl-BE');
-      });
+      // then
+      const currentLocale = localeService.currentLocale;
+      assert.strictEqual(currentLocale, 'nl-BE');
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+      sinon.assert.calledWith(intlService.setLocale, 'nl');
+      sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+      assert.strictEqual(metricsService.context.locale, 'nl-BE');
     });
   });
 
   module('setBestLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      module('when the current domain is "fr"', function () {
-        test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
-          // given
-          const dayjsService = this.owner.lookup('service:dayjs');
-          sinon.stub(dayjsService, 'setLocale');
-          const intlService = this.owner.lookup('service:intl');
-          sinon.stub(intlService, 'setLocale');
-          const cookiesService = this.owner.lookup('service:cookies');
-          sinon.stub(cookiesService, 'write');
-          sinon.stub(cookiesService, 'exists').returns(false);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.setBestLocale({ queryParams: null, user: null });
-
-          // then
-          sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
+    module('when the current domain extension is "fr"', function (hooks) {
+      hooks.beforeEach(function () {
+        currentDomainService.getExtension.returns('fr');
       });
 
-      module('when the current domain extension is "org"', function () {
-        module('when no current user', function () {
-          module('when there is no overriding language', function () {
-            test('sets the the default locale', async function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
+      test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', 'nl');
+        sinon.stub(cookiesService, 'write');
 
-              // when
-              localeService.setBestLocale({ queryParams: null, user: null });
+        // when
+        localeService.setBestLocale({ queryParams: null });
 
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-
-          module('when the overriding language is supported', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-
-          module('when the overriding language is not supported', function () {
-            test('sets the default locale', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'xxx' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-        });
-
-        module('when user is loaded', function () {
-          module('when there is no overriding language', function () {
-            module('when the user language is supported', function () {
-              test('sets the locale with the user language', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'nl' };
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, 'nl');
-                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-                assert.strictEqual(metricsService.context.locale, 'nl');
-              });
-            });
-
-            module('when the user language is not supported', function () {
-              test('sets the default locale', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'tlh' }; // tlh: Klingon locale
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-              });
-            });
-          });
-
-          module('when the overriding language is given', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-        });
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'fr-FR');
       });
     });
 
-    module('when useLocale feature toggle is enabled', function (hooks) {
+    module('when the current domain extension is "org"', function (hooks) {
       hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+        currentDomainService.getExtension.returns('org');
       });
 
-      module('when the current domain extension is "fr"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('fr');
-        });
+      test('sets the default locale', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', '');
+        sinon.stub(cookiesService, 'write');
 
-        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // when
+        localeService.setBestLocale({ queryParams: null });
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+      });
+
+      module('when there is query param "lang"', function () {
+        test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', 'nl');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is query param "locale"', function () {
+        test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is a cookie', function () {
+        test('sets the locale with the "locale" cookie value', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-BE');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, 'fr-FR');
+          assert.strictEqual(currentLocale, 'fr-BE');
         });
       });
 
-      module('when the current domain extension is "org"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('org');
-        });
-
-        test('sets the default locale', async function (assert) {
+      module('when there is an unsupported cookie', function () {
+        test('sets the nearest supported base language', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', '');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'en-CA');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+          assert.strictEqual(currentLocale, 'en');
         });
+      });
 
-        module('when there is query param "lang"', function () {
-          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
+      module('when the detected locale is fr-FR', function () {
+        test('always returns fr for not France domain', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-FR');
 
-            // when
-            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+          // when
+          localeService.setBestLocale({ queryParams: null });
 
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is query param "locale"', function () {
-          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
-
-            // when
-            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is a cookie', function () {
-          test('sets the locale with the "locale" cookie value', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-BE');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is an unsupported cookie', function () {
-          test('sets the nearest supported base language', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'en-CA');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'en');
-          });
-        });
-
-        module('when the detected locale is fr-FR', function () {
-          test('always returns fr for not France domain', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-FR');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr');
-          });
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr');
         });
       });
     });

--- a/certif/tests/unit/services/session-test.js
+++ b/certif/tests/unit/services/session-test.js
@@ -27,7 +27,7 @@ module('Unit | Service | session', function (hooks) {
 
       // then
       sinon.assert.calledOnce(service.currentUser.load);
-      sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams: undefined });
+      sinon.assert.calledWith(service.locale.setBestLocale, { queryParams: undefined });
       assert.ok(true);
     });
   });
@@ -61,13 +61,13 @@ module('Unit | Service | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
+        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
         assert.false(service.data.localeNotSupported);
       });
     });
 
     module('when locale is not supported', function () {
-      test('loads the current user, sets locale sets data.localeNotSupported to true', async function (assert) {
+      test('loads the current user, sets locale sets data.localeNotSupported to false', async function (assert) {
         // given
         const queryParams = { lang: 'es' };
 
@@ -78,8 +78,8 @@ module('Unit | Service | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
-        assert.true(service.data.localeNotSupported);
+        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
+        assert.false(service.data.localeNotSupported);
       });
     });
   });

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,5 +4,4 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isAutoShareEnabled;
-  @attr('boolean') useLocale;
 }

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -35,47 +35,26 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('currentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('returns the intl locale', function (assert) {
+    module('when current locale is not set', function () {
+      test('returns the default locale', function (assert) {
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr');
+      });
+    });
+
+    module('when current locale is set', function () {
+      test('returns the current locale', function (assert) {
         // given
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+        localeService.setCurrentLocale('fr-BE');
 
         // when
         const currentLocale = localeService.currentLocale;
 
         // then
         assert.strictEqual(currentLocale, 'fr-BE');
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      module('when current locale is not set', function () {
-        test('returns the default locale', function (assert) {
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr');
-        });
-      });
-
-      module('when current locale is set', function () {
-        test('returns the current locale', function (assert) {
-          // given
-          localeService.setCurrentLocale('fr-BE');
-
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr-BE');
-        });
       });
     });
   });
@@ -185,327 +164,141 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('set app locale', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const locale = DEFAULT_LOCALE;
+    test('set app locale in the cookies', function (assert) {
+      // given
+      const dayjsService = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjsService, 'setLocale');
+      const intlService = this.owner.lookup('service:intl');
+      sinon.stub(intlService, 'setLocale');
+      const cookiesService = this.owner.lookup('service:cookies');
+      sinon.stub(cookiesService, 'write');
+      const locale = 'nl-BE';
 
-        // when
-        localeService.setCurrentLocale(locale);
+      // when
+      localeService.setCurrentLocale(locale);
 
-        // then
-        sinon.assert.calledWith(intlService.setLocale, locale);
-        sinon.assert.calledWith(dayjsService.setLocale, locale);
-        assert.strictEqual(metricsService.context.locale, locale);
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      test('set app locale in the cookies', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const cookiesService = this.owner.lookup('service:cookies');
-        sinon.stub(cookiesService, 'write');
-        const locale = 'nl-BE';
-
-        // when
-        localeService.setCurrentLocale(locale);
-
-        // then
-        const currentLocale = localeService.currentLocale;
-        assert.strictEqual(currentLocale, 'nl-BE');
-        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
-        sinon.assert.calledWith(intlService.setLocale, 'nl');
-        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-        assert.strictEqual(metricsService.context.locale, 'nl-BE');
-      });
+      // then
+      const currentLocale = localeService.currentLocale;
+      assert.strictEqual(currentLocale, 'nl-BE');
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+      sinon.assert.calledWith(intlService.setLocale, 'nl');
+      sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+      assert.strictEqual(metricsService.context.locale, 'nl-BE');
     });
   });
 
   module('setBestLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      module('when the current domain is "fr"', function () {
-        test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
-          // given
-          const dayjsService = this.owner.lookup('service:dayjs');
-          sinon.stub(dayjsService, 'setLocale');
-          const intlService = this.owner.lookup('service:intl');
-          sinon.stub(intlService, 'setLocale');
-          const cookiesService = this.owner.lookup('service:cookies');
-          sinon.stub(cookiesService, 'write');
-          sinon.stub(cookiesService, 'exists').returns(false);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.setBestLocale({ queryParams: null, user: null });
-
-          // then
-          sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
+    module('when the current domain extension is "fr"', function (hooks) {
+      hooks.beforeEach(function () {
+        currentDomainService.getExtension.returns('fr');
       });
 
-      module('when the current domain extension is "org"', function () {
-        module('when no current user', function () {
-          module('when there is no overriding language', function () {
-            test('sets the the default locale', async function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
+      test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', 'nl');
+        sinon.stub(cookiesService, 'write');
 
-              // when
-              localeService.setBestLocale({ queryParams: null, user: null });
+        // when
+        localeService.setBestLocale({ queryParams: null });
 
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-
-          module('when the overriding language is supported', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-
-          module('when the overriding language is not supported', function () {
-            test('sets the default locale', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'xxx' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-        });
-
-        module('when user is loaded', function () {
-          module('when there is no overriding language', function () {
-            module('when the user language is supported', function () {
-              test('sets the locale with the user language', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'nl' };
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, 'nl');
-                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-                assert.strictEqual(metricsService.context.locale, 'nl');
-              });
-            });
-
-            module('when the user language is not supported', function () {
-              test('sets the default locale', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'tlh' }; // tlh: Klingon locale
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-              });
-            });
-          });
-
-          module('when the overriding language is given', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-        });
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'fr-FR');
       });
     });
 
-    module('when useLocale feature toggle is enabled', function (hooks) {
+    module('when the current domain extension is "org"', function (hooks) {
       hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+        currentDomainService.getExtension.returns('org');
       });
 
-      module('when the current domain extension is "fr"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('fr');
-        });
+      test('sets the default locale', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', '');
+        sinon.stub(cookiesService, 'write');
 
-        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // when
+        localeService.setBestLocale({ queryParams: null });
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+      });
+
+      module('when there is query param "lang"', function () {
+        test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', 'nl');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is query param "locale"', function () {
+        test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is a cookie', function () {
+        test('sets the locale with the "locale" cookie value', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-BE');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, 'fr-FR');
+          assert.strictEqual(currentLocale, 'fr-BE');
         });
       });
 
-      module('when the current domain extension is "org"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('org');
-        });
-
-        test('sets the default locale', async function (assert) {
+      module('when there is an unsupported cookie', function () {
+        test('sets the nearest supported base language', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', '');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'en-CA');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+          assert.strictEqual(currentLocale, 'en');
         });
+      });
 
-        module('when there is query param "lang"', function () {
-          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
+      module('when the detected locale is fr-FR', function () {
+        test('always returns fr for not France domain', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-FR');
 
-            // when
-            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+          // when
+          localeService.setBestLocale({ queryParams: null });
 
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is query param "locale"', function () {
-          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
-
-            // when
-            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is a cookie', function () {
-          test('sets the locale with the "locale" cookie value', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-BE');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is an unsupported cookie', function () {
-          test('sets the nearest supported base language', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'en-CA');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'en');
-          });
-        });
-
-        module('when the detected locale is fr-FR', function () {
-          test('always returns fr for not France domain', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-FR');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr');
-          });
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr');
         });
       });
     });

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,5 +1,3 @@
-import Model, { attr } from '@ember-data/model';
+import Model from '@ember-data/model';
 
-export default class FeatureToggle extends Model {
-  @attr('boolean') useLocale;
-}
+export default class FeatureToggle extends Model {}

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -5,7 +5,6 @@ import SessionService from 'ember-simple-auth/services/session';
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
   @service locale;
-  @service featureToggles;
   @service url;
 
   routeAfterAuthentication = 'authenticated';
@@ -20,14 +19,8 @@ export default class CurrentSessionService extends SessionService {
     await this.currentUser.load();
 
     const queryParams = transition?.to?.queryParams;
-    this.locale.setBestLocale({ user: this.currentUser.prescriber, queryParams });
-
-    if (!this.featureToggles.featureToggles?.useLocale && this.currentUser.prescriber) {
-      // should not happen with new locale system because we dont rely on user lang anymore.
-      this.data.localeNotSupported = !this.locale.isSupportedLocale(this.currentUser.prescriber?.lang);
-    } else {
-      this.data.localeNotSupported = false;
-    }
+    this.locale.setBestLocale({ queryParams });
+    this.data.localeNotSupported = false;
   }
 
   handleInvalidation() {

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -35,47 +35,26 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('currentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('returns the intl locale', function (assert) {
+    module('when current locale is not set', function () {
+      test('returns the default locale', function (assert) {
+        // when
+        const currentLocale = localeService.currentLocale;
+
+        // then
+        assert.strictEqual(currentLocale, 'fr');
+      });
+    });
+
+    module('when current locale is set', function () {
+      test('returns the current locale', function (assert) {
         // given
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'primaryLocale').value('fr-BE');
+        localeService.setCurrentLocale('fr-BE');
 
         // when
         const currentLocale = localeService.currentLocale;
 
         // then
         assert.strictEqual(currentLocale, 'fr-BE');
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      module('when current locale is not set', function () {
-        test('returns the default locale', function (assert) {
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr');
-        });
-      });
-
-      module('when current locale is set', function () {
-        test('returns the current locale', function (assert) {
-          // given
-          localeService.setCurrentLocale('fr-BE');
-
-          // when
-          const currentLocale = localeService.currentLocale;
-
-          // then
-          assert.strictEqual(currentLocale, 'fr-BE');
-        });
       });
     });
   });
@@ -185,327 +164,141 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('setCurrentLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      test('set app locale', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const locale = DEFAULT_LOCALE;
+    test('set app locale in the cookies', function (assert) {
+      // given
+      const dayjsService = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjsService, 'setLocale');
+      const intlService = this.owner.lookup('service:intl');
+      sinon.stub(intlService, 'setLocale');
+      const cookiesService = this.owner.lookup('service:cookies');
+      sinon.stub(cookiesService, 'write');
+      const locale = 'nl-BE';
 
-        // when
-        localeService.setCurrentLocale(locale);
+      // when
+      localeService.setCurrentLocale(locale);
 
-        // then
-        sinon.assert.calledWith(intlService.setLocale, locale);
-        sinon.assert.calledWith(dayjsService.setLocale, locale);
-        assert.strictEqual(metricsService.context.locale, locale);
-      });
-    });
-
-    module('when useLocale feature toggle is enabled', function (hooks) {
-      hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
-      });
-
-      test('set app locale in the cookies', function (assert) {
-        // given
-        const dayjsService = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjsService, 'setLocale');
-        const intlService = this.owner.lookup('service:intl');
-        sinon.stub(intlService, 'setLocale');
-        const cookiesService = this.owner.lookup('service:cookies');
-        sinon.stub(cookiesService, 'write');
-        const locale = 'nl-BE';
-
-        // when
-        localeService.setCurrentLocale(locale);
-
-        // then
-        const currentLocale = localeService.currentLocale;
-        assert.strictEqual(currentLocale, 'nl-BE');
-        sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
-        sinon.assert.calledWith(intlService.setLocale, 'nl');
-        sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-        assert.strictEqual(metricsService.context.locale, 'nl-BE');
-      });
+      // then
+      const currentLocale = localeService.currentLocale;
+      assert.strictEqual(currentLocale, 'nl-BE');
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'nl-BE');
+      sinon.assert.calledWith(intlService.setLocale, 'nl');
+      sinon.assert.calledWith(dayjsService.setLocale, 'nl');
+      assert.strictEqual(metricsService.context.locale, 'nl-BE');
     });
   });
 
   module('setBestLocale', function () {
-    module('when useLocale feature toggle is disabled', function () {
-      module('when the current domain is "fr"', function () {
-        test('sets the locale with "fr" and adds a cookie locale with "fr-FR"', function (assert) {
-          // given
-          const dayjsService = this.owner.lookup('service:dayjs');
-          sinon.stub(dayjsService, 'setLocale');
-          const intlService = this.owner.lookup('service:intl');
-          sinon.stub(intlService, 'setLocale');
-          const cookiesService = this.owner.lookup('service:cookies');
-          sinon.stub(cookiesService, 'write');
-          sinon.stub(cookiesService, 'exists').returns(false);
-          currentDomainService.getExtension.returns('fr');
-
-          // when
-          localeService.setBestLocale({ queryParams: null, user: null });
-
-          // then
-          sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-FR');
-          sinon.assert.calledWith(intlService.setLocale, 'fr');
-          sinon.assert.calledWith(dayjsService.setLocale, 'fr');
-          assert.strictEqual(metricsService.context.locale, 'fr');
-        });
+    module('when the current domain extension is "fr"', function (hooks) {
+      hooks.beforeEach(function () {
+        currentDomainService.getExtension.returns('fr');
       });
 
-      module('when the current domain extension is "org"', function () {
-        module('when no current user', function () {
-          module('when there is no overriding language', function () {
-            test('sets the the default locale', async function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
+      test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', 'nl');
+        sinon.stub(cookiesService, 'write');
 
-              // when
-              localeService.setBestLocale({ queryParams: null, user: null });
+        // when
+        localeService.setBestLocale({ queryParams: null });
 
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-
-          module('when the overriding language is supported', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-
-          module('when the overriding language is not supported', function () {
-            test('sets the default locale', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const queryParams = { lang: 'xxx' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user: null });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-              sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-              assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-            });
-          });
-        });
-
-        module('when user is loaded', function () {
-          module('when there is no overriding language', function () {
-            module('when the user language is supported', function () {
-              test('sets the locale with the user language', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'nl' };
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, 'nl');
-                sinon.assert.calledWith(dayjsService.setLocale, 'nl');
-                assert.strictEqual(metricsService.context.locale, 'nl');
-              });
-            });
-
-            module('when the user language is not supported', function () {
-              test('sets the default locale', async function (assert) {
-                // given
-                const dayjsService = this.owner.lookup('service:dayjs');
-                sinon.stub(dayjsService, 'setLocale');
-                const intlService = this.owner.lookup('service:intl');
-                sinon.stub(intlService, 'setLocale');
-                currentDomainService.getExtension.returns('org');
-                const user = { lang: 'tlh' }; // tlh: Klingon locale
-
-                // when
-                localeService.setBestLocale({ queryParams: null, user });
-
-                // then
-                sinon.assert.calledWith(intlService.setLocale, DEFAULT_LOCALE);
-                sinon.assert.calledWith(dayjsService.setLocale, DEFAULT_LOCALE);
-                assert.strictEqual(metricsService.context.locale, DEFAULT_LOCALE);
-              });
-            });
-          });
-
-          module('when the overriding language is given', function () {
-            test('sets the locale with the overriding language', function (assert) {
-              // given
-              const dayjsService = this.owner.lookup('service:dayjs');
-              sinon.stub(dayjsService, 'setLocale');
-              const intlService = this.owner.lookup('service:intl');
-              sinon.stub(intlService, 'setLocale');
-              currentDomainService.getExtension.returns('org');
-              const user = { lang: 'nl' };
-              const queryParams = { lang: 'es' };
-
-              // when
-              localeService.setBestLocale({ queryParams, user });
-
-              // then
-              sinon.assert.calledWith(intlService.setLocale, 'es');
-              sinon.assert.calledWith(dayjsService.setLocale, 'es');
-              assert.strictEqual(metricsService.context.locale, 'es');
-            });
-          });
-        });
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, 'fr-FR');
       });
     });
 
-    module('when useLocale feature toggle is enabled', function (hooks) {
+    module('when the current domain extension is "org"', function (hooks) {
       hooks.beforeEach(function () {
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ useLocale: true });
+        currentDomainService.getExtension.returns('org');
       });
 
-      module('when the current domain extension is "fr"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('fr');
-        });
+      test('sets the default locale', async function (assert) {
+        // given
+        const cookiesService = this.owner.lookup('service:cookies');
+        cookiesService.write('locale', '');
+        sinon.stub(cookiesService, 'write');
 
-        test('returns fr-FR (and bypass the cookie)', async function (assert) {
+        // when
+        localeService.setBestLocale({ queryParams: null });
+
+        // then
+        const currentLocale = localeService.currentLocale;
+        assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+      });
+
+      module('when there is query param "lang"', function () {
+        test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', 'nl');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is query param "locale"', function () {
+        test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr');
+
+          // when
+          localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
+
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr-BE');
+        });
+      });
+
+      module('when there is a cookie', function () {
+        test('sets the locale with the "locale" cookie value', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-BE');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, 'fr-FR');
+          assert.strictEqual(currentLocale, 'fr-BE');
         });
       });
 
-      module('when the current domain extension is "org"', function (hooks) {
-        hooks.beforeEach(function () {
-          currentDomainService.getExtension.returns('org');
-        });
-
-        test('sets the default locale', async function (assert) {
+      module('when there is an unsupported cookie', function () {
+        test('sets the nearest supported base language', async function (assert) {
           // given
           const cookiesService = this.owner.lookup('service:cookies');
-          cookiesService.write('locale', '');
-          sinon.stub(cookiesService, 'write');
+          cookiesService.write('locale', 'en-CA');
 
           // when
           localeService.setBestLocale({ queryParams: null });
 
           // then
           const currentLocale = localeService.currentLocale;
-          assert.strictEqual(currentLocale, DEFAULT_LOCALE);
+          assert.strictEqual(currentLocale, 'en');
         });
+      });
 
-        module('when there is query param "lang"', function () {
-          test('sets the locale with the "lang" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
+      module('when the detected locale is fr-FR', function () {
+        test('always returns fr for not France domain', async function (assert) {
+          // given
+          const cookiesService = this.owner.lookup('service:cookies');
+          cookiesService.write('locale', 'fr-FR');
 
-            // when
-            localeService.setBestLocale({ queryParams: { lang: 'fr-BE' } });
+          // when
+          localeService.setBestLocale({ queryParams: null });
 
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is query param "locale"', function () {
-          test('sets the locale with the "locale" query param (bypass the cookie)', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr');
-
-            // when
-            localeService.setBestLocale({ queryParams: { locale: 'fr-BE' } });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is a cookie', function () {
-          test('sets the locale with the "locale" cookie value', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-BE');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr-BE');
-          });
-        });
-
-        module('when there is an unsupported cookie', function () {
-          test('sets the nearest supported base language', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'en-CA');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'en');
-          });
-        });
-
-        module('when the detected locale is fr-FR', function () {
-          test('always returns fr for not France domain', async function (assert) {
-            // given
-            const cookiesService = this.owner.lookup('service:cookies');
-            cookiesService.write('locale', 'fr-FR');
-
-            // when
-            localeService.setBestLocale({ queryParams: null });
-
-            // then
-            const currentLocale = localeService.currentLocale;
-            assert.strictEqual(currentLocale, 'fr');
-          });
+          // then
+          const currentLocale = localeService.currentLocale;
+          assert.strictEqual(currentLocale, 'fr');
         });
       });
     });

--- a/orga/tests/unit/services/session-test.js
+++ b/orga/tests/unit/services/session-test.js
@@ -27,7 +27,7 @@ module('Unit | Service | session', function (hooks) {
 
       // then
       sinon.assert.calledOnce(service.currentUser.load);
-      sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams: undefined });
+      sinon.assert.calledWith(service.locale.setBestLocale, { queryParams: undefined });
       assert.ok(true);
     });
   });
@@ -61,13 +61,13 @@ module('Unit | Service | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
+        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
         assert.false(service.data.localeNotSupported);
       });
     });
 
     module('when locale is not supported', function () {
-      test('loads the current user, sets locale sets data.localeNotSupported to true', async function (assert) {
+      test('loads the current user, sets locale sets data.localeNotSupported to false', async function (assert) {
         // given
         const queryParams = { lang: 'es' };
         service.locale.isSupportedLocale = sinon.stub().returns(false);
@@ -77,8 +77,8 @@ module('Unit | Service | session', function (hooks) {
 
         // then
         sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { user, queryParams });
-        assert.true(service.data.localeNotSupported);
+        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
+        assert.false(service.data.localeNotSupported);
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème

Le feature toggle useLocale est en production, recette et ra depuis plusieurs semaines. De plus, on se base maintenant sur le cookie avec getUserLocale(request) dans plusieurs endpoints du code,

## ⛱️ Proposition
On peut supprimer le feature toggle dans les applications frontend :

  1.  Dans mon-pix :

        `mon-pix/app/models/feature-toggle.js` supprimer le feature toggle

       ` mon-pix/app/services/locale.js` conserver le comportement uniquement quand il est activé

       ` mon-pix/tests/unit/services/locale-test.js` supprimer les tests liés au feature toggle désactivé

   2. Dans admin :

        - `admin/app/models/feature-toggle.js` supprimer le feature toggle

        - `admin/app/services/locale.js` copier celui de `mon-pix` (ne pas oublier de conserver les imports et le commentaire)

        - `admin/tests/unit/services/locale-test.js` copier celui de `mon-pix` (ne pas oublier de conserver les imports et le commentaire)

   3. Dans orga :

        - `orga/app/models/feature-toggle.js` supprimer le feature toggle

        - `orga/app/services/locale.js` copier celui de mon-pix (ne pas oublier de conserver les imports et le commentaire)

        - `orga/tests/unit/services/locale-test.js` copier celui de `mon-pix` (ne pas oublier de conserver les imports et le commentaire)

   4. Dans certif :

        - `certif/app/models/feature-toggle.js` supprimer le feature toggle

        - `certif/app/services/locale.js` copier celui de `mon-pix` (ne pas oublier de conserver les imports et le commentaire)

        - `certif/tests/unit/services/locale-test.js` copier celui de `mon-pix` (ne pas oublier de conserver les imports et le commentaire)

## 🌊 Remarques

RAS

## 🏄 Pour tester

- sur toutes les applications front, sur le domaine `.fr` :
  - vérifier que que le cookie  locale est  fr-FR
  - vérifier que l'ajout d'un query param lang ou locale est inopérant
- sur toutes les applications front, avec le domaine `.org` :
  - vérifier que l'ajout d'un query param lang ou locale supportée modifie le cookie locale
  - vérifier que l'ajout d'un query param lang ou locale non supporté mais proche modifie le cookie locale avec la nearest locale (ex en-CA > en )
  - vérifier que l'ajout d'un query param lang ou locale non supportée modifie le cookie locale dans la nearest locale la plus proche de la langue du navigateur