### PR TITLE
[FEATURE] Revoir les typo des modules (PIX-19502)

### DIFF
--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -9,10 +9,13 @@
     margin: var(--pix-spacing-1x) 0;
   }
 
-  h4,
+  h4 {
+    @extend %pix-title-xs;
+  }
+
   h5,
   h6 {
-    font-weight: var(--pix-font-medium);
+    @extend %pix-title-xxs;
   }
 
   a:not([class]) {

--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -72,7 +72,7 @@
 
     summary {
       color: var(--pix-neutral-900);
-      font-weight: var(--pix-font-medium);
+      font-weight: var(--pix-font-bold);
     }
   }
 

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -1,7 +1,7 @@
 .element-custom-draft {
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__iframe {

--- a/mon-pix/app/components/module/element/_download.scss
+++ b/mon-pix/app/components/module/element/_download.scss
@@ -3,7 +3,7 @@
 .element-download {
   &__intro {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__description {
@@ -48,7 +48,7 @@
     @extend %pix-body-m;
 
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__button {

--- a/mon-pix/app/components/module/element/_embed.scss
+++ b/mon-pix/app/components/module/element/_embed.scss
@@ -9,7 +9,7 @@
 
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__reset {

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -3,7 +3,7 @@
 .element-qcm {
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__direction {

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -3,7 +3,7 @@
 .element-qcu-discovery {
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__direction {

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -3,7 +3,7 @@
 .element-qcu {
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__direction {

--- a/mon-pix/app/components/module/element/_qrocm.scss
+++ b/mon-pix/app/components/module/element/_qrocm.scss
@@ -3,7 +3,7 @@
 .element-qrocm {
   &__instruction {
     margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__direction {

--- a/mon-pix/app/components/module/element/flashcards/_flashcards.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards.scss
@@ -11,7 +11,7 @@
 
   &__instruction {
     padding-bottom: var(--pix-spacing-6x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__recto-verso {
@@ -58,7 +58,7 @@
 
     &__question {
       color: var(--pix-neutral-900);
-      font-weight: var(--pix-font-medium);
+      font-weight: var(--pix-font-bold);
     }
 
     &__answer {
@@ -73,7 +73,9 @@
         font-weight: var(--pix-font-bold);
         line-height: 24px;
         border-radius: var(--modulix-radius-s);
-        transition: color 400ms, box-shadow 400ms;
+        transition:
+          color 400ms,
+          box-shadow 400ms;
 
         &--no {
           color: var(--pix-error-500);

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -12,7 +12,7 @@
   }
 
   &__instruction {
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__cards {

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -20,7 +20,7 @@ $grain-card-border-radius: var(--pix-spacing-4x);
   &__header {
     margin-bottom: var(--pix-spacing-6x);
     padding: 0 var(--pix-spacing-4x);
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 
   &__card,

--- a/mon-pix/app/components/module/instruction/_details.scss
+++ b/mon-pix/app/components/module/instruction/_details.scss
@@ -80,7 +80,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    font-weight: var(--pix-font-medium);
+    font-weight: var(--pix-font-bold);
   }
 }
 


### PR DESCRIPTION
## 🔆 Problème

Le font weight `medium` est déprécié.

## ⛱️ Proposition

Dans les modules, les remplacer par `bold`.

En profiter pour remplacer les titres des `h4`/`h5`/`h6` pour qu'ils utilisent la typo des titres.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Sur [/modules/preview](https://app-pr13537.review.pix.fr/modules/preview), constater que "Voici une leçon" est un sous-titre.

Sur [un module](https://app-pr13537.review.pix.fr/modules/bac-a-sable/passage) avec des éléments en gras : instruction... voir que le niveau de graisse est plus important.
