### PR TITLE
[FEATURE] Ne pas remonter les campagnes liées à des parcours combinés sur la page d'accueil et mes-parcours (PIX-19478).

### DIFF
--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -272,6 +272,15 @@ const register = async function (server) {
           params: Joi.object({
             userId: identifiersType.userId,
           }),
+          query: Joi.object({
+            filter: Joi.object({
+              states: Joi.array().required(),
+            }).required(),
+            page: Joi.object({
+              number: Joi.number().integer().empty('').allow(null).optional(),
+              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
+            }).default({}),
+          }),
         },
         handler: campaignParticipationController.getCampaignParticipationOverviews,
         notes: [

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -913,6 +913,69 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       });
     });
 
+    context('when campaign is related to combined-course', function () {
+      it('should not return them', async function () {
+        const campaign = databaseBuilder.factory.buildCampaign();
+
+        const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildQuestForCombinedCourse({
+          name: 'Combinix',
+          rewardType: null,
+          rewardId: null,
+          code: 'COMBINIX1',
+          organizationId: campaignInCombinedCourse.organizationId,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaignInCombinedCourse.id,
+                  comparison: 'equal',
+                },
+                status: {
+                  data: 'SHARED',
+                  comparison: 'equal',
+                },
+              },
+            },
+            {
+              requirement_type: 'passages',
+              comparison: 'all',
+              data: {
+                moduleId: {
+                  data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+                  comparison: 'equal',
+                },
+                isTerminated: {
+                  data: true,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        databaseBuilder.factory.campaignParticipationOverviewFactory.build({
+          userId,
+          campaignId: campaignInCombinedCourse.id,
+        });
+        databaseBuilder.factory.campaignParticipationOverviewFactory.build({
+          userId,
+          campaignId: campaign.id,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { campaignParticipationOverviews } =
+          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+
+        // then
+        expect(campaignParticipationOverviews).to.have.lengthOf(1);
+      });
+    });
+
     context('canRetry computation', function () {
       it('should compute canRetry as true when all conditions are met', async function () {
         // given


### PR DESCRIPTION
## 🔆 Problème
Nous ne souhaitons pas qu'un prescrit puisse rejoindre une campagne liée à un parcours combiné, sans passer par le parcours combiné. 

## ⛱️ Proposition

Nous supprimons l'affichage des campagnes liées aux parcours combinés

## 🌊 Remarques

- Les contextes de notre API sont relous, et provoquent des dépendances circulaires, quand est-ce qu'on passe en découpage par features ? 🧌  

## 🏄 Pour tester

- Se connecter à Pix App
- Passer un combinix
- Aller dans la page mes-parcours et constater qu'on ne voit pas la campagne du combinix