### PR TITLE
[FEATURE] Ajouter une indication de progression au stepper horizontal (PIX-19432)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -13,14 +13,56 @@
     padding: var(--pix-spacing-1x) var(--pix-spacing-4x) var(--pix-spacing-1x) var(--pix-spacing-2x);
     border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
-
-    .stepper-controls__position {
-      margin: 0;
-    }
   }
 
   &__steps {
     display: flex;
+  }
+}
+
+.stepper-controls {
+  &__position {
+    margin: 0;
+  }
+
+  &__step-bars {
+    display: flex;
+    gap: 32px;
+    align-items: center;
+  }
+}
+
+.stepper-controls__step-bar {
+  position: relative;
+  width: 12px;
+  height: 12px;
+  background: var(--pix-neutral-500);
+  border-radius: 50%;
+
+  &.disable {
+    opacity: .3;
+  }
+
+  &.active::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    border: 2px solid var(--pix-neutral-0);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    content: '';
+  }
+
+  &:not(:last-child)::after {
+    position: absolute;
+    top: 50%;
+    left: calc(100% + 4px);
+    width: 24px;
+    border-bottom: 2px solid var(--pix-neutral-500);
+    transform: translateY(-50%);
+    content: '';
   }
 }
 

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -48,6 +48,7 @@ export default class ModulixStep extends Component {
         aria-hidden={{if @isHidden "true"}}
         aria-roledescription={{t "pages.modulix.stepper.step.aria-role-description"}}
         aria-label={{t "pages.modulix.stepper.step.aria-label" currentStep=@currentStep totalSteps=@totalSteps}}
+        role="group"
       >
         {{#each this.displayableElements as |element|}}
           <div class="grain-card-content__element">

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import eq from 'ember-truth-helpers/helpers/eq';
 import Step from 'mon-pix/components/module/component/step';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
@@ -155,7 +156,7 @@ export default class ModulixStepper extends Component {
   <template>
     <div
       class="stepper stepper--{{@direction}}"
-      aria-live="polite"
+      aria-live="{{if (eq @direction 'vertical') 'polite'}}"
       aria-roledescription="{{t 'pages.modulix.stepper.aria-role-description'}}"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
     >
@@ -171,7 +172,7 @@ export default class ModulixStepper extends Component {
           <p
             class="stepper-controls__position"
             aria-label="{{t
-              'pages.modulix.stepper.step.position'
+              'pages.modulix.stepper.step.aria-label'
               currentStep=(inc this.displayedStepIndex)
               totalSteps=this.totalSteps
             }}"
@@ -199,6 +200,7 @@ export default class ModulixStepper extends Component {
         <div
           id={{this.id}}
           class="stepper__steps"
+          aria-live="polite"
           style={{htmlUnsafe (concat "--current-step-index:" this.displayedStepIndex)}}
         >
           {{#if this.hasDisplayableSteps}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -48,6 +48,11 @@ export default class ModulixStepper extends Component {
     return !this.stepIsActive(index);
   }
 
+  @action
+  stepBarIsDisabled(index) {
+    return index > this.stepsToDisplay.length - 1;
+  }
+
   get hasDisplayableSteps() {
     return this.displayableSteps.length > 0;
   }
@@ -180,6 +185,16 @@ export default class ModulixStepper extends Component {
             @triggerAction={{this.goBackToNextStep}}
             aria-controls={{this.id}}
           />
+          <div class="stepper-controls__step-bars" aria-hidden="true">
+            {{#each this.displayableSteps as |_ index|}}
+              <div
+                class="stepper-controls__step-bar
+                  {{if (this.stepIsActive index) 'active'}}
+                  {{if (this.stepBarIsDisabled index) 'disable'}}"
+              >
+              </div>
+            {{/each}}
+          </div>
         </div>
         <div
           id={{this.id}}

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -708,6 +708,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(
           <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
         );
+        // await this.pauseTest();
 
         // then
         assert.dom(find('#stepper-container-id-1')).exists();
@@ -721,7 +722,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           .dom(find('.stepper--horizontal'))
           .hasAria('roleDescription', t('pages.modulix.stepper.aria-role-description'));
         assert
-          .dom(screen.getByLabelText('1 sur 2'))
+          .dom(screen.getByRole('group'))
           .hasAria('roleDescription', t('pages.modulix.stepper.step.aria-role-description'));
       });
 
@@ -765,22 +766,22 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         );
 
         // then
-        const title = screen.getByLabelText(
-          t('pages.modulix.stepper.step.position', {
+        const title = screen.getByRole('paragraph', {
+          name: t('pages.modulix.stepper.step.aria-label', {
             currentStep: 1,
             totalSteps: 2,
           }),
-        );
+        });
         assert.dom(title).exists();
         await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
         assert
           .dom(
-            screen.getByLabelText(
-              t('pages.modulix.stepper.step.position', {
+            screen.getByRole('paragraph', {
+              name: t('pages.modulix.stepper.step.aria-label', {
                 currentStep: 2,
                 totalSteps: 2,
               }),
-            ),
+            }),
           )
           .exists();
       });
@@ -812,7 +813,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
         // then
-        assert.dom(screen.getByLabelText('1 sur 2'));
+        assert
+          .dom(
+            screen.getByRole('group', {
+              name: t('pages.modulix.stepper.step.aria-label', {
+                currentStep: 1,
+                totalSteps: 2,
+              }),
+            }),
+          )
+          .exists();
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
@@ -883,12 +893,12 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         );
         assert
           .dom(
-            screen.getByLabelText(
-              t('pages.modulix.stepper.step.position', {
+            screen.getByRole('group', {
+              name: t('pages.modulix.stepper.step.aria-label', {
                 currentStep: 1,
                 totalSteps: 2,
               }),
-            ),
+            }),
           )
           .exists();
       });
@@ -1262,7 +1272,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.dom(screen.getByLabelText('1 sur 1')).exists();
+            assert
+              .dom(
+                screen.getByRole('group', {
+                  name: t('pages.modulix.stepper.step.aria-label', {
+                    currentStep: 1,
+                    totalSteps: 1,
+                  }),
+                }),
+              )
+              .exists();
             assert
               .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
               .doesNotExist();
@@ -1357,8 +1376,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
           // then
           assert.strictEqual(screen.getAllByLabelText('1 sur 2', { disabled: true }).length, 1);
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
-          assert.dom(screen.getByLabelText('2 sur 2')).isFocused();
+          assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
+          assert.dom(screen.getByRole('group', { name: '2 sur 2' })).isFocused();
         });
 
         test('should enable the controls previous button', async function (assert) {
@@ -1450,7 +1469,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
             ),
               // then
-              assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
+              assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
             assert
               .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
               .isFocused();
@@ -1553,7 +1572,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               );
 
               // then
-              assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
+              assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
               assert
                 .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
                 .isFocused();
@@ -1640,8 +1659,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
           // then
-          assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
-          assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
+          assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
+          assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
         });
 
         module('when has unsupported elements', function () {
@@ -1687,8 +1706,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             );
 
             // then
-            assert.strictEqual(screen.getAllByLabelText('1 sur 2').length, 1);
-            assert.strictEqual(screen.getAllByLabelText('2 sur 2').length, 1);
+            assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
+            assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
           });
         });
       });


### PR DESCRIPTION
## 🔆 Problème

Il faut ajouter une indication de progression au stepper horizontal pour rendre ça plus cool.

## ⛱️ Proposition

Ajouter les points de progression, non cliquables, à droite du numéro d'étape.
Maquette ici : https://www.figma.com/design/0RcwMBD5KmmbAxVOf2OH0D/Modulix?node-id=172-1579&m=dev

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Aller sur le [bac-a-sable](https://app-pr13517.review.pix.fr/modules/bac-a-sable/passage)
- Afficher le stepper horizontal
- Répondre à plusieurs questions du stepper
- Constater que les "petits points" s'affichent différemment selon l'étape où on est.
