### PR TITLE
[FEATURE] Ajouter l'animation au défilement des étapes (PIX-19286)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -70,9 +70,13 @@
     border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
     transform: translateX(calc(-1 * var(--stepper-gap-between-steps-with-step-width) * var(--current-step-index)));
-    transition: transform .5s ease-in-out;
+
+    @media (not (prefers-reduced-motion: reduce)) {
+      transition: transform .5s ease-in-out;
+    }
 
     &--from-right {
+      /* calcule la position de la slide pour qu'elle apparaisse à droite en désincrémentant son index */
       transform: translateX(calc(-1 * var(--stepper-gap-between-steps-with-step-width) * (var(--current-step-index) - 1)));
     }
 

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -61,7 +61,7 @@
     --stepper-previous-slide-visible-width: 10px;
     --stepper-gap-between-steps: calc(50vw - 50% - var(--stepper-previous-slide-visible-width));
     --stepper-gap-between-steps-with-step-width: calc(var(--stepper-gap-between-steps) + 100%);
-    --stepper-gap-between-line-and-step: 4px;
+    --stepper-gap-between-line-and-step: 14px;
 
     flex: 0 0 100%;
     align-items: center;

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -70,6 +70,11 @@
     border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
     transform: translateX(calc(-1 * var(--stepper-gap-between-steps-with-step-width) * var(--current-step-index)));
+    transition: transform .5s ease-in-out;
+
+    &--from-right {
+      transform: translateX(calc(-1 * var(--stepper-gap-between-steps-with-step-width) * (var(--current-step-index) - 1)));
+    }
 
     /* Line between steps */
     &:not(.stepper-step--last-step) {

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -23,6 +23,10 @@ export default class ModulixStep extends Component {
     return this.args.currentStep === this.args.totalSteps;
   }
 
+  get shouldAppearToRight() {
+    return this.args.isActive && this.args.shouldAppearToRight;
+  }
+
   @action
   focusAndScroll(htmlElement) {
     if (!this.args.isActive || this.args.preventScrollAndFocus) {
@@ -35,7 +39,9 @@ export default class ModulixStep extends Component {
   <template>
     {{#if this.hasDisplayableElements}}
       <section
-        class="stepper__step {{if this.isLastStep 'stepper-step--last-step'}}"
+        class="stepper__step
+          {{if this.isLastStep 'stepper-step--last-step'}}
+          {{if this.shouldAppearToRight 'stepper__step--from-right'}}"
         tabindex="-1"
         {{didInsert this.focusAndScroll}}
         inert={{if @isHidden true}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -53,6 +53,11 @@ export default class ModulixStepper extends Component {
     return this.displayableSteps.length > 0;
   }
 
+  get userPrefersReducedMotion() {
+    const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    return userPrefersReducedMotion.matches;
+  }
+
   @action
   goBackToPreviousStep() {
     if (this.displayedStepIndex === 0) {
@@ -76,10 +81,13 @@ export default class ModulixStepper extends Component {
     this.args.onStepperNextStep(currentStepPosition);
     this.displayedStepIndex = currentStepPosition;
     this.preventScrollAndFocus = false;
-    this.shouldAppearToRight = true;
-    setTimeout(() => {
-      this.shouldAppearToRight = false;
-    }, 0);
+
+    if (!this.userPrefersReducedMotion) {
+      this.shouldAppearToRight = true;
+      setTimeout(() => {
+        this.shouldAppearToRight = false;
+      }, 0);
+    }
   }
 
   @action

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -33,6 +33,8 @@ export default class ModulixStepper extends Component {
   @tracked
   preventScrollAndFocus = false;
 
+  @tracked shouldAppearToRight = false;
+
   @action
   stepIsActive(index) {
     return this.displayedStepIndex === index;
@@ -74,6 +76,10 @@ export default class ModulixStepper extends Component {
     this.args.onStepperNextStep(currentStepPosition);
     this.displayedStepIndex = currentStepPosition;
     this.preventScrollAndFocus = false;
+    this.shouldAppearToRight = true;
+    setTimeout(() => {
+      this.shouldAppearToRight = false;
+    }, 0);
   }
 
   @action
@@ -187,6 +193,7 @@ export default class ModulixStepper extends Component {
                 @onNextButtonClick={{this.displayNextStep}}
                 @shouldDisplayNextButton={{this.shouldDisplayNextButton}}
                 @preventScrollAndFocus={{this.preventScrollAndFocus}}
+                @shouldAppearToRight={{this.shouldAppearToRight}}
               />
             {{/each}}
           {{/if}}


### PR DESCRIPTION
## 🔆 Problème

Le stepper horizontal n'est pas animé.

## ⛱️ Proposition

Ajouter l'animation au défilement des étapes.

## 🌊 Remarques

L'espace entre les lignes qui sépare les steps a été augmenté.
Petit dessin pour comprendre le calcul de la classe `stepper-step--from-right` : 
<img width="773" height="521" alt="image" src="https://github.com/user-attachments/assets/4b4f2f7e-057d-42e4-9da9-e63994c540ac" />


## 🏄 Pour tester

https://app-pr13494.review.pix.fr/modules/bac-a-sable/passage
Se rendre sur le stepper horizontal et faire défiler les steps !
