### PR TITLE
[FEATURE] Récupération de l'historique des référentiels de certification d'une complémentaire (PIX-18345).

### DIFF
--- a/api/src/certification/configuration/application/complementary-certification-controller.js
+++ b/api/src/certification/configuration/application/complementary-certification-controller.js
@@ -2,6 +2,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as attachableTargetProfilesSerializer from '../infrastructure/serializers/attachable-target-profiles-serializer.js';
 import * as complementaryCertificationSerializer from '../infrastructure/serializers/complementary-certification-serializer.js';
 import * as certificationConsolidatedFrameworkSerializer from '../infrastructure/serializers/consolidated-framework-serializer.js';
+import * as frameworkHistorySerializer from '../infrastructure/serializers/framework-history-serializer.js';
 
 const findComplementaryCertifications = async function () {
   const complementaryCertifications = await usecases.findComplementaryCertifications();
@@ -48,11 +49,22 @@ const getCurrentConsolidatedFramework = async function (request) {
   return certificationConsolidatedFrameworkSerializer.serialize(currentConsolidatedFramework);
 };
 
+const getFrameworkHistory = async function (request) {
+  const { complementaryCertificationKey } = request.params;
+
+  const frameworkHistory = await usecases.getFrameworkHistory({
+    complementaryCertificationKey,
+  });
+
+  return frameworkHistorySerializer.serialize({ complementaryCertificationKey, frameworkHistory });
+};
+
 const complementaryCertificationController = {
-  findComplementaryCertifications,
-  searchAttachableTargetProfilesForComplementaryCertifications,
-  createConsolidatedFramework,
-  getCurrentConsolidatedFramework,
   calibrateConsolidatedFramework,
+  createConsolidatedFramework,
+  findComplementaryCertifications,
+  getCurrentConsolidatedFramework,
+  getFrameworkHistory,
+  searchAttachableTargetProfilesForComplementaryCertifications,
 };
 export { complementaryCertificationController };

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -158,6 +158,34 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/complementary-certifications/{complementaryCertificationKey}/framework-history',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            complementaryCertificationKey: Joi.string().valid(...Object.values(ComplementaryCertificationKeys)),
+          }),
+        },
+        handler: complementaryCertificationController.getFrameworkHistory,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec un de ces rôles : Super Admin, Certif ou Métier',
+          "Elle permet de récupérer l'historique des référentiels d'une complémentaire",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/certification/configuration/domain/usecases/get-framework-history.js
+++ b/api/src/certification/configuration/domain/usecases/get-framework-history.js
@@ -1,0 +1,17 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/ComplementaryCertificationKeys.js').ComplementaryCertificationKeys} ComplementaryCertificationKeys
+ * @typedef {import ('./index.js').ConsolidatedFrameworkRepository} ConsolidatedFrameworkRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {ComplementaryCertificationKeys} params.complementaryCertificationKey
+ * @param {ConsolidatedFrameworkRepository} params.consolidatedFrameworkRepository
+ */
+export const getFrameworkHistory = async ({ complementaryCertificationKey, consolidatedFrameworkRepository }) => {
+  const frameworkHistory = await consolidatedFrameworkRepository.getFrameworkHistory({
+    complementaryCertificationKey,
+  });
+
+  return frameworkHistory;
+};

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -52,6 +52,7 @@ import { exportScoWhitelist } from './export-sco-whitelist.js';
 import { findComplementaryCertifications } from './find-complementary-certifications.js';
 import { getActiveFlashAssessmentConfiguration } from './get-active-flash-assessment-configuration.js';
 import { getCurrentConsolidatedFramework } from './get-current-consolidated-framework.js';
+import { getFrameworkHistory } from './get-framework-history.js';
 import { importScoWhitelist } from './import-sco-whitelist.js';
 import { searchAttachableTargetProfiles } from './search-attachable-target-profiles.js';
 
@@ -64,6 +65,7 @@ const usecasesWithoutInjectedDependencies = {
   findComplementaryCertifications,
   getActiveFlashAssessmentConfiguration,
   getCurrentConsolidatedFramework,
+  getFrameworkHistory,
   importScoWhitelist,
   searchAttachableTargetProfiles,
 };

--- a/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/consolidated-framework-repository.js
@@ -41,6 +41,18 @@ export async function getCurrentFrameworkByComplementaryCertificationKey({ compl
   return _toDomain({ certificationFrameworksChallengesDTO: currentFrameworkChallengesDTO });
 }
 
+export async function getFrameworkHistory({ complementaryCertificationKey }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const frameworks = await knexConn('certification-frameworks-challenges')
+    .select('version')
+    .distinct('version')
+    .where({ complementaryCertificationKey })
+    .orderBy('version', 'desc');
+
+  return frameworks.map(({ version }) => version);
+}
+
 /**
  * @param {Object} params
  * @param {String} params.version

--- a/api/src/certification/configuration/infrastructure/serializers/framework-history-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/framework-history-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function ({ complementaryCertificationKey, frameworkHistory }) {
+  return new Serializer('framework-history', {
+    id: 'complementaryCertificationKey',
+    attributes: ['complementaryCertificationKey', 'history'],
+  }).serialize({ complementaryCertificationKey, history: frameworkHistory });
+};
+
+export { serialize };

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -537,4 +537,54 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       ]);
     });
   });
+
+  describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/framework-history', function () {
+    it('should return the framework history for given complementaryCertificationKey', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+      const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification.clea({});
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: 'rec123',
+        createdAt: new Date('2024-01-11'),
+      });
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: complementaryCertification.key,
+        challengeId: 'rec123',
+        createdAt: new Date('2025-01-11'),
+      });
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        complementaryCertificationKey: otherComplementaryCertification.key,
+        challengeId: 'rec123',
+        createdAt: new Date('2023-01-11'),
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/complementary-certifications/${complementaryCertification.key}/framework-history`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal({
+        id: complementaryCertification.key,
+        type: 'framework-histories',
+        attributes: {
+          'complementary-certification-key': complementaryCertification.key,
+          history: ['20250111000000', '20240111000000'],
+        },
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/consolidated-framework-repository_test.js
@@ -179,6 +179,64 @@ describe('Certification | Configuration | Integration | Repository | consolidate
     });
   });
 
+  describe('#getFrameworkHistory', function () {
+    it('should return an empty array when there is no framework history', async function () {
+      // given
+      const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+
+      // when
+      const frameworkHistory = await consolidatedFrameworkRepository.getFrameworkHistory({
+        complementaryCertificationKey,
+      });
+
+      // then
+      expect(frameworkHistory).to.deep.equal([]);
+    });
+
+    it('should return the framework history', async function () {
+      // given
+      const version1 = '20240315000000';
+      const version2 = '20250621000000';
+      const version3 = '20260101000000';
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'GOOD_KEY',
+      });
+      const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'OTHER_KEY',
+      });
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version1,
+        challengeId: 'rec123',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version2,
+        challengeId: 'rec234',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version2,
+        challengeId: 'rec345',
+        complementaryCertificationKey: otherComplementaryCertification.key,
+      });
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version3,
+        challengeId: 'rec456',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const frameworkHistory = await consolidatedFrameworkRepository.getFrameworkHistory({
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+
+      // then
+      expect(frameworkHistory).to.deep.equal([version3, version2, version1]);
+    });
+  });
+
   describe('#save', function () {
     it('should update framework challenges with discriminant, difficulty and calibrationId properties', async function () {
       // given

--- a/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
@@ -151,4 +151,53 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
       });
     });
   });
+
+  describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/framework-history', function () {
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(complementaryCertificationController, 'getFrameworkHistory').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/framework-history`,
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(complementaryCertificationController.getFrameworkHistory);
+      });
+    });
+
+    const authorizedRoles = ['SuperAdmin', 'Certif', 'Metier'];
+
+    authorizedRoles.forEach((role) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should return 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, `checkAdminMemberHasRole${role}`).returns(true);
+          sinon.stub(complementaryCertificationController, 'getFrameworkHistory').returns('ok');
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(
+            'GET',
+            `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/framework-history`,
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(complementaryCertificationController.getFrameworkHistory);
+        });
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/get-framework-history_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-framework-history_test.js
@@ -1,0 +1,31 @@
+import { getFrameworkHistory } from '../../../../../../src/certification/configuration/domain/usecases/get-framework-history.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | UseCase | get-framework-history', function () {
+  it('should return the framework history', async function () {
+    // given
+    const complementaryCertificationKey = Symbol('complementaryCertificationKey');
+
+    const consolidatedFrameworkRepository = {
+      getFrameworkHistory: sinon.stub(),
+    };
+
+    const currentFrameworkVersion = '20250607080000';
+    const previousFrameworkVersion = '20241021080000';
+
+    consolidatedFrameworkRepository.getFrameworkHistory.resolves([currentFrameworkVersion, previousFrameworkVersion]);
+
+    // when
+    const frameworkHistory = await getFrameworkHistory({
+      complementaryCertificationKey,
+      consolidatedFrameworkRepository,
+    });
+
+    // then
+    expect(consolidatedFrameworkRepository.getFrameworkHistory).to.have.been.calledOnceWithExactly({
+      complementaryCertificationKey,
+    });
+
+    expect(frameworkHistory).to.deep.equal([currentFrameworkVersion, previousFrameworkVersion]);
+  });
+});

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
@@ -1,0 +1,28 @@
+import * as serializer from '../../../../../../src/certification/configuration/infrastructure/serializers/framework-history-serializer.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Unit | Serializer | consolidated-framework-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize a framework history to JSONAPI', function () {
+      // given
+      const frameworkHistory = ['20250101080000', '20240101080000', '20230101080000'];
+      const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+
+      // when
+      const serializedFrameworkHistory = serializer.serialize({ complementaryCertificationKey, frameworkHistory });
+
+      // then
+      expect(serializedFrameworkHistory).to.deep.equal({
+        data: {
+          attributes: {
+            'complementary-certification-key': ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            history: frameworkHistory,
+          },
+          id: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+          type: 'framework-histories',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Il n'est pas possible de voir toutes les versions qui ont été créées pour un référentiel de certification complémentaire

## ⛱️ Proposition

Création d'une route dédiée pour récupérer l'historique des versions d'un référentiel de certification

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

```
TOKEN=$(curl --insecure 'https://admin-pr13533.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13533.review.pix.fr/api/admin/complementary-certifications/DROIT/framework-history \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X GET| jq '.'
```