### PR TITLE
[FEATURE] Retrait des dernières mentions au statut "TO_SHARE" (PIX-19389)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -85,7 +85,7 @@ test('Assessment campaign', async ({ page }) => {
     await page.getByLabel('Navigation principale').getByRole('link', { name: 'Campagnes' }).click();
     await page.getByRole('link', { name: 'campagne pro', exact: true }).click();
     await expect(
-      page.getByRole('region').filter({ hasText: 'Participations terminées Retrouvez ici' }).getByRole('definition'),
+      page.getByRole('region').filter({ hasText: 'Participations terminées' }).getByRole('definition'),
     ).toBeVisible();
     await expect(
       page.getByRole('region').filter({ hasText: 'Total de participants' }).getByRole('definition'),

--- a/orga/app/components/campaign/activity/delete-participation-modal.gjs
+++ b/orga/app/components/campaign/activity/delete-participation-modal.gjs
@@ -42,14 +42,10 @@ const DELETE_PARTICIPATION_MODAL_WARNING = {
   ASSESSMENT: {
     STARTED:
       'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.started-participation',
-    TO_SHARE:
-      'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation',
     SHARED:
       'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation',
   },
   PROFILES_COLLECTION: {
-    TO_SHARE:
-      'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation',
     SHARED:
       'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.shared-participation',
   },

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -123,12 +123,9 @@ export default class ParticipationFilters extends Component {
   }
 
   get statusOptions() {
-    const { type } = this.args.campaign;
-
     const statuses = ['STARTED', 'SHARED'];
-    const finalType = type === 'EXAM' ? 'ASSESSMENT' : type;
     return statuses.map((status) => {
-      const label = this.intl.t(`components.participation-status.${status}-${finalType}`);
+      const label = this.intl.t(`components.participation-status.${status}`);
       return { value: status, label };
     });
   }

--- a/orga/app/components/ui/last-participation-date-tooltip.gjs
+++ b/orga/app/components/ui/last-participation-date-tooltip.gjs
@@ -15,6 +15,11 @@ export default class LastParticipationDateTooltip extends Component {
   }
 
   get participationStatusLabel() {
+    if (this.args.participationStatus === 'TO_SHARE') {
+      return this.intl.t(
+        `pages.participants-list.latest-participation-information-tooltip.participation-STARTED-status`,
+      );
+    }
     return this.intl.t(
       `pages.participants-list.latest-participation-information-tooltip.participation-${this.args.participationStatus}-status`,
     );

--- a/orga/tests/acceptance/campaign-activity-test.js
+++ b/orga/tests/acceptance/campaign-activity-test.js
@@ -87,7 +87,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       const screen = await visit('/campagnes/1');
 
       await click(screen.getByLabelText(t('pages.campaign-activity.table.column.status')));
-      await click(await screen.findByRole('option', { name: t('components.participation-status.STARTED-ASSESSMENT') }));
+      await click(await screen.findByRole('option', { name: t('components.participation-status.STARTED') }));
       await clickByName('Effacer les filtres');
 
       // then
@@ -139,7 +139,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       const screen = await visit('/campagnes/1');
 
       await click(screen.getByLabelText(t('pages.campaign-activity.table.column.status')));
-      await click(await screen.findByRole('option', { name: t('components.participation-status.STARTED-ASSESSMENT') }));
+      await click(await screen.findByRole('option', { name: t('components.participation-status.STARTED') }));
 
       // then
       assert.strictEqual(currentURL(), '/campagnes/1?status=STARTED');

--- a/orga/tests/integration/components/campaign/activity/delete-participation-modal-test.js
+++ b/orga/tests/integration/components/campaign/activity/delete-participation-modal-test.js
@@ -105,27 +105,6 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           );
         });
 
-        test('it is a participation to share for an assessment campaign', async function (assert) {
-          this.set('campaign.type', 'ASSESSMENT');
-          this.set('participation.status', 'TO_SHARE');
-
-          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
-  @campaign={{this.campaign}}
-  @participation={{this.participation}}
-  @isModalOpen={{this.isModalOpen}}
-  @closeModal={{this.closeModal}}
-  @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
-/>`);
-
-          assert.ok(
-            screen.getByText(
-              t(
-                'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation',
-              ),
-            ),
-          );
-        });
-
         test('it is a shared participation for an assessment campaign', async function (assert) {
           this.set('campaign.type', 'ASSESSMENT');
           this.set('participation.status', 'SHARED');
@@ -142,27 +121,6 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
             screen.getByText(
               t(
                 'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation',
-              ),
-            ),
-          );
-        });
-
-        test('it is a participation to share for a profiles collection campaign', async function (assert) {
-          this.set('campaign.type', 'PROFILES_COLLECTION');
-          this.set('participation.status', 'TO_SHARE');
-
-          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
-  @campaign={{this.campaign}}
-  @participation={{this.participation}}
-  @isModalOpen={{this.isModalOpen}}
-  @closeModal={{this.closeModal}}
-  @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
-/>`);
-
-          assert.ok(
-            screen.getByText(
-              t(
-                'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation',
               ),
             ),
           );

--- a/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
+++ b/orga/tests/integration/components/campaign/filter/participation-filters-test.gjs
@@ -816,7 +816,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       await click(screen.getByLabelText(t('pages.campaign-results.filters.type.status.title')));
       await click(
         await screen.findByRole('option', {
-          name: t('components.participation-status.STARTED-ASSESSMENT'),
+          name: t('components.participation-status.STARTED'),
         }),
       );
 
@@ -846,7 +846,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       assert
         .dom(
           await screen.findByRole('option', {
-            name: t('components.participation-status.STARTED-ASSESSMENT'),
+            name: t('components.participation-status.STARTED'),
             selected: true,
           }),
         )
@@ -875,8 +875,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         options.map((option) => option.innerText),
         [
           t('pages.campaign-results.filters.type.status.empty'),
-          t('components.participation-status.STARTED-ASSESSMENT'),
-          t('components.participation-status.SHARED-ASSESSMENT'),
+          t('components.participation-status.STARTED'),
+          t('components.participation-status.SHARED'),
         ],
       );
     });

--- a/orga/tests/integration/components/ui/last-participation-date-tooltip-test.js
+++ b/orga/tests/integration/components/ui/last-participation-date-tooltip-test.js
@@ -125,7 +125,7 @@ module('Integration | Component | Ui::LastParticipationDateTooltip', function (h
     );
     assert.ok(
       screen.getByText(
-        t('pages.participants-list.latest-participation-information-tooltip.participation-TO_SHARE-status'),
+        t('pages.participants-list.latest-participation-information-tooltip.participation-STARTED-status'),
       ),
     );
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1395,8 +1395,7 @@
         "campaign-status": "Status: ",
         "campaign-type": "Type: ",
         "participation-SHARED-status": "Submitted",
-        "participation-STARTED-status": "In progress",
-        "participation-TO_SHARE-status": "Pending"
+        "participation-STARTED-status": "In progress"
       }
     },
     "places": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -626,12 +626,10 @@
         "warning": {
           "assessment-campaign-participation": {
             "shared-participation": "The participant will no longer be able to access the results of this test.",
-            "started-participation": "The participant will not be able to complete this test.",
-            "to-share-participation": "The Participant will not be able to send in their results."
+            "started-participation": "The participant will not be able to complete this test."
           },
           "profiles-collection-campaign-participation": {
-            "shared-participation": "The participant will no longer be able to submit their profile through this campaign.",
-            "to-share-participation": "The participant will no longer be able to submit their profile through this campaign."
+            "shared-participation": "The participant will no longer be able to submit their profile through this campaign."
           }
         }
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1226,8 +1226,7 @@
           "title": {
             "assessment": "Assessments",
             "profiles-collection": "Profile collections"
-          },
-          "to-share": "Pending: {count}"
+          }
         },
         "empty-state": "No activity yet. As soon as {organizationLearnerFirstName} {organizationLearnerLastName} participates in a campaign, you will be able to follow their progress here.",
         "participation-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1226,8 +1226,7 @@
           "title": {
             "assessment": "Évaluations",
             "profiles-collection": "Collectes de profil"
-          },
-          "to-share": "En attente : {count}"
+          }
         },
         "empty-state": "Aucune activité pour l’instant ! Envoyez une campagne à {organizationLearnerFirstName} {organizationLearnerLastName} et commencez à suivre sa progression.",
         "participation-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -132,7 +132,7 @@
     },
     "submitted-count": {
       "loader": "Chargement des résultats ou profils reçus",
-      "title": "Paticipations terminées"
+      "title": "Participations terminées"
     }
   },
   "charts": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -626,12 +626,10 @@
         "warning": {
           "assessment-campaign-participation": {
             "shared-participation": "Le participant ne pourra plus accéder aux résultats de cette campagne.",
-            "started-participation": "Le participant ne pourra plus reprendre cette participation.",
-            "to-share-participation": "Le participant ne pourra pas envoyer ses résultats."
+            "started-participation": "Le participant ne pourra plus reprendre cette participation."
           },
           "profiles-collection-campaign-participation": {
-            "shared-participation": "Le participant ne pourra plus participer à cette collecte de profil.",
-            "to-share-participation": "Le participant ne pourra pas envoyer son profil."
+            "shared-participation": "Le participant ne pourra plus participer à cette collecte de profil."
           }
         }
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1395,8 +1395,7 @@
         "campaign-status": "Statut : ",
         "campaign-type": "Type : ",
         "participation-SHARED-status": "Reçu",
-        "participation-STARTED-status": "En cours",
-        "participation-TO_SHARE-status": "En attente d'envoi"
+        "participation-STARTED-status": "En cours"
       }
     },
     "places": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1226,8 +1226,7 @@
           "title": {
             "assessment": "Beoordelingen",
             "profiles-collection": "Verzamelingen van profielen"
-          },
-          "to-share": "In afwachting van: {count}"
+          }
         },
         "empty-state": "Momenteel geen activiteit! Stuur een campagne naar {organizationLearnerFirstName} {organizationLearnerLastName} en begin met het bijhouden van de voortgang.",
         "participation-list": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -626,12 +626,10 @@
         "warning": {
           "assessment-campaign-participation": {
             "shared-participation": "De deelnemer heeft geen toegang meer tot de resultaten van deze test.",
-            "started-participation": "De deelnemer kan deze test niet voltooien.",
-            "to-share-participation": "The Participant will not be able to send in their results."
+            "started-participation": "De deelnemer kan deze test niet voltooien."
           },
           "profiles-collection-campaign-participation": {
-            "shared-participation": "De deelnemer zal niet langer kunnen deelnemen aan deze profielverzameling.",
-            "to-share-participation": "Deelnemers kunnen hun profiel niet verzenden."
+            "shared-participation": "De deelnemer zal niet langer kunnen deelnemen aan deze profielverzameling."
           }
         }
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1395,9 +1395,7 @@
         "campaign-status": "Status:",
         "campaign-type": "Type:",
         "participation-SHARED-status": "Ontvangen",
-        "participation-STARTED-status": "Bezig",
-        "participation-TO_SHARE-status": "In afwachting van verzending"
-      }
+        "participation-STARTED-status": "Bezig"      }
     },
     "places": {
       "before-date": "op",


### PR DESCRIPTION
## 🔆 Problème

On mentionne un statut de participations qui n'existe plus
## ⛱️ Proposition

Retirer ces mentions

## 🌊 Remarques

On en a profité pour faire du ménage dans des traductions qui ne sont plus appelées
## 🏄 Pour tester

- Aller dans la liste de participants et "hover" l'infobulle à côté de la date de dernière participation
- ne plus y retrouver de mention au status to-share
- Tenter de supprimer des participants
- Ne plus voir de mention au statut to-share
- Mélanger 500g de Farine, 1l de lait, 4 oeufs, un schlouk de rhum et une dose de sucre
- Sortir la crêpière et faire les crêpes
- Les faire livrer chez Mâche