### PR TITLE
[FEATURE] Ajouter une illustration et une description aux parcours combinés (PIX-19016)

### DIFF
--- a/api/db/database-builder/factory/build-quest.js
+++ b/api/db/database-builder/factory/build-quest.js
@@ -9,6 +9,8 @@ const buildQuest = function ({
   id = databaseBuffer.getNextId(),
   code = null,
   name = 'Ma quête',
+  description = null,
+  illustration = null,
   organizationId = null,
   createdAt = new Date(),
   updatedAt,
@@ -25,6 +27,8 @@ const buildQuest = function ({
     id,
     code,
     name,
+    description,
+    illustration,
     organizationId,
     createdAt,
     updatedAt: updatedAt ?? createdAt,
@@ -49,11 +53,12 @@ const buildQuestForCombinedCourse = function ({
   code = 'COMBINIX1',
   name = 'Mon parcours combiné',
   organizationId,
+  description = 'Le but de ma quête',
+  illustration = 'images/illustration.svg',
   ...args
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
-
-  return buildQuest({ ...args, code, name, organizationId });
+  return buildQuest({ ...args, code, name, organizationId, description, illustration });
 };
 
 export { buildQuest, buildQuestForCombinedCourse };

--- a/api/db/migrations/20250911080220_add-description-and-illustration-columns-to-quests.js
+++ b/api/db/migrations/20250911080220_add-description-and-illustration-columns-to-quests.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'quests';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text('description').defaultTo(null).comment('Description for quests');
+    table.string('illustration').defaultTo(null).comment('URL for quest illustration');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('description');
+    table.dropColumn('illustration');
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -78,6 +78,9 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
     rewardType: null,
     rewardId: null,
     code: 'COMBINIX1',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
     organizationId,
     eligibilityRequirements: [],
     successRequirements: [

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -14,17 +14,21 @@ const schema = Joi.object({
   code: Joi.string().required(),
   organizationId: Joi.number().required(),
   name: Joi.string().required(),
+  description: Joi.string().allow(null),
+  illustration: Joi.string().allow(null),
 });
 export class CombinedCourse {
   #quest;
 
-  constructor({ id, code, organizationId, name } = {}, quest) {
+  constructor({ id, code, organizationId, name, description, illustration } = {}, quest) {
     this.id = id;
     this.code = code;
     this.organizationId = organizationId;
     this.name = name;
+    this.description = description;
+    this.illustration = illustration;
 
-    this.#validate({ id, code, organizationId, name });
+    this.#validate({ id, code, organizationId, name, description, illustration });
 
     this.#quest = quest;
   }
@@ -44,8 +48,8 @@ export class CombinedCourse {
 export class CombinedCourseDetails extends CombinedCourse {
   items = null;
 
-  constructor({ id, code, organizationId, name }, quest, participation) {
-    super({ id, code, organizationId, name }, quest);
+  constructor({ id, code, organizationId, name, description, illustration }, quest, participation) {
+    super({ id, code, organizationId, name, description, illustration }, quest);
     if (!participation) {
       this.status = CombinedCourseStatuses.NOT_STARTED;
     } else {

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -5,7 +5,10 @@ import { CombinedCourse } from '../../domain/models/CombinedCourse.js';
 const getByCode = async ({ code }) => {
   const knexConn = DomainTransaction.getConnection();
 
-  const quest = await knexConn('quests').select('id', 'organizationId', 'code', 'name').where('code', code).first();
+  const quest = await knexConn('quests')
+    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration')
+    .where('code', code)
+    .first();
   if (!quest) {
     throw new NotFoundError(`Le parcours combiné portant le code ${code} n'existe pas`);
   }
@@ -17,7 +20,7 @@ const getById = async ({ id }) => {
   const knexConn = DomainTransaction.getConnection();
 
   const quest = await knexConn('quests')
-    .select('id', 'organizationId', 'code', 'name')
+    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration')
     .where('id', id)
     .whereNotNull('organizationId')
     .whereNotNull('code')
@@ -32,7 +35,7 @@ const getById = async ({ id }) => {
 const findByCampaignId = async ({ campaignId }) => {
   const knexConn = DomainTransaction.getConnection();
   const quests = await knexConn('quests')
-    .select('id', 'organizationId', 'code', 'name')
+    .select('id', 'organizationId', 'code', 'name', 'description', 'illustration')
     .whereNotNull('code')
     .whereJsonSupersetOf('successRequirements', [{ data: { campaignId: { data: campaignId } } }]);
 

--- a/api/src/quest/infrastructure/serializers/combined-course-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourse) {
   return new Serializer('combined-courses', {
-    attributes: ['name', 'code', 'organizationId', 'status', 'items'],
+    attributes: ['name', 'code', 'organizationId', 'status', 'description', 'illustration', 'items'],
     items: {
       ref: 'id',
       included: true,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -39,7 +39,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
       // given
       const id = 1;
       const { id: organizationId } = databaseBuilder.factory.buildOrganization();
-      const quest = databaseBuilder.factory.buildQuest({ id: 1, code: 'COMBINIX1', organizationId });
+      const quest = databaseBuilder.factory.buildQuestForCombinedCourse({ id: 1, code: 'COMBINIX1', organizationId });
       await databaseBuilder.commit();
 
       // when
@@ -72,10 +72,14 @@ describe('Quest | Integration | Repository | combined-course', function () {
       campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
       const code = 'ABCDE1234';
       const name = 'Mon parcours Combiné';
+      const description = 'Le but de ma quête';
+      const illustration = 'images/illustration.svg';
       quest = databaseBuilder.factory.buildQuestForCombinedCourse({
         code,
         name,
         organizationId,
+        description,
+        illustration,
         successRequirements: [
           {
             requirement_type: 'campaignParticipations',

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-serializer_test.js
@@ -19,6 +19,8 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course', functi
           code: 'COMBINIX1',
           'organization-id': 1,
           status: CombinedCourseStatuses.NOT_STARTED,
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          illustration: '/illustrations/image.svg',
         },
         type: 'combined-courses',
         id: '1',

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -47,7 +47,15 @@ function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
     });
 
   combinedCourse =
-    combinedCourse ?? new CombinedCourse({ id: 1, code: 'COMBINIX1', organizationId: 1, name: 'Mon parcours' });
+    combinedCourse ??
+    new CombinedCourse({
+      id: 1,
+      code: 'COMBINIX1',
+      organizationId: 1,
+      name: 'Mon parcours',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      illustration: '/illustrations/image.svg',
+    });
 
   const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
   const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest);

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -11,7 +11,7 @@ const Content = <template>
     <div class="combined-course-item__content">
       <div class="combined-course-item__icon">
         {{#if @iconUrl}}
-          <img class="campaign-step__image" role="presentation" src={{@iconUrl}} alt="" />
+          <img role="presentation" src={{@iconUrl}} alt="" height="42" />
         {{/if}}
       </div>
       <div class="combined-course-item__text">

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -18,27 +18,39 @@ export default class CombinedCourses extends Component {
   <template>
     <div class="combined-course">
       <div class="combined-course__header">
-        <h1>{{@combinedCourse.name}} </h1>
+        <div>
+          <h1>{{@combinedCourse.name}}</h1>
+          <div class="combined-course-header__info">
+            <div class="combined-course-info__description">
+              {{@combinedCourse.description}}
+            </div>
+          </div>
+          {{#if (eq @combinedCourse.status "COMPLETED")}}
+            <section class="combined-course-completed">
+              <img src="/images/illustrations/combined-course/completed.svg" />
+              <CompletedText />
+            </section>
+          {{else if (eq @combinedCourse.status "NOT_STARTED")}}
+            <div>
+              <PixButton
+                @type="submit"
+                @triggerAction={{this.startQuestParticipation}}
+                @loading-color="white"
+                @size="large"
+              >{{t "pages.combined-courses.content.start-button"}}
+              </PixButton>
+            </div>
+          {{else if (eq @combinedCourse.status "STARTED")}}
+            <div>
+              <PixButton @type="submit" @triggerAction={{this.goToNextItem}} @loading-color="white" @size="large">{{t
+                  "pages.combined-courses.content.resume-button"
+                }}
+              </PixButton>
+            </div>
+          {{/if}}
+        </div>
+        <img alt="" role="presentation" src={{@combinedCourse.illustration}} />
       </div>
-      {{#if (eq @combinedCourse.status "COMPLETED")}}
-        <section class="combined-course-completed">
-          <img src="/images/illustrations/combined-course/completed.svg" />
-          <CompletedText />
-        </section>
-      {{else if (eq @combinedCourse.status "NOT_STARTED")}}
-        <PixButton
-          @type="submit"
-          @triggerAction={{this.startQuestParticipation}}
-          @loading-color="white"
-          @size="large"
-        >{{t "pages.combined-courses.content.start-button"}}
-        </PixButton>
-      {{else if (eq @combinedCourse.status "STARTED")}}
-        <PixButton @type="submit" @triggerAction={{this.goToNextItem}} @loading-color="white" @size="large">{{t
-            "pages.combined-courses.content.resume-button"
-          }}
-        </PixButton>
-      {{/if}}
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}
         <CombinedCourseItem

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -8,7 +8,7 @@ import eq from 'ember-truth-helpers/helpers/eq';
 import CombinedCourseItem from '../combined-course/combined-course-item';
 
 const CompletedText = <template>
-  <div class="completed-text" ...attributes>
+  <div class="completed-text">
     <h2 class="completed-text__title">{{t "pages.combined-courses.completed.title"}}</h2>
     <p class="completed-text__description">{{t "pages.combined-courses.completed.description"}}</p>
   </div>
@@ -16,41 +16,39 @@ const CompletedText = <template>
 
 export default class CombinedCourses extends Component {
   <template>
-    <div class="combined-course">
-      <div class="combined-course__header">
+    <section class="combined-course">
+      <header class="combined-course__header">
         <div>
           <h1>{{@combinedCourse.name}}</h1>
-          <div class="combined-course-header__info">
-            <div class="combined-course-info__description">
-              {{@combinedCourse.description}}
-            </div>
-          </div>
+
           {{#if (eq @combinedCourse.status "COMPLETED")}}
-            <section class="combined-course-completed">
-              <img src="/images/illustrations/combined-course/completed.svg" />
+            <div class="combined-course-completed">
+              <img src="/images/illustrations/combined-course/completed.svg" alt="" role="presentation" />
               <CompletedText />
-            </section>
-          {{else if (eq @combinedCourse.status "NOT_STARTED")}}
-            <div>
-              <PixButton
-                @type="submit"
-                @triggerAction={{this.startQuestParticipation}}
-                @loading-color="white"
-                @size="large"
-              >{{t "pages.combined-courses.content.start-button"}}
-              </PixButton>
             </div>
+          {{/if}}
+
+          <div class={{unless (eq @combinedCourse.status "COMPLETED") "combined-course__description"}}>
+            {{@combinedCourse.description}}
+          </div>
+
+          {{#if (eq @combinedCourse.status "NOT_STARTED")}}
+            <PixButton
+              @type="submit"
+              @triggerAction={{this.startQuestParticipation}}
+              @loading-color="white"
+              @size="large"
+            >{{t "pages.combined-courses.content.start-button"}}
+            </PixButton>
           {{else if (eq @combinedCourse.status "STARTED")}}
-            <div>
-              <PixButton @type="submit" @triggerAction={{this.goToNextItem}} @loading-color="white" @size="large">{{t
-                  "pages.combined-courses.content.resume-button"
-                }}
-              </PixButton>
-            </div>
+            <PixButton @type="submit" @triggerAction={{this.goToNextItem}} @loading-color="white" @size="large">{{t
+                "pages.combined-courses.content.resume-button"
+              }}
+            </PixButton>
           {{/if}}
         </div>
         <img alt="" role="presentation" src={{@combinedCourse.illustration}} />
-      </div>
+      </header>
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}
         <CombinedCourseItem
@@ -60,7 +58,7 @@ export default class CombinedCourses extends Component {
           @onClick={{if (eq @combinedCourse.status "NOT_STARTED") this.startQuestParticipation noop}}
         />
       {{/each}}
-    </div>
+    </section>
   </template>
 
   @service currentUser;

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -11,6 +11,8 @@ export default class CombinedCourse extends Model {
   @attr('string') code;
   @attr() organizationId;
   @attr('string') status;
+  @attr('string') description;
+  @attr('string') illustration;
 
   @hasMany('combined-course-item', { async: false, inverse: 'combinedCourse' }) items;
 

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -3,15 +3,34 @@
 .combined-course {
   padding: var(--pix-spacing-12x) 80px;
 
+  &__header {
+    display: flex;
+    gap: var(--pix-spacing-8x);
+
+    h1 {
+      @extend %pix-title-m;
+
+      margin-bottom: var(--pix-spacing-4x);
+    }
+  }
+
+  &__description {
+    @extend %pix-body-l;
+
+    margin-bottom: var(--pix-spacing-6x);
+  }
+
   &-completed {
     display: flex;
     gap: var(--pix-spacing-4x);
     align-items: center;
+    margin-bottom: var(--pix-spacing-8x);
     padding: var(--pix-spacing-6x);
     background: var(--pix-secondary-100);
     border: 1px solid var(--pix-secondary-500);
     border-radius: 16px;
-    box-shadow: 2px 6px 0 1px var(--pix-secondary-700);
+    // stylelint-disable color-no-hex
+    box-shadow: 2px 6px 0 1px #CF9430;
 
     .completed-text {
       display: flex;
@@ -20,48 +39,19 @@
 
       &__title {
         @extend %pix-title-s;
+
+        margin-bottom: var(--pix-spacing-2x);
       }
 
       &__description {
         @extend %pix-body-m;
       }
-
     }
   }
 
   &__divider {
     margin: var(--pix-spacing-6x) 0;
     border-top: 1px solid var(--pix-neutral-100);
-  }
-
-  &__header {
-  display: flex;
-  padding: var(--pix-spacing-10x) 0 var(--pix-spacing-6x) 0;
-
-
-    h1 {
-      @extend %pix-title-m;
-
-      margin-bottom: var(--pix-spacing-4x);
-  }
-  }
-
-}
-
-.combined-course-header {
-    &__info {
-      display: flex;
-    }
-}
-
-.combined-course-info {
-  &__description {
-  display: flex;
-  align-self: stretch;
-
-  @extend %pix-body-l;
-
-  margin-bottom: var(--pix-spacing-4x);
   }
 }
 
@@ -70,7 +60,7 @@
   gap: var(--pix-spacing-4x);
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--pix-spacing-10x);
+  margin-bottom: var(--pix-spacing-4x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: var(--pix-neutral-0);
   border: 1px solid var(--pix-primary-100);

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -36,17 +36,33 @@
 
   &__header {
   display: flex;
-  flex-direction: column;
-  gap: var(--pix-spacing-2x);
-  align-items: flex-start;
-  align-self: stretch;
   padding: var(--pix-spacing-10x) 0 var(--pix-spacing-6x) 0;
+
 
     h1 {
       @extend %pix-title-m;
+
+      margin-bottom: var(--pix-spacing-4x);
   }
   }
 
+}
+
+.combined-course-header {
+    &__info {
+      display: flex;
+    }
+}
+
+.combined-course-info {
+  &__description {
+  display: flex;
+  align-self: stretch;
+
+  @extend %pix-body-l;
+
+  margin-bottom: var(--pix-spacing-4x);
+  }
 }
 
 .combined-course-item {

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -32,6 +32,23 @@ module('Integration | Component | combined course', function (hooks) {
       // then
       assert.ok(screen.getByRole('heading', { name: 'Combinix' }));
     });
+    test('should display description on course if they exist', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.NOT_STARTED,
+        code: 'COMBINIX9',
+        description: 'Le but de ma quête',
+      });
+
+      this.setProperties({ combinedCourse });
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+      assert.ok(screen.getByText('Le but de ma quête'));
+    });
   });
 
   module('when there is a formation item', function () {


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir afficher un paragraphe de description et une illustration côté parcours combiné.

## ⛱️ Proposition
On ajoute les deux champs dans la table "quests" en BDD.
On ajoute un titre et une description sur le model Combined Course pour pouvoir les remonter côté front.

## 🏄 Pour tester
Lancer un parcours combiné avec le compte attestation-blank@example.net et le code COMBINIX1.