### PR TITLE
[FEATURE] Afficher l'historique des versions du référentiel d'une complémentaire (PIX-18347).

### DIFF
--- a/admin/app/adapters/framework-history.js
+++ b/admin/app/adapters/framework-history.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class FrameworkHistoryAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  queryRecord(store, type, complementaryCertificationKey) {
+    const url = `${this.host}/${this.namespace}/complementary-certifications/${complementaryCertificationKey}/framework-history`;
+    return this.ajax(url, 'GET');
+  }
+}

--- a/admin/app/components/complementary-certifications/item/framework.gjs
+++ b/admin/app/components/complementary-certifications/item/framework.gjs
@@ -7,11 +7,13 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import FrameworkDetails from './framework/framework-details';
+import FrameworkHistory from './framework/framework-history';
 
 export default class ComplementaryCertificationFramework extends Component {
   @service store;
   @service router;
   @tracked currentConsolidatedFramework;
+  @tracked frameworkHistory;
 
   constructor() {
     super(...arguments);
@@ -31,6 +33,9 @@ export default class ComplementaryCertificationFramework extends Component {
       'certification-consolidated-framework',
       complementaryCertification.key,
     );
+
+    const frameworkHistory = await this.store.queryRecord('framework-history', complementaryCertification.key);
+    this.frameworkHistory = frameworkHistory?.history;
   }
 
   <template>
@@ -52,6 +57,10 @@ export default class ComplementaryCertificationFramework extends Component {
 
     {{#if this.currentConsolidatedFramework}}
       <FrameworkDetails @currentConsolidatedFramework={{this.currentConsolidatedFramework}} />
+    {{/if}}
+
+    {{#if this.frameworkHistory.length}}
+      <FrameworkHistory @history={{this.frameworkHistory}} />
     {{/if}}
   </template>
 }

--- a/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
@@ -1,0 +1,28 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { t } from 'ember-intl';
+
+<template>
+  <section class="framework-details">
+    <h2 class="framework-details__title">
+      {{t "components.complementary-certifications.item.framework.history.title"}}
+    </h2>
+
+    <PixTable
+      @variant="admin"
+      @caption={{t "components.complementary-certifications.item.framework.history.table.caption"}}
+      @data={{@history}}
+    >
+      <:columns as |version context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            Version
+          </:header>
+          <:cell>
+            {{version}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  </section>
+</template>

--- a/admin/app/models/framework-history.js
+++ b/admin/app/models/framework-history.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FrameworkHistory extends Model {
+  @attr() history;
+}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -576,6 +576,18 @@ function routes() {
     return schema.certificationConsolidatedFrameworks.find(request.params.key);
   });
 
+  this.get('admin/complementary-certifications/:key/framework-history', (schema, request) => {
+    return {
+      data: {
+        id: request.params.key,
+        type: 'framework-histories',
+        attributes: {
+          history: [],
+        },
+      },
+    };
+  });
+
   this.put('/admin/sessions/:id/comment', (schema, request) => {
     const sessionToUpdate = schema.sessions.find(request.params.id);
     const params = JSON.parse(request.requestBody);

--- a/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
@@ -28,6 +28,7 @@ module('Integration | Component | complementary-certifications/item/framework', 
     });
 
     store.peekRecord = sinon.stub().resolves('complementary-certification-key');
+    store.queryRecord = sinon.stub().resolves({});
   });
 
   test('it should display a creation form button for framework', async function (assert) {
@@ -84,6 +85,56 @@ module('Integration | Component | complementary-certifications/item/framework', 
           }),
         )
         .doesNotExist();
+    });
+  });
+
+  module('#frameworkHistory', function () {
+    module('when there is no existing framework history', function () {
+      test('it should not display the framework history', async function (assert) {
+        // given
+        store.findRecord = sinon.stub().resolves({
+          hasMany: sinon.stub().returns({
+            value: sinon.stub().returns([]),
+          }),
+        });
+        store.queryRecord = sinon.stub().resolves({ history: [] });
+
+        // when
+        const screen = await render(<template><Framework /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: t('components.complementary-certifications.item.framework.history.title'),
+            }),
+          )
+          .doesNotExist();
+      });
+    });
+
+    module('when there are existing framework versions', function () {
+      test('it should display the framework history', async function (assert) {
+        // given
+        store.findRecord = sinon.stub().resolves({
+          hasMany: sinon.stub().returns({
+            value: sinon.stub().returns([]),
+          }),
+        });
+        store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
+
+        // when
+        const screen = await render(<template><Framework /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: t('components.complementary-certifications.item.framework.history.title'),
+            }),
+          )
+          .exists();
+      });
     });
   });
 });

--- a/admin/tests/integration/components/complementary-certifications/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/framework-history-test.gjs
@@ -1,0 +1,39 @@
+import { render } from '@1024pix/ember-testing-library';
+import FrameworkHistory from 'pix-admin/components/complementary-certifications/item/framework/framework-history';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display the framework history', async function (assert) {
+    // given
+    const frameworkHistory = ['20250101080000', '20240101080000', '20230101080000'];
+
+    // when
+    const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} /></template>);
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: t('components.complementary-certifications.item.framework.history.title'),
+        }),
+      )
+      .exists();
+
+    assert
+      .dom(
+        screen.getByRole('table', {
+          name: t('components.complementary-certifications.item.framework.history.table.caption'),
+        }),
+      )
+      .exists();
+
+    assert.strictEqual(screen.getAllByRole('row').length, frameworkHistory.length + 1);
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0] })).exists();
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[1] })).exists();
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[2] })).exists();
+  });
+});

--- a/admin/tests/unit/adapters/framework-history-test.js
+++ b/admin/tests/unit/adapters/framework-history-test.js
@@ -1,0 +1,24 @@
+import { setupTest } from 'ember-qunit';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | framework-history', function (hooks) {
+  setupTest(hooks);
+
+  module('#queryRecord', function () {
+    test('it builds request with specific payload and url', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:framework-history');
+      const store = this.owner.lookup('service:store');
+      sinon.stub(adapter, 'ajax');
+
+      // when
+      adapter.queryRecord(store, 'framework-history', 'DROIT');
+
+      // then
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/complementary-certifications/DROIT/framework-history`;
+      assert.ok(adapter.ajax.calledWith(expectedUrl, 'GET'));
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -412,6 +412,12 @@
           "details": {
             "title": "Current consolidated framework details"
           },
+          "history": {
+            "table": {
+              "caption": "Versions list in descending order"
+            },
+            "title": "Framework versions history"
+          },
           "no-current-framework": "No consolidated framework is currently used.",
           "tab": "Consolidated framework"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -413,6 +413,12 @@
             "empty-current-framework": "Le référentiel cadre actuel est vide.",
             "title": "Détails du référentiel cadre actuel"
           },
+          "history": {
+            "table": {
+              "caption": "Liste des versions par ordre décroissant"
+            },
+            "title": "Historique des versions du référentiel"
+          },
           "no-current-framework": "Aucun référentiel cadre n'est utilisé actuellement.",
           "tab": "Référentiel cadre"
         },


### PR DESCRIPTION
## 🔆 Problème

Sur admin, l'écran de détail d'une certification complémentaire n'affiche pas encore l'historique des versions de son référentiel.

## ⛱️ Proposition

Afficher un écart listant les versions du référentiel de la complémentaire par ordre décroissant.

## 🏄 Pour tester

En RA, sur PixAdmin :
- choisir une complémentaire
- créer autant de nouvelles que souhaitées
- vérifier qu'un tableau s'affiche bien pour lister les versions créées.
