### PR TITLE
[FEATURE] Créer la table pix-teams (PIX-19494)

### DIFF
--- a/api/db/migrations/20250912133240_create-pix-teams-table.js
+++ b/api/db/migrations/20250912133240_create-pix-teams-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'pix-teams';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.string('name').notNullable().comment('Team label');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Nous avons besoin de mettre en place une nouvelle table pix-teams pour référencer les équipes Pix et permettre de lier une organisation à une équipe via une clé étrangère optionnelle

## ⛱️ Proposition

créer une table pix-teams avec les colonnes : id, name, createdAt, updatedAt

## 🌊 Remarques

Non

## 🏄 Pour tester

- Vérifier la présence en base de la nouvelle table