### PR TITLE
[FEATURE] Autoriser la création de campagnes de parcours combinés sur des profils cibles non rattachés (PIX-19490).

### DIFF
--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -31,17 +31,25 @@ import { SavedCampaign } from './models/SavedCampaign.js';
  */
 
 /**
+ * @typedef CampaignCreationOptions
+ * @type {object}
+ * @property {boolean} allowCreationWithoutTargetProfileShare
+ */
+
+/**
  * @function
  * @name save
  *
  * @param {CampaignPayload|Array<CampaignPayload>} campaigns
+ * @param {CampaignCreationOptions} options
  * @returns {Promise<SavedCampaign|Array<CampaignPayload>>}
  * @throws {UserNotAuthorizedToCreateCampaignError} to be improved to handle different error types
  */
-export const save = async (campaigns) => {
+export const save = async (campaigns, options) => {
   if (Array.isArray(campaigns)) {
     const savedCampaign = await usecases.createCampaigns({
       campaignsToCreate: campaigns,
+      options,
     });
 
     return savedCampaign.map((campaign) => new SavedCampaign(campaign));
@@ -53,6 +61,7 @@ export const save = async (campaigns) => {
         ownerId: campaigns.creatorId,
         multipleSendings: false,
       },
+      options,
     });
 
     return new SavedCampaign(savedCampaign);

--- a/api/src/prescription/campaign/domain/usecases/create-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaign.js
@@ -7,6 +7,7 @@ const createCampaign = async function ({
   accessCodeRepository,
   campaignCreatorRepository,
   codeGenerator,
+  options,
 }) {
   const userId = campaign.creatorId;
   const ownerId = campaign.ownerId;
@@ -18,8 +19,13 @@ const createCampaign = async function ({
   const generatedCampaignCode = await codeGenerator.generate(accessCodeRepository);
 
   const campaignCreator = await campaignCreatorRepository.get(organizationId);
-
-  const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });
+  const campaignForCreation = campaignCreator.createCampaign(
+    {
+      ...campaign,
+      code: generatedCampaignCode,
+    },
+    options,
+  );
 
   return campaignAdministrationRepository.save(campaignForCreation);
 };

--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -1,5 +1,6 @@
 const createCampaigns = async function ({
   campaignsToCreate,
+  options,
   campaignAdministrationRepository,
   accessCodeRepository,
   campaignCreatorRepository,
@@ -15,10 +16,13 @@ const createCampaigns = async function ({
     const generatedCampaignCode = await codeGenerator.generate(accessCodeRepository);
     const campaignCreator = await campaignCreatorRepository.get(campaign.organizationId);
 
-    const campaignToCreate = await campaignCreator.createCampaign({
-      ...campaign,
-      code: generatedCampaignCode,
-    });
+    const campaignToCreate = await campaignCreator.createCampaign(
+      {
+        ...campaign,
+        code: generatedCampaignCode,
+      },
+      options,
+    );
     enrichedCampaignsData.push(campaignToCreate);
   }
   return campaignAdministrationRepository.save(enrichedCampaignsData);

--- a/api/src/quest/infrastructure/repositories/campaign-repository.js
+++ b/api/src/quest/infrastructure/repositories/campaign-repository.js
@@ -12,7 +12,7 @@ export const get = async function ({ id, campaignsApi }) {
 
 export const save = async function ({ campaigns, campaignsApi }) {
   const campaignToCreate = campaigns.map(_toDTO);
-  const createdCampaigns = await campaignsApi.save(campaignToCreate);
+  const createdCampaigns = await campaignsApi.save(campaignToCreate, { allowCreationWithoutTargetProfileShare: true });
   return createdCampaigns.map((campaign) => new Campaign(campaign));
 };
 

--- a/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/unit/application/api/campaigns-api_test.js
@@ -10,6 +10,7 @@ describe('Unit | API | Campaigns', function () {
   describe('#save', function () {
     describe('When creator is not in organization or has no right to use target profile', function () {
       it('should throw an error', async function () {
+        const options = Symbol('abc');
         const createCampaignStub = sinon.stub(usecases, 'createCampaign');
         createCampaignStub
           .withArgs({
@@ -24,18 +25,22 @@ describe('Unit | API | Campaigns', function () {
               organizationId: 1,
               multipleSendings: false,
             },
+            options,
           })
           .rejects(new UserNotAuthorizedToCreateCampaignError());
 
         // when
-        const error = await catchErr(campaignApi.save)({
-          name: 'ABCDiag',
-          title: 'Mon diagnostic Pix',
-          targetProfileId: 1,
-          organizationId: 1,
-          creatorId: 2,
-          customLandingPageText: 'Bienvenue',
-        });
+        const error = await catchErr(campaignApi.save)(
+          {
+            name: 'ABCDiag',
+            title: 'Mon diagnostic Pix',
+            targetProfileId: 1,
+            organizationId: 1,
+            creatorId: 2,
+            customLandingPageText: 'Bienvenue',
+          },
+          options,
+        );
 
         // then
         expect(error).is.instanceOf(UserNotAuthorizedToCreateCampaignError);

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignCreator_test.js
@@ -50,6 +50,27 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
   });
 
   describe('#createCampaign', function () {
+    describe('when the creator is allowed to create the campaign', function () {
+      it('creates the campaign', function () {
+        const availableTargetProfileIds = [1, 2];
+        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+        const campaignData = {
+          name: 'campagne utilisateur',
+          type: CampaignTypes.ASSESSMENT,
+          creatorId: 1,
+          ownerId: 1,
+          organizationId: 2,
+          targetProfileId: 2,
+          multipleSendings: true,
+        };
+        const expectedCampaignForCreation = new CampaignForCreation(campaignData);
+
+        const campaignForCreation = creator.createCampaign(campaignData);
+
+        expect(campaignForCreation).to.deep.equal(expectedCampaignForCreation);
+      });
+    });
+
     describe('when campaign type is not supported', function () {
       it('throws a CampaignTypeError', async function () {
         const error = await catchErr(function () {
@@ -72,46 +93,49 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
       });
     });
 
-    describe('when the creator is allowed to create the campaign', function () {
-      it('creates the campaign', function () {
-        const availableTargetProfileIds = [1, 2];
-        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
-        const campaignData = {
-          name: 'campagne utilisateur',
-          type: CampaignTypes.ASSESSMENT,
-          creatorId: 1,
-          ownerId: 1,
-          organizationId: 2,
-          targetProfileId: 2,
-          multipleSendings: true,
-        };
-        const expectedCampaignForCreation = new CampaignForCreation(campaignData);
-
-        const campaignForCreation = creator.createCampaign(campaignData);
-
-        expect(campaignForCreation).to.deep.equal(expectedCampaignForCreation);
-      });
-    });
-
     describe('when the campaign to create is an assessment campaign', function () {
       describe('when the creator cannot use the targetProfileId', function () {
-        it('throws an error', async function () {
-          const availableTargetProfileIds = [1, 2];
-          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
-          const campaignData = {
-            name: 'campagne utilisateur',
-            type: CampaignTypes.ASSESSMENT,
-            creatorId: 1,
-            ownerId: 1,
-            organizationId: 2,
-            targetProfileId: 5,
-          };
-          const error = await catchErr(creator.createCampaign, creator)(campaignData);
+        describe('when the option allowCreationWithoutTargetProfileShare is true', function () {
+          it('creates the campaign', function () {
+            const availableTargetProfileIds = [1, 2];
+            const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+            const campaignData = {
+              name: 'campagne utilisateur',
+              type: CampaignTypes.ASSESSMENT,
+              creatorId: 1,
+              ownerId: 1,
+              organizationId: 2,
+              targetProfileId: 5,
+              multipleSendings: true,
+            };
+            const expectedCampaignForCreation = new CampaignForCreation(campaignData);
 
-          expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-          expect(error.message).to.equal(
-            `Organization does not have an access to the profile ${campaignData.targetProfileId}`,
-          );
+            const campaignForCreation = creator.createCampaign(campaignData, {
+              allowCreationWithoutTargetProfileShare: true,
+            });
+
+            expect(campaignForCreation).to.deep.equal(expectedCampaignForCreation);
+          });
+        });
+        describe('when the option allowCreationWithoutTargetProfileShare is undefined', function () {
+          it('throws an error', async function () {
+            const availableTargetProfileIds = [1, 2];
+            const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+            const campaignData = {
+              name: 'campagne utilisateur',
+              type: CampaignTypes.ASSESSMENT,
+              creatorId: 1,
+              ownerId: 1,
+              organizationId: 2,
+              targetProfileId: 5,
+            };
+            const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+            expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+            expect(error.message).to.equal(
+              `Organization does not have an access to the profile ${campaignData.targetProfileId}`,
+            );
+          });
         });
       });
 
@@ -136,44 +160,6 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
         });
       });
 
-      describe('campaign without user profile', function () {
-        it('throws an error when campaign without user profile is not available', async function () {
-          organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = false;
-          const availableTargetProfileIds = [1, 2];
-          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
-          const campaignData = {
-            name: 'campagne utilisateur',
-            type: CampaignTypes.EXAM,
-            creatorId: 1,
-            ownerId: 1,
-            organizationId: 2,
-            targetProfileId: 2,
-          };
-
-          const error = await catchErr(creator.createCampaign, creator)(campaignData);
-
-          expect(error).to.be.instanceOf(OrganizationNotAuthorizedToCreateCampaignError);
-        });
-
-        it('should create a campaign if type exam when feature is enable', async function () {
-          organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = true;
-          const availableTargetProfileIds = [1, 2];
-          const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
-          const campaignData = {
-            name: 'campagne utilisateur',
-            type: CampaignTypes.EXAM,
-            creatorId: 1,
-            ownerId: 1,
-            organizationId: 2,
-            targetProfileId: 2,
-          };
-
-          const result = creator.createCampaign(campaignData);
-
-          expect(result.type).to.be.equal(CampaignTypes.EXAM);
-        });
-      });
-
       describe('when the targetProfileId is not given', function () {
         it('throws an error', async function () {
           const availableTargetProfileIds = [1, 2];
@@ -193,6 +179,90 @@ describe('Unit | Domain | Models | CampaignCreator', function () {
           expect(error.invalidAttributes).to.deep.equal([
             { attribute: 'targetProfileId', message: 'TARGET_PROFILE_IS_REQUIRED' },
           ]);
+        });
+      });
+    });
+
+    describe('campaign without user profile (EXAM)', function () {
+      it('should create a campaign if type exam when feature is enabled', async function () {
+        organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = true;
+        const availableTargetProfileIds = [1, 2];
+        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+        const campaignData = {
+          name: 'campagne utilisateur',
+          type: CampaignTypes.EXAM,
+          creatorId: 1,
+          ownerId: 1,
+          organizationId: 2,
+          targetProfileId: 2,
+        };
+
+        const result = creator.createCampaign(campaignData);
+
+        expect(result.type).to.be.equal(CampaignTypes.EXAM);
+      });
+      it('throws an error when campaign without user profile is not available', async function () {
+        organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = false;
+        const availableTargetProfileIds = [1, 2];
+        const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+        const campaignData = {
+          name: 'campagne utilisateur',
+          type: CampaignTypes.EXAM,
+          creatorId: 1,
+          ownerId: 1,
+          organizationId: 2,
+          targetProfileId: 2,
+        };
+
+        const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+        expect(error).to.be.instanceOf(OrganizationNotAuthorizedToCreateCampaignError);
+      });
+
+      describe('when the creator cannot use the targetProfileId', function () {
+        describe('when the option allowCreationWithoutTargetProfileShare is true', function () {
+          it('creates the campaign', function () {
+            organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = true;
+            const availableTargetProfileIds = [1, 2];
+            const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+            const campaignData = {
+              name: 'campagne utilisateur',
+              type: CampaignTypes.EXAM,
+              creatorId: 1,
+              ownerId: 1,
+              organizationId: 2,
+              targetProfileId: 5,
+              multipleSendings: true,
+            };
+            const expectedCampaignForCreation = new CampaignForCreation(campaignData);
+
+            const campaignForCreation = creator.createCampaign(campaignData, {
+              allowCreationWithoutTargetProfileShare: true,
+            });
+
+            expect(campaignForCreation).to.deep.equal(expectedCampaignForCreation);
+          });
+        });
+        describe('when the option allowCreationWithoutTargetProfileShare is undefined', function () {
+          it('throws an error', async function () {
+            organizationFeatures[ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key] = true;
+            const availableTargetProfileIds = [1, 2];
+            const creator = new CampaignCreator({ availableTargetProfileIds, organizationFeatures });
+            const campaignData = {
+              name: 'campagne utilisateur',
+              type: CampaignTypes.EXAM,
+              creatorId: 1,
+              ownerId: 1,
+              organizationId: 2,
+              targetProfileId: 5,
+            };
+            const error = await catchErr(creator.createCampaign, creator)(campaignData);
+
+            expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+            expect(error.message).to.equal(
+              `Organization does not have an access to the profile ${campaignData.targetProfileId}`,
+            );
+          });
         });
       });
     });

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
@@ -41,9 +41,10 @@ describe('Unit | UseCase | create-campaign', function () {
       availableTargetProfileIds: [targetProfileId],
       organizationFeatures: {},
     });
+    const options = Symbol('options');
     campaignCreator.createCampaign = sinon
       .stub()
-      .withArgs({ ...campaignData, code })
+      .withArgs({ ...campaignData, code }, options)
       .returns(campaignToCreate);
 
     codeGeneratorStub.generate.resolves(code);
@@ -59,11 +60,10 @@ describe('Unit | UseCase | create-campaign', function () {
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator: codeGeneratorStub,
+      options,
     });
 
     // then
-    expect(campaignCreator.createCampaign).to.have.been.calledWithExactly({ ...campaignData, code });
-    expect(campaignAdministrationRepository.save).to.have.been.calledWithExactly(campaignToCreate);
     expect(campaign).to.deep.equal(savedCampaign);
   });
 

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
   let userRepositoryStub;
   let organizationRepositoryStub;
   let createdCampaignsSymbol;
+  let options;
 
   beforeEach(function () {
     campaignAdministrationRepositoryStub = {
@@ -74,12 +75,12 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
     const campaignCreatorPOJO = {
       createCampaign: sinon.stub(),
     };
-
+    options = Symbol('options');
     campaignCreatorPOJO.createCampaign
-      .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId })
+      .withArgs({ ...campaignsToCreate[0], type: CampaignTypes.ASSESSMENT, code: code1, ownerId: someoneId }, options)
       .resolves(campaignsWithAllData[0]);
     campaignCreatorPOJO.createCampaign
-      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId })
+      .withArgs({ ...campaignsToCreate[1], type: CampaignTypes.ASSESSMENT, code: code2, ownerId: someoneId }, options)
       .resolves(campaignsWithAllData[1]);
 
     campaignCreatorRepositoryStub = {
@@ -102,6 +103,7 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
 
       const result = await createCampaigns({
         campaignsToCreate,
+        options,
         accessCodeRepository,
         campaignAdministrationRepository: campaignAdministrationRepositoryStub,
         codeGenerator: codeGeneratorStub,

--- a/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/campaign-repository_test.js
@@ -26,6 +26,7 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign', function () 
     campaignsApiStub = {
       get: sinon.stub(),
       getByCode: sinon.stub(),
+      save: sinon.stub(),
     };
     campaignsApiStub.get.withArgs(id).resolves(new Campaign(expectedResult));
     campaignsApiStub.getByCode.withArgs(code).resolves(new Campaign(expectedResult));
@@ -81,19 +82,20 @@ describe('Quest | Unit | Infrastructure | Repositories | campaign', function () 
         },
       ];
 
-      const campaignsApiStub = {
-        save: sinon.stub(),
-      };
-
       const expectedCreatedCampaigns = campaigns.map((campaign, index) => ({
         ...campaign,
         id: index,
         code: `code${index}`,
       }));
-      campaignsApiStub.save.withArgs(campaigns).resolves(expectedCreatedCampaigns);
+      campaignsApiStub.save
+        .withArgs(campaigns, { allowCreationWithoutTargetProfileShare: true })
+        .resolves(expectedCreatedCampaigns);
 
       // when
-      const result = await campaignRepository.save({ campaigns, campaignsApi: campaignsApiStub });
+      const result = await campaignRepository.save(
+        { campaigns, campaignsApi: campaignsApiStub },
+        { allowCreationWithoutTargetProfileShare: true },
+      );
 
       // then
       expect(result).to.deep.equal([


### PR DESCRIPTION
## 🔆 Problème

Les profils cibles correspondant à des parcours combinés ne sont pas forcément rattachés aux organisations pour lesquelles on veut créer des campagnes pour des parcours combinés.

## ⛱️ Proposition

Dans le cadre de la création de parcours combinés, autoriser la création de campagnes même si le profil cible n'est pas lié à l'organisation.

## 🌊 Remarques

L'API interne de création de campagnes autorise maintenant le passage d'une option pour gérer ce cas : `allowCreationWithoutTargetProfileShare`

## 🏄 Pour tester

Créer un parcours combiné portant sur un profil cible non rattaché à l'organisation cible.
