### PR TITLE
[FEATURE] Changement de wording stepper vertical (PIX-19435) (PIX-19472)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -13,137 +13,6 @@
   },
   "sections": [
     {
-      "id": "b0d428ab-a4ae-45e0-83fd-786fbd9c03dc",
-      "type": "practise",
-      "grains": [
-        {
-          "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
-          "type": "challenge",
-          "title": "Un fichier à télécharger",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
-                "type": "download",
-                "files": [
-                  { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
-                  { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
-                ]
-              }
-            },
-            {
-              "type": "element",
-              "element": {
-                "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
-                "type": "qcu",
-                "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
-                "proposals": [
-                  {
-                    "id": "1",
-                    "content": "Des recettes de lasagne",
-                    "feedback": {
-                      "state": "Incorrect.",
-                      "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "content": "Des recettes de pâté en croûte",
-                    "feedback": {
-                      "state": "Incorrect.",
-                      "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "content": "Des recettes végétariennes",
-                    "feedback": {
-                      "state": "Correct&#8239;!",
-                      "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
-                    }
-                  }
-                ],
-                "solution": "3"
-              }
-            }
-          ]
-        },
-        {
-          "id": "8147aced-4150-4a5d-afed-54c7a9dff056",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
-                "type": "text",
-                "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
-              }
-            }
-          ]
-        },
-        {
-          "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
-          "type": "lesson",
-          "title": "Vidéo de présentation de Pix",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-                "type": "text",
-                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-              }
-            },
-            {
-              "type": "element",
-              "element": {
-                "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
-                "type": "video",
-                "title": "Vidéo de présentation de Pix",
-                "url": "https://assets.pix.org/modules/bac-a-sable/presentation.mp4",
-                "subtitles": "",
-                "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
-                "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
-              }
-            }
-          ]
-        },
-        {
-          "id": "6566cc3a-9d74-4bd9-bda0-3dcb37129a26",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
-                "type": "text",
-                "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
-              }
-            }
-          ]
-        },
-        {
-          "id": "358e6d74-4adf-463a-9bf4-69ddca521d87",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "41186193-1c38-4827-84b7-e70848367d42",
-                "type": "text",
-                "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "cfaefec9-e185-43b8-8258-e8beff6dd56b",
       "type": "question-yourself",
       "grains": [
@@ -471,6 +340,137 @@
                     }
                   }
                 ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "b0d428ab-a4ae-45e0-83fd-786fbd9c03dc",
+      "type": "practise",
+      "grains": [
+        {
+          "id": "b14df125-82d5-4d55-a660-7b34cd9ea1ab",
+          "type": "challenge",
+          "title": "Un fichier à télécharger",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
+                "type": "download",
+                "files": [
+                  { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
+                  { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
+                ]
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "31106aeb-8346-44a6-8ed4-ebaa2106a373",
+                "type": "qcu",
+                "instruction": "<p>Quelle type de recette souhaite obtenir l'utilisateur dans l'image&nbsp;?</p>",
+                "proposals": [
+                  {
+                    "id": "1",
+                    "content": "Des recettes de lasagne",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Erreur, ce ne sont pas des lasagnes</p>"
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "content": "Des recettes de pâté en croûte",
+                    "feedback": {
+                      "state": "Incorrect.",
+                      "diagnosis": "<p>Non, ce ne sont pas des recettes de pâté en croûte</p>"
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "content": "Des recettes végétariennes",
+                    "feedback": {
+                      "state": "Correct&#8239;!",
+                      "diagnosis": "<p>Bonne réponse ! Ce sont bien des recettes végétariennes</p>"
+                    }
+                  }
+                ],
+                "solution": "3"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8147aced-4150-4a5d-afed-54c7a9dff056",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5da6a142-c66b-42d4-9afd-86d369ebd2b5",
+                "type": "text",
+                "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">📺</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
+          "type": "lesson",
+          "title": "Vidéo de présentation de Pix",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                "type": "text",
+                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
+                "type": "video",
+                "title": "Vidéo de présentation de Pix",
+                "url": "https://assets.pix.org/modules/bac-a-sable/presentation.mp4",
+                "subtitles": "",
+                "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
+                "poster": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg"
+              }
+            }
+          ]
+        },
+        {
+          "id": "6566cc3a-9d74-4bd9-bda0-3dcb37129a26",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "1df5f2eb-f8f9-4a07-ab56-2c001541306b",
+                "type": "text",
+                "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "358e6d74-4adf-463a-9bf4-69ddca521d87",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "41186193-1c38-4827-84b7-e70848367d42",
+                "type": "text",
+                "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>"
               }
             }
           ]

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -70,7 +70,7 @@ export default class ModulixStep extends Component {
             @variant="primary"
             @triggerAction={{@onNextButtonClick}}
             class="stepper__next-button"
-          >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
+          >{{@nextButtonName}}</PixButton>
         {{/if}}
       </section>
     {{/if}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -206,6 +206,7 @@ export default class ModulixStepper extends Component {
                 @shouldDisplayNextButton={{this.shouldDisplayHorizontalNextButton}}
                 @preventScrollAndFocus={{this.preventScrollAndFocus}}
                 @shouldAppearToRight={{this.shouldAppearToRight}}
+                @nextButtonName={{t "pages.modulix.buttons.stepper.next.horizontal.name"}}
               />
             {{/each}}
           {{/if}}
@@ -229,6 +230,7 @@ export default class ModulixStepper extends Component {
               @onExpandToggle={{@onExpandToggle}}
               @onNextButtonClick={{this.displayNextStep}}
               @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
+              @nextButtonName={{t "pages.modulix.buttons.stepper.next.vertical.name"}}
             />
           {{/each}}
         {{/if}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -1,4 +1,3 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
@@ -119,8 +118,13 @@ export default class ModulixStepper extends Component {
     });
   }
 
-  get shouldDisplayNextButton() {
+  get shouldDisplayHorizontalNextButton() {
     return this.hasNextStep && this.allAnswerableElementsAreAnsweredInCurrentStep;
+  }
+
+  @action
+  shouldDisplayVerticalNextButton(currentIndex) {
+    return this.shouldDisplayHorizontalNextButton && this.stepIsActive(currentIndex);
   }
 
   get totalSteps() {
@@ -199,7 +203,7 @@ export default class ModulixStepper extends Component {
                 @onFileDownload={{@onFileDownload}}
                 @onExpandToggle={{@onExpandToggle}}
                 @onNextButtonClick={{this.displayNextStep}}
-                @shouldDisplayNextButton={{this.shouldDisplayNextButton}}
+                @shouldDisplayNextButton={{this.shouldDisplayHorizontalNextButton}}
                 @preventScrollAndFocus={{this.preventScrollAndFocus}}
                 @shouldAppearToRight={{this.shouldAppearToRight}}
               />
@@ -223,16 +227,10 @@ export default class ModulixStepper extends Component {
               @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
               @onExpandToggle={{@onExpandToggle}}
+              @onNextButtonClick={{this.displayNextStep}}
+              @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
             />
           {{/each}}
-          {{#if this.shouldDisplayNextButton}}
-            <PixButton
-              aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
-              @variant="primary"
-              @triggerAction={{this.displayNextStep}}
-              class="stepper__next-button"
-            >{{t "pages.modulix.buttons.stepper.next.name"}}</PixButton>
-          {{/if}}
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1694,7 +1694,12 @@
           },
           "next": {
             "ariaLabel": "Go to the next step",
-            "name": "Next"
+            "horizontal": {
+              "name": "Next"
+            },
+            "vertical": {
+              "name": "Read more"
+            }
           }
         }
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1670,16 +1670,21 @@
           }
         },
         "stepper": {
-          "next": {
-            "ariaLabel": "Ir al paso siguiente",
-            "name": "Siguiente"
-          },
           "controls": {
             "next": {
               "ariaLabel": "Paso siguiente"
             },
             "previous": {
               "ariaLabel": "Paso anterior"
+            }
+          },
+          "next": {
+            "ariaLabel": "Ir al paso siguiente",
+            "horizontal": {
+              "name": "Siguiente"
+            },
+            "vertical": {
+              "name": "Leer más"
             }
           }
         }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1694,7 +1694,12 @@
           },
           "next": {
             "ariaLabel": "Aller à l'étape suivante",
-            "name": "Suivant"
+            "horizontal": {
+              "name": "Suivant"
+            },
+            "vertical": {
+              "name": "Lire la suite"
+            }
           }
         }
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1674,16 +1674,21 @@
           }
         },
         "stepper": {
-          "next": {
-            "ariaLabel": "Ga naar de volgende stap",
-            "name": "Volgende"
-          },
           "controls": {
             "next": {
               "ariaLabel": "Volgende stap"
             },
             "previous": {
               "ariaLabel": "Vorige stap"
+            }
+          },
+          "next": {
+            "ariaLabel": "Ga naar de volgende stap",
+            "horizontal": {
+              "name": "Volgende"
+            },
+            "vertical": {
+              "name": "Lees verder"
             }
           }
         }


### PR DESCRIPTION
## ⛱️ Proposition

Changer le libellé des boutons “Suivant” dans le stepper vertical en "Lire la suite" (demande design).

## 🌊 Remarques

Aussi retour en arrière sur l'ordre des sections du bac à sable.

En profiter pour utiliser le bouton suivant de la Step.

## 🏄 Pour tester

Vérifier dans [le bac-a-sable](https://app-pr13520.review.pix.fr/modules/bac-a-sable/passage) que les boutons d'accès à l'étape suivante ont un nom différent en horizontal et en vertical.