### PR TITLE
[TECH] :recycle: Arrête d'utiliser l'attribut `hasComplementaryReferential` pour définir une certification CLEA (pix-19159)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification.js
+++ b/api/db/database-builder/factory/build-complementary-certification.js
@@ -8,7 +8,6 @@ function buildComplementaryCertification({
   createdAt = new Date('2020-01-01'),
   minimumReproducibilityRate = 70.0,
   minimumReproducibilityRateLowerLevel = 60.0,
-  hasComplementaryReferential = true,
   hasExternalJury = false,
   certificationExtraTime = 45,
 } = {}) {
@@ -19,7 +18,6 @@ function buildComplementaryCertification({
     createdAt,
     minimumReproducibilityRate,
     minimumReproducibilityRateLowerLevel,
-    hasComplementaryReferential,
     hasExternalJury,
     certificationExtraTime,
   };
@@ -33,7 +31,6 @@ buildComplementaryCertification.clea = function ({
   id = databaseBuffer.getNextId(),
   minimumReproducibilityRate = 50.0,
   minimumReproducibilityRateLowerLevel = 50.0,
-  hasComplementaryReferential = false,
   hasExternalJury = false,
   certificationExtraTime = 0,
 }) {
@@ -44,7 +41,6 @@ buildComplementaryCertification.clea = function ({
     createdAt: new Date('2020-01-01'),
     minimumReproducibilityRate,
     minimumReproducibilityRateLowerLevel,
-    hasComplementaryReferential,
     hasExternalJury,
     certificationExtraTime,
   });
@@ -54,7 +50,6 @@ buildComplementaryCertification.droit = function ({
   id = databaseBuffer.getNextId(),
   minimumReproducibilityRate = 75,
   minimumReproducibilityRateLowerLevel = 60,
-  hasComplementaryReferential = true,
   hasExternalJury = false,
   certificationExtraTime = 45,
 }) {
@@ -65,7 +60,6 @@ buildComplementaryCertification.droit = function ({
     createdAt: new Date('2020-01-01'),
     minimumReproducibilityRate,
     minimumReproducibilityRateLowerLevel,
-    hasComplementaryReferential,
     hasExternalJury,
     certificationExtraTime,
   });
@@ -75,7 +69,6 @@ buildComplementaryCertification.pixEdu1erDegre = function ({
   id = databaseBuffer.getNextId(),
   minimumReproducibilityRate = 70,
   minimumReproducibilityRateLowerLevel = 60,
-  hasComplementaryReferential = true,
   hasExternalJury = true,
   certificationExtraTime = 45,
 }) {
@@ -86,7 +79,6 @@ buildComplementaryCertification.pixEdu1erDegre = function ({
     createdAt: new Date('2020-01-01'),
     minimumReproducibilityRate,
     minimumReproducibilityRateLowerLevel,
-    hasComplementaryReferential,
     hasExternalJury,
     certificationExtraTime,
   });
@@ -96,7 +88,6 @@ buildComplementaryCertification.pixEdu2ndDegre = function ({
   id = databaseBuffer.getNextId(),
   minimumReproducibilityRate = 70,
   minimumReproducibilityRateLowerLevel = 60,
-  hasComplementaryReferential = true,
   hasExternalJury = true,
   certificationExtraTime = 45,
 }) {
@@ -107,7 +98,6 @@ buildComplementaryCertification.pixEdu2ndDegre = function ({
     createdAt: new Date('2020-01-01'),
     minimumReproducibilityRate,
     minimumReproducibilityRateLowerLevel,
-    hasComplementaryReferential,
     hasExternalJury,
     certificationExtraTime,
   });

--- a/api/src/certification/complementary-certification/domain/models/ComplementaryCertification.js
+++ b/api/src/certification/complementary-certification/domain/models/ComplementaryCertification.js
@@ -1,9 +1,11 @@
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+
 class ComplementaryCertification {
-  constructor({ id, label, key, hasComplementaryReferential }) {
+  constructor({ id, label, key }) {
     this.id = id;
     this.label = label;
     this.key = key;
-    this.hasComplementaryReferential = hasComplementaryReferential;
+    this.hasComplementaryReferential = key !== ComplementaryCertificationKeys.CLEA;
   }
 }
 

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
@@ -5,19 +5,19 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 function _toDomain(row) {
+  const hasComplementaryReferential = row.key !== ComplementaryCertificationKeys.CLEA;
   return new ComplementaryCertification({
     ...row,
+    hasComplementaryReferential,
   });
 }
 
 const findAll = async function () {
-  const result = await knex
-    .from('complementary-certifications')
-    .select('id', 'label', 'key', 'hasComplementaryReferential')
-    .orderBy('id', 'asc');
+  const result = await knex.from('complementary-certifications').select('id', 'label', 'key').orderBy('id', 'asc');
 
   return result.map(_toDomain);
 };

--- a/api/src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js
+++ b/api/src/certification/evaluation/domain/models/ComplementaryCertificationCourse.js
@@ -1,7 +1,9 @@
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+
 class ComplementaryCertificationCourse {
-  constructor({ complementaryCertificationKey, hasComplementaryReferential } = {}) {
+  constructor({ complementaryCertificationKey } = {}) {
     this.complementaryCertificationKey = complementaryCertificationKey;
-    this.hasComplementaryReferential = hasComplementaryReferential;
+    this.hasComplementaryReferential = complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA;
   }
 }
 

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-course-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-course-repository.js
@@ -7,7 +7,6 @@ export const findByCertificationCourseId = async function ({ certificationCourse
   const result = await knexConn('complementary-certification-courses')
     .select({
       complementaryCertificationKey: 'complementary-certifications.key',
-      hasComplementaryReferential: 'complementary-certifications.hasComplementaryReferential',
     })
     .where({ certificationCourseId })
     .leftJoin(

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { ComplementaryCertificationScoringCriteria } from '../../domain/models/ComplementaryCertificationScoringCriteria.js';
 
 export const findByCertificationCourseId = async function ({ certificationCourseId }) {
@@ -10,7 +11,7 @@ export const findByCertificationCourseId = async function ({ certificationCourse
       minimumReproducibilityRate: 'complementary-certifications.minimumReproducibilityRate',
       minimumReproducibilityRateLowerLevel: 'complementary-certifications.minimumReproducibilityRateLowerLevel',
       complementaryCertificationBadgeKey: 'badges.key',
-      hasComplementaryReferential: 'complementary-certifications.hasComplementaryReferential',
+      complementaryCertificationKey: 'complementary-certifications.key',
       minimumEarnedPix: 'complementary-certification-badges.minimumEarnedPix',
     })
     .join(
@@ -33,10 +34,12 @@ export const findByCertificationCourseId = async function ({ certificationCourse
       complementaryCertificationBadgeKey,
       minimumReproducibilityRate,
       minimumReproducibilityRateLowerLevel,
-      hasComplementaryReferential,
+      complementaryCertificationKey,
       minimumEarnedPix,
-    }) =>
-      new ComplementaryCertificationScoringCriteria({
+    }) => {
+      const hasComplementaryReferential = complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA;
+
+      return new ComplementaryCertificationScoringCriteria({
         complementaryCertificationCourseId,
         complementaryCertificationBadgeId,
         complementaryCertificationBadgeKey,
@@ -44,6 +47,7 @@ export const findByCertificationCourseId = async function ({ certificationCourse
         minimumReproducibilityRateLowerLevel: Number(minimumReproducibilityRateLowerLevel),
         hasComplementaryReferential,
         minimumEarnedPix,
-      }),
+      });
+    },
   );
 };

--- a/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/certification-point-of-contact.repository.js
@@ -28,8 +28,7 @@ const getAllowedCenterAccesses = async function (centerList) {
         `array_agg(json_build_object(
           'id', "complementary-certifications".id,
           'label', "complementary-certifications".label,
-          'key', "complementary-certifications".key,
-          'hasComplementaryReferential', "complementary-certifications"."hasComplementaryReferential"
+          'key', "complementary-certifications".key
         ) order by "complementary-certifications".id)`,
       ),
     })

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { getVersionNumber } from '../../../certification/configuration/domain/services/get-version-number.js';
+import { ComplementaryCertificationKeys } from '../../../certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { config } from '../../config.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { Accessibility } from '../../domain/models/Challenge.js';
@@ -125,13 +126,12 @@ export async function findActiveFlashCompatible({
   successProbabilityThreshold = config.features.successProbabilityThreshold,
   accessibilityAdjustmentNeeded = false,
   complementaryCertificationKey,
-  hasComplementaryReferential,
 } = {}) {
   _assertLocaleIsDefined(locale);
   const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
   let challengeDtos;
 
-  if (hasComplementaryReferential) {
+  if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
     const version = getVersionNumber(date);
 
     challengeDtos = await _findChallengesForComplementaryCertification({

--- a/api/tests/certification/evaluation/integration/domain/services/scoring/score-double-certification-v3_test.js
+++ b/api/tests/certification/evaluation/integration/domain/services/scoring/score-double-certification-v3_test.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { scoreDoubleCertificationV3 } from '../../../../../../../src/certification/evaluation/domain/services/scoring/score-double-certification-v3.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../../../../../../src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../../../../../src/certification/session-management/infrastructure/repositories/complementary-certification-course-result-repository.js';
+import { ComplementaryCertificationKeys } from '../../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import * as certificationAssessmentRepository from '../../../../../../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as assessmentResultRepository from '../../../../../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
@@ -24,7 +25,7 @@ describe('Certification | Evaluation | Integration | Domain | Services | Scoring
           complementaryCertificationBadgeId: 501,
           minimumReproducibilityRate: 80,
           minimumEarnedPix: 500,
-          hasComplementaryReferential: false,
+          key: ComplementaryCertificationKeys.CLEA,
         });
         _buildComplementaryCertificationCourse({
           certificationCourseId: 900,
@@ -71,7 +72,7 @@ describe('Certification | Evaluation | Integration | Domain | Services | Scoring
             complementaryCertificationBadgeId: 501,
             minimumReproducibilityRate: 80,
             minimumEarnedPix: 500,
-            hasComplementaryReferential: false,
+            key: ComplementaryCertificationKeys.CLEA,
           });
           _buildComplementaryCertificationCourse({
             certificationCourseId: 900,
@@ -154,17 +155,17 @@ function _buildComplementaryCertificationBadge({
   complementaryCertificationId,
   minimumReproducibilityRate,
   minimumEarnedPix,
-  hasComplementaryReferential,
   targetProfileId,
   level,
+  key,
 }) {
   databaseBuilder.factory.buildComplementaryCertification({
     id: complementaryCertificationId,
     minimumReproducibilityRate,
-    hasComplementaryReferential,
+    key,
   });
   const { id: badgeId } = databaseBuilder.factory.buildBadge({
-    key: 'badge_key',
+    key,
     isCertifiable: true,
     targetProfileId,
   });

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-course-repository_test.js
@@ -26,7 +26,6 @@ describe('Integration | Certification | Evaluation | Repository | Complementary-
         // then
         expect(result).to.be.instanceOf(ComplementaryCertificationCourse);
         expect(result.complementaryCertificationKey).to.equal(complementaryCertification.key);
-        expect(result.hasComplementaryReferential).to.equal(complementaryCertification.hasComplementaryReferential);
       });
     });
 

--- a/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
+++ b/api/tests/certification/evaluation/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
@@ -1,4 +1,5 @@
 import * as complementaryCertificationScoringCriteriaRepository from '../../../../../../src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | complementary certification scoring criteria', function () {
@@ -14,14 +15,12 @@ describe('Integration | Repository | complementary certification scoring criteri
       const complementaryCertification1 = databaseBuilder.factory.buildComplementaryCertification({
         minimumReproducibilityRate: 70,
         minimumReproducibilityRateLowerLevel: 60,
-        hasComplementaryReferential: true,
-        key: 'REF',
+        key: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
       });
       const complementaryCertification2 = databaseBuilder.factory.buildComplementaryCertification({
         minimumReproducibilityRate: 75,
         minimumReproducibilityRateLowerLevel: 60,
-        hasComplementaryReferential: false,
-        key: 'NO_REF',
+        key: ComplementaryCertificationKeys.CLEA,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -49,6 +48,7 @@ describe('Integration | Repository | complementary certification scoring criteri
       });
 
       databaseBuilder.factory.buildComplementaryCertificationCourse({
+        complementaryCertificationId: complementaryCertification2.id,
         certificationCourseId: 12,
         complementaryCertificationBadgeId: 768,
       });
@@ -68,7 +68,7 @@ describe('Integration | Repository | complementary certification scoring criteri
           minimumReproducibilityRate: complementaryCertification1.minimumReproducibilityRate,
           minimumReproducibilityRateLowerLevel: complementaryCertification1.minimumReproducibilityRateLowerLevel,
           complementaryCertificationBadgeKey: badge1.key,
-          hasComplementaryReferential: complementaryCertification1.hasComplementaryReferential,
+          hasComplementaryReferential: true,
         }),
         domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria({
           complementaryCertificationCourseId: complementaryCertificationCourse2.id,
@@ -76,7 +76,7 @@ describe('Integration | Repository | complementary certification scoring criteri
           minimumReproducibilityRate: complementaryCertification2.minimumReproducibilityRate,
           minimumReproducibilityRateLowerLevel: complementaryCertification2.minimumReproducibilityRateLowerLevel,
           complementaryCertificationBadgeKey: badge2.key,
-          hasComplementaryReferential: complementaryCertification2.hasComplementaryReferential,
+          hasComplementaryReferential: false,
           minimumEarnedPix: complementaryCertificationBadge2.minimumEarnedPix,
         }),
       ]);

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
@@ -426,19 +426,16 @@ describe('Integration | Identity Access Management |  Repository | Certification
           id: 1,
           label: 'Certif comp 1',
           key: 'COMP_1',
-          hasComplementaryReferential: false,
         };
         const secondComplementaryCertification = {
           id: 2,
           label: 'Certif comp 2',
           key: 'COMP_2',
-          hasComplementaryReferential: true,
         };
         const thirdComplementaryCertification = {
           id: 3,
           label: 'Certif comp 3',
           key: 'COMP_3',
-          hasComplementaryReferential: false,
         };
         databaseBuilder.factory.buildComplementaryCertification(firstComplementaryCertification);
         databaseBuilder.factory.buildComplementaryCertification(secondComplementaryCertification);
@@ -545,13 +542,11 @@ describe('Integration | Identity Access Management |  Repository | Certification
             id: 1,
             label: 'Certif comp 1',
             key: 'COMP_1',
-            hasComplementaryReferential: false,
           };
           const secondComplementaryCertification = {
             id: 2,
             label: 'Certif comp 2',
             key: 'COMP_2',
-            hasComplementaryReferential: true,
           };
           databaseBuilder.factory.buildComplementaryCertification(firstComplementaryCertification);
           databaseBuilder.factory.buildComplementaryCertification(secondComplementaryCertification);

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1765,7 +1765,6 @@ describe('Integration | Repository | challenge-repository', function () {
           date: candidateReconciliationDate,
           locale: 'fr',
           complementaryCertificationKey: complementaryCertification.key,
-          hasComplementaryReferential: complementaryCertification.hasComplementaryReferential,
         });
 
         // then

--- a/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
+++ b/api/tests/tooling/domain-builder/factory/certification/complementary-certification/build-complementary-certification.js
@@ -5,13 +5,11 @@ const buildComplementaryCertification = function ({
   id = 1,
   label = 'Complementary certification name',
   key = ComplementaryCertificationKeys.PIX_PLUS_DROIT,
-  hasComplementaryReferential = true,
 } = {}) {
   return new ComplementaryCertification({
     id,
     label,
     key,
-    hasComplementaryReferential,
   });
 };
 


### PR DESCRIPTION
:warning: en attente de livraison de la PR https://github.com/1024pix/pix/pull/13564

## 🔆 Problème

Nous avons un attribut de base de donnée (et de code) qui est assez peu clair. Tout ça pour distinguer les certifications CLEA (qui sont particuliers) des autres certifications complémentaires.

## ⛱️ Proposition

Réduire la friction pour gagner en lisibilité en supprimant l'attribut `hasComplementaryReferential` pour utiliser un test sur la clef de complémentaire `CLEA` à la place.

Cette PR est un premier pas. Et masque la suppression de cette colonne dans le repository. Il faudrait remonter cette modification dans le modèle par la suite.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Non régression sur une certification cœur, complémentaire et CLEA jusqu'au scoring.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
