### PR TITLE
[FEATURE] Supprimer la mention des 4 jours avant de repasser dans PixOrga (PIX-19464)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -295,12 +295,12 @@
       "type": {
         "explanation": {
           "ASSESSMENT": "Campaign of type assessment",
-          "EXAM": "Interrogation mode [beta]",
+          "EXAM": "Exam mode [beta]",
           "PROFILES_COLLECTION": "Campaign of type profiles collection"
         },
         "information": {
           "ASSESSMENT": "Assessment",
-          "EXAM": "Interrogation mode [beta]",
+          "EXAM": "Exam mode [beta]",
           "PROFILES_COLLECTION": "Profiles collection"
         }
       }
@@ -692,7 +692,7 @@
       "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
       "multiple-sendings": {
         "assessments": {
-          "info": "If you choose to allow multiple submissions, the participants will be able to take the test again 4 days after and submit their results several times by re-entering the campaign code.",
+          "info": "If you choose to allow multiple submissions, participants will be able to take the test several times by re-entering the campaign code. You will have access to all the results.",
           "question-label": "Do you want to allow participants to submit their results more than once?"
         },
         "info-title": "Multiple submissions",
@@ -716,8 +716,8 @@
       "purpose": {
         "assessment": "Assess participants",
         "assessment-info": "An assessment campaign tests participants on specific topics.",
-        "exam": "Interrogation mode [beta]",
-        "exam-info": "A ‘interrogation mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
+        "exam": "Exam mode [beta]",
+        "exam-info": "A ‘exam mode’ campaign enables participants to be tested on specific topics, without taking their user profile into account or having any impact on it. The campaign's questions are personalised for each participant, depending on how far they have progressed along the route.",
         "label": "What is the purpose of your campaign?",
         "profiles-collection": "Collect the participants' Pix profiles",
         "profiles-collection-info": "A profile collection campaign retrieves the participants’ Pix profile: their level for each competence and their pix score.",
@@ -909,7 +909,7 @@
         "title": "Multiple Sendings",
         "tooltip": {
           "aria-label": "Description of multiple sendings",
-          "text": "If you choose to allow multiple submissions, the participants will be able to submit their participation several times by re-entering the campaign code. Within Pix Orga you will find the latest sent."
+          "text": "If you choose to allow multiple submissions, the participants will be able to submit their participation several times by re-entering the campaign code."
         }
       },
       "personalised-test-title": "Title of the customised test",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -692,7 +692,7 @@
       "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne 4 jours après et envoyer ses résultats plusieurs fois, en saisissant à nouveau le code.",
+          "info": "Si vous choisissez l’envoi multiple, le participant pourra repasser la campagne plusieurs fois, en saisissant à nouveau le code. Vous aurez accès à tous les résultats.",
           "question-label": "Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ?"
         },
         "info-title": "Envoi multiple",
@@ -909,7 +909,7 @@
         "title": "Envoi multiple",
         "tooltip": {
           "aria-label": "Description de l'envoi multiple",
-          "text": "Si l’envoi multiple est activé, le participant peut envoyer plusieurs fois sa participation en saisissant à nouveau le code campagne. Au sein de Pix Orga, vous trouverez la dernière envoyée."
+          "text": "Si l’envoi multiple est activé, le participant peut envoyer plusieurs fois sa participation en saisissant à nouveau le code campagne."
         }
       },
       "personalised-test-title": "Titre du parcours",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -692,7 +692,7 @@
       "legal-warning": "* In overeenstemming met de Franse wet op gegevensbescherming en als verantwoordelijke voor de verwerking van de gegevens, vragen we niet naar bijzonder identificerende of belangrijke gegevens, tenzij dit absoluut noodzakelijk is. Het burgerservicenummer (BSN) moet worden vermeden, net als gevoelige gegevens.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Als je ervoor kiest om meerdere inzendingen te verzenden, kan de deelnemer de campagne 4 dagen later opnieuw uitvoeren en zijn resultaten meerdere keren verzenden door de code opnieuw in te voeren. In Pix Orga zie je hun laatste inzending.",
+          "info": "Als u ervoor kiest om meerdere inzendingen toe te staan, kunnen deelnemers de test meerdere keren afleggen door de campagnecode opnieuw in te voeren. U krijgt toegang tot alle resultaten.",
           "question-label": "Wil je deelnemers toestaan hun resultaten meer dan één keer te versturen?"
         },
         "info-title": "Meervoudig verzenden",
@@ -909,7 +909,7 @@
         "title": "Meervoudig verzenden",
         "tooltip": {
           "aria-label": "Beschrijving van meervoudige verzending",
-          "text": "Als meervoudige verzending is geactiveerd, kan de deelnemer zijn deelname meerdere keren versturen door de campagnecode opnieuw in te voeren. Je vindt de laatst verzonden inzending in Pix Orga."
+          "text": "Als meervoudige verzending is geactiveerd, kan de deelnemer zijn deelname meerdere keren versturen door de campagnecode opnieuw in te voeren."
         }
       },
       "personalised-test-title": "Titel test",


### PR DESCRIPTION
## 🔆 Problème

Dans la description de la fonctionnalité “envoi multiple”, on parle des 4 jours avant de repasser une campagne. On veut supprimer cette mention puisque maintenant le délai est à 0. 

## ⛱️ Proposition


## 🌊 Remarques

Petit bonus qui n’a rien à voir : renommer le mode interro en exam mode pour les anglophones suite à un retour métier. 

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
