### PR TITLE
[FEATURE] Cacher le code campagne lorsque celle ci est intégré à un parcours combiné (PIX-19312).

### DIFF
--- a/api/src/prescription/campaign/domain/read-models/CampaignReport.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignReport.js
@@ -26,6 +26,7 @@ class CampaignReport {
     multipleSendings,
     targetProfileName,
   } = {}) {
+    this.isFromCombinedCourse = false;
     this.targetProfileName = targetProfileName;
     this.id = id;
     this.name = name;
@@ -69,6 +70,10 @@ class CampaignReport {
 
   get isArchived() {
     return Boolean(this.archivedAt);
+  }
+
+  setIsFromCombinedCourse(isFromCombinedCourse) {
+    this.isFromCombinedCourse = isFromCombinedCourse;
   }
 
   setTargetProfileInformation(targetProfile) {

--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -1,4 +1,4 @@
-import * as injectedCombinedCourseApi from '../../../../quest/application/api/combined-course-api.js';
+import { findByCampaignId } from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 
 const getCampaign = async function ({
   campaignId,
@@ -6,12 +6,11 @@ const getCampaign = async function ({
   campaignReportRepository,
   stageCollectionRepository,
   stageAcquisitionRepository,
-  combinedCourseApi = injectedCombinedCourseApi,
 }) {
   const campaignReport = await campaignReportRepository.get(campaignId);
 
-  const existingCombinedCourse = await combinedCourseApi.getByCampaignId(campaignId);
-  campaignReport.setIsFromCombinedCourse(Boolean(existingCombinedCourse));
+  const existingCombinedCourse = await findByCampaignId({ campaignId });
+  campaignReport.setIsFromCombinedCourse(existingCombinedCourse.length > 0);
 
   if (campaignReport.isAssessment || campaignReport.isExam) {
     const [badges, stageCollection, masteryRates] = await Promise.all([

--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -1,11 +1,17 @@
+import * as injectedCombinedCourseApi from '../../../../quest/application/api/combined-course-api.js';
+
 const getCampaign = async function ({
   campaignId,
   badgeRepository,
   campaignReportRepository,
   stageCollectionRepository,
   stageAcquisitionRepository,
+  combinedCourseApi = injectedCombinedCourseApi,
 }) {
   const campaignReport = await campaignReportRepository.get(campaignId);
+
+  const existingCombinedCourse = await combinedCourseApi.getByCampaignId(campaignId);
+  campaignReport.setIsFromCombinedCourse(Boolean(existingCombinedCourse));
 
   if (campaignReport.isAssessment || campaignReport.isExam) {
     const [badges, stageCollection, masteryRates] = await Promise.all([

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -43,6 +43,7 @@ const serialize = function (campaignReports, meta) {
       'groups',
       'multipleSendings',
       'targetProfile',
+      'isFromCombinedCourse',
     ],
     stages: {
       ref: 'id',

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -1,7 +1,4 @@
-import * as badgeRepository from '../../../../../../src/evaluation/infrastructure/repositories/badge-repository.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
-import * as campaignReportRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js';
-import * as campaignRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import {
   CampaignParticipationStatuses,
   CampaignTypes,
@@ -10,24 +7,17 @@ import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign', function () {
   context('Type ASSESSMENT', function () {
-    let userId;
     let campaign;
     let targetProfileId;
 
     beforeEach(async function () {
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      userId = databaseBuilder.factory.buildUser().id;
       targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       campaign = databaseBuilder.factory.buildCampaign({
         name: 'TroTro',
         targetProfileId,
         organizationId,
         type: CampaignTypes.ASSESSMENT,
-      });
-
-      databaseBuilder.factory.buildMembership({
-        organizationId,
-        userId,
       });
 
       await databaseBuilder.commit();
@@ -37,9 +27,6 @@ describe('Integration | UseCase | get-campaign', function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
       });
 
       // then
@@ -59,10 +46,6 @@ describe('Integration | UseCase | get-campaign', function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
-        userId,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
       });
 
       // then
@@ -78,10 +61,6 @@ describe('Integration | UseCase | get-campaign', function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
-        userId,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
       });
 
       // then
@@ -122,10 +101,6 @@ describe('Integration | UseCase | get-campaign', function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
-        userId,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
       });
 
       // then
@@ -152,9 +127,6 @@ describe('Integration | UseCase | get-campaign', function () {
         // when
         const resultCampaign = await usecases.getCampaign({
           campaignId: campaign.id,
-          badgeRepository,
-          campaignRepository,
-          campaignReportRepository,
         });
 
         // then
@@ -167,14 +139,12 @@ describe('Integration | UseCase | get-campaign', function () {
     });
 
     context('when there are participations', function () {
-      let userId;
       let targetProfileId;
       let campaign;
       let resultCampaign;
 
       before(async function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        userId = databaseBuilder.factory.buildUser().id;
         targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
         databaseBuilder.factory.buildBadge({ targetProfileId });
         const stageId = databaseBuilder.factory.buildStage({ targetProfileId }).id;
@@ -184,10 +154,7 @@ describe('Integration | UseCase | get-campaign', function () {
           organizationId,
           type: CampaignTypes.EXAM,
         });
-        databaseBuilder.factory.buildMembership({
-          organizationId,
-          userId,
-        });
+
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           masteryRate: 0.3,
@@ -211,9 +178,6 @@ describe('Integration | UseCase | get-campaign', function () {
 
         resultCampaign = await usecases.getCampaign({
           campaignId: campaign.id,
-          badgeRepository,
-          campaignRepository,
-          campaignReportRepository,
         });
       });
 
@@ -237,7 +201,6 @@ describe('Integration | UseCase | get-campaign', function () {
     it('should not set average Result', async function () {
       //given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const userId = databaseBuilder.factory.buildUser().id;
       const campaignId = databaseBuilder.factory.buildCampaign({
         name: 'NO_SE',
         organizationId,
@@ -246,11 +209,6 @@ describe('Integration | UseCase | get-campaign', function () {
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
         organizationId,
       }).id;
-
-      databaseBuilder.factory.buildMembership({
-        organizationId,
-        userId,
-      });
 
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId,
@@ -262,9 +220,6 @@ describe('Integration | UseCase | get-campaign', function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId,
-        badgeRepository,
-        campaignRepository,
-        campaignReportRepository,
       });
 
       // then

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -6,6 +6,62 @@ import {
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign', function () {
+  context('Campaign on Combined Course', function () {
+    let campaign, organizationId, targetProfileId;
+
+    beforeEach(async function () {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      campaign = databaseBuilder.factory.buildCampaign({
+        name: 'TroTro',
+        targetProfileId,
+        organizationId,
+        type: CampaignTypes.ASSESSMENT,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should defined isFromCombinedCourse to true when campaign register on combined course', async function () {
+      // given
+      databaseBuilder.factory.buildQuestForCombinedCourse({
+        code: 'ABCDE1234',
+        name: 'Mon parcours Combiné',
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+      });
+
+      // then
+      expect(resultCampaign.isFromCombinedCourse).true;
+    });
+
+    it('should defined isFromCombinedCourse to false when campaign is not register on combined course', async function () {
+      // when
+      const resultCampaign = await usecases.getCampaign({
+        campaignId: campaign.id,
+      });
+
+      // then
+      expect(resultCampaign.isFromCombinedCourse).false;
+    });
+  });
   context('Type ASSESSMENT', function () {
     let campaign;
     let targetProfileId;

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -129,6 +129,7 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
             'average-result': report.averageResult,
             'reached-stage': report.reachedStage,
             'total-stage': report.totalStage,
+            'is-from-combined-course': report.isFromCombinedCourse,
           },
         },
         included: [

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -1,3 +1,4 @@
+import { CampaignReport } from '../../../../src/prescription/campaign/domain/read-models/CampaignReport.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
 import { domainBuilder, expect } from '../../../test-helper.js';
 
@@ -116,6 +117,30 @@ describe('Unit | Domain | Models | CampaignReport', function () {
       campaignReport.computeAverageResult([0.13, 0.52]);
 
       expect(campaignReport.averageResult).to.equal(0.325);
+    });
+  });
+
+  describe('#setIsFromCombinedCourse', function () {
+    it('should define isFromCombinedCourse to false by default', function () {
+      const campaignReport = new CampaignReport();
+
+      expect(campaignReport.isFromCombinedCourse).false;
+    });
+
+    it('should define isFromCombinedCourse to false when not combined course defined', function () {
+      const campaignReport = new CampaignReport();
+
+      campaignReport.setIsFromCombinedCourse(false);
+
+      expect(campaignReport.isFromCombinedCourse).false;
+    });
+
+    it('should define isFromCombinedCourse to true when combined course defined', function () {
+      const campaignReport = new CampaignReport();
+
+      campaignReport.setIsFromCombinedCourse(true);
+
+      expect(campaignReport.isFromCombinedCourse).true;
     });
   });
 });

--- a/orga/app/components/campaign/empty-state.gjs
+++ b/orga/app/components/campaign/empty-state.gjs
@@ -8,12 +8,12 @@ import CopyPasteButton from '../copy-paste-button';
 export default class EmptyState extends Component {
   @service url;
 
-  get campaignCode() {
-    return this.args.campaignCode;
+  get displayCopyPasteButton() {
+    return this.args.campaignCode && !this.args.isFromCombinedCourse;
   }
 
   get campaignUrl() {
-    return `${this.url.campaignsRootUrl}${this.campaignCode}`;
+    return `${this.url.campaignsRootUrl}${this.args.campaignCode}`;
   }
 
   <template>
@@ -21,7 +21,7 @@ export default class EmptyState extends Component {
       <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
       <div class="empty-state__text">
-        {{#if this.campaignCode}}
+        {{#if this.displayCopyPasteButton}}
           <p>{{t "pages.campaign.empty-state-with-copy-link"}}</p>
 
           <CopyPasteButton

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -81,20 +81,22 @@ export default class Header extends Component {
               </dd>
             </div>
           {{/if}}
-          <div class="campaign-header-title__detail-item">
-            <dt class="label-text">
-              {{t "pages.campaign.code"}}
-            </dt>
-            <dd class="campaign-header-title__campaign-code">
-              <span>{{@campaign.code}}</span>
-              <CopyPasteButton
-                @clipBoardtext={{@campaign.code}}
-                @successMessage={{t "pages.campaign.copy.code.success"}}
-                @defaultMessage={{t "pages.campaign.copy.code.default"}}
-                class="hide-on-mobile"
-              />
-            </dd>
-          </div>
+          {{#unless @campaign.isFromCombinedCourse}}
+            <div class="campaign-header-title__detail-item">
+              <dt class="label-text">
+                {{t "pages.campaign.code"}}
+              </dt>
+              <dd class="campaign-header-title__campaign-code">
+                <span>{{@campaign.code}}</span>
+                <CopyPasteButton
+                  @clipBoardtext={{@campaign.code}}
+                  @successMessage={{t "pages.campaign.copy.code.success"}}
+                  @defaultMessage={{t "pages.campaign.copy.code.default"}}
+                  class="hide-on-mobile"
+                />
+              </dd>
+            </div>
+          {{/unless}}
         </dl>
       </:tools>
     </PageTitle>

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -25,6 +25,7 @@ export default class Campaign extends Model {
   @attr('number') targetProfileThematicResultCount;
   @attr('boolean') targetProfileHasStage;
   @attr('boolean') targetProfileAreKnowledgeElementsResettable;
+  @attr('boolean') isFromCombinedCourse;
   @attr('number') participationsCount;
   @attr('number') sharedParticipationsCount;
   @attr('number') averageResult;

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.gjs
@@ -34,7 +34,10 @@ import EmptyState from 'pix-orga/components/campaign/empty-state';
     {{#if @controller.isGarAuthenticationMethod}}
       <EmptyState />
     {{else}}
-      <EmptyState @campaignCode={{@model.campaign.code}} />
+      <EmptyState
+        @campaignCode={{@model.campaign.code}}
+        @isFromCombinedCourse={{@model.campaign.isFromCombinedCourse}}
+      />
     {{/if}}
   {{/if}}
 </template>

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.gjs
@@ -46,7 +46,10 @@ const levels = [
     {{#if @controller.isGarAuthenticationMethod}}
       <EmptyState />
     {{else}}
-      <EmptyState @campaignCode={{@model.campaign.code}} />
+      <EmptyState
+        @campaignCode={{@model.campaign.code}}
+        @isFromCombinedCourse={{@model.campaign.isFromCombinedCourse}}
+      />
     {{/if}}
   {{/if}}
 </template>

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.gjs
@@ -38,7 +38,10 @@ import AssessmentList from 'pix-orga/components/campaign/results/assessment-list
     {{#if @controller.isGarAuthenticationMethod}}
       <EmptyState />
     {{else}}
-      <EmptyState @campaignCode={{@model.campaign.code}} />
+      <EmptyState
+        @campaignCode={{@model.campaign.code}}
+        @isFromCombinedCourse={{@model.campaign.isFromCombinedCourse}}
+      />
     {{/if}}
   {{/if}}
 </template>

--- a/orga/app/templates/authenticated/campaigns/campaign/profile-results.gjs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profile-results.gjs
@@ -20,6 +20,6 @@ import ProfileList from 'pix-orga/components/campaign/results/profile-list';
       class="profile-results__list"
     />
   {{else}}
-    <EmptyState @campaignCode={{@model.campaign.code}} />
+    <EmptyState @campaignCode={{@model.campaign.code}} @isFromCombinedCourse={{@model.campaign.isFromCombinedCourse}} />
   {{/if}}
 </template>

--- a/orga/tests/integration/components/campaign/empty-state-test.js
+++ b/orga/tests/integration/components/campaign/empty-state-test.js
@@ -15,6 +15,17 @@ module('Integration | Component | Campaign::EmptyState', function (hooks) {
       assert.dom(screen.getByText(t('pages.campaign.empty-state-with-copy-link'))).exists();
       assert.dom(screen.getByRole('button', { name: t('pages.campaign.copy.link.default') })).exists();
     });
+
+    module('When campaign is From combined course', function () {
+      test('displays the empty message without copy button', async function (assert) {
+        // when
+        const screen = await render(hbs`<Campaign::EmptyState @campaignCode='ACDC' @isFromCombinedCourse={{true}} />`);
+
+        // then
+        assert.dom(screen.getByText(t('pages.campaign.empty-state'))).exists();
+        assert.dom(screen.queryByRole('button', { name: t('pages.campaign.copy.link.default') })).doesNotExist();
+      });
+    });
   });
 
   module('when no campaign code is given', function () {

--- a/orga/tests/integration/components/campaign/header/title-test.js
+++ b/orga/tests/integration/components/campaign/header/title-test.js
@@ -16,6 +16,7 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
       createdAt: new Date('2021-04-14'),
       ownerFullName: 'Mulan Fa',
       type: 'ASSESSMENT',
+      isFromCombinedCourse: false,
     };
 
     // when
@@ -29,6 +30,46 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
     assert.ok(screen.getByText('1234PixTest'));
     assert.ok(screen.getByText('Mulan Fa'));
     assert.ok(screen.getByText('14/04/2021'));
+  });
+
+  module('campaign code display', function () {
+    test('it should display campaign code when campaign is not from combined course', async function (assert) {
+      // given
+      this.campaign = {
+        name: 'campagne 1',
+        code: '1234PixTest',
+        createdAt: new Date('2021-04-14'),
+        ownerFullName: 'Mulan Fa',
+        type: 'ASSESSMENT',
+        isFromCombinedCourse: false,
+      };
+
+      // when
+      const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+      // then
+      assert.ok(screen.getByText('1234PixTest'));
+      assert.ok(screen.getByText(t('pages.campaign.code')));
+    });
+
+    test('it should not display campaign code when campaign is from combined course', async function (assert) {
+      // given
+      this.campaign = {
+        name: 'campagne 1',
+        code: '1234PixTest',
+        createdAt: new Date('2021-04-14'),
+        ownerFullName: 'Mulan Fa',
+        type: 'ASSESSMENT',
+        isFromCombinedCourse: true,
+      };
+
+      // when
+      const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+      // then
+      assert.notOk(screen.queryByText('1234PixTest'));
+      assert.notOk(screen.queryByText(t('pages.campaign.code')));
+    });
   });
 
   module('multiple sending display', function (hooks) {


### PR DESCRIPTION
## 🔆 Problème

On voit le code campagne dans les Combinix, ce que nous ne voulons pas

## ⛱️ Proposition

Cacher cette informations là ou elle est préstente

## 🌊 Remarques

Suppression du bruits d'un fichier de tests

## 🏄 Pour tester
Aller sur l'orga Attestations => Campagnes CODE1234

- [x]  Voir le empty state pour qu'il ne contiennent plus le copy paste button du code campagne
- [x] Aller sur la page paramètres et vérifier que le code disparaît pour les campagnes dans un combinix
- [x] Idem => Vérifier la suppression du lien direct

Et vérifier sur les autres organisations que le code apparaît pour ces emplacements