### PR TITLE
[FEATURE] Empêcher la création d'une campagne avec un code qui existe déjà sur un parcours combiné (PIX-19467)

### DIFF
--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -9,11 +9,11 @@ import dayjs from 'dayjs';
 import _ from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
-import * as campaignAdministrationRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import { CampaignParticipationStatuses } from '../../src/prescription/shared/domain/constants.js';
-import { generate } from '../../src/shared/domain/services/code-generator.js';
+import * as codeGenerator from '../../src/shared/domain/services/code-generator.js';
 import { learningContentCache as cache } from '../../src/shared/infrastructure/caches/learning-content-cache.js';
+import * as accessCodeRepository from '../../src/shared/infrastructure/repositories/access-code-repository.js';
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../src/shared/infrastructure/repositories/skill-repository.js';
 import { computeParticipantResultsShared as computeParticipationResults } from '../prod/compute-participation-results.js';
@@ -238,7 +238,7 @@ async function _createCampaign({ organizationId, campaignType, targetProfileId, 
   if (!adminMemberId) {
     throw new Error(`Organisation ${organizationId} n'a pas de membre ADMIN.`);
   }
-  const code = await generate(campaignAdministrationRepository);
+  const code = await codeGenerator.generate(accessCodeRepository);
   const [{ id: campaignId }] = await knex('campaigns')
     .returning('id')
     .insert({

--- a/api/scripts/prod/create-profiles-collection-campaigns.js
+++ b/api/scripts/prod/create-profiles-collection-campaigns.js
@@ -2,9 +2,9 @@ import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as campaignUpdateValidator from '../../src/prescription/campaign/domain/validators/campaign-update-validator.js';
-import * as campaignRepository from '../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import { CampaignTypes } from '../../src/prescription/shared/domain/constants.js';
 import * as codeGenerator from '../../src/shared/domain/services/code-generator.js';
+import * as accessCodeRepository from '../../src/shared/infrastructure/repositories/access-code-repository.js';
 import { PromiseUtils } from '../../src/shared/infrastructure/utils/promise-utils.js';
 import { parseCsvWithHeader } from '../helpers/csvHelpers.js';
 
@@ -41,7 +41,7 @@ async function prepareCampaigns(campaignsData) {
       };
 
       campaignUpdateValidator.validate(campaign);
-      campaign.code = await codeGenerator.generate(campaignRepository, generatedList);
+      campaign.code = await codeGenerator.generate(accessCodeRepository, generatedList);
       generatedList.push(campaign.code);
 
       if (isLaunchedFromCommandLine)

--- a/api/src/prescription/campaign/domain/usecases/create-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaign.js
@@ -4,6 +4,7 @@ const createCampaign = async function ({
   campaign,
   userRepository,
   campaignAdministrationRepository,
+  accessCodeRepository,
   campaignCreatorRepository,
   codeGenerator,
 }) {
@@ -14,7 +15,7 @@ const createCampaign = async function ({
   await _checkUserIsAMemberOfOrganization({ userRepository, organizationId, userId });
   await _checkUserIsAMemberOfOrganization({ userRepository, organizationId, userId: ownerId });
 
-  const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
+  const generatedCampaignCode = await codeGenerator.generate(accessCodeRepository);
 
   const campaignCreator = await campaignCreatorRepository.get(organizationId);
 

--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -1,6 +1,7 @@
 const createCampaigns = async function ({
   campaignsToCreate,
   campaignAdministrationRepository,
+  accessCodeRepository,
   campaignCreatorRepository,
   codeGenerator,
   userRepository,
@@ -11,7 +12,7 @@ const createCampaigns = async function ({
     await _checkIfOwnerIsExistingUser(userRepository, campaign.ownerId);
     await _checkIfOrganizationExists(organizationRepository, campaign.organizationId);
 
-    const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
+    const generatedCampaignCode = await codeGenerator.generate(accessCodeRepository);
     const campaignCreator = await campaignCreatorRepository.get(campaign.organizationId);
 
     const campaignToCreate = await campaignCreator.createCampaign({

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -9,6 +9,7 @@ import * as organizationFeatureApi from '../../../../organizational-entities/app
 import * as codeGenerator from '../../../../shared/domain/services/code-generator.js';
 import * as placementProfileService from '../../../../shared/domain/services/placement-profile-service.js';
 import { featureToggles } from '../../../../shared/infrastructure/feature-toggles/index.js';
+import * as accessCodeRepository from '../../../../shared/infrastructure/repositories/access-code-repository.js';
 import { adminMemberRepository } from '../../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as assessmentRepository from '../../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
@@ -76,6 +77,7 @@ const dependencies = {
   organizationRepository,
   placementProfileService,
   stageRepository,
+  accessCodeRepository,
   stageCollectionRepository,
   stageAcquisitionRepository,
   targetProfileRepository: campaignRepositories.targetProfileRepository, // TODO

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
@@ -1,6 +1,11 @@
 import { CampaignUniqueCodeError, UnknownCampaignId } from './../errors.js';
 
-const updateCampaignCode = async function ({ campaignId, campaignCode, campaignAdministrationRepository }) {
+const updateCampaignCode = async function ({
+  campaignId,
+  campaignCode,
+  campaignAdministrationRepository,
+  accessCodeRepository,
+}) {
   const campaign = await campaignAdministrationRepository.get(campaignId);
   if (!campaign) {
     throw new UnknownCampaignId();
@@ -8,7 +13,7 @@ const updateCampaignCode = async function ({ campaignId, campaignCode, campaignA
 
   campaign.updateFields({ code: campaignCode });
 
-  const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: campaignCode });
+  const isCodeAvailable = await accessCodeRepository.isCodeAvailable({ code: campaignCode });
   if (!isCodeAvailable) {
     throw new CampaignUniqueCodeError();
   }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -143,10 +143,6 @@ const save = async function (campaigns, dependencies = { skillRepository }) {
   }
 };
 
-const isCodeAvailable = async function ({ code }) {
-  return !(await knex('campaigns').first('id').where({ code }));
-};
-
 const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId }) {
   const trx = await knex.transaction();
   const randomBytesBuffer = await cryptoService.randomBytes(16);
@@ -206,15 +202,4 @@ export const deleteExternalIdLabelFromCampaigns = (campaignIds) => {
     .whereIn('campaign-features.campaignId', campaignIds);
 };
 
-export {
-  archiveCampaigns,
-  get,
-  getByCode,
-  getByIds,
-  isCodeAvailable,
-  isFromSameOrganization,
-  remove,
-  save,
-  swapCampaignCodes,
-  update,
-};
+export { archiveCampaigns, get, getByCode, getByIds, isFromSameOrganization, remove, save, swapCampaignCodes, update };

--- a/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
@@ -8,8 +8,8 @@ import * as campaignCreatorRepository from '../../../../../../src/prescription/c
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CAMPAIGN_FEATURES, ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import * as codeGenerator from '../../../../../../src/shared/domain/services/code-generator.js';
+import * as accessCodeRepository from '../../../../../../src/shared/infrastructure/repositories/access-code-repository.js';
 import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
-
 describe('Integration | UseCases | create-campaign', function () {
   let userId;
   let organizationId;
@@ -61,6 +61,7 @@ describe('Integration | UseCases | create-campaign', function () {
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator,
+      accessCodeRepository,
     });
 
     // then
@@ -97,6 +98,7 @@ describe('Integration | UseCases | create-campaign', function () {
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator,
+      accessCodeRepository,
     });
 
     // then
@@ -125,6 +127,7 @@ describe('Integration | UseCases | create-campaign', function () {
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator,
+      accessCodeRepository,
     });
 
     // then

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -9,29 +9,6 @@ import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants
 import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Campaign Administration', function () {
-  describe('#isCodeAvailable', function () {
-    beforeEach(async function () {
-      databaseBuilder.factory.buildCampaign({ code: 'BADOIT710' });
-      await databaseBuilder.commit();
-    });
-
-    it('should resolve true if the code is available', async function () {
-      // when
-      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: 'FRANCE998' });
-
-      // then
-      expect(isCodeAvailable).to.be.true;
-    });
-
-    it('should resolve false if the code is not available', async function () {
-      // when
-      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: 'BADOIT710' });
-
-      // then
-      expect(isCodeAvailable).to.be.false;
-    });
-  });
-
   describe('#getByIds', function () {
     it('should return null if campaigns does not exists', async function () {
       // given & when

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -7,6 +7,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
   let codeGeneratorStub;
   let campaignsToCreate;
   let campaignAdministrationRepositoryStub;
+  const accessCodeRepository = Symbol('accessCodeRepository');
   let campaignCreatorRepositoryStub;
   let userRepositoryStub;
   let organizationRepositoryStub;
@@ -31,7 +32,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     codeGeneratorStub = {
       generate: sinon
         .stub()
-        .withArgs(campaignAdministrationRepositoryStub)
+        .withArgs(accessCodeRepository)
         .onFirstCall()
         .resolves(code1)
         .onSecondCall()
@@ -101,6 +102,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
 
       const result = await createCampaigns({
         campaignsToCreate,
+        accessCodeRepository,
         campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,
@@ -119,6 +121,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
 
       const error = await catchErr(createCampaigns)({
         campaignsToCreate,
+        accessCodeRepository,
         campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,
@@ -135,6 +138,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
 
       const error = await catchErr(createCampaigns)({
         campaignsToCreate,
+        accessCodeRepository,
         campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,
         campaignCreatorRepository: campaignCreatorRepositoryStub,

--- a/api/tests/unit/domain/services/code-generator_test.js
+++ b/api/tests/unit/domain/services/code-generator_test.js
@@ -5,18 +5,18 @@ import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Services | code generator', function () {
   describe('#createCode', function () {
-    const campaignRepository = {
+    const accessCodeRepository = {
       isCodeAvailable: () => undefined,
     };
 
     beforeEach(function () {
-      sinon.stub(campaignRepository, 'isCodeAvailable');
-      campaignRepository.isCodeAvailable.resolves(true);
+      sinon.stub(accessCodeRepository, 'isCodeAvailable');
+      accessCodeRepository.isCodeAvailable.resolves(true);
     });
 
     it('should create a code with a length of 9 characters', function () {
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then((code) => {
@@ -26,7 +26,7 @@ describe('Unit | Domain | Services | code generator', function () {
 
     it('should create a code beginning with 6 letters', function () {
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then((code) => {
@@ -37,7 +37,7 @@ describe('Unit | Domain | Services | code generator', function () {
 
     it('should create a code finishing with 3 numbers', function () {
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then((code) => {
@@ -48,17 +48,17 @@ describe('Unit | Domain | Services | code generator', function () {
 
     it('should not be already assigned', function () {
       // given
-      campaignRepository.isCodeAvailable.onCall(0).resolves(false);
-      campaignRepository.isCodeAvailable.onCall(1).resolves(true);
+      accessCodeRepository.isCodeAvailable.onCall(0).resolves(false);
+      accessCodeRepository.isCodeAvailable.onCall(1).resolves(true);
 
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then((generatedCode) => {
-        expect(campaignRepository.isCodeAvailable).to.have.been.called;
+        expect(accessCodeRepository.isCodeAvailable).to.have.been.called;
 
-        const existingCampaignCode = campaignRepository.isCodeAvailable.callsArg(0);
+        const existingCampaignCode = accessCodeRepository.isCodeAvailable.callsArg(0);
         expect(generatedCode).to.not.equal(existingCampaignCode);
       });
     });
@@ -67,7 +67,7 @@ describe('Unit | Domain | Services | code generator', function () {
       sinon.spy(randomString, 'generate');
 
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then(() => {
@@ -80,7 +80,7 @@ describe('Unit | Domain | Services | code generator', function () {
       sinon.spy(randomString, 'generate');
 
       // when
-      const promise = codeGenerator.generate(campaignRepository);
+      const promise = codeGenerator.generate(accessCodeRepository);
 
       // then
       return promise.then(() => {
@@ -105,7 +105,7 @@ describe('Unit | Domain | Services | code generator', function () {
       randomString.generate.onCall(3).returns('543');
 
       // when
-      const promise = codeGenerator.generate(campaignRepository, [pendingCode]);
+      const promise = codeGenerator.generate(accessCodeRepository, [pendingCode]);
 
       // then
       return promise.then((generatedCode) => {


### PR DESCRIPTION
## 🔆 Problème
Pour empêcher la création d’un code en doublon au moment du parcours combiné, on a 
`const code = await codeGenerator.generate(accessCodeRepository, pendingCodes);
`qui va chercher à la fois dans les campagnes et les parcours combinés.
On n'a pas le même comportement lors de la création d'une campagne, on ne va pas chercher si le code existe déjà au sein des parcours combinés.

## ⛱️ Proposition
Appeler, à la création de campagne (voir usecases createCampaign et createCampaigns) la méthode codeGenerator.generate avec le bon repository, accessCodeRepository, qui va s'occuper de faire le check sur les deux types (campagnes et parcours combinés).

## 🏄 Pour tester
Tests de non-régression sur la création de campagnes en masse sur Pix Admin, MAJ de campagne via Pix Admin, sur la création de campagne dans PixOrga, les deux scripts generate-campaign-with-participants et create-profiles-collection-campaigns.