### PR TITLE
[FEATURE] Extraire les boutons d'action des grains de la carte (PIX-19491)

### DIFF
--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -24,7 +24,8 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   }
 
   &__card,
-  &-card__tag {
+  &-card__tag,
+  &-card__footer {
     @media (not (prefers-reduced-motion: reduce)) {
       animation: 0.8s fade-in ease-in-out;
 

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -61,8 +61,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
 .grain-card {
   &__footer {
     padding: var(--pix-spacing-2x) 0;
-    border-top: 0 solid var(--pix-neutral-100);
-    border-radius: 0 0 $grain-card-border-radius $grain-card-border-radius;
   }
 
   &--summary {
@@ -73,7 +71,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   &--lesson {
     padding: var(--pix-spacing-6x);
     background: var(--pix-primary-10);
-    border-radius: var(--pix-spacing-4x);
   }
 }
 

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -303,31 +303,31 @@ export default class ModuleGrain extends Component {
             {{/if}}
           {{/each}}
         </div>
-
-        {{#if this.shouldDisplaySkipButton}}
-          <footer class="grain-card__footer">
-            <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
-              {{this.skipButtonLabel}}
-            </PixButton>
-          </footer>
-        {{/if}}
-
-        {{#if this.shouldDisplayContinueButton}}
-          <footer class="grain-card__footer">
-            <PixButton @variant="primary" @triggerAction={{@onGrainContinue}}>
-              {{t "pages.modulix.buttons.grain.continue"}}
-            </PixButton>
-          </footer>
-        {{/if}}
-
-        {{#if @shouldDisplayTerminateButton}}
-          <footer class="grain-card__footer">
-            <PixButton @variant="primary" @triggerAction={{this.onModuleTerminate}}>
-              {{t "pages.modulix.buttons.grain.terminate"}}
-            </PixButton>
-          </footer>
-        {{/if}}
       </div>
+
+      {{#if this.shouldDisplaySkipButton}}
+        <footer class="grain-card__footer">
+          <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
+            {{this.skipButtonLabel}}
+          </PixButton>
+        </footer>
+      {{/if}}
+
+      {{#if this.shouldDisplayContinueButton}}
+        <footer class="grain-card__footer">
+          <PixButton @variant="primary" @triggerAction={{@onGrainContinue}}>
+            {{t "pages.modulix.buttons.grain.continue"}}
+          </PixButton>
+        </footer>
+      {{/if}}
+
+      {{#if @shouldDisplayTerminateButton}}
+        <footer class="grain-card__footer">
+          <PixButton @variant="primary" @triggerAction={{this.onModuleTerminate}}>
+            {{t "pages.modulix.buttons.grain.terminate"}}
+          </PixButton>
+        </footer>
+      {{/if}}
     </article>
   </template>
 }


### PR DESCRIPTION
## 🔆 Problème

CTA “Continuer”/”Passer” : semble ne pas être à la même place en fonction des grains

## ⛱️ Proposition

Déplacer le CTA en dehors de la carte des leçons

## 🌊 Remarques

Nettoyage code mort.

## 🏄 Pour tester

Sur [un module](https://app-pr13525.review.pix.fr/modules/bac-a-sable/passage) avec grains leçon/résumé, vérifier que les styles sont plus adaptés
