### PR TITLE
[FEATURE] Faire en sorte que la preview soit ISO design (PIX-19473)

### DIFF
--- a/mon-pix/app/components/module/_module-preview.scss
+++ b/mon-pix/app/components/module/_module-preview.scss
@@ -20,8 +20,6 @@
   }
 
   &__passage {
-    @extend .module-passage;
-
     width: 100%;
   }
 

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -69,6 +69,14 @@ export default class ModulixPreview extends Component {
               "alt": "Dessin détaillé dans l'alternative textuelle",
               "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
             }
+          },
+          {
+            "type": "element",
+            "element": {
+              "id": "5555555a-5555-5bcd-e555-5f5555gh5555",
+              "type": "text",
+              "content": "<p>Quelques objets sont visibles dans l'image :</p><ul><li>Un ordinateur</li><li>Un satellite</li><li>Des étoiles</li></ul>"
+            }
           }
         ]
       }
@@ -163,7 +171,7 @@ export default class ModulixPreview extends Component {
     {{/unless}}
 
     <div class="module-preview {{if this.moduleCodeDisplayed 'module-preview--with-editor'}}">
-      <aside class="module-preview__passage">
+      <aside class="module-preview__passage module-passage">
         <div class="module-preview-passage__title">
           <h1>{{this.formattedModule.title}}</h1>
         </div>


### PR DESCRIPTION
## 🔆 Problème

Certains styles ne sont pas ISO entre la preview et le passage de module. Est en cause la classe `.module-passage` pour le normalize de Modulix qui n’est pas appliqué dans le contexte de la preview.

Sont identifiés : 
- manque de liste à puce en preview
- les titres H4/H5 ne sont pas stylisés en preview

## ⛱️ Proposition

Ajouter la classe `module-passage` dans le contexte de la preview car l'`extend` SCSS ne semble pas copier les styles enfants.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier que [la démo dans la preview](https://app-pr13521.review.pix.fr/modules/preview) a bien des styles du normalize css de modulix : liste à puces affichée et titre H4 stylisé
