### PR TITLE
[FEATURE] Redirection de l'utilisateur s'il tape un code de parcours combiné après /campagnes dans l'URL (PIX-18781)

### DIFF
--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -3,8 +3,14 @@ import { service } from '@ember/service';
 
 export default class CampaignsRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
-    return this.store.queryRecord('campaign', { filter: { code: params.code } });
+    const verifiedCode = await this.store.findRecord('verified-code', params.code);
+    if (verifiedCode.type === 'campaign') {
+      return this.store.queryRecord('campaign', { filter: { code: params.code } });
+    } else {
+      this.router.replaceWith('combined-courses', verifiedCode.id);
+    }
   }
 }

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -11,6 +11,7 @@ import { module, test } from 'qunit';
 import { authenticate, authenticateByGAR } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import setupIntl from '../helpers/setup-intl';
+import { unabortedVisit } from '../helpers/unaborted-visit';
 
 const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
@@ -444,6 +445,24 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           // then
           assert.strictEqual(currentURL(), '/campagnes');
           assert.dom(screen.getByText(t('pages.fill-in-campaign-code.errors.not-found'))).exists();
+        });
+      });
+      module('When verified code type is combined course', function () {
+        test('should redirect to combined course', async function (assert) {
+          // given
+          await authenticate(prescritUser);
+          server.create('combined-course', {
+            code: 'COMBINIX1',
+            organizationId: 1,
+            items: [],
+          });
+          server.create('verified-code', { id: 'COMBINIX1', type: 'combined-course' });
+
+          // when
+          await unabortedVisit('/campagnes/COMBINIX1');
+
+          // then
+          assert.strictEqual(currentURL(), '/parcours/COMBINIX1');
         });
       });
 

--- a/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
@@ -186,6 +186,22 @@ module('Acceptance | Combined course | Start Combined course workflow', function
           });
         });
       });
+      module('When verified code type is campaign', function () {
+        test('should redirect to campaign', async function (assert) {
+          // given
+          server.create('campaign', {
+            code: 'CAMPAIGN',
+            organizationId: 1,
+            items: [],
+          });
+
+          // when
+          await unabortedVisit('/parcours/CAMPAIGN');
+
+          // then
+          assert.strictEqual(currentURL(), '/campagnes/CAMPAIGN/evaluation/didacticiel');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
Actuellement, l'utilisateur peut accéder directement à une campagne s'il tape un code de campagnes après /parcours (on avait voulu limiter la confusion dans les usages entre parcours combinés et campagnes). Mais à l'inverse, taper un code de parcours combiné après /campagnes, emmenait sur la page "Oups".

## ⛱️ Proposition
On redirige l'utilisateur s'il tape un code de parcours combiné après /campagnes vers la page de parcours combiné.

## 🏄 Pour tester
Se connecter sur pix-app avec le compte attestation-blank@example.net.
Taper dans la barre d'adresse /campagnes/COMBINIX1 pour vérifier la redirection.