### PR TITLE
[BUGFIX] Afficher le message correspondant au statut UPLOADING dans la bannière d'import des prescrits

### DIFF
--- a/orga/app/components/import/banner.gjs
+++ b/orga/app/components/import/banner.gjs
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 import dayjs from 'dayjs';
 
 const statusI18nLabel = {
-  STARTED: 'upload-in-progress',
+  UPLOADING: 'upload-in-progress',
   UPLOADED: 'validation-in-progress',
   UPLOAD_ERROR: 'upload-error',
   VALIDATED: 'import-in-progress',
@@ -57,7 +57,7 @@ export default class ImportBanner extends Component {
       return this.intl.t('pages.organization-participants-import.banner.warning-banner', { htmlSafe: true });
     }
 
-    const status = this.args.isLoading ? 'STARTED' : this.args.organizationImportDetail?.status;
+    const status = this.args.isLoading ? 'UPLOADING' : this.args.organizationImportDetail?.status;
 
     const title = this.intl.t(`pages.organization-participants-import.banner.${statusI18nLabel[status]}`);
     return title;

--- a/orga/app/models/organization-import-detail.js
+++ b/orga/app/models/organization-import-detail.js
@@ -21,6 +21,6 @@ export default class OrganizationImportDetail extends Model {
   }
 
   get inProgress() {
-    return ['UPLOADED', 'VALIDATED'].includes(this.status);
+    return ['UPLOADING', 'UPLOADED', 'VALIDATED'].includes(this.status);
   }
 }

--- a/orga/tests/integration/components/import-information-banner_test.gjs
+++ b/orga/tests/integration/components/import-information-banner_test.gjs
@@ -45,7 +45,7 @@ module('Integration | Component | ImportInformationBanner', function (hooks) {
     assert.notOk(screen.queryByText(t('components.import-information-banner.error')));
     assert.notOk(screen.queryByText(t('components.import-information-banner.in-progress')));
   });
-  ['UPLOADED', 'VALIDATED'].forEach(async function (status) {
+  ['UPLOADING', 'UPLOADED', 'VALIDATED'].forEach(async function (status) {
     test(`display import in progress banner when status is ${status}`, async function (assert) {
       //given
       const store = this.owner.lookup('service:store');

--- a/orga/tests/integration/components/import/banner_test.gjs
+++ b/orga/tests/integration/components/import/banner_test.gjs
@@ -21,6 +21,25 @@ module('Integration | Component | Import::Banner', function (hooks) {
       assert.ok(screen.getByText(t('pages.organization-participants-import.banner.upload-in-progress')));
     });
 
+    test('it should display loading message when upload is finished but job has not started', async function (assert) {
+      // when
+      const store = this.owner.lookup('service:store');
+      const organizationImportDetail = store.createRecord('organization-import-detail', {
+        status: 'UPLOADING',
+        createdAt: new Date(2023, 10, 2),
+        createdBy: { firstName: 'Obi', lastName: 'Wan' },
+      });
+      const isLoading = false;
+      const screen = await render(
+        <template>
+          <ImportBanner @isLoading={{isLoading}} @organizationImportDetail={{organizationImportDetail}} />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText(t('pages.organization-participants-import.banner.upload-in-progress')));
+    });
+
     test('it should display loading message when there is already an import', async function (assert) {
       // when
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## 🔆 Problème

Lorsqu’on fait un import d’un fichier volumineux et qu’on change de page, alors que le fichier est toujours en cours de téléversement, on affiche une bannière d’info sans texte

## ⛱️ Proposition

Modification de la clef de statut STARTED en UPLOADING pour utiliser le statut par défaut à la création renvoyée par le back

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Faire un upload de fichier
- Rapidement se déplacer sur la liste des prescrits pour voir la bannière avec le message indiquant l'envoi en cours
