### PR TITLE
[BUGFIX] L'état du bouton de réponse des QAB n'est pas réinitialisé (PIX-19466)

### DIFF
--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -70,6 +70,7 @@ export default class ModuleQab extends ModuleElement {
       this.displayedCards.shift();
       this.currentCardStatus = '';
       this.selectedOption = null;
+      document.activeElement.blur();
 
       if (this.displayedCards.length === 0) {
         this.currentStep = 'score';

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -106,6 +106,8 @@ module('Integration | Component | Module | QAB', function (hooks) {
           .doesNotHaveClass('qab-proposal-button--selected');
         assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasAttribute('aria-disabled');
         assert.dom(screen.getByRole('status')).hasText('Bonne réponse !');
+        await clock.tickAsync(NEXT_CARD_DELAY);
+        assert.notEqual(document.activeElement, screen.getByRole('button', { name: 'Option A: Vrai' }));
       });
     });
 
@@ -126,6 +128,8 @@ module('Integration | Component | Module | QAB', function (hooks) {
         assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasClass('qab-proposal-button--selected');
         assert.dom(screen.getByRole('button', { name: 'Option B: Faux' })).hasAttribute('aria-disabled');
         assert.dom(screen.getByRole('status')).hasText('Mauvaise réponse.');
+        await clock.tickAsync(NEXT_CARD_DELAY);
+        assert.notEqual(document.activeElement, screen.getByRole('button', { name: 'Option B: Faux' }));
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

> En gros après qu'on a répondu à une carte, le bouton sur lequel on a cliqué reste grisé comme survolé

Le problème est dû au fait que, comme les éléments HTML de réponse ne sont pas recréés, le focus reste arbitrairement sur la dernière réponse choisie.

## ⛱️ Proposition

Réinitialiser le focus lorsqu'une nouvelle carte est affichée.

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13513.review.pix.fr/modules/bac-a-sable)
2. Aller jusqu'au QAB
3. Répondre à une question
4. Après l'animation, constater qu'aucune réponse s'est selectionnée
5. Appuyez sur la touche Tab et constater que la réponse A est sélectionnée