### PR TITLE
[FEATURE] Retirer la possibilité de supprimer une participation d'un campagne lié à un Parcours combiné (PIX-19322).

### DIFF
--- a/orga/app/components/campaign/activity/participants-list.gjs
+++ b/orga/app/components/campaign/activity/participants-list.gjs
@@ -25,7 +25,11 @@ export default class ParticipantsList extends Component {
   @tracked participationToDelete;
 
   get canDeleteParticipation() {
-    return this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber?.id;
+    const isCampaignFromCombinedCourse = this.args.campaign.isFromCombinedCourse;
+    const hasDeletionPermission =
+      this.currentUser.isAdminInOrganization || this.args.campaign.ownerId == this.currentUser.prescriber?.id;
+
+    return !isCampaignFromCombinedCourse && hasDeletionPermission;
   }
 
   @action

--- a/orga/tests/integration/components/campaign/activity/participants-list-test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list-test.js
@@ -210,6 +210,34 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
   });
 
   module('#deleteParticipation', function () {
+    module('when the campaign is linked to a combined course', function () {
+      test('should not display delete participation button', async function (assert) {
+        class CurrentUserStub extends Service {
+          isAdminInOrganization = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        this.campaign = { externalIdLabel: 'id', type: 'ASSESSMENT', isFromCombinedCourse: true };
+        this.participations = [
+          {
+            firstName: 'Joe',
+            lastName: 'La frite',
+            status: 'TO_SHARE',
+            participantExternalId: 'patate',
+          },
+        ];
+
+        const screen = await render(hbs`<Campaign::Activity::ParticipantsList
+  @campaign={{this.campaign}}
+  @participations={{this.participations}}
+  @onClickParticipant={{this.noop}}
+  @onFilter={{this.noop}}
+/>`);
+
+        assert.notOk(screen.queryByRole('button', { name: 'Supprimer la participation' }));
+      });
+    });
+
     module('when the user is admin', function () {
       test('it should display the trash to delete the participation', async function (assert) {
         class CurrentUserStub extends Service {


### PR DESCRIPTION
## 🔆 Problème

On peut supprimer une participation liée a un parcours combiné. Ce qui ne devrait pas être le cas
## ⛱️ Proposition

Empecher la suppression via le FRONT, le Back arrive pas de panique

## 🌊 Remarques

RAS

## 🏄 Pour tester

- [x] Effectuer la parcours combiné lié à la campagne code123 avec le compte `attestation-blank` sur PixApp
- [x] Aller sur PixOrga, dans l'organisation Atttestations, toutes les campagnes. Vérifier que sur la page des participants de cette campagne nous ne pouvons pas supprimer la participation d'attestation blank. 
- [x] Aller sur l'orga SCO / SUP / Pro et vérifier que l'on peut toujours supprimer les participations aux campagnes. 