### PR TITLE
[FEATURE] Empêcher de supprimer les quêtes dont l'id correspond à un parcours combiné (PIX-19017)

### DIFF
--- a/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
+++ b/api/src/quest/domain/usecases/create-or-update-quests-in-batch.js
@@ -5,6 +5,7 @@ import { createReadStream } from 'node:fs';
 
 import { getDataBuffer } from '../../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
 import { QUEST_HEADER } from '../constants.js';
 import { Quest } from '../models/Quest.js';
@@ -14,9 +15,10 @@ export const createOrUpdateQuestsInBatch = withTransaction(
    * @param {Object} params - A parameter object.
    * @param {string} params.filePath - path of csv file which contains quests
    * @param {QuestRepository} params.questRepository - questRepository to use.
+   * @param {QuestRepository} params.combinedCourseRepository - combinedCourseRepository to use.
    * @returns {Promise<void>}
    */
-  async ({ filePath, questRepository }) => {
+  async ({ filePath, questRepository, combinedCourseRepository }) => {
     const deleteQuestIds = [];
     const updatedOrNewQuest = [];
 
@@ -26,13 +28,26 @@ export const createOrUpdateQuestsInBatch = withTransaction(
     const csvParser = new CsvParser(buffer, QUEST_HEADER);
     const csvData = csvParser.parse();
 
-    csvData.forEach(({ questId, content, deleteQuest }) => {
+    for (const { questId, content, deleteQuest } of csvData) {
+      if (questId) {
+        try {
+          const isCombinedCourse = await combinedCourseRepository.getById({ id: questId });
+          if (isCombinedCourse) {
+            continue;
+          }
+        } catch (e) {
+          if (!(e instanceof NotFoundError)) {
+            throw Error;
+          }
+        }
+      }
+
       if (deleteQuest?.toLowerCase() === 'oui' && questId) {
         deleteQuestIds.push(questId);
       } else {
         updatedOrNewQuest.push(new Quest({ id: questId || undefined, ...JSON.parse(content) }));
       }
-    });
+    }
 
     if (deleteQuestIds.length > 0) {
       await questRepository.deleteByIds({ questIds: deleteQuestIds });

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -13,6 +13,22 @@ const getByCode = async ({ code }) => {
   return new CombinedCourse(quest);
 };
 
+const getById = async ({ id }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const quest = await knexConn('quests')
+    .select('id', 'organizationId', 'code', 'name')
+    .where('id', id)
+    .whereNotNull('organizationId')
+    .whereNotNull('code')
+    .first();
+  if (!quest) {
+    throw new NotFoundError(`Le parcours combiné pour l'id ${id} n'existe pas`);
+  }
+
+  return new CombinedCourse(quest);
+};
+
 const findByCampaignId = async ({ campaignId }) => {
   const knexConn = DomainTransaction.getConnection();
   const quests = await knexConn('quests')
@@ -42,4 +58,4 @@ const _toDTO = (combinedCourse) => {
   };
 };
 
-export { findByCampaignId, getByCode, saveInBatch };
+export { findByCampaignId, getByCode, getById, saveInBatch };

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -34,6 +34,35 @@ describe('Quest | Integration | Repository | combined-course', function () {
     });
   });
 
+  describe('#getById', function () {
+    it('should return a quest if quest id exists', async function () {
+      // given
+      const id = 1;
+      const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+      const quest = databaseBuilder.factory.buildQuest({ id: 1, code: 'COMBINIX1', organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourseResult = await combinedCourseRepository.getById({ id });
+
+      // then
+      expect(combinedCourseResult).to.be.an.instanceof(CombinedCourse);
+      expect(combinedCourseResult).to.deep.equal(new CombinedCourse(quest));
+    });
+
+    it('should throw NotFoundError if quest does not exist', async function () {
+      // given
+      const id = 1;
+
+      // when
+      const error = await catchErr(combinedCourseRepository.getById)({ id });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.equal(`Le parcours combiné pour l'id ${id} n'existe pas`);
+    });
+  });
+
   describe('#getByCampaignId', function () {
     let organizationId, quest, campaignId;
 


### PR DESCRIPTION
## 🔆 Problème
Les quêtes peuvent être supprimées côté Admin en modifiant une valeur dans une colonne. On veut empêcher que les quêtes qui sont des parcours combinés soient supprimées par erreur.

## ⛱️ Proposition
Si l'id de quête correspond à une quête de type parcours combiné, alors on ignore tout le traitement.

## 🏄 Pour tester
Aller sur PixAdmin, page Administration.
Télécharger un template de quête et le remplir avec un questId qui correspond à un parcours combiné (SELECT * FROM quests where code IS NOT NULL) et remplir "oui" dans la colonne delete quest.
Vérifier en base que l'entrée existe toujours après avoir uploadé le csv.