### PR TITLE
[FEATURE] Revoir la typo des titres de grain (leçon...) (PIX-19434)

### DIFF
--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -2,14 +2,16 @@
 
 .module-passage {
   /** Revert Pix UI styles for Modulix */
-  h3,
   h4,
+  h5,
+  h6,
   p {
     margin: var(--pix-spacing-1x) 0;
   }
 
-  h3,
-  h4 {
+  h4,
+  h5,
+  h6 {
     font-weight: var(--pix-font-medium);
   }
 


### PR DESCRIPTION
## 🔆 Problème

Depuis la migration des niveaux de titre, les titres de grain ne sont plus en gras et ne respectent donc pas le token. 

## ⛱️ Proposition

Modifier la règle CSS pour que les règles sur `.module-passage h3` deviennent `.module-passage h4`.

Prévoir également le `h5` et le `h6`.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier que les titres des grains sont bien de nouveau en gras cf. https://ui.pix.fr/?path=/docs/design-tokens-typographie--docs#titres

Vérifier que les titres des contenus n'aient qu'un petit niveau de gras sans changement de typo (body/roboto).
