### PR TITLE
[FEATURE] Add consume on postmessage Height from embed for resizing embed (PIX-19497)

### DIFF
--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -14,12 +14,17 @@ import Qrocm from './content/qrocm';
 
 export default class ChallengeContent extends Component {
   @tracked isRebootable = false;
+  @tracked heightFromPostMessage = 0;
 
   constructor() {
     super(...arguments);
     window.addEventListener('message', ({ data }) => {
       if (data?.from === 'pix' && data?.type === 'init') {
         this.isRebootable = !!data.rebootable;
+      }
+
+      if (data?.from === 'pix' && data?.type === 'height') {
+        this.heightFromPostMessage = data.height;
       }
     });
   }
@@ -70,7 +75,8 @@ export default class ChallengeContent extends Component {
           <EmbeddedSimulator
             @url={{@challenge.embedUrl}}
             @title={{@challenge.embedTitle}}
-            @height={{@challenge.embedHeight}}
+            @heightFromChallenge={{@challenge.embedHeight}}
+            @heightFromPostMessage={{this.heightFromPostMessage}}
             @isGDevelop={{@challenge.isEmbedGDevelop}}
             @hideSimulator={{@isDisabled}}
             @isMediaWithForm={{this.isMediaWithForm}}

--- a/junior/app/components/challenge/content/embedded-simulator.gjs
+++ b/junior/app/components/challenge/content/embedded-simulator.gjs
@@ -1,22 +1,23 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
-import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import didRender from '../../../modifiers/did-render';
 
 export default class EmbeddedSimulator extends Component {
-  get embedDocumentHeightStyle() {
-    const { isGDevelop, height: configuredHeight } = this.args;
-    const height = configuredHeight ?? '600';
-    const cssProperties = isGDevelop ? `max-height: ${height}px; aspect-ratio: 860/680` : `height: ${height}px`;
-    return htmlSafe(cssProperties);
-  }
-
   @action
   setIframeHtmlElement(htmlElement) {
     this.iframe = htmlElement;
+    if (this.args.heightFromPostMessage) {
+      this.iframe.height = this.args.heightFromPostMessage + 'px';
+    } else if (this.args.heightFromChallenge) {
+      this.iframe.height = this.args.heightFromChallenge + 'px';
+    }
+
+    if (this.args.isGDevelop) {
+      this.iframe.aspectRatio = '860/680';
+    }
   }
 
   @action
@@ -46,13 +47,14 @@ export default class EmbeddedSimulator extends Component {
       {{#if @hideSimulator}}
         <div class="challenge-embed-simulator__overlay"></div>
       {{/if}}
-
       <iframe
         tabindex={{if @hideSimulator "-1"}}
         class="challenge-embed-simulator__iframe"
         src="{{@url}}"
         title="{{@title}}"
-        style="{{this.embedDocumentHeightStyle}}"
+        allowfullscreen="true"
+        webkitallowfullscreen="true"
+        mozallowfullscreen="true"
         {{didRender this.setIframeHtmlElement}}
       >
       </iframe>

--- a/junior/app/styles/pages/identified/missions/introduction.scss
+++ b/junior/app/styles/pages/identified/missions/introduction.scss
@@ -19,7 +19,7 @@
   &__media {
     display: flex;
     justify-content: center;
-    min-height: 400px;
+    min-width: 400px;
     margin: var(--pix-spacing-4x) 140px;
     padding: var(--pix-spacing-4x);
     background-color: var(--pix-neutral-0);


### PR DESCRIPTION
## 🔆 Problème

1. Les emebed on du mal a se resize.
2. La fonctionnalité plein écran des vidéo ne marche pas

## ⛱️ Proposition

Lire les postMessage des embed de pix pour récupéré leur hauteur!

## 🌊 Remarques

Pas simple pour tester

## 🏄 Pour tester

Se balader dans les missions et resize la fenêtre lorsqu'il y a des embed => c'est censé se resize :)
!! Pour les vidéo, si la PR coté Pix-épreuve n'est pas mergé il faut check dans le dom et changer l'url pour mettre une vidéo qui envoie des postMessage de taille. (chose qui n'éxistait pas)
exemple => https://epreuves-pr2613.review.pix.fr/fr/video/junior-communiquer_adulte_di2.html


