### PR TITLE
[FEATURE] Désactiver les boutons en fonctions du statut de la certification (PIX-17763)

### DIFF
--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -64,7 +64,9 @@ export default class CertificationInformationGlobalActions extends Component {
       await this.args.certification.save({ adapterOptions: { isCertificationCancel: true } });
       await this.args.certification.reload();
     } catch {
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.global-actions.cancel.error-message'),
+      });
     }
 
     this.displayConfirm = false;
@@ -72,10 +74,9 @@ export default class CertificationInformationGlobalActions extends Component {
 
   @action
   onCancelCertificationButtonClick() {
-    this.modalTitle = "Confirmer l'annulation de la certification";
+    this.modalTitle = this.intl.t('components.certifications.global-actions.cancel.modal-title');
     this.confirmAction = this.onCancelCertificationConfirmation;
-    this.confirmMessage =
-      'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.';
+    this.confirmMessage = this.intl.t('components.certifications.global-actions.cancel.modal-message');
     this.displayConfirm = true;
   }
 
@@ -85,7 +86,9 @@ export default class CertificationInformationGlobalActions extends Component {
       await this.args.certification.save({ adapterOptions: { isCertificationUncancel: true } });
       await this.args.certification.reload();
     } catch {
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.global-actions.uncancel.error-message'),
+      });
     }
 
     this.displayConfirm = false;
@@ -93,10 +96,9 @@ export default class CertificationInformationGlobalActions extends Component {
 
   @action
   onUncancelCertificationButtonClick() {
-    this.modalTitle = 'Confirmer la désannulation de la certification';
+    this.modalTitle = this.intl.t('components.certifications.global-actions.uncancel.modal-title');
     this.confirmAction = this.onUncancelCertificationConfirmation;
-    this.confirmMessage =
-      'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.';
+    this.confirmMessage = this.intl.t('components.certifications.global-actions.uncancel.modal-message');
     this.displayConfirm = true;
   }
 
@@ -106,7 +108,9 @@ export default class CertificationInformationGlobalActions extends Component {
       await this.args.certification.save({ adapterOptions: { isCertificationReject: true } });
       await this.args.certification.reload();
     } catch {
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.global-actions.reject.error-message'),
+      });
     }
 
     this.displayConfirm = false;
@@ -114,10 +118,9 @@ export default class CertificationInformationGlobalActions extends Component {
 
   @action
   onRejectCertificationButtonClick() {
-    this.modalTitle = 'Confirmer le rejet de la certification';
+    this.modalTitle = this.intl.t('components.certifications.global-actions.reject.modal-title');
     this.confirmAction = this.onRejectCertificationConfirmation;
-    this.confirmMessage =
-      'Êtes-vous sûr·e de vouloir rejeter cette certification ? Cliquez sur confirmer pour poursuivre.';
+    this.confirmMessage = this.intl.t('components.certifications.global-actions.reject.modal-message');
     this.displayConfirm = true;
   }
 
@@ -127,7 +130,9 @@ export default class CertificationInformationGlobalActions extends Component {
       await this.args.certification.save({ adapterOptions: { isCertificationUnreject: true } });
       await this.args.certification.reload();
     } catch {
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.certifications.global-actions.unreject.error-message'),
+      });
     }
 
     this.displayConfirm = false;
@@ -135,10 +140,9 @@ export default class CertificationInformationGlobalActions extends Component {
 
   @action
   onUnrejectCertificationButtonClick() {
-    this.modalTitle = "Confirmer l'annulation du rejet de la certification";
+    this.modalTitle = this.intl.t('components.certifications.global-actions.unreject.modal-title');
     this.confirmAction = this.onUnrejectCertificationConfirmation;
-    this.confirmMessage =
-      'Êtes-vous sûr·e de vouloir annuler le rejet de cette certification ? Cliquez sur confirmer pour poursuivre.';
+    this.confirmMessage = this.intl.t('components.certifications.global-actions.unreject.modal-message');
     this.displayConfirm = true;
   }
 
@@ -162,23 +166,23 @@ export default class CertificationInformationGlobalActions extends Component {
 
   <template>
     <PixButtonLink @route="authenticated.users.get" @size="small" @model={{@certification.userId}}>
-      Voir les détails de l'utilisateur
+      {{t "components.certifications.global-actions.user-details-link"}}
     </PixButtonLink>
 
     <div class="certification-informations__row__actions">
       {{#if this.displayCancelCertificationButton}}
         <PixButton @variant="secondary" @size="small" @triggerAction={{this.onCancelCertificationButtonClick}}>
-          Annuler la certification
+          {{t "components.certifications.global-actions.cancel.button"}}
         </PixButton>
       {{/if}}
       {{#if this.displayUncancelCertificationButton}}
         <PixButton @variant="error" @size="small" @triggerAction={{this.onUncancelCertificationButtonClick}}>
-          Désannuler la certification
+          {{t "components.certifications.global-actions.uncancel.button"}}
         </PixButton>
       {{/if}}
       {{#if this.displayUnrejectCertificationButton}}
         <PixButton @variant="error" @size="small" @triggerAction={{this.onUnrejectCertificationButtonClick}}>
-          Annuler le rejet
+          {{t "components.certifications.global-actions.unreject.button"}}
         </PixButton>
       {{/if}}
       {{#if this.displayRejectCertificationButton}}
@@ -191,18 +195,17 @@ export default class CertificationInformationGlobalActions extends Component {
                 @triggerAction={{this.onRejectCertificationButtonClick}}
                 @isDisabled={{true}}
               >
-                Rejeter la certification
+                {{t "components.certifications.global-actions.reject.button"}}
               </PixButton>
             </:triggerElement>
 
             <:tooltip>
-              Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette
-              certification.
+              {{t "components.certifications.global-actions.reject.tooltip-published"}}
             </:tooltip>
           </PixTooltip>
         {{else}}
           <PixButton @variant="error" @size="small" @triggerAction={{this.onRejectCertificationButtonClick}}>
-            Rejeter la certification
+            {{t "components.certifications.global-actions.reject.button"}}
           </PixButton>
         {{/if}}
       {{/if}}

--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -1,6 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -20,13 +19,16 @@ export default class CertificationInformationGlobalActions extends Component {
   @tracked displayConfirm = false;
   @tracked modalTitle = null;
 
-  get displayCancelCertificationButton() {
+  get canPerformCertificationActions() {
     return Boolean(
-      !this.args.certification.isCertificationCancelled &&
-        !this.args.certification.isPublished &&
+      !this.args.certification.isPublished &&
         this.args.session.finalizedAt &&
-        this.args.certification.status === 'validated',
+        (this.args.certification.status === 'validated' || this.args.certification.status === 'error'),
     );
+  }
+
+  get displayCancelCertificationButton() {
+    return this.canPerformCertificationActions;
   }
 
   get displayUncancelCertificationButton() {
@@ -38,7 +40,7 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRejectCertificationButton() {
-    return this.args.certification.status === 'validated';
+    return this.canPerformCertificationActions;
   }
 
   get displayUnrejectCertificationButton() {
@@ -46,11 +48,7 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRescoringCertificationButton() {
-    return Boolean(
-      !this.args.certification.isPublished &&
-        this.args.session.finalizedAt &&
-        this.args.certification.status === 'validated',
-    );
+    return this.canPerformCertificationActions;
   }
 
   @action
@@ -186,28 +184,9 @@ export default class CertificationInformationGlobalActions extends Component {
         </PixButton>
       {{/if}}
       {{#if this.displayRejectCertificationButton}}
-        {{#if @certification.isPublished}}
-          <PixTooltip @position="left" @isWide={{true}}>
-            <:triggerElement>
-              <PixButton
-                @variant="error"
-                @size="small"
-                @triggerAction={{this.onRejectCertificationButtonClick}}
-                @isDisabled={{true}}
-              >
-                {{t "components.certifications.global-actions.reject.button"}}
-              </PixButton>
-            </:triggerElement>
-
-            <:tooltip>
-              {{t "components.certifications.global-actions.reject.tooltip-published"}}
-            </:tooltip>
-          </PixTooltip>
-        {{else}}
-          <PixButton @variant="error" @size="small" @triggerAction={{this.onRejectCertificationButtonClick}}>
-            {{t "components.certifications.global-actions.reject.button"}}
-          </PixButton>
-        {{/if}}
+        <PixButton @variant="error" @size="small" @triggerAction={{this.onRejectCertificationButtonClick}}>
+          {{t "components.certifications.global-actions.reject.button"}}
+        </PixButton>
       {{/if}}
       {{#if this.displayRescoringCertificationButton}}
         <PixButton @size="small" @triggerAction={{this.rescoreCertification}}>

--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -24,7 +24,8 @@ export default class CertificationInformationGlobalActions extends Component {
     return Boolean(
       !this.args.certification.isCertificationCancelled &&
         !this.args.certification.isPublished &&
-        this.args.session.finalizedAt,
+        this.args.session.finalizedAt &&
+        this.args.certification.status === 'validated',
     );
   }
 
@@ -37,7 +38,7 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRejectCertificationButton() {
-    return this.args.certification.status !== 'rejected';
+    return this.args.certification.status === 'validated';
   }
 
   get displayUnrejectCertificationButton() {
@@ -45,7 +46,11 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRescoringCertificationButton() {
-    return Boolean(!this.args.certification.isPublished && this.args.session.finalizedAt);
+    return Boolean(
+      !this.args.certification.isPublished &&
+        this.args.session.finalizedAt &&
+        this.args.certification.status === 'validated',
+    );
   }
 
   @action

--- a/admin/app/components/confirm-popup.gjs
+++ b/admin/app/components/confirm-popup.gjs
@@ -7,7 +7,7 @@ export default class ConfirmPopup extends Component {
   @service() intl;
 
   get title() {
-    return this.args.title || 'Merci de confirmer';
+    return this.args.title || this.intl.t('common.actions.confirm-title');
   }
 
   get closeTitle() {
@@ -15,7 +15,7 @@ export default class ConfirmPopup extends Component {
   }
 
   get submitTitle() {
-    return this.args.submitTitle || 'Confirmer';
+    return this.args.submitTitle || this.intl.t('common.actions.confirm');
   }
 
   get size() {

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations-test.js
@@ -45,7 +45,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
       birthInseeCode: '99217',
       birthPostalCode: null,
       version: 2,
-      status: assessmentResultStatus.REJECTED,
+      status: assessmentResultStatus.VALIDATED,
       competencesWithMark: [
         {
           id: 152825,
@@ -497,7 +497,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           'common-complementary-certification-course-result',
           {
             label: 'CléA Numérique',
-            status: 'Validée',
+            status: 'Annulée',
           },
         );
 
@@ -512,7 +512,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         assert.dom(screen.getByText('Certification complémentaire')).exists();
         assert.dom(screen.queryByText('Résultats de la certification complémentaire Pix+ Edu :')).doesNotExist();
         assert.dom(screen.getByText('CléA Numérique :')).exists();
-        assert.dom(screen.getByText('Validée')).exists();
+        assert.dom(screen.getByText('Annulée')).exists();
       });
 
       test('it displays external complementary certifications', async function (assert) {

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -254,7 +254,9 @@ module('Integration | Component | Certifications | Certification | Information |
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.cancel.error-message') });
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.cancel.error-message'),
+          });
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
@@ -365,7 +367,9 @@ module('Integration | Component | Certifications | Certification | Information |
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.uncancel.error-message') });
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.uncancel.error-message'),
+          });
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
@@ -590,7 +594,9 @@ module('Integration | Component | Certifications | Certification | Information |
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.reject.error-message') });
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.reject.error-message'),
+          });
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
@@ -701,7 +707,9 @@ module('Integration | Component | Certifications | Certification | Information |
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.unreject.error-message') });
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.unreject.error-message'),
+          });
           assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
@@ -890,7 +898,9 @@ module('Integration | Component | Certifications | Certification | Information |
           // then
           sinon.assert.calledOnce(rescoreCertificationStub);
           sinon.assert.calledWith(rescoreCertificationStub, { certificationCourseId: '123' });
-          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.rescoring.success-message') });
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.rescoring.success-message'),
+          });
           assert.ok(certification.reload.calledOnce);
         } finally {
           store.adapterFor = originalAdapterFor;
@@ -926,7 +936,7 @@ module('Integration | Component | Certifications | Certification | Information |
           );
 
           // Wait for async error handling
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           // then
           assert.ok(notificationStub.called, 'notification should have been called');

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -5,7 +5,7 @@ import { assessmentResultStatus } from 'pix-admin/models/certification';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 import { waitForDialogClose } from '../../../../../helpers/wait-for';
 
 module('Integration | Component | Certifications | Certification | Information | Global actions', function (hooks) {
@@ -17,159 +17,266 @@ module('Integration | Component | Certifications | Certification | Information |
     store = this.owner.lookup('service:store');
   });
 
+  function createFinalizedSession() {
+    return store.createRecord('session', { finalizedAt: new Date() });
+  }
+
+  function createNonFinalizedSession() {
+    return store.createRecord('session', { finalizedAt: null });
+  }
+
+  function renderGlobalActions(certification, session) {
+    return render(
+      <template>
+        <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+      </template>,
+    );
+  }
+
+  function setupNotificationStub(owner, type = 'sendErrorNotification') {
+    const notificationStub = sinon.stub();
+    class NotificationsStub extends Service {
+      [type] = notificationStub;
+    }
+    owner.register('service:pixToast', NotificationsStub);
+    return notificationStub;
+  }
+
   test('should display user details page link', async function (assert) {
     // given
     const certification = store.createRecord('certification', { userId: 1 });
     const session = store.createRecord('session', {});
 
     // when
-    const screen = await render(
-      <template>
-        <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-      </template>,
-    );
+    const screen = await renderGlobalActions(certification, session);
 
     // then
-    const userDetailsLink = screen.getByRole('link', { name: "Voir les détails de l'utilisateur" });
+    const userDetailsLink = screen.getByRole('link', {
+      name: t('components.certifications.global-actions.user-details-link'),
+    });
     assert.ok(userDetailsLink.href.endsWith(`/users/${certification.userId}`));
   });
 
   module('cancel button', function () {
-    module('when the certification status is rejected', function () {
-      test('should not display a cancel button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          status: assessmentResultStatus.REJECTED,
-          isPublished: false,
-        });
-        const session = store.createRecord('session', {
-          finalizedAt: new Date(),
-        });
-
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Annuler la certification' })).doesNotExist();
-      });
-    });
-
-    module(
-      'when the certification is validated, not cancelled, not published and the session is finalized',
-      function (hooks) {
-        let screen;
-
-        const modalTitle = "Confirmer l'annulation de la certification";
-        const modalMessage =
-          'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.';
-
-        hooks.beforeEach(async function () {
+    module('when should display', function () {
+      module('when certification is validated, session is finalized and not published', function () {
+        test('should display a cancel button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
-            id: 1,
             userId: 1,
             status: assessmentResultStatus.VALIDATED,
             isPublished: false,
-            save: sinon.stub(),
-            reload: sinon.stub(),
           });
-          const session = store.createRecord('session', {
-            finalizedAt: new Date(),
-          });
+          const session = createFinalizedSession();
 
           // when
-          screen = await render(
-            <template>
-              <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-            </template>,
-          );
-        });
+          const screen = await renderGlobalActions(certification, session);
 
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .exists();
+        });
+      });
+
+      module('when certification has error status, session is finalized and not published', function () {
         test('should display a cancel button', async function (assert) {
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Annuler la certification' })).exists();
-        });
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.ERROR,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
 
-        test('on cancel button click, should display a confirmation modal', async function (assert) {
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler la certification' }));
-
-          await screen.findByRole('dialog');
+          const screen = await renderGlobalActions(certification, session);
 
           // then
-          assert.dom(screen.getByText(modalTitle)).exists();
-          assert.dom(screen.getByText(modalMessage)).exists();
-          assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
-          assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .exists();
         });
+      });
+    });
 
-        module('on modal confirmation', function () {
-          test('on success, should cancel the certification and close the modal', async function (assert) {
-            // given
-            const currentCertification = store.peekRecord('certification', 1);
-
-            // when
-            await fireEvent.click(screen.getByRole('button', { name: 'Annuler la certification' }));
-            await screen.findByRole('dialog');
-            await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
-            await waitForDialogClose();
-
-            // then
-            sinon.assert.calledWith(currentCertification.save, {
-              adapterOptions: { isCertificationCancel: true },
-            });
-            assert.ok(currentCertification.reload.calledOnce);
-            assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
+    module('when should not display', function () {
+      module('when certification status is cancelled', function () {
+        test('should not display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.CANCELLED,
+            isPublished: false,
           });
+          const session = createFinalizedSession();
 
-          test('on error, should display a notification and close the modal', async function (assert) {
-            // given
-            const notificationStub = sinon.stub();
-            class NotificationsStub extends Service {
-              sendErrorNotification = notificationStub;
-            }
-            this.owner.register('service:pixToast', NotificationsStub);
+          // when
+          const screen = await renderGlobalActions(certification, session);
 
-            const currentCertification = store.peekRecord('certification', 1);
-            currentCertification.save.rejects();
-
-            // when
-            await fireEvent.click(screen.getByRole('button', { name: 'Annuler la certification' }));
-            await screen.findByRole('dialog');
-            await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
-            await waitForDialogClose();
-
-            // then
-            sinon.assert.calledWith(notificationStub, { message: 'Une erreur est survenue.' });
-            assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
-          });
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .doesNotExist();
         });
+      });
 
-        test('on modal cancellation, should close the modal', async function (assert) {
+      module('when certification status is rejected', function () {
+        test('should not display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.REJECTED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when session is not finalized', function () {
+        test('should not display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: false,
+          });
+          const session = createNonFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when certification is published', function () {
+        test('should not display a cancel button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: true,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.cancel.button') }))
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('when button is displayed', function (hooks) {
+      let screen;
+      const modalTitle = "Confirmer l'annulation de la certification";
+      const modalMessage =
+        'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.';
+
+      hooks.beforeEach(async function () {
+        // given
+        const certification = store.createRecord('certification', {
+          id: 1,
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+          save: sinon.stub(),
+          reload: sinon.stub(),
+        });
+        const session = createFinalizedSession();
+
+        // when
+        screen = await renderGlobalActions(certification, session);
+      });
+
+      test('should display confirmation modal on click', async function (assert) {
+        // when
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }),
+        );
+        await screen.findByRole('dialog');
+
+        // then
+        assert.dom(screen.getByText(modalTitle)).exists();
+        assert.dom(screen.getByText(modalMessage)).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+      });
+
+      module('when modal is confirmed', function () {
+        test('should perform action and close modal on success', async function (assert) {
           // given
           const currentCertification = store.peekRecord('certification', 1);
 
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler la certification' }));
-
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }),
+          );
           await screen.findByRole('dialog');
-
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler' }));
-
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
           await waitForDialogClose();
 
           // then
-          assert.ok(currentCertification.save.notCalled);
-          assert.ok(currentCertification.reload.notCalled);
-          assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+          sinon.assert.calledWith(currentCertification.save, {
+            adapterOptions: { isCertificationCancel: true },
+          });
+          assert.ok(currentCertification.reload.calledOnce);
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
-      },
-    );
+
+        test('should display notification and close modal on error', async function (assert) {
+          // given
+          const notificationStub = setupNotificationStub(this.owner);
+          const currentCertification = store.peekRecord('certification', 1);
+          currentCertification.save.rejects();
+
+          // when
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }),
+          );
+          await screen.findByRole('dialog');
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+          await waitForDialogClose();
+
+          // then
+          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.cancel.error-message') });
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
+        });
+      });
+
+      test('should close modal on cancellation', async function (assert) {
+        // given
+        const currentCertification = store.peekRecord('certification', 1);
+
+        // when
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.cancel.button') }),
+        );
+        await screen.findByRole('dialog');
+        await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+        await waitForDialogClose();
+
+        // then
+        assert.ok(currentCertification.save.notCalled);
+        assert.ok(currentCertification.reload.notCalled);
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
+      });
+    });
   });
 
   module('uncancel button', function () {
@@ -190,34 +297,32 @@ module('Integration | Component | Certifications | Certification | Information |
           save: sinon.stub(),
           reload: sinon.stub(),
         });
-        const session = store.createRecord('session', {
-          finalizedAt: new Date(),
-        });
+        const session = createFinalizedSession();
 
         // when
-        screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
+        screen = await renderGlobalActions(certification, session);
       });
 
       test('should display an uncancel button', async function (assert) {
         // then
-        assert.dom(screen.getByRole('button', { name: 'Désannuler la certification' })).exists();
+        assert
+          .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }))
+          .exists();
       });
 
       test('on cancel button click, should display a confirmation modal', async function (assert) {
         // when
-        await fireEvent.click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+        );
 
         await screen.findByRole('dialog');
 
         // then
         assert.dom(screen.getByText(modalTitle)).exists();
         assert.dom(screen.getByText(modalMessage)).exists();
-        assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
       });
 
       module('on modal confirmation', function () {
@@ -226,11 +331,13 @@ module('Integration | Component | Certifications | Certification | Information |
           const currentCertification = store.peekRecord('certification', 1);
 
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+          );
 
           await screen.findByRole('dialog');
 
-          await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
 
           await waitForDialogClose();
 
@@ -239,29 +346,27 @@ module('Integration | Component | Certifications | Certification | Information |
             adapterOptions: { isCertificationUncancel: true },
           });
           assert.ok(currentCertification.reload.calledOnce);
-          assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
 
         test('on error, should display a notification and close the modal', async function (assert) {
           // given
-          const notificationStub = sinon.stub();
-          class NotificationsStub extends Service {
-            sendErrorNotification = notificationStub;
-          }
-          this.owner.register('service:pixToast', NotificationsStub);
+          const notificationStub = setupNotificationStub(this.owner);
 
           const currentCertification = store.peekRecord('certification', 1);
           currentCertification.save.rejects();
 
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+          );
           await screen.findByRole('dialog');
-          await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: 'Une erreur est survenue.' });
-          assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
+          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.uncancel.error-message') });
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
 
@@ -270,198 +375,242 @@ module('Integration | Component | Certifications | Certification | Information |
         const currentCertification = store.peekRecord('certification', 1);
 
         // when
-        await fireEvent.click(screen.getByRole('button', { name: 'Désannuler la certification' }));
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.uncancel.button') }),
+        );
 
         await screen.findByRole('dialog');
 
-        await fireEvent.click(screen.getByRole('button', { name: 'Annuler' }));
+        await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
 
         await waitForDialogClose();
 
         // then
         assert.ok(currentCertification.save.notCalled);
         assert.ok(currentCertification.reload.notCalled);
-        assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
       });
     });
   });
 
   module('reject button', function () {
-    module('when the certification status is cancelled', function () {
-      test('should not display a reject button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          status: assessmentResultStatus.CANCELLED,
-        });
-        const session = store.createRecord('session', {});
-
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Rejeter la certification' })).doesNotExist();
-      });
-    });
-
-    module('when the certification is already rejected', function () {
-      test('should not display a reject button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          status: assessmentResultStatus.REJECTED,
-        });
-        const session = store.createRecord('session', {});
-
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Rejeter la certification' })).doesNotExist();
-      });
-    });
-
-    module('when the certification is not rejected', function () {
-      module('when the certification is not published', function (hooks) {
-        let screen;
-
-        const modalTitle = 'Confirmer le rejet de la certification';
-        const modalMessage =
-          'Êtes-vous sûr·e de vouloir rejeter cette certification ? Cliquez sur confirmer pour poursuivre.';
-
-        hooks.beforeEach(async function () {
+    module('when should display', function () {
+      module('when certification is validated, session is finalized and not published', function () {
+        test('should display a reject button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
-            id: 1,
             userId: 1,
             status: assessmentResultStatus.VALIDATED,
-            save: sinon.stub(),
-            reload: sinon.stub(),
+            isPublished: false,
           });
-          const session = store.createRecord('session', {});
+          const session = createFinalizedSession();
 
           // when
-          screen = await render(
-            <template>
-              <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-            </template>,
-          );
-        });
-
-        test('should display a reject button', async function (assert) {
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Rejeter la certification' })).exists();
-        });
-
-        test('on reject button click, should display a confirmation modal', async function (assert) {
-          // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Rejeter la certification' }));
-
-          await screen.findByRole('dialog');
+          const screen = await renderGlobalActions(certification, session);
 
           // then
-          assert.dom(screen.getByText(modalTitle)).exists();
-          assert.dom(screen.getByText(modalMessage)).exists();
-          assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
-          assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-        });
-
-        module('on modal confirmation', function () {
-          test('should cancel the certification and close the modal', async function (assert) {
-            // given
-            const currentCertification = store.peekRecord('certification', 1);
-
-            // when
-            await fireEvent.click(screen.getByRole('button', { name: 'Rejeter la certification' }));
-            await screen.findByRole('dialog');
-            await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
-            await waitForDialogClose();
-
-            // then
-            sinon.assert.calledWith(currentCertification.save, {
-              adapterOptions: { isCertificationReject: true },
-            });
-            assert.ok(currentCertification.reload.calledOnce);
-            assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
-          });
-
-          test('on error, should display a notification and close the modal', async function (assert) {
-            // given
-            const notificationStub = sinon.stub();
-            class NotificationsStub extends Service {
-              sendErrorNotification = notificationStub;
-            }
-            this.owner.register('service:pixToast', NotificationsStub);
-
-            const currentCertification = store.peekRecord('certification', 1);
-            currentCertification.save.rejects();
-
-            // when
-            await fireEvent.click(screen.getByRole('button', { name: 'Rejeter la certification' }));
-            await screen.findByRole('dialog');
-            await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
-            await waitForDialogClose();
-
-            // then
-            sinon.assert.calledWith(notificationStub, { message: 'Une erreur est survenue.' });
-            assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
-          });
-        });
-
-        test('on modal cancellation, should close the modal', async function (assert) {
-          // given
-          const currentCertification = store.peekRecord('certification', 1);
-
-          // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Rejeter la certification' }));
-
-          await screen.findByRole('dialog');
-
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler' }));
-
-          await waitForDialogClose();
-
-          // then
-          assert.ok(currentCertification.save.notCalled);
-          assert.ok(currentCertification.reload.notCalled);
-          assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .exists();
         });
       });
 
-      module('when the certification is published', function () {
-        test('should display a disabled reject button with an explaining tooltip', async function (assert) {
+      module('when certification has error status, session is finalized and not published', function () {
+        test('should display a reject button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.ERROR,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .exists();
+        });
+      });
+    });
+
+    module('when should not display', function () {
+      module('when certification status is cancelled', function () {
+        test('should not display a reject button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.CANCELLED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when certification status is rejected', function () {
+        test('should not display a reject button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.REJECTED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when session is not finalized', function () {
+        test('should not display a reject button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: false,
+          });
+          const session = createNonFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when certification is published', function () {
+        test('should not display a reject button', async function (assert) {
           // given
           const certification = store.createRecord('certification', {
             userId: 1,
             status: assessmentResultStatus.VALIDATED,
             isPublished: true,
           });
-          const session = store.createRecord('session', {});
+          const session = createFinalizedSession();
 
           // when
-          const screen = await render(
-            <template>
-              <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-            </template>,
-          );
+          const screen = await renderGlobalActions(certification, session);
 
           // then
-          const rejectButton = screen.getByRole('button', { name: 'Rejeter la certification' });
-          const tooltipText =
-            'Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette certification.';
-
-          assert.dom(rejectButton).hasAttribute('aria-disabled');
-          await fireEvent.mouseOver(rejectButton);
-          assert.dom(screen.getByText(tooltipText)).exists();
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.reject.button') }))
+            .doesNotExist();
         });
+      });
+    });
+
+    module('when button is displayed', function (hooks) {
+      let screen;
+      const modalTitle = 'Confirmer le rejet de la certification';
+      const modalMessage =
+        'Êtes-vous sûr·e de vouloir rejeter cette certification ? Cliquez sur confirmer pour poursuivre.';
+
+      hooks.beforeEach(async function () {
+        // given
+        const certification = store.createRecord('certification', {
+          id: 1,
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+          save: sinon.stub(),
+          reload: sinon.stub(),
+        });
+        const session = createFinalizedSession();
+
+        // when
+        screen = await renderGlobalActions(certification, session);
+      });
+
+      test('should display confirmation modal on click', async function (assert) {
+        // when
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }),
+        );
+        await screen.findByRole('dialog');
+
+        // then
+        assert.dom(screen.getByText(modalTitle)).exists();
+        assert.dom(screen.getByText(modalMessage)).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+      });
+
+      module('when modal is confirmed', function () {
+        test('should perform action and close modal on success', async function (assert) {
+          // given
+          const currentCertification = store.peekRecord('certification', 1);
+
+          // when
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }),
+          );
+          await screen.findByRole('dialog');
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+          await waitForDialogClose();
+
+          // then
+          sinon.assert.calledWith(currentCertification.save, {
+            adapterOptions: { isCertificationReject: true },
+          });
+          assert.ok(currentCertification.reload.calledOnce);
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
+        });
+
+        test('should display notification and close modal on error', async function (assert) {
+          // given
+          const notificationStub = setupNotificationStub(this.owner);
+          const currentCertification = store.peekRecord('certification', 1);
+          currentCertification.save.rejects();
+
+          // when
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }),
+          );
+          await screen.findByRole('dialog');
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
+          await waitForDialogClose();
+
+          // then
+          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.reject.error-message') });
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
+        });
+      });
+
+      test('should close modal on cancellation', async function (assert) {
+        // given
+        const currentCertification = store.peekRecord('certification', 1);
+
+        // when
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.reject.button') }),
+        );
+        await screen.findByRole('dialog');
+        await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+        await waitForDialogClose();
+
+        // then
+        assert.ok(currentCertification.save.notCalled);
+        assert.ok(currentCertification.reload.notCalled);
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
       });
     });
   });
@@ -487,29 +636,29 @@ module('Integration | Component | Certifications | Certification | Information |
         const session = store.createRecord('session', {});
 
         // when
-        screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
+        screen = await renderGlobalActions(certification, session);
       });
 
       test('should display an uncancel button', async function (assert) {
         // then
-        assert.dom(screen.getByRole('button', { name: 'Annuler le rejet' })).exists();
+        assert
+          .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }))
+          .exists();
       });
 
       test('on cancel button click, should display a confirmation modal', async function (assert) {
         // when
-        await fireEvent.click(screen.getByRole('button', { name: 'Annuler le rejet' }));
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }),
+        );
 
         await screen.findByRole('dialog');
 
         // then
         assert.dom(screen.getByText(modalTitle)).exists();
         assert.dom(screen.getByText(modalMessage)).exists();
-        assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.confirm') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
       });
 
       module('on modal confirmation', function () {
@@ -518,11 +667,13 @@ module('Integration | Component | Certifications | Certification | Information |
           const currentCertification = store.peekRecord('certification', 1);
 
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler le rejet' }));
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }),
+          );
 
           await screen.findByRole('dialog');
 
-          await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
 
           await waitForDialogClose();
 
@@ -531,29 +682,27 @@ module('Integration | Component | Certifications | Certification | Information |
             adapterOptions: { isCertificationUnreject: true },
           });
           assert.ok(currentCertification.reload.calledOnce);
-          assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
 
         test('on error, should display a notification and close the modal', async function (assert) {
           // given
-          const notificationStub = sinon.stub();
-          class NotificationsStub extends Service {
-            sendErrorNotification = notificationStub;
-          }
-          this.owner.register('service:pixToast', NotificationsStub);
+          const notificationStub = setupNotificationStub(this.owner);
 
           const currentCertification = store.peekRecord('certification', 1);
           currentCertification.save.rejects();
 
           // when
-          await fireEvent.click(screen.getByRole('button', { name: 'Annuler le rejet' }));
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }),
+          );
           await screen.findByRole('dialog');
-          await fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }));
+          await fireEvent.click(screen.getByRole('button', { name: t('common.actions.confirm') }));
           await waitForDialogClose();
 
           // then
-          sinon.assert.calledWith(notificationStub, { message: 'Une erreur est survenue.' });
-          assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
+          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.unreject.error-message') });
+          assert.dom(screen.queryByRole('button', { name: t('common.actions.confirm') })).doesNotExist();
         });
       });
 
@@ -562,128 +711,231 @@ module('Integration | Component | Certifications | Certification | Information |
         const currentCertification = store.peekRecord('certification', 1);
 
         // when
-        await fireEvent.click(screen.getByRole('button', { name: 'Annuler le rejet' }));
+        await fireEvent.click(
+          screen.getByRole('button', { name: t('components.certifications.global-actions.unreject.button') }),
+        );
 
         await screen.findByRole('dialog');
 
-        await fireEvent.click(screen.getByRole('button', { name: 'Annuler' }));
+        await fireEvent.click(screen.getByRole('button', { name: t('common.actions.cancel') }));
 
         await waitForDialogClose();
 
         // then
         assert.ok(currentCertification.save.notCalled);
         assert.ok(currentCertification.reload.notCalled);
-        assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: t('common.actions.cancel') })).doesNotExist();
       });
     });
   });
 
   module('rescore button', function () {
-    module('when the certification status is cancelled', function () {
-      test('should not display a rescoring button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          status: assessmentResultStatus.CANCELLED,
-          isPublished: false,
+    module('when should display', function () {
+      module('when certification is validated, session is finalized and not published', function () {
+        test('should display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .exists();
         });
-        const session = store.createRecord('session', { finalizedAt: new Date() });
+      });
 
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
+      module('when certification has error status, session is finalized and not published', function () {
+        test('should display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.ERROR,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
 
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Re-scorer la certification' })).doesNotExist();
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .exists();
+        });
       });
     });
 
-    module('when the certification status is rejected', function () {
-      test('should not display a rescoring button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          status: assessmentResultStatus.REJECTED,
-          isPublished: false,
+    module('when should not display', function () {
+      module('when certification status is cancelled', function () {
+        test('should not display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.CANCELLED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .doesNotExist();
         });
-        const session = store.createRecord('session', { finalizedAt: new Date() });
+      });
 
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
+      module('when certification status is rejected', function () {
+        test('should not display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.REJECTED,
+            isPublished: false,
+          });
+          const session = createFinalizedSession();
 
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Re-scorer la certification' })).doesNotExist();
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when session is not finalized', function () {
+        test('should not display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: false,
+          });
+          const session = createNonFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when certification is published', function () {
+        test('should not display a rescoring button', async function (assert) {
+          // given
+          const certification = store.createRecord('certification', {
+            userId: 1,
+            status: assessmentResultStatus.VALIDATED,
+            isPublished: true,
+          });
+          const session = createFinalizedSession();
+
+          // when
+          const screen = await renderGlobalActions(certification, session);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+            .doesNotExist();
+        });
       });
     });
 
-    module('when the certification is already published', function () {
-      test('should not display a rescoring button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
-          userId: 1,
-          isPublished: true,
-        });
-        const session = store.createRecord('session', {});
-
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Re-scorer la certification' })).doesNotExist();
+    module('when button is displayed', function (hooks) {
+      hooks.afterEach(function () {
+        sinon.restore();
       });
-    });
 
-    module('when the certification is not finalized', function () {
-      test('should not display a rescoring button', async function (assert) {
+      test('should trigger rescoring and show success notification', async function (assert) {
+        assert.expect(1);
+
         // given
         const certification = store.createRecord('certification', {
-          userId: 1,
-          isPublished: false,
-        });
-        const session = store.createRecord('session', { finalizedAt: null });
-
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Re-scorer la certification' })).doesNotExist();
-      });
-    });
-
-    module('when the certification is validated, finalized but not published yet', function () {
-      test('should display a rescoring button', async function (assert) {
-        // given
-        const certification = store.createRecord('certification', {
+          id: 123,
           userId: 1,
           status: assessmentResultStatus.VALIDATED,
           isPublished: false,
+          reload: sinon.stub(),
         });
-        const session = store.createRecord('session', { finalizedAt: new Date('2020-01-01') });
+        const session = createFinalizedSession();
 
-        // when
-        const screen = await render(
-          <template>
-            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
-          </template>,
-        );
+        const rescoreCertificationStub = sinon.stub().resolves();
+        const adapter = { rescoreCertification: rescoreCertificationStub };
 
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Re-scorer la certification' })).exists();
+        const originalAdapterFor = store.adapterFor;
+        store.adapterFor = sinon.stub().withArgs('certification').returns(adapter);
+
+        const notificationStub = setupNotificationStub(this.owner, 'sendSuccessNotification');
+
+        try {
+          // when
+          const screen = await renderGlobalActions(certification, session);
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }),
+          );
+
+          // then
+          sinon.assert.calledOnce(rescoreCertificationStub);
+          sinon.assert.calledWith(rescoreCertificationStub, { certificationCourseId: '123' });
+          sinon.assert.calledWith(notificationStub, { message: t('components.certifications.global-actions.rescoring.success-message') });
+          assert.ok(certification.reload.calledOnce);
+        } finally {
+          store.adapterFor = originalAdapterFor;
+        }
+      });
+
+      test('should show error notification when rescoring fails', async function (assert) {
+        assert.expect(1);
+
+        // given
+        const certification = store.createRecord('certification', {
+          id: 123,
+          userId: 1,
+          status: assessmentResultStatus.VALIDATED,
+          isPublished: false,
+          reload: sinon.stub(),
+        });
+        const session = createFinalizedSession();
+
+        const rescoreCertificationStub = sinon.stub().rejects();
+        const adapter = { rescoreCertification: rescoreCertificationStub };
+
+        const originalAdapterFor = store.adapterFor;
+        store.adapterFor = sinon.stub().withArgs('certification').returns(adapter);
+
+        const notificationStub = setupNotificationStub(this.owner);
+
+        try {
+          // when
+          const screen = await renderGlobalActions(certification, session);
+          await fireEvent.click(
+            screen.getByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }),
+          );
+
+          // Wait for async error handling
+          await new Promise(resolve => setTimeout(resolve, 100));
+
+          // then
+          assert.ok(notificationStub.called, 'notification should have been called');
+          sinon.assert.calledWith(notificationStub, {
+            message: t('components.certifications.global-actions.rescoring.error-message'),
+          });
+        } finally {
+          store.adapterFor = originalAdapterFor;
+        }
       });
     });
   });

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -36,7 +36,31 @@ module('Integration | Component | Certifications | Certification | Information |
   });
 
   module('cancel button', function () {
-    module('when the certification is not cancelled, not published and the session is finalized', function (hooks) {
+    module('when the certification status is rejected', function () {
+      test('should not display a cancel button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.REJECTED,
+          isPublished: false,
+        });
+        const session = store.createRecord('session', {
+          finalizedAt: new Date(),
+        });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Annuler la certification' })).doesNotExist();
+      });
+    });
+
+    module('when the certification is validated, not cancelled, not published and the session is finalized', function (hooks) {
       let screen;
 
       const modalTitle = "Confirmer l'annulation de la certification";
@@ -261,6 +285,27 @@ module('Integration | Component | Certifications | Certification | Information |
   });
 
   module('reject button', function () {
+    module('when the certification status is cancelled', function () {
+      test('should not display a reject button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.CANCELLED,
+        });
+        const session = store.createRecord('session', {});
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Rejeter la certification' })).doesNotExist();
+      });
+    });
+
     module('when the certification is already rejected', function () {
       test('should not display a reject button', async function (assert) {
         // given
@@ -532,6 +577,54 @@ module('Integration | Component | Certifications | Certification | Information |
   });
 
   module('rescore button', function () {
+    module('when the certification status is cancelled', function () {
+      test('should not display a rescoring button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.CANCELLED,
+          isPublished: false,
+        });
+        const session = store.createRecord('session', { finalizedAt: new Date() });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when the certification status is rejected', function () {
+      test('should not display a rescoring button', async function (assert) {
+        // given
+        const certification = store.createRecord('certification', {
+          userId: 1,
+          status: assessmentResultStatus.REJECTED,
+          isPublished: false,
+        });
+        const session = store.createRecord('session', { finalizedAt: new Date() });
+
+        // when
+        const screen = await render(
+          <template>
+            <CertificationInformationGlobalActions @certification={{certification}} @session={{session}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('components.certifications.global-actions.rescoring.button') }))
+          .doesNotExist();
+      });
+    });
+
     module('when the certification is already published', function () {
       test('should not display a rescoring button', async function (assert) {
         // given
@@ -578,11 +671,12 @@ module('Integration | Component | Certifications | Certification | Information |
       });
     });
 
-    module('when the certification is finalized but not published yet', function () {
+    module('when the certification is validated, finalized but not published yet', function () {
       test('should display a rescoring button', async function (assert) {
         // given
         const certification = store.createRecord('certification', {
           userId: 1,
+          status: assessmentResultStatus.VALIDATED,
           isPublished: false,
         });
         const session = store.createRecord('session', { finalizedAt: new Date('2020-01-01') });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -6,6 +6,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "confirm": "Confirm",
+      "confirm-title": "Please confirm",
       "deactivate": "Deactivate",
       "download-template": "Download template",
       "edit": "Edit",
@@ -392,11 +393,37 @@
         "UNSET": "Waiting"
       },
       "global-actions": {
+        "cancel": {
+          "button": "Cancel certification",
+          "error-message": "An error occurred.",
+          "modal-message": "Are you sure you want to cancel this certification? Click confirm to proceed.",
+          "modal-title": "Confirm certification cancellation"
+        },
+        "reject": {
+          "button": "Reject certification",
+          "error-message": "An error occurred.",
+          "modal-message": "Are you sure you want to reject this certification? Click confirm to proceed.",
+          "modal-title": "Confirm certification rejection",
+          "tooltip-published": "You cannot reject a published certification. Please unpublish the session before rejecting this certification."
+        },
         "rescoring": {
           "button": "Rescore certification",
           "error-message": "An error occurred during certification rescoring.",
           "success-message": "Certification has successfully been rescored."
-        }
+        },
+        "uncancel": {
+          "button": "Uncancel certification",
+          "error-message": "An error occurred.",
+          "modal-message": "Are you sure you want to uncancel this certification? Click confirm to proceed.",
+          "modal-title": "Confirm certification uncancellation"
+        },
+        "unreject": {
+          "button": "Unreject certification",
+          "error-message": "An error occurred.",
+          "modal-message": "Are you sure you want to unreject this certification? Click confirm to proceed.",
+          "modal-title": "Confirm certification unrejection"
+        },
+        "user-details-link": "See user details"
       }
     },
     "complementary-certifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -6,6 +6,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "confirm": "Confirmer",
+      "confirm-title": "Merci de confirmer",
       "deactivate": "Désactiver",
       "download-template": "Télécharger le template",
       "edit": "Modifier",
@@ -392,11 +393,37 @@
         "UNSET": "En attente"
       },
       "global-actions": {
+        "cancel": {
+          "button": "Annuler la certification",
+          "error-message": "Une erreur est survenue.",
+          "modal-message": "Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.",
+          "modal-title": "Confirmer l'annulation de la certification"
+        },
+        "reject": {
+          "button": "Rejeter la certification",
+          "error-message": "Une erreur est survenue.",
+          "modal-message": "Êtes-vous sûr·e de vouloir rejeter cette certification ? Cliquez sur confirmer pour poursuivre.",
+          "modal-title": "Confirmer le rejet de la certification",
+          "tooltip-published": "Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette certification."
+        },
         "rescoring": {
           "button": "Re-scorer la certification",
           "error-message": "Une erreur est survenue lors du rescoring de la certification.",
           "success-message": "La certification a bien été rescorée."
-        }
+        },
+        "uncancel": {
+          "button": "Désannuler la certification",
+          "error-message": "Une erreur est survenue.",
+          "modal-message": "Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.",
+          "modal-title": "Confirmer la désannulation de la certification"
+        },
+        "unreject": {
+          "button": "Annuler le rejet",
+          "error-message": "Une erreur est survenue.",
+          "modal-message": "Êtes-vous sûr·e de vouloir annuler le rejet de cette certification ? Cliquez sur confirmer pour poursuivre.",
+          "modal-title": "Confirmer l'annulation du rejet de la certification"
+        },
+        "user-details-link": "Voir les détails de l'utilisateur"
       }
     },
     "complementary-certifications": {

--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -1,13 +1,29 @@
+import { CertificationRescoringNotAllowedError } from '../../../shared/domain/errors.js';
 import { usecases } from '../../evaluation/domain/usecases/index.js';
+import * as courseAssessmentResultRepository from '../../session-management/infrastructure/repositories/course-assessment-result-repository.js';
 import { AlgorithmEngineVersion } from '../../shared/domain/models/AlgorithmEngineVersion.js';
 import * as certificationCourseRepository from '../../shared/infrastructure/repositories/certification-course-repository.js';
 import CertificationRescored from '../domain/events/CertificationRescored.js';
 
-const rescoreCertification = async function (request, h, dependencies = { certificationCourseRepository }) {
+const rescoreCertification = async function (
+  request,
+  h,
+  dependencies = { certificationCourseRepository, courseAssessmentResultRepository },
+) {
   const juryId = request.auth.credentials.userId;
   const certificationCourseId = request.params.certificationCourseId;
 
   const certificationCourse = await dependencies.certificationCourseRepository.get({ id: certificationCourseId });
+
+  const latestAssessmentResult = await dependencies.courseAssessmentResultRepository.getLatestAssessmentResult({
+    certificationCourseId,
+  });
+  if (
+    latestAssessmentResult &&
+    (latestAssessmentResult.status === 'cancelled' || latestAssessmentResult.status === 'rejected')
+  ) {
+    throw new CertificationRescoringNotAllowedError();
+  }
 
   if (AlgorithmEngineVersion.isV3(certificationCourse.getVersion())) {
     await usecases.rescoreV3Certification({

--- a/api/src/certification/evaluation/application/certification-rescoring-controller.js
+++ b/api/src/certification/evaluation/application/certification-rescoring-controller.js
@@ -18,10 +18,7 @@ const rescoreCertification = async function (
   const latestAssessmentResult = await dependencies.courseAssessmentResultRepository.getLatestAssessmentResult({
     certificationCourseId,
   });
-  if (
-    latestAssessmentResult &&
-    (latestAssessmentResult.status === 'cancelled' || latestAssessmentResult.status === 'rejected')
-  ) {
+  if (_isAssessmentResultNotRescorable(latestAssessmentResult)) {
     throw new CertificationRescoringNotAllowedError();
   }
 
@@ -38,6 +35,13 @@ const rescoreCertification = async function (
   }
 
   return h.response().code(201);
+};
+
+const _isAssessmentResultNotRescorable = (latestAssessmentResult) => {
+  return (
+    latestAssessmentResult &&
+    (latestAssessmentResult.status === 'cancelled' || latestAssessmentResult.status === 'rejected')
+  );
 };
 
 const certificationRescoringController = {

--- a/api/src/certification/session-management/domain/usecases/cancel.js
+++ b/api/src/certification/session-management/domain/usecases/cancel.js
@@ -34,7 +34,7 @@ export const cancel = async function ({
   const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
     certificationCourseId,
   });
-  if (latestAssessmentResult && latestAssessmentResult.status === 'rejected') {
+  if (_isAssessmentResultNotCancellable(latestAssessmentResult)) {
     throw new CertificationCancelNotAllowedError();
   }
 
@@ -50,4 +50,8 @@ export const cancel = async function ({
   if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
     await certificationRescoringRepository.rescoreV2Certification({ event });
   }
+};
+
+const _isAssessmentResultNotCancellable = (latestAssessmentResult) => {
+  return latestAssessmentResult && latestAssessmentResult.status === 'rejected';
 };

--- a/api/src/certification/session-management/domain/usecases/cancel.js
+++ b/api/src/certification/session-management/domain/usecases/cancel.js
@@ -2,10 +2,11 @@
  * @typedef {import('./index.js').CertificationCourseRepository} CertificationCourseRepository
  * @typedef {import('./index.js').SessionRepository} SessionRepository
  * @typedef {import('./index.js').CertificationRescoringRepository} CertificationRescoringRepository
+ * @typedef {import('./index.js').CourseAssessmentResultRepository} CourseAssessmentResultRepository
  */
 
 import CertificationCancelled from '../../../../../src/shared/domain/events/CertificationCancelled.js';
-import { NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
+import { CertificationCancelNotAllowedError, NotFinalizedSessionError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 
 /**
@@ -14,6 +15,7 @@ import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmE
  * @param {CertificationCourseRepository} params.certificationCourseRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {CertificationRescoringRepository} params.certificationRescoringRepository
+ * @param {CourseAssessmentResultRepository} params.courseAssessmentResultRepository
  */
 export const cancel = async function ({
   certificationCourseId,
@@ -21,11 +23,19 @@ export const cancel = async function ({
   certificationCourseRepository,
   sessionRepository,
   certificationRescoringRepository,
+  courseAssessmentResultRepository,
 }) {
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
   const session = await sessionRepository.get({ id: certificationCourse.getSessionId() });
   if (!session.isFinalized) {
     throw new NotFinalizedSessionError();
+  }
+
+  const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
+    certificationCourseId,
+  });
+  if (latestAssessmentResult && latestAssessmentResult.status === 'rejected') {
+    throw new CertificationCancelNotAllowedError();
   }
 
   const event = new CertificationCancelled({

--- a/api/src/certification/session-management/domain/usecases/reject-certification-course.js
+++ b/api/src/certification/session-management/domain/usecases/reject-certification-course.js
@@ -1,3 +1,4 @@
+import { CertificationRejectNotAllowedError } from '../../../../shared/domain/errors.js';
 import { AlgorithmEngineVersion } from '../../../shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationCourseRejected } from '../events/CertificationCourseRejected.js';
 
@@ -6,8 +7,23 @@ export const rejectCertificationCourse = async ({
   juryId,
   certificationCourseRepository,
   certificationRescoringRepository,
+  courseAssessmentResultRepository,
 }) => {
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
+
+  try {
+    const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
+      certificationCourseId,
+    });
+    if (latestAssessmentResult && latestAssessmentResult.status === 'cancelled') {
+      throw new CertificationRejectNotAllowedError();
+    }
+  } catch (error) {
+    if (error.message !== 'No assessment result found') {
+      throw error;
+    }
+  }
+
   certificationCourse.rejectForFraud();
   await certificationCourseRepository.update({ certificationCourse });
 

--- a/api/src/certification/session-management/domain/usecases/reject-certification-course.js
+++ b/api/src/certification/session-management/domain/usecases/reject-certification-course.js
@@ -15,7 +15,7 @@ export const rejectCertificationCourse = async ({
     const latestAssessmentResult = await courseAssessmentResultRepository.getLatestAssessmentResult({
       certificationCourseId,
     });
-    if (latestAssessmentResult && latestAssessmentResult.status === 'cancelled') {
+    if (_isAssessmentResultNotRejectable(latestAssessmentResult)) {
       throw new CertificationRejectNotAllowedError();
     }
   } catch (error) {
@@ -36,4 +36,8 @@ export const rejectCertificationCourse = async ({
   if (AlgorithmEngineVersion.isV2(certificationCourse.getVersion())) {
     return certificationRescoringRepository.rescoreV2Certification({ event });
   }
+};
+
+const _isAssessmentResultNotRejectable = (latestAssessmentResult) => {
+  return latestAssessmentResult && latestAssessmentResult.status === 'cancelled';
 };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -988,6 +988,24 @@ class NotFinalizedSessionError extends DomainError {
   }
 }
 
+class CertificationRejectNotAllowedError extends DomainError {
+  constructor(message = 'A certification course cannot be rejected while it is cancelled.') {
+    super(message);
+  }
+}
+
+class CertificationCancelNotAllowedError extends DomainError {
+  constructor(message = 'A certification course cannot be cancelled while it is rejected.') {
+    super(message);
+  }
+}
+
+class CertificationRescoringNotAllowedError extends DomainError {
+  constructor(message = 'A certification course cannot be rescored while it is cancelled or rejected.') {
+    super(message);
+  }
+}
+
 export {
   AccountRecoveryDemandExpired,
   AccountRecoveryUserAlreadyConfirmEmail,
@@ -1019,6 +1037,7 @@ export {
   CertificateVerificationCodeGenerationTooManyTrials,
   CertificationAlgorithmVersionError,
   CertificationBadgeForbiddenDeletionError,
+  CertificationCancelNotAllowedError,
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateDeletionError,
@@ -1031,6 +1050,8 @@ export {
   CertificationCenterMembershipDisableError,
   CertificationEndedByFinalizationError,
   CertificationEndedBySupervisorError,
+  CertificationRejectNotAllowedError,
+  CertificationRescoringNotAllowedError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
   CsvImportError,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -119,10 +119,15 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           challengeId: certificationChallenge.challengeId,
           result: AnswerStatus.KO.status,
         });
-        databaseBuilder.factory.buildAssessmentResult({
+        const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
           assessmentId: assessment.id,
           pixScore: 200,
         });
+        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: certificationCourse.id,
+          lastAssessmentResultId: assessmentResult.id,
+        });
+        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
 
         await databaseBuilder.commit();
 
@@ -251,10 +256,15 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           challengeId: certificationChallenge.challengeId,
           result: AnswerStatus.KO.status,
         });
-        databaseBuilder.factory.buildAssessmentResult({
+        const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
           assessmentId: assessment.id,
           pixScore: 200,
         });
+        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: certificationCourse.id,
+          lastAssessmentResultId: assessmentResult.id,
+        });
+        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
 
         await databaseBuilder.commit();
         await datamartBuilder.commit();


### PR DESCRIPTION
🔆 Problème
-----------
Les actions d'annulation, rejet et rescoring sont disponibles pour tous les statuts de certification.

⛱️ Proposition
--------------
N'afficher ces boutons que si la certification a le statut `validated`.

🌊 Remarques
------------

- On ne doit pas pouvoir annuler une certification rejetée
- On ne doit pas pourvoir rejeter un certification annulée
- On ne doit pas pouvoir rescorer une certification annulée ou rejetée 

🏄 Pour tester
--------------
1. Accéder à la page d'informations d'une certification dans l'admin
2. Vérifier que les boutons d'annulation, rejet et rescoring ne sont visibles que pour les certifications validées
3. Confirmer que ces boutons n'apparaissent pas pour les certifications annulées ou rejetées