### PR TITLE
[FEATURE] Afficher le bon titre pour l'attestation pour le ministère des armées (PIX-19503)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/attestation-result.gjs
@@ -19,6 +19,7 @@ export default class AttestationResult extends Component {
   }
 
   get resultTitle() {
+    if (this.result.reward.key === 'MINARM') return `components.campaigns.attestation-result.title.minarm`;
     return `components.campaigns.attestation-result.title.digital-awarness`;
   }
 

--- a/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
+++ b/mon-pix/tests/integration/components/campaign/skill-review/attestation-result-test.gjs
@@ -26,17 +26,31 @@ module('Integration | Component | Campaign | Skill Review | attestation-result',
       assert.dom(screen.getByText(obtainedTitle)).exists();
     });
 
-    test('it should display the attestation title', async function (assert) {
-      const result = [
-        {
-          reward: { key: 'SIXTH_GRADE' },
-          obtained: true,
-        },
-      ];
+    module('attestation title', function () {
+      test('it should display sixth grade attestation title', async function (assert) {
+        const result = [
+          {
+            reward: { key: 'SIXTH_GRADE' },
+            obtained: true,
+          },
+        ];
 
-      const screen = await render(<template><AttestationResult @results={{result}} /></template>);
-      const rewardTitle = t(`components.campaigns.attestation-result.title.digital-awarness`);
-      assert.dom(screen.getByText(rewardTitle)).exists();
+        const screen = await render(<template><AttestationResult @results={{result}} /></template>);
+        const rewardTitle = t(`components.campaigns.attestation-result.title.digital-awarness`);
+        assert.dom(screen.getByText(rewardTitle)).exists();
+      });
+      test('it should display minarm attestation title', async function (assert) {
+        const result = [
+          {
+            reward: { key: 'MINARM' },
+            obtained: true,
+          },
+        ];
+
+        const screen = await render(<template><AttestationResult @results={{result}} /></template>);
+        const rewardTitle = t(`components.campaigns.attestation-result.title.minarm`);
+        assert.dom(screen.getByText(rewardTitle)).exists();
+      });
     });
 
     test('it should display the download button', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -268,7 +268,8 @@
         "not-obtained": "Attestation not obtained",
         "obtained": "Attestation obtained",
         "title": {
-          "digital-awarness": "Digital awareness"
+          "digital-awarness": "Digital awareness",
+          "minarm": "Digital base"
         }
       },
       "results-loader": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -268,6 +268,7 @@
         "not-obtained": "Certificado no obtenido :",
         "obtained": "Certificado obtenido",
         "title": {
+          "minarm": "Base digital",
           "digital-awarness": "Conciencia digital"
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -268,7 +268,8 @@
         "not-obtained": "Attestation non obtenue :",
         "obtained": "Attestation obtenue",
         "title": {
-          "digital-awarness": "Sensibilisation au numérique"
+          "digital-awarness": "Sensibilisation au numérique",
+          "minarm": "Socle numérique"
         }
       },
       "results-loader": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -268,6 +268,7 @@
         "not-obtained": "Certificaat niet verkregen :",
         "obtained": "Verkregen certificaat",
         "title": {
+          "minarm": "Digitale sokkel",
           "digital-awarness": "Digitaal bewustzijn"
         }
       },


### PR DESCRIPTION
## 🔆 Problème
Le titre pour l'attestation du ministère des armées n'était pas le bon

## ⛱️ Proposition
Afficher le titre pour l'attestation du ministère des armées

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
Obtenir une attestation MINARM, et voir le bon titre s'afficher