### PR TITLE
[FEATURE] Bloquer l'accès à la page paramètre de PixOrga d'une campagne appartenant à un Parcours Combiné (PIX-19314).

### DIFF
--- a/orga/app/components/campaign/header/tabs.gjs
+++ b/orga/app/components/campaign/header/tabs.gjs
@@ -62,9 +62,11 @@ export default class CampaignTabs extends Component {
           </LinkTo>
         {{/if}}
 
-        <LinkTo @route="authenticated.campaigns.campaign.settings" @model={{@campaign}}>
-          {{t "pages.campaign.tab.settings"}}
-        </LinkTo>
+        {{#unless @campaign.isFromCombinedCourse}}
+          <LinkTo @route="authenticated.campaigns.campaign.settings" @model={{@campaign}}>
+            {{t "pages.campaign.tab.settings"}}
+          </LinkTo>
+        {{/unless}}
       </PixTabs>
 
       <div class="campaign-header-tabs__export-button hide-on-mobile">

--- a/orga/app/routes/authenticated/campaigns/campaign/settings.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/settings.js
@@ -1,6 +1,18 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class SettingsRoute extends Route {
+  @service router;
+
+  beforeModel(transition) {
+    const campaignId = transition.to.parent.params.campaign_id;
+    const campaign = this.modelFor('authenticated.campaigns.campaign');
+
+    if (campaign.isFromCombinedCourse) {
+      this.router.replaceWith('authenticated.campaigns.campaign', campaignId);
+    }
+  }
+
   model() {
     return this.modelFor('authenticated.campaigns.campaign');
   }

--- a/orga/tests/integration/components/campaign/header/tabs-test.js
+++ b/orga/tests/integration/components/campaign/header/tabs-test.js
@@ -49,28 +49,44 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
     fileSaver.save.resolves();
   });
 
-  module('Common campaign navigation', function (hooks) {
-    hooks.beforeEach(async function () {
-      this.campaign = store.createRecord('campaign', { id: '12' });
-      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
-    });
+  module('Common campaign navigation', function () {
+    module('settings item', function () {
+      test('it should display campaign settings item', async function (assert) {
+        this.campaign = store.createRecord('campaign', { id: '12' });
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const settingsLink = screen.getByRole('link', { name: t('pages.campaign.tab.settings') });
 
-    test('it should display campaign settings item', async function (assert) {
-      const settingsLink = screen.getByRole('link', { name: t('pages.campaign.tab.settings') });
+        assert.dom(settingsLink).hasAttribute('href', '/campagnes/12/parametres');
+      });
 
-      assert.dom(settingsLink).hasAttribute('href', '/campagnes/12/parametres');
+      test('should not display campaign settings item on combined course', async function (assert) {
+        this.campaign = store.createRecord('campaign', { id: '12', isFromCombinedCourse: true });
+        screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+        const settingsLink = screen.queryByRole('link', { name: t('pages.campaign.tab.settings') });
+
+        assert.dom(settingsLink).doesNotExist();
+      });
     });
 
     test('it should display activity item', async function (assert) {
+      this.campaign = store.createRecord('campaign', { id: '12' });
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+
       const activityLink = screen.getByRole('link', { name: t('pages.campaign.tab.activity') });
       assert.dom(activityLink).hasAttribute('href', '/campagnes/12');
     });
 
     test('it should display export button result', async function (assert) {
+      this.campaign = store.createRecord('campaign', { id: '12' });
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+
       assert.ok(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
     });
 
     test('dipslay notification error on data export', async function (assert) {
+      this.campaign = store.createRecord('campaign', { id: '12' });
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+
       fileSaver.save.rejects();
       await click(screen.getByRole('button', { name: t('pages.campaign.actions.export-results') }));
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/settings-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/settings-test.js
@@ -1,0 +1,74 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/campaign/settings', function (hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/campaigns/campaign/settings');
+  });
+
+  module('beforeModel', function () {
+    module('When campaign is from combined course', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      test('should redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated.campaigns.campaign').returns({ isFromCombinedCourse: true });
+
+        //when
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+        //then
+        assert.ok(replaceWithStub.calledWithExactly('authenticated.campaigns.campaign', campaignId));
+      });
+    });
+
+    module('When campaign is not from combined course', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      test('should not redirect on main campaign page', function (assert) {
+        //given
+        const campaignId = Symbol('CampaignId');
+
+        const modelForStub = sinon.stub(route, 'modelFor');
+        const replaceWithStub = sinon.stub(route.router, 'replaceWith');
+
+        modelForStub.withArgs('authenticated.campaigns.campaign').returns({ isFromCombinedCourse: false });
+
+        //when
+        route.beforeModel({
+          to: {
+            parent: {
+              params: {
+                campaign_id: campaignId,
+              },
+            },
+          },
+        });
+
+        //then
+        assert.notOk(replaceWithStub.called);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Une campagne d'un parcours combiné n'a aucune utilité de modifier les paramètres de campagnes

## ⛱️ Proposition

Bloquer l'accès à la page paramètre et cacher ce lien

## 🌊 Remarques

RAS

## 🏄 Pour tester

Aller sur l'orga Attestations et vérifier que pour la campagne ayant le code CODE1234, l'onglet paramètres n'est plus. ainsi que son accès via la route `campagnes/{campaignId}/paramètres` . Merci bisou