### PR TITLE
[FEATURE] Enlever le fond de couleur sur les grains "défi" (PIX-19043)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -70,11 +70,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     background: var(--modulix-summary-card-background);
   }
 
-  &--challenge {
-    padding: var(--pix-spacing-6x);
-    background: var(--modulix-challenge-card-background);
-  }
-
   &--lesson {
     padding: var(--pix-spacing-6x);
     background: var(--pix-primary-10);


### PR DESCRIPTION
## ⛱️ Proposition

Enlever le fond de couleur sur les grains "défi".

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier sur [le module bac-a-sable](https://app-pr13485.review.pix.fr/modules/preview/bac-a-sable) que dans la section "S'exercer", le premier grain est bien de type défi et n'a plus de fond de couleur.
