### PR TITLE
[FEATURE] Ajouter les pre handler sur les deux routes de suppression de campagnes PixOrga et PixAdmin (PIX-19321).

### DIFF
--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -224,6 +224,9 @@ const register = async function (server) {
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
           },
+          {
+            method: securityPreHandlers.checkCampaignBelongsToCombinedCourse,
+          },
         ],
         validate: {
           params: Joi.object({

--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -64,7 +64,10 @@ const register = async function (server) {
       method: 'DELETE',
       path: '/api/campaigns/{campaignId}/campaign-participations/{campaignParticipationId}',
       config: {
-        pre: [{ method: securityPreHandlers.checkAuthorizationToManageCampaign }],
+        pre: [
+          { method: securityPreHandlers.checkAuthorizationToManageCampaign },
+          { method: securityPreHandlers.checkCampaignBelongsToCombinedCourse },
+        ],
         validate: {
           params: Joi.object({
             campaignId: identifiersType.campaignId,

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -75,7 +75,7 @@ describe('Acceptance | API | Campaign Participations', function () {
     });
   });
 
-  describe('DELETE /api/admin/campaigns/{campaignId/campaign-participations/{campaignParticipationId}', function () {
+  describe('DELETE /api/admin/campaigns/{campaignId}/campaign-participations/{campaignParticipationId}', function () {
     it('should return 204 HTTP status code', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();


### PR DESCRIPTION
## 🔆 Problème

On a caché dans une précédente PR le bouton supprimer une participation côté FRONT sur PixOrga. Mais l'API n'est pas protégé. c'est pas bien

## ⛱️ Proposition

Ajouter les pre handler sur les deux routes autorisant la suppression de participation.

## 🌊 Remarques

Il manque un ticket FRONT pour cacher le bouton de suppression sur PixAdmin

## 🏄 Pour tester

- [x] Effectuer la parcours combiné lié à la campagne code123 avec le compte `attestation-blank` sur PixApp
- [x] Aller sur PixOrga, dans l'organisation Atttestations, toutes les campagnes. Tenter de supprimer une participations, Admirez ce superbe message d'erreur. 
- [ ] Aller sur PixAdmin, au niveau du user `attestation-blank` supprimer sa participation au niveau de la Participation lié aux parcours combiné, Admirez de nouveau ce superbe message d'erreur. 