### PR TITLE
[FEATURE] Ajouter le statut dans l'event QABCardAnsweredEvent (PIX-18918)

### DIFF
--- a/api/src/devcomp/domain/models/passage-events/qab-events.js
+++ b/api/src/devcomp/domain/models/passage-events/qab-events.js
@@ -1,8 +1,9 @@
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { PassageEventWithElement } from './PassageEventWithElement.js';
+import { PassageEventWithElementAnswered } from './PassageEventWithElementAnswered.js';
 
-class QABCardAnsweredEvent extends PassageEventWithElement {
-  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId, chosenProposal }) {
+class QABCardAnsweredEvent extends PassageEventWithElementAnswered {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, cardId, answer, status }) {
     super({
       type: 'QAB_CARD_ANSWERED',
       id,
@@ -11,7 +12,9 @@ class QABCardAnsweredEvent extends PassageEventWithElement {
       passageId,
       sequenceNumber,
       elementId,
-      data: { cardId, chosenProposal },
+      answer,
+      status,
+      data: { cardId },
     });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a QABCardAnsweredEvent');

--- a/api/src/devcomp/domain/models/passage-events/qab-events.js
+++ b/api/src/devcomp/domain/models/passage-events/qab-events.js
@@ -18,7 +18,6 @@ class QABCardAnsweredEvent extends PassageEventWithElementAnswered {
     });
 
     assertNotNullOrUndefined(cardId, 'The cardId is required for a QABCardAnsweredEvent');
-    assertNotNullOrUndefined(chosenProposal, 'The chosenProposal is required for a QABCardAnsweredEvent');
   }
 }
 

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -74,37 +74,6 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
         expect(error.message).to.equal('The cardId is required for a QABCardAnsweredEvent');
       });
     });
-
-    describe('when chosenProposal is not given', function () {
-      it('should throw an error', function () {
-        // given
-        const id = Symbol('id');
-        const occurredAt = new Date();
-        const createdAt = new Date();
-        const passageId = 2;
-        const sequenceNumber = 3;
-        const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
-        const cardId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
-
-        // when
-        const error = catchErrSync(
-          () =>
-            new QABCardAnsweredEvent({
-              id,
-              occurredAt,
-              createdAt,
-              passageId,
-              sequenceNumber,
-              elementId,
-              cardId,
-            }),
-        )();
-
-        // then
-        expect(error).to.be.instanceOf(DomainError);
-        expect(error.message).to.equal('The chosenProposal is required for a QABCardAnsweredEvent');
-      });
-    });
   });
 
   describe('#QABCardRetriedEvent', function () {

--- a/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/qab-events_test.js
@@ -16,7 +16,8 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
       const sequenceNumber = 3;
       const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
       const cardId = 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6';
-      const chosenProposal = 'A';
+      const answer = 'A';
+      const status = 'ok';
 
       // when
       const qabCardAnsweredEvent = new QABCardAnsweredEvent({
@@ -27,7 +28,8 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
         sequenceNumber,
         elementId,
         cardId,
-        chosenProposal,
+        answer,
+        status,
       });
 
       // then
@@ -37,7 +39,7 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
       expect(qabCardAnsweredEvent.createdAt).to.equal(createdAt);
       expect(qabCardAnsweredEvent.passageId).to.equal(passageId);
       expect(qabCardAnsweredEvent.sequenceNumber).to.equal(sequenceNumber);
-      expect(qabCardAnsweredEvent.data).to.deep.equal({ cardId, chosenProposal, elementId });
+      expect(qabCardAnsweredEvent.data).to.deep.equal({ cardId, answer, elementId, status });
     });
 
     describe('when cardId is not given', function () {
@@ -49,7 +51,8 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
         const passageId = 2;
         const sequenceNumber = 3;
         const elementId = '05112f63-0b47-4774-b638-6669c4e3a26d';
-        const chosenProposal = 'A';
+        const answer = 'A';
+        const status = 'ok';
 
         // when
         const error = catchErrSync(
@@ -61,7 +64,8 @@ describe('Integration | Devcomp | Domain | Models | passage-events | qab-events'
               passageId,
               sequenceNumber,
               elementId,
-              chosenProposal,
+              answer,
+              status,
             }),
         )();
 

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -273,7 +273,8 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
           elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f98',
           type: 'QAB_CARD_ANSWERED',
           cardId: '34b916b9-9103-4060-818d-98b2dc67111d',
-          chosenProposal: 'A',
+          answer: 'A',
+          status: 'ko',
         };
         // when
         const builtEvent = PassageEventFactory.build(rawEvent);

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -96,11 +96,13 @@ export default class ModuleQab extends ModuleElement {
 
     this.cardStatuses.set(this.currentCard.id, this.currentCardStatus);
     window.setTimeout(async () => await this.goToNextCard(), NEXT_CARD_TRANSITION_DELAY);
+    const status = this.currentCardStatus === 'success' ? 'ok' : 'ko';
     this.passageEvents.record({
       type: 'QAB_CARD_ANSWERED',
       data: {
         cardId: this.currentCard.id,
-        chosenProposal: event.submitter.value,
+        answer: event.submitter.value,
+        status,
         elementId: this.element.id,
       },
     });

--- a/mon-pix/tests/integration/components/module/qab_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab_test.gjs
@@ -81,7 +81,8 @@ module('Integration | Component | Module | QAB', function (hooks) {
         type: 'QAB_CARD_ANSWERED',
         data: {
           cardId: qabElement.cards[0].id,
-          chosenProposal: 'A',
+          answer: 'A',
+          status: 'ok',
           elementId: qabElement.id,
         },
       });
@@ -112,7 +113,7 @@ module('Integration | Component | Module | QAB', function (hooks) {
     });
 
     module('when user chooses proposal B', function () {
-      test('should display proposal B as selected and card status as error', async function (assert) {
+      test('should display proposal B as selected and card status as error, and send an event with ko status', async function (assert) {
         // given
         const qabElement = _getQabElement();
 
@@ -121,6 +122,15 @@ module('Integration | Component | Module | QAB', function (hooks) {
         await click(screen.getByRole('button', { name: 'Option B: Faux' }));
 
         // then
+        sinon.assert.calledWithExactly(passageEventRecordStub, {
+          type: 'QAB_CARD_ANSWERED',
+          data: {
+            cardId: qabElement.cards[0].id,
+            answer: 'B',
+            status: 'ko',
+            elementId: qabElement.id,
+          },
+        });
         assert
           .dom(screen.getByRole('button', { name: 'Option A: Vrai' }))
           .doesNotHaveClass('qab-proposal-button--selected');


### PR DESCRIPTION
## 🔆 Problème

Dans l'event QABCardAnsweredEvent, on ne précise pas si la réponse de l'utilisateur est correcte ou non.

## ⛱️ Proposition

Ajouter le champ `status` pour QABCardAnsweredEvent.

## 🌊 Remarques

- J'ai changé le type dont hérite QABCardAnsweredEvent pour suivre la logique de QCUAnsweredEvent
- Désormais, QABCardAnsweredEvent hérite de PassageEventWithElementAnswered, qui contrôle déjà dans son constructeur si les champs `answer`et `status`sont bien fournis.
- Front modifié en conséquence

## 🏄 Pour tester
- Ouvrir le [bac-a-sable](https://app-pr13553.review.pix.fr/modules/bac-a-sable)
- Afficher le QAB Pétanque
- Ouvrir l'onglet réseau du mode Devéloppeur du navigateur, et répondre `A` la première carte
- Vérifier que `POST /passage-events` est bien appelé avec un retour 204, avec un status "success"
- Répondre `A` à la deuxième carte
- Vérifier que `POST /passage-events` est bien appelé avec un retour 204, avec un status "error"
