### PR TITLE
[FEATURE] Passage du vouvoiement au tutoiement sur certains textes espagnols (PIX-19458)

### DIFF
--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2016,9 +2016,9 @@
             "reset": "Poner a cero y volver a intentarlo todo",
             "retry": "Repetir el test"
           },
-          "description": "Su organizador le pedirá que repita el curso.",
+          "description": "Tu organizador te pedira que repites la prueba.",
           "retryIn": "Aún no puede retomar este curso. Vuelva dentro de {duration}.",
-          "title": "Mejore sus resultados"
+          "title": "Mejora tus resultados"
         },
         "see-trainings": "Ver los cursos",
         "shared-message": "Tus resultados se enviaron el {date} a las {time}."
@@ -2050,7 +2050,7 @@
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
         "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
-        "notification-with-auto-share": "Repita las preguntas fallidas para mejorar su resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+        "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {
@@ -2066,7 +2066,7 @@
       "tabs": {
         "aria-label": "3 pestañas con los resultados",
         "results-details": {
-          "description": "Descubra sus competencias en detalle, organizadas por áreas específicas, para comprender mejor sus puntos fuertes y sus áreas de mejora. Identifica tus puntos fuertes y las áreas en las que puedes centrar tus esfuerzos para seguir progresando.",
+          "description": "Descubra tus competencias en detalle, organizadas por áreas específicas, para comprender mejor tus puntos fuertes y tus áreas de mejora. Identifica tus puntos fuertes y las áreas en las que puedes centrar tus esfuerzos para seguir progresando.",
           "tab-label": "Detalle de los resultados",
           "title": "Detalle de los resultados"
         },


### PR DESCRIPTION
## 🔆 Problème

L'écran de fin de parcours contenait à la fois du vouvoiement et du tutoiement.

## ⛱️ Proposition

Harmoniser les écrans impactés avec du tutoiement.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Créer une organisation avec la fonctionnalité "Envoi multiple sur les campagnes d'évaluation" cochée
- Créer une campagne et bien cocher "Oui" à la question "Souhaitez vous permettre aux participants d'envoyer plusieurs fois leurs résultats?" 
- Passer la campagne et arriver sur la page de fin de parcours
- Vérifier que les éléments sont modifiés sur la page de fin de de parcours
	- Point 1 : "Mejore sus resultados" est devenu "Mejora tus resultados"
	- Point 2 : "Su organizador le pedira que repita el curso" est devenu "Tu organizador te pedira que repites la prueba."
	- Point 3 : "Repitas las preguntas faillidas para mejora **su** resultado y seguir procesando" est devenu "Repite las preguntas fallidas para mejorar **tu** resultado y seguir progresando."
	- Point 2 : "Descubre sus competencias en detalle, organizadas por áreas específicas, para comprender mejor sus puntos fuertes y sus áreas de mejora." est devenue "Descubre tus competencias en detalle, organizadas por áreas específicas, para comprender mejor tus puntos fuertes y tus áreas de mejora."