### PR TITLE
[TECH] Modifier le libellé des locales des invitations aux centres de certification dans pix-admin (PIX-19344)

### DIFF
--- a/admin/app/adapters/certification-center-invitation.js
+++ b/admin/app/adapters/certification-center-invitation.js
@@ -12,7 +12,7 @@ export default class CertificationCenterInvitationAdapter extends ApplicationAda
     if (query.certificationCenterId) {
       const url = `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/invitations`;
       return this.ajax(url, 'POST', {
-        data: { data: { attributes: { email: query.email, language: query.language, role: query.role } } },
+        data: { data: { attributes: { email: query.email, locale: query.locale, role: query.role } } },
       });
     }
 

--- a/admin/app/components/certification-centers/invitations-action.gjs
+++ b/admin/app/components/certification-centers/invitations-action.gjs
@@ -16,15 +16,19 @@ export default class CertificationCenterInvitationsAction extends Component {
 
   localeOptions = [
     {
-      label: 'Français',
+      label: 'Français (France)',
       value: 'fr-FR',
     },
     {
-      label: 'Francophone',
+      label: 'Français (Belgique)',
+      value: 'fr-BE',
+    },
+    {
+      label: 'Français (International)',
       value: 'fr',
     },
     {
-      label: 'Anglais',
+      label: 'English (International)',
       value: 'en',
     },
   ];

--- a/admin/app/components/certification-centers/invitations-action.gjs
+++ b/admin/app/components/certification-centers/invitations-action.gjs
@@ -11,13 +11,13 @@ import { tracked } from '@glimmer/tracking';
 export default class CertificationCenterInvitationsAction extends Component {
   @service intl;
 
-  @tracked invitationLanguage = this.languagesOptions[0].value;
+  @tracked invitationLocale = this.localeOptions[0].value;
   @tracked invitationRole = this.rolesOptions[0].value;
 
-  languagesOptions = [
+  localeOptions = [
     {
       label: 'Français',
-      value: 'fr-fr',
+      value: 'fr-FR',
     },
     {
       label: 'Francophone',
@@ -54,8 +54,8 @@ export default class CertificationCenterInvitationsAction extends Component {
   }
 
   @action
-  changeInvitationLanguage(value) {
-    this.invitationLanguage = value;
+  changeInvitationLocale(value) {
+    this.invitationLocale = value;
   }
 
   <template>
@@ -74,9 +74,9 @@ export default class CertificationCenterInvitationsAction extends Component {
           </PixInput>
 
           <PixSelect
-            @options={{this.languagesOptions}}
-            @value={{this.invitationLanguage}}
-            @onChange={{this.changeInvitationLanguage}}
+            @options={{this.localeOptions}}
+            @value={{this.invitationLocale}}
+            @onChange={{this.changeInvitationLocale}}
             @placeholder="Choix de la langue"
             @hideDefaultOption={{true}}
           >
@@ -95,7 +95,7 @@ export default class CertificationCenterInvitationsAction extends Component {
 
           <PixButton
             @size="small"
-            @triggerAction={{fn @createInvitation this.invitationLanguage this.certificationCenterRoleValue}}
+            @triggerAction={{fn @createInvitation this.invitationLocale this.certificationCenterRoleValue}}
             aria-label="Inviter un membre"
             class="certification-center-invitations-form-container__button"
             name="Inviter"

--- a/admin/app/components/certification-centers/invitations.gjs
+++ b/admin/app/components/certification-centers/invitations.gjs
@@ -49,7 +49,7 @@ export default class CertificationCenterInvitations extends Component {
                 Locale
               </:header>
               <:cell>
-                {{invitation.language}}
+                {{invitation.locale}}
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>

--- a/admin/app/components/organizations/invitations-action.gjs
+++ b/admin/app/components/organizations/invitations-action.gjs
@@ -10,10 +10,10 @@ import { tracked } from '@glimmer/tracking';
 
 export default class OrganizationInvitationsAction extends Component {
   @service intl;
-  @tracked organizationInvitationLang = this.languagesOptions[0].value;
+  @tracked organizationInvitationLang = this.localeOptions[0].value;
   @tracked organizationInvitationRole = this.rolesOptions[0].value;
 
-  get languagesOptions() {
+  get localeOptions() {
     return [
       {
         label: 'Français',
@@ -78,7 +78,7 @@ export default class OrganizationInvitationsAction extends Component {
             </PixInput>
 
             <PixSelect
-              @options={{this.languagesOptions}}
+              @options={{this.localeOptions}}
               @value={{this.organizationInvitationLang}}
               @onChange={{this.changeOrganizationInvitationLang}}
               @placeholder="Langue"

--- a/admin/app/controllers/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/invitations.js
@@ -26,7 +26,7 @@ export default class AuthenticatedCertificationCentersGetInvitationsController e
   }
 
   @action
-  async createInvitation(language, role) {
+  async createInvitation(locale, role) {
     const email = this.userEmailToInvite?.trim();
     if (!this._isEmailToInviteValid(email)) {
       return;
@@ -35,7 +35,7 @@ export default class AuthenticatedCertificationCentersGetInvitationsController e
     try {
       await this.store.queryRecord('certification-center-invitation', {
         email,
-        language,
+        locale,
         role,
         certificationCenterId: this.model.certificationCenterId,
       });
@@ -49,11 +49,12 @@ export default class AuthenticatedCertificationCentersGetInvitationsController e
 
   @action
   async sendNewCertificationCenterInvitation(certificationCenterInvitation) {
-    const { email, language, role } = certificationCenterInvitation;
+    const { email, locale, role } = certificationCenterInvitation;
+
     try {
       await this.store.queryRecord('certification-center-invitation', {
         email,
-        language,
+        locale,
         role,
         certificationCenterId: this.model.certificationCenterId,
       });

--- a/admin/app/models/certification-center-invitation.js
+++ b/admin/app/models/certification-center-invitation.js
@@ -7,7 +7,7 @@ export default class CertificationCenterInvitationModel extends Model {
   @attr email;
   @attr updatedAt;
   @attr role;
-  @attr language;
+  @attr locale;
 
   @belongsTo('certification-center', { async: true, inverse: null }) certificationCenter;
 

--- a/admin/tests/integration/components/certification-centers/invitations-action-test.gjs
+++ b/admin/tests/integration/components/certification-centers/invitations-action-test.gjs
@@ -11,7 +11,7 @@ module('Integration | Component | certification-center-invitations-action', func
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it should create certification-center invitation with default language', async function (assert) {
+  test('it should create certification-center invitation with default locale', async function (assert) {
     // given
     const createInvitationStub = sinon.stub();
     const onChangeUserEmailToInvite = () => {};
@@ -28,10 +28,10 @@ module('Integration | Component | certification-center-invitations-action', func
     await click(screen.getByRole('button', { name: 'Inviter un membre' }));
 
     // then
-    assert.ok(createInvitationStub.calledWith('fr-fr'));
+    assert.ok(createInvitationStub.calledWith('fr-FR'));
   });
 
-  test('it creates a certification-center invitation with choosen language and choosen role', async function (assert) {
+  test('it creates a certification-center invitation with choosen locale and choosen role', async function (assert) {
     // given
     const createInvitationStub = sinon.stub();
     const onChangeUserEmailToInvite = () => {};

--- a/admin/tests/integration/components/certification-centers/invitations-action-test.gjs
+++ b/admin/tests/integration/components/certification-centers/invitations-action-test.gjs
@@ -48,7 +48,7 @@ module('Integration | Component | certification-center-invitations-action', func
 
     await click(screen.getByRole('button', { name: 'Choisir la langue de l’email d’invitation' }));
     await screen.findByRole('listbox');
-    await click(screen.getByRole('option', { name: 'Anglais' }));
+    await click(screen.getByRole('option', { name: 'English (International)' }));
     await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
     await click(screen.getByRole('button', { name: 'Choisir le rôle du membre' }));

--- a/admin/tests/integration/components/certification-centers/invitations-test.gjs
+++ b/admin/tests/integration/components/certification-centers/invitations-test.gjs
@@ -36,12 +36,12 @@ module('Integration | Component | Certification Centers | Invitations', function
       const certificationCenterInvitation1 = store.createRecord('certification-center-invitation', {
         email: 'elo.dela@example.net',
         updatedAt: invitationUpdatedAt1,
-        language: 'fr-FR',
+        locale: 'fr-FR',
       });
       const certificationCenterInvitation2 = store.createRecord('certification-center-invitation', {
         email: 'alain.finis@example.net',
         updatedAt: invitationUpdatedAt2,
-        language: 'fr-BE',
+        locale: 'fr-BE',
       });
       const certificationCenterInvitations = [certificationCenterInvitation1, certificationCenterInvitation2];
       const cancelCertificationCenterInvitation = sinon.stub();
@@ -63,6 +63,7 @@ module('Integration | Component | Certification Centers | Invitations', function
       const table = screen.getByRole('table', {
         name: t('components.certification-centers.invitations.table.caption'),
       });
+
       assert.dom(screen.getByRole('heading', { name: 'Invitations' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Adresse e-mail' })).exists();
       assert.dom(within(table).getByRole('columnheader', { name: 'Date de dernier envoi' })).exists();

--- a/admin/tests/unit/adapters/certification-center-invitation-test.js
+++ b/admin/tests/unit/adapters/certification-center-invitation-test.js
@@ -26,7 +26,7 @@ module('Unit | Adapter | certification-center-invitation', function (hooks) {
       const adapter = this.owner.lookup('adapter:certification-center-invitation');
       const store = this.owner.lookup('service:store');
       sinon.stub(adapter, 'ajax');
-      const query = { certificationCenterId: 666, email: 'super@example.net', language: 'fr-fr', role: 'MEMBER' };
+      const query = { certificationCenterId: 666, email: 'super@example.net', locale: 'fr-fr', role: 'MEMBER' };
 
       // when
       adapter.queryRecord(store, 'certification-center-invitation', query);
@@ -34,7 +34,7 @@ module('Unit | Adapter | certification-center-invitation', function (hooks) {
       // then
       const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-centers/666/invitations`;
       const expectedPayload = {
-        data: { data: { attributes: { email: 'super@example.net', language: 'fr-fr', role: 'MEMBER' } } },
+        data: { data: { attributes: { email: 'super@example.net', locale: 'fr-fr', role: 'MEMBER' } } },
       };
       sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
       assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations-test.js
@@ -43,17 +43,17 @@ module('Unit | Controller | authenticated/certification-centers/get/invitations'
         store.queryRecord = queryRecordStub;
 
         controller.userEmailToInvite = 'yuno@clover.net';
-        const language = 'fr';
+        const locale = 'fr';
         const role = 'MEMBER';
 
         // when
-        await controller.createInvitation(language, role);
+        await controller.createInvitation(locale, role);
 
         //then
         assert.ok(
           queryRecordStub.calledWith('certification-center-invitation', {
             email: 'yuno@clover.net',
-            language,
+            locale,
             role,
             certificationCenterId: 1,
           }),
@@ -96,7 +96,7 @@ module('Unit | Controller | authenticated/certification-centers/get/invitations'
         store.queryRecord = queryRecordStub;
         const certificationCenterInvitation = {
           email: 'test@example.net',
-          language: 'en',
+          locale: 'en',
           role: 'member',
           certificationCenterId: 1,
         };
@@ -126,7 +126,7 @@ module('Unit | Controller | authenticated/certification-centers/get/invitations'
         controller.CUSTOM_ERROR_MESSAGES = customErrors;
         const certificationCenterInvitation = {
           email: 'test@example.net',
-          language: 'en',
+          locale: 'en',
           role: 'member',
           certificationCenterId: 1,
         };

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.controller.js
@@ -23,7 +23,7 @@ const sendInvitationForAdmin = async function (request, h, dependencies = { cert
     await usecases.createOrUpdateCertificationCenterInvitationForAdmin({
       certificationCenterId,
       email: invitationInformation.email,
-      locale: getNearestSupportedLocale(invitationInformation.language),
+      locale: getNearestSupportedLocale(invitationInformation.locale),
       role: invitationInformation.role,
     });
 

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
@@ -63,7 +63,7 @@ export const certificationCenterInvitationAdminRoutes = [
           data: {
             attributes: {
               email: Joi.string().email().required(),
-              language: Joi.string().valid('fr-fr', 'fr-FR', 'fr-BE', 'fr', 'nl', 'nl-BE', 'en'),
+              locale: Joi.string().valid('fr-fr', 'fr-FR', 'fr-BE', 'fr', 'nl', 'nl-BE', 'en'),
               role: Joi.string().valid('ADMIN', 'MEMBER').allow(null),
             },
           },

--- a/api/src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
@@ -10,13 +10,7 @@ const serialize = function (invitations) {
 
 const serializeForAdmin = function (invitations) {
   return new Serializer('certification-center-invitations', {
-    transform: (invitation) => {
-      return {
-        ...invitation,
-        language: invitation.locale,
-      };
-    },
-    attributes: ['email', 'updatedAt', 'role', 'language'],
+    attributes: ['email', 'updatedAt', 'role', 'locale'],
   }).serialize(invitations);
 };
 
@@ -24,7 +18,7 @@ const deserializeForAdmin = function (payload) {
   return new Deserializer().deserialize(payload).then((record) => {
     return {
       email: record.email,
-      language: record.language,
+      locale: record.locale,
       role: record.role,
     };
   });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.admin.route.test.js
@@ -59,7 +59,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
           attributes: {
             email: 'alex.terieur@example.net',
             role: 'MEMBER',
-            language: 'fr',
+            locale: 'fr',
             'updated-at': now,
           },
         },
@@ -69,7 +69,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
           attributes: {
             email: 'sarah.pelle@example.net',
             role: 'ADMIN',
-            language: 'fr',
+            locale: 'fr',
             'updated-at': now,
           },
         },
@@ -106,7 +106,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
           data: {
             attributes: {
               email: 'some.user@example.net',
-              language: 'fr-fr',
+              locale: 'fr-FR',
               role: CertificationCenterInvitation.Roles.ADMIN,
             },
           },
@@ -122,7 +122,7 @@ describe('Acceptance | Team | Application | Route | Admin | Certification Center
         'updated-at': now,
         email: 'some.user@example.net',
         role: 'ADMIN',
-        language: 'fr-FR',
+        locale: 'fr-FR',
       });
     });
   });

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -227,7 +227,7 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
             attributes: {
               email: updatedCertificationCenterInvitation.email,
               role: updatedCertificationCenterInvitation.role,
-              language: updatedCertificationCenterInvitation.locale,
+              locale: updatedCertificationCenterInvitation.locale,
               'updated-at': updatedCertificationCenterInvitation.updatedAt,
             },
           },

--- a/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.admin.controller.test.js
+++ b/api/tests/team/unit/application/certification-center-invitation/certification-center-invitation.admin.controller.test.js
@@ -50,7 +50,7 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
     it('should return 201 HTTP status code with data if there isn’t an already pending invitation', async function () {
       // given
       const email = 'some.user@example.net';
-      const language = 'fr-FR';
+      const locale = 'fr-FR';
       const role = null;
       const certificationCenterId = 7;
       const payload = {
@@ -58,7 +58,7 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
           type: 'certification-center-invitations',
           attributes: {
             email,
-            language,
+            locale,
             role,
           },
         },
@@ -66,12 +66,12 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
 
       certificationCenterInvitationSerializerStub.deserializeForAdmin.withArgs(payload).resolves({
         email,
-        language,
+        locale,
       });
       usecases.createOrUpdateCertificationCenterInvitationForAdmin
         .withArgs({
           email,
-          locale: language,
+          locale,
           role,
           certificationCenterId,
         })
@@ -102,10 +102,10 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
     it('should return 200 HTTP status code with data if there is already a pending existing invitation', async function () {
       // given
       const email = 'some.user@example.net';
-      const language = 'fr-fr';
+      const locale = 'fr-fr';
       const role = 'ADMIN';
 
-      certificationCenterInvitationSerializerStub.deserializeForAdmin.resolves({ email, language });
+      certificationCenterInvitationSerializerStub.deserializeForAdmin.resolves({ email, locale });
       usecases.createOrUpdateCertificationCenterInvitationForAdmin.resolves({
         certificationCenterInvitation: 'an invitation',
         isInvitationCreated: false,
@@ -122,7 +122,7 @@ describe('Unit | Team | Application | Controller | Admin | Certification Center 
               type: 'certification-center-invitations',
               attributes: {
                 email,
-                language,
+                locale,
                 role,
               },
             },

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
@@ -56,7 +56,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
             email: 'anne.atole@example.net',
             'updated-at': now,
             role: 'MEMBER',
-            language: 'fr',
+            locale: 'fr',
           },
         },
       });
@@ -70,7 +70,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
         data: {
           type: 'certification-center-invitations',
           attributes: {
-            language: 'fr-fr',
+            locale: 'fr-FR',
             email: 'email@example.net',
             role: 'ADMIN',
           },
@@ -82,7 +82,7 @@ describe('Unit | Team | Serializer | JSONAPI | certification-center-invitation-s
 
       // then
       expect(json).to.deep.equal({
-        language: 'fr-fr',
+        locale: 'fr-FR',
         email: 'email@example.net',
         role: 'ADMIN',
       });


### PR DESCRIPTION
## 🔆 Problème

Revoir le wording des langues lors des envois d'invitations pour les centres de certification dans Pix Admin.

## ⛱️ Proposition

- Dans Pix Admin > Centres de certification > Invitations. Il y a un menu déroulant, il faut modifier les libellés et mettre les locales supportées par Certif. 

- Les valeurs qui doivent apparaitre 

  - English (International) - en

  - Français (France) - fr-FR

  - Français (Belgique) - fr-BE

  - Français (International) - fr

- REVOIR LE PAYLOAD: 

  - Remplacer language par locale côté Front et API

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Depuis pix-admin
  - Envoyer une invitation à rejoindre un centre de certification
  - Constater les nouveaux labels dans le choix des locales 