### PR TITLE
[BUMP] Mise à jour de @1024pix/epreuves-components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -82,7 +82,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.2.1",
+        "@1024pix/epreuves-components": "^1.4.0",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -123,11 +123,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.1.tgz",
-      "integrity": "sha512-zjji+bVdSTiAy0h5ZcOpKbNlD7zJRkE4CJhFXXtidJgcRiw0QLlQHvcirPnBr+FSv5FrUJlyi8rH8kAhhvZJ1w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
+      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -82,7 +82,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.4.0",
+        "@1024pix/epreuves-components": "^1.4.2",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -123,10 +123,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
-      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
+      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.2.1",
+    "@1024pix/epreuves-components": "^1.4.0",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.4.0",
+    "@1024pix/epreuves-components": "^1.4.2",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -43,6 +43,71 @@
           ]
         },
         {
+          "id": "ccba5524-57fd-41d4-94d7-732b0e4d6612",
+          "type": "discovery",
+          "title": "clickable-image",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "35ff5487-dd88-4574-a575-1689a5aaefee",
+                "type": "text",
+                "content": "<p>clickable-image</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "dfa8ac80-86ba-4278-9e02-a160b9c38c3b",
+                "type": "custom",
+                "tagName": "clickable-image",
+                "props": {
+                  "image": {
+                    "src": "https://assets.pix.org/modules/salon-connecte.webp",
+                    "alt": "Salon connecté",
+                    "width": 1536,
+                    "height": 1024
+                  },
+                  "areas": [
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 390, "y1": 120, "x2": 842, "y2": 400 },
+                      "info": "Pixvidéo : Vous avez aimé « Les chroniques de Flundertown », vous aimerez sûrement « Autant en emporte les fleurs »."
+                    },
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 510, "y1": 588, "x2": 702, "y2": 635 },
+                      "info": "Jeu vidéo : Kart Party, le jeu s’adapte en fonction du niveau du joueur"
+                    },
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 248, "y1": 398, "x2": 325, "y2": 492 },
+                      "info": "Enceinte connectée : Paramètre activé « Reconnaissance vocale »"
+                    },
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 828, "y1": 560, "x2": 1042, "y2": 725 },
+                      "info": "ChatPix : « Que puis-je faire pour toi aujourd’hui ? »",
+                      "tooltipPosition": "bottom"
+                    },
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 122, "y1": 796, "x2": 318, "y2": 916 },
+                      "info": "Robot aspirateur : Paramètre activé « Détection automatique des obstacles et adaptation du parcours »"
+                    },
+                    {
+                      "shape": "rect",
+                      "coords": { "x1": 986, "y1": 148, "x2": 1100, "y2": 230 },
+                      "info": "Thermostat mural : Paramètre activé « Température idéale et économie d’énergie »",
+                      "tooltipPosition": "bottom"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "208deb8a-4580-4a33-8ca5-32205f5f07dd",
           "type": "discovery",
           "title": "complete-phrase",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -315,6 +315,64 @@
           ]
         },
         {
+          "id": "4581ec80-3ac1-4226-9e70-b8c9e3527873",
+          "type": "discovery",
+          "title": "flip-cards",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "aae71cdd-6420-4c38-871e-aace67aa8392",
+                "type": "text",
+                "content": "<p>flip-cards</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "c1af1c71-cde4-47bb-9880-dfb0f4118ee1",
+                "type": "custom",
+                "tagName": "flip-cards",
+                "props": {
+                  "name": "Exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité",
+                  "cardList": [
+                    {
+                      "name": "Transport",
+                      "description": "Lecture de plaques d’immatriculation pour automatiser les péages",
+                      "icon": "https://assets.pix.org/modules/flip-cards/icon-truck.svg",
+                      "image": "https://assets.pix.org/modules/flip-cards/transport.png"
+                    },
+                    {
+                      "name": "Santé",
+                      "description": "Analyse de radios pour détecter des signes de cancer",
+                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-heart.svg",
+                      "image": "https://assets.pix.org/modules/flip-cards/transport.png"
+                    },
+                    {
+                      "name": "Culture",
+                      "description": "Reconnaissance des textes pour classer des documents dans une bibliothèque",
+                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-palette.svg",
+                      "image": "https://assets.pix.org/modules/flip-cards/transport.png"
+                    },
+                    {
+                      "name": "Agriculture",
+                      "description": "Survol de champs et prise de photos pour détecter un manque d’eau",
+                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-tractor.svg",
+                      "image": "https://assets.pix.org/modules/flip-cards/transport.png"
+                    },
+                    {
+                      "name": "Sécurité",
+                      "description": "Reconnaissance des visages pour identifier des personnes autorisées",
+                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-shield.svg",
+                      "image": "https://assets.pix.org/modules/flip-cards/transport.png"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
           "id": "d31c9fb7-ebaf-4d60-be31-a5c1aafa5ecf",
           "type": "discovery",
           "title": "message-conversation",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -13,54 +13,6 @@
   },
   "sections": [
     {
-      "id": "5f7badec-9ffd-4e99-99d6-05aa3d978343",
-      "type": "discovery",
-      "title": "capacity-calculation",
-      "components": [
-        {
-          "type": "element",
-          "element": {
-            "id": "5335cbac-503c-4aa0-a984-8c07897ff8e4",
-            "type": "text",
-            "content": "<p>capacity-calculation</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "4b7eb96e-134c-4b65-9513-cd57d9ed1e89",
-            "type": "custom",
-            "tagName": "capacity-calculation",
-            "props": {
-              "titleLevel": 2,
-              "images": {
-                "initial": {
-                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-initial.svg",
-                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-initial.svg"
-                },
-                "normal_weak": {
-                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
-                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                },
-                "normal_medium": {
-                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
-                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                },
-                "warning": {
-                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-warning.svg",
-                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-warning.svg"
-                },
-                "error": {
-                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-error.svg",
-                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-error.svg"
-                }
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
       "id": "be0a544c-99bd-4fbc-99b4-a52b5456a008",
       "type": "blank",
       "grains": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -13,9 +13,105 @@
   },
   "sections": [
     {
+      "id": "5f7badec-9ffd-4e99-99d6-05aa3d978343",
+      "type": "discovery",
+      "title": "capacity-calculation",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "5335cbac-503c-4aa0-a984-8c07897ff8e4",
+            "type": "text",
+            "content": "<p>capacity-calculation</p>"
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "4b7eb96e-134c-4b65-9513-cd57d9ed1e89",
+            "type": "custom",
+            "tagName": "capacity-calculation",
+            "props": {
+              "titleLevel": 2,
+              "images": {
+                "initial": {
+                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-initial.svg",
+                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-initial.svg"
+                },
+                "normal_weak": {
+                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
+                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
+                },
+                "normal_medium": {
+                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
+                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
+                },
+                "warning": {
+                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-warning.svg",
+                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-warning.svg"
+                },
+                "error": {
+                  "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-error.svg",
+                  "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-error.svg"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "id": "be0a544c-99bd-4fbc-99b4-a52b5456a008",
       "type": "blank",
       "grains": [
+        {
+          "id": "5f7badec-9ffd-4e99-99d6-05aa3d978343",
+          "type": "discovery",
+          "title": "capacity-calculation",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "5335cbac-503c-4aa0-a984-8c07897ff8e4",
+                "type": "text",
+                "content": "<p>capacity-calculation</p>"
+              }
+            },
+            {
+              "type": "element",
+              "element": {
+                "id": "4b7eb96e-134c-4b65-9513-cd57d9ed1e89",
+                "type": "custom",
+                "tagName": "capacity-calculation",
+                "props": {
+                  "titleLevel": 2,
+                  "images": {
+                    "initial": {
+                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-initial.svg",
+                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-initial.svg"
+                    },
+                    "normal_weak": {
+                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
+                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
+                    },
+                    "normal_medium": {
+                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
+                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
+                    },
+                    "warning": {
+                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-warning.svg",
+                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-warning.svg"
+                    },
+                    "error": {
+                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-error.svg",
+                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-error.svg"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
         {
           "id": "5161dd9c-0ed3-43a8-b550-ced9e2c539ba",
           "type": "discovery",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.2.1",
+        "@1024pix/epreuves-components": "^1.4.0",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,11 +101,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.1.tgz",
-      "integrity": "sha512-zjji+bVdSTiAy0h5ZcOpKbNlD7zJRkE4CJhFXXtidJgcRiw0QLlQHvcirPnBr+FSv5FrUJlyi8rH8kAhhvZJ1w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
+      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.0",
+        "@1024pix/epreuves-components": "^1.4.2",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,10 +101,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
-      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
+      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.2.1",
+    "@1024pix/epreuves-components": "^1.4.0",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.0",
+    "@1024pix/epreuves-components": "^1.4.2",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.0",
+        "@1024pix/epreuves-components": "^1.4.2",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -808,10 +808,11 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
-      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
+      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.2.1",
+        "@1024pix/epreuves-components": "^1.4.0",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -808,11 +808,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.2.1.tgz",
-      "integrity": "sha512-zjji+bVdSTiAy0h5ZcOpKbNlD7zJRkE4CJhFXXtidJgcRiw0QLlQHvcirPnBr+FSv5FrUJlyi8rH8kAhhvZJ1w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.0.tgz",
+      "integrity": "sha512-TbP1eoRi3qmRNOdqXB1Wsw2HdNT+9JX7S7S4ZWe6oZMfU6JneUAmqvDkG8nQOngIynhjBkwh6YAomk+8knigAA==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.2.1",
+    "@1024pix/epreuves-components": "^1.4.0",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.0",
+    "@1024pix/epreuves-components": "^1.4.2",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🔆 Problème

Il y a 3 nouveaux POI à prendre en compte.

## ⛱️ Proposition

MàJ @1024pix/epreuves-components et ajouter les POI clickable-image, flips-cards et capacity-calculation.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Aller sur le module demo-epreuves-components et vérifier que clickable-image, flip-cards et capacity-calculation s’affichent bien.