### PR TITLE
[FEATURE] Bloquer la suppression d'une campagne appartenant à un parcours combiné pour les prescripteurs (PIX-19352)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -1,5 +1,7 @@
+import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 import { EventLoggingJob } from '../../../../shared/domain/models/jobs/EventLoggingJob.js';
 import { MembershipNotFound } from '../../../../team/application/api/errors/MembershipNotFound.js';
+import { CampaignBelongsToCombinedCourseError } from '../errors.js';
 import { CampaignsDestructor } from '../models/CampaignsDestructor.js';
 
 const deleteCampaigns = async ({
@@ -26,6 +28,13 @@ const deleteCampaigns = async ({
     }
   }
   const pixAdminMember = await adminMemberRepository.get({ userId });
+
+  for (const campaignId of campaignIds) {
+    const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });
+    if (combinedCourses.length > 0) {
+      throw new CampaignBelongsToCombinedCourseError();
+    }
+  }
 
   const campaignsToDelete = await campaignAdministrationRepository.getByIds(campaignIds);
   const campaignParticipationsToDelete = await campaignParticipationRepository.getByCampaignIds(campaignIds);

--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -1,6 +1,5 @@
 import * as CombinedCourseRepository from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
 import { EventLoggingJob } from '../../../../shared/domain/models/jobs/EventLoggingJob.js';
-import { MembershipNotFound } from '../../../../team/application/api/errors/MembershipNotFound.js';
 import { CampaignBelongsToCombinedCourseError } from '../errors.js';
 import { CampaignsDestructor } from '../models/CampaignsDestructor.js';
 
@@ -19,15 +18,11 @@ const deleteCampaigns = async ({
   eventLoggingJobRepository,
 }) => {
   let membership;
-
-  try {
-    membership = await organizationMembershipRepository.getByUserIdAndOrganizationId({ userId, organizationId });
-  } catch (error) {
-    if (!(error instanceof MembershipNotFound)) {
-      throw error;
-    }
-  }
   const pixAdminMember = await adminMemberRepository.get({ userId });
+
+  if (!pixAdminMember) {
+    membership = await organizationMembershipRepository.getByUserIdAndOrganizationId({ userId, organizationId });
+  }
 
   for (const campaignId of campaignIds) {
     const combinedCourses = await CombinedCourseRepository.findByCampaignId({ campaignId });


### PR DESCRIPTION
## 🔆 Problème

Un prescripteur ne doit pas supprimer la campagne d’un parcours combiné pour le moment.  

## ⛱️ Proposition

Une vérification est faite pour empêcher la suppression d'une campagne appartenant à un parcours combiné au niveau de la route api.

## 🌊 Remarques

Il a été nécessaire d'importer directement le repository des parcours combiné du fait d'une dépendance cyclique.

## 🏄 Pour tester

- Je me connecte à Pix Orga avec admin-orga
- Je me rends sur l'organisation Attestation
- J'affiche les campagnes
- Je sélectionne la campagne dont le code est CODE123
- Je tente d'effectuer une suppression
- Un toast d'erreur s'affiche
