### PR TITLE
[FEATURE] Ajout d'un lien de sortie sur les parcours combinés (PIX-19504)

### DIFF
--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -17,6 +18,12 @@ const CompletedText = <template>
 export default class CombinedCourses extends Component {
   <template>
     <section class="combined-course">
+      <div class="combined-course__exit">
+        <PixButtonLink @variant="tertiary" @route="authenticated" @iconAfter="doorOpen">
+          {{t "common.actions.quit"}}
+        </PixButtonLink>
+      </div>
+
       <header class="combined-course__header">
         <div>
           <h1>{{@combinedCourse.name}}</h1>
@@ -82,4 +89,5 @@ export default class CombinedCourses extends Component {
     this.router.transitionTo(item.route, item.reference, { queryParams: { redirection: item.redirection } });
   }
 }
+
 function noop() {}

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -3,6 +3,13 @@
 .combined-course {
   padding: var(--pix-spacing-12x) 80px;
 
+  &__exit {
+    display: flex;
+    flex-direction: column;
+    align-items: end;
+    margin-bottom: var(--pix-spacing-2x);
+  }
+
   &__header {
     display: flex;
     gap: var(--pix-spacing-8x);
@@ -120,12 +127,12 @@
   }
 
   &__current-item-tag {
-  display: flex;
-  gap: var(--pix-spacing-1x);
-  align-items: center;
-  padding: 6px var(--pix-spacing-4x);
-  background: var(--pix-tertiary-100);
-  border-radius: 50px;
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    align-items: center;
+    padding: 6px var(--pix-spacing-4x);
+    background: var(--pix-tertiary-100);
+    border-radius: 50px;
   }
 
   &__duration {
@@ -136,9 +143,9 @@
     font-size: 13px;
     line-height: 18px;
 
-      &__icon {
+    &__icon {
       width: 16px;
       height: 16px;
-  }
+    }
   }
 }

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -49,6 +49,28 @@ module('Integration | Component | combined course', function (hooks) {
         <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
       assert.ok(screen.getByText('Le but de ma quête'));
     });
+    test('should display exit button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.owner.lookup('service:router');
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: 'NOT_STARTED',
+        code: 'COMBINIX9',
+        name: 'Combinix',
+      });
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      const link = screen.getByRole('link', { name: t('common.actions.quit') });
+      assert.dom(link).hasAttribute('href', '/');
+    });
   });
 
   module('when there is a formation item', function () {
@@ -301,7 +323,7 @@ module('Integration | Component | combined course', function (hooks) {
 
       // when
       const screen = await render(hbs`
-    <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
       // then
       assert.ok(screen.getByText(t('pages.combined-courses.items.completed')));
@@ -343,7 +365,7 @@ module('Integration | Component | combined course', function (hooks) {
 
     // when
     const screen = await render(hbs`
-        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+      <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
     // then
     await click(screen.getByRole('button', { name: 'Reprendre mon parcours' }));
@@ -382,7 +404,7 @@ module('Integration | Component | combined course', function (hooks) {
 
     // when
     const screen = await render(hbs`
-        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+      <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
     // then
     assert.ok(screen.getByRole('button', { name: 'Reprendre mon parcours' }));


### PR DESCRIPTION
## 🔆 Problème

Il n'y a pas de moyen d'interrompre le parcours combinés hormis saisir un nouveau lien dans la barre d'URL du navigateur.

## ⛱️ Proposition

Ajouter une lien "Quitter" qui redirige vers l'accueil de Pix App.

## 🏄 Pour tester

Passer un parcours combiné.
-> Le bouton quitter est présent sur la page du parcours (uniquement) quelque soit l'étape (avant, pendant, après).

