### PR TITLE
[TECH] Mettre à jour les tests Playwright pour prendre en compte la nouvelle page d'accueil (PIX-19417)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/login/pix-orga.test.ts
+++ b/high-level-tests/e2e-playwright/tests/login/pix-orga.test.ts
@@ -24,7 +24,7 @@ test('login, cgu and logout', async ({ page, globalTestId }: { page: Page; globa
     await cgu.waitFor();
     await loginPage.acceptCGU();
 
-    await expect(page).toHaveURL(/campagnes\/les-miennes$/);
+    await expect(page).toHaveURL('http://localhost:4201/');
   });
 
   await test.step('Logout and login, without having to accept CGU', async function () {
@@ -35,6 +35,6 @@ test('login, cgu and logout', async ({ page, globalTestId }: { page: Page; globa
     const loginPage = new PixOrgaPage(page);
     await loginPage.login(email, 'Coucoulesdevs66');
 
-    await expect(page).toHaveURL(/campagnes\/les-miennes$/);
+    await expect(page).toHaveURL('http://localhost:4201/');
   });
 });


### PR DESCRIPTION
## 🔆 Problème

Les tests e2e de Pix Orga vérifiaient l'URL de redirection après connexion avec un pattern regex `/campagnes\/les-miennes$/` qui ne correspondait plus à l'URL réelle de la page d'accueil de l'organisation.

## ⛱️ Proposition

Mise à jour des assertions d'URL dans le test de connexion Pix Orga pour utiliser l'URL directe `http://localhost:4201/` au lieu du pattern regex obsolète.

Les modifications concernent deux étapes du test :
- Après l'acceptation des CGU lors de la première connexion
- Après la reconnexion sans avoir à accepter les CGU

## 🌊 Remarques

Cette modification assure que les tests e2e reflètent fidèlement le comportement actuel de l'application après connexion.

## 🏄 Pour tester

CI 🆗 