### PR TITLE
[FEATURE] Renvoyer les `width`/`height` et type des éléments images si elles sont disponibles (PIX-19461)

### DIFF
--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -13,8 +13,9 @@ class Image extends Element {
    * @param{string} params.alternativeText
    * @param{string} [params.legend]
    * @param{string} [params.licence]
+   * @param{import('../../../../shared/domain/models/PixAssetImageInfos.js').PixAssetImageInfos} [params.infos]
    */
-  constructor({ id, url, alt, alternativeText, legend, licence }) {
+  constructor({ id, url, alt, alternativeText, legend, licence, infos }) {
     super({ id, type: 'image' });
 
     assertNotNullOrUndefined(url, 'The URL is required for an image');
@@ -30,6 +31,7 @@ class Image extends Element {
     this.alternativeText = alternativeText;
     this.legend = legend;
     this.licence = licence;
+    this.infos = infos;
 
     if (URL.parse(url).hostname !== Image.#VALID_HOSTNAME) {
       throw new DomainError('The image URL must be from "assets.pix.org"');

--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -11,8 +11,8 @@ class Image extends Element {
    * @param{string} params.url
    * @param{string} params.alt
    * @param{string} params.alternativeText
-   * @param{string} params.legend
-   * @param{string} params.licence
+   * @param{string} [params.legend]
+   * @param{string} [params.licence]
    */
   constructor({ id, url, alt, alternativeText, legend, licence }) {
     super({ id, type: 'image' });

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -1,3 +1,4 @@
+import { getAssetInfos } from '../../../shared/infrastructure/repositories/pix-assets-repository.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { ModuleInstantiationError } from '../../domain/errors.js';
 import { BlockInput } from '../../domain/models/block/BlockInput.js';
@@ -124,7 +125,7 @@ export class ModuleFactory {
       case 'expand':
         return ModuleFactory.#buildExpand(element);
       case 'image':
-        return ModuleFactory.#buildImage(element);
+        return await ModuleFactory.#buildImage(element);
       case 'separator':
         return ModuleFactory.#buildSeparator(element);
       case 'text':
@@ -198,7 +199,7 @@ export class ModuleFactory {
     });
   }
 
-  static #buildImage(element) {
+  static async #buildImage(element) {
     return new Image({
       id: element.id,
       url: element.url,
@@ -206,6 +207,7 @@ export class ModuleFactory {
       alternativeText: element.alternativeText,
       legend: element.legend,
       licence: element.licence,
+      infos: await getAssetInfos(element.url),
     });
   }
 

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -54,7 +54,7 @@ export class ModuleFactory {
                   .map((component) => {
                     switch (component.type) {
                       case 'element': {
-                        const element = ModuleFactory.#buildElement(component.element, moduleData.isBeta);
+                        const element = ModuleFactory.#buildElement(component.element);
                         if (element) {
                           return new ComponentElement({ element });
                         } else {
@@ -67,7 +67,7 @@ export class ModuleFactory {
                             return new Step({
                               elements: step.elements
                                 .map((element) => {
-                                  const domainElement = ModuleFactory.#buildElement(element, moduleData.isBeta);
+                                  const domainElement = ModuleFactory.#buildElement(element);
                                   if (domainElement) {
                                     return domainElement;
                                   } else {
@@ -97,7 +97,7 @@ export class ModuleFactory {
     }
   }
 
-  static #buildElement(element, isBeta) {
+  static #buildElement(element) {
     switch (element.type) {
       case 'custom':
         return ModuleFactory.#buildCustom(element);
@@ -110,7 +110,7 @@ export class ModuleFactory {
       case 'expand':
         return ModuleFactory.#buildExpand(element);
       case 'image':
-        return ModuleFactory.#buildImage(element, isBeta);
+        return ModuleFactory.#buildImage(element);
       case 'separator':
         return ModuleFactory.#buildSeparator(element);
       case 'text':
@@ -184,7 +184,7 @@ export class ModuleFactory {
     });
   }
 
-  static #buildImage(element, isBeta) {
+  static #buildImage(element) {
     return new Image({
       id: element.id,
       url: element.url,
@@ -192,7 +192,6 @@ export class ModuleFactory {
       alternativeText: element.alternativeText,
       legend: element.legend,
       licence: element.licence,
-      isBeta,
     });
   }
 

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -8,10 +8,12 @@ async function getAllByIds({ ids, moduleDatasource }) {
   try {
     const modules = await moduleDatasource.getAllByIds(ids);
 
-    return modules.map((moduleData) => {
-      const version = _computeModuleVersion(moduleData);
-      return ModuleFactory.build({ ...moduleData, version });
-    });
+    return await Promise.all(
+      modules.map(async (moduleData) => {
+        const version = _computeModuleVersion(moduleData);
+        return await ModuleFactory.build({ ...moduleData, version });
+      }),
+    );
   } catch (error) {
     throw new NotFoundError(error.message);
   }
@@ -27,7 +29,7 @@ async function getBySlug({ slug, moduleDatasource }) {
 
 async function list({ moduleDatasource }) {
   const modulesData = await moduleDatasource.list();
-  return modulesData.map((moduleData) => ModuleFactory.build(moduleData));
+  return Promise.all(modulesData.map(async (moduleData) => await ModuleFactory.build(moduleData)));
 }
 
 export { getAllByIds, getById, getBySlug, list };
@@ -44,7 +46,7 @@ async function _getModule({ ref, moduleDatasource, query }) {
     const moduleData = await method(query);
     const version = _computeModuleVersion(moduleData);
 
-    return ModuleFactory.build({ ...moduleData, version });
+    return await ModuleFactory.build({ ...moduleData, version });
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();

--- a/api/src/shared/domain/models/PixAssetImageInfos.js
+++ b/api/src/shared/domain/models/PixAssetImageInfos.js
@@ -1,0 +1,30 @@
+export class PixAssetImageInfos {
+  static #SUPPORTED_RASTER_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+  static #SUPPORTED_VECTOR_TYPES = ['image/svg+xml'];
+
+  /**
+   * @param{object} params
+   * @param{number} [params.width]
+   * @param{number} [params.height]
+   * @param{string} [params.contentType]
+   */
+  constructor({ width, height, contentType }) {
+    if (width) {
+      this.width = width;
+    }
+
+    if (height) {
+      this.height = height;
+    }
+
+    if (PixAssetImageInfos.#SUPPORTED_RASTER_TYPES.includes(contentType)) {
+      this.type = 'raster';
+      return;
+    }
+
+    if (PixAssetImageInfos.#SUPPORTED_VECTOR_TYPES.includes(contentType)) {
+      this.type = 'vector';
+      return;
+    }
+  }
+}

--- a/api/src/shared/infrastructure/datasources/pix-assets/pix-assets-client.js
+++ b/api/src/shared/infrastructure/datasources/pix-assets/pix-assets-client.js
@@ -2,10 +2,11 @@
  * @param{URL} assetUrl
  */
 export async function fetchAssetsMetadata(assetUrl) {
-  const assetResponse = await fetch(assetUrl, { method: 'OPTIONS' });
+  const assetResponse = await fetch(assetUrl, { method: 'HEAD' });
+
   if (!assetResponse.ok) {
     throw new Error(`Failed to fetch asset ${assetUrl}: ${assetResponse.status} ${assetResponse.statusText}`);
   }
 
-  return assetResponse.json();
+  return assetResponse.headers;
 }

--- a/api/src/shared/infrastructure/datasources/pix-assets/pix-assets-client.js
+++ b/api/src/shared/infrastructure/datasources/pix-assets/pix-assets-client.js
@@ -1,0 +1,11 @@
+/**
+ * @param{URL} assetUrl
+ */
+export async function fetchAssetsMetadata(assetUrl) {
+  const assetResponse = await fetch(assetUrl, { method: 'OPTIONS' });
+  if (!assetResponse.ok) {
+    throw new Error(`Failed to fetch asset ${assetUrl}: ${assetResponse.status} ${assetResponse.statusText}`);
+  }
+
+  return assetResponse.json();
+}

--- a/api/src/shared/infrastructure/repositories/pix-assets-repository.js
+++ b/api/src/shared/infrastructure/repositories/pix-assets-repository.js
@@ -1,0 +1,44 @@
+import { PixAssetImageInfos } from '../../domain/models/PixAssetImageInfos.js';
+import { fetchAssetsMetadata } from '../datasources/pix-assets/pix-assets-client.js';
+import { logger } from '../utils/logger.js';
+
+export const VALID_HOSTNAME = 'assets.pix.org';
+
+export function getValidHostname() {
+  return VALID_HOSTNAME;
+}
+
+const knownAssetsInfos = new Map();
+
+/**
+ * @param{string} assetUrl
+ */
+export async function getAssetInfos(assetUrl) {
+  if (knownAssetsInfos.has(assetUrl)) {
+    logger.debug(`PixAsset - asset "${assetUrl}" found. Returning cached informations`);
+    return knownAssetsInfos.get(assetUrl);
+  }
+
+  if (!URL.canParse(assetUrl)) {
+    throw new Error(`Asset URL "${assetUrl}" is invalid`);
+  }
+
+  const url = new URL(assetUrl);
+  if (url.hostname !== VALID_HOSTNAME) {
+    throw new Error(`Asset URL "${url.hostname}" hostname is not handled. Use "${VALID_HOSTNAME}"`);
+  }
+
+  const assetMetadata = await fetchAssetsMetadata(url);
+
+  const assetInfos = new PixAssetImageInfos({
+    width: assetMetadata.get('x-object-meta-width') ? Number.parseInt(assetMetadata.get('x-object-meta-width')) : null,
+    height: assetMetadata.get('x-object-meta-height')
+      ? Number.parseInt(assetMetadata.get('x-object-meta-height'))
+      : null,
+    contentType: assetMetadata.get('content-type'),
+  });
+  logger.debug(`PixAsset - Unknown asset "${url}", caching its informations.`);
+  knownAssetsInfos.set(assetUrl, assetInfos);
+
+  return assetInfos;
+}

--- a/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/controller-getBySlug_test.js
@@ -1,6 +1,6 @@
 import { config } from '../../../../../src/shared/config.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
-import { createServer, expect } from '../../../../test-helper.js';
+import { createServer, expect, nock } from '../../../../test-helper.js';
 
 describe('Acceptance | Controller | modules-controller-getBySlug', function () {
   let server;
@@ -12,6 +12,7 @@ describe('Acceptance | Controller | modules-controller-getBySlug', function () {
   describe('GET /api/modules/:slug', function () {
     context('when module exists', function () {
       it('should return module', async function () {
+        nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
         const options = {
           method: 'GET',
           url: `/api/modules/bien-ecrire-son-adresse-mail`,
@@ -24,6 +25,7 @@ describe('Acceptance | Controller | modules-controller-getBySlug', function () {
       });
 
       it('should return module with redirectionUrl', async function () {
+        nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
         const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
         const encryptedRedirectionUrl = await cryptoService.encrypt(expectedUrl, config.module.secret);
         const options = {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Controller | passage-controller', function () {
     describe('when user is not authenticated', function () {
       it('should create a new passage and response with a 201', async function () {
         // given
+        nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
         const expectedResponse = {
           type: 'passages',
           attributes: {
@@ -64,6 +65,7 @@ describe('Acceptance | Controller | passage-controller', function () {
     describe('when user is authenticated', function () {
       it('should create a new passage and response with a 201', async function () {
         // given
+        nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
         const user = databaseBuilder.factory.buildUser();
         await databaseBuilder.commit();
         const moduleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';

--- a/api/tests/devcomp/acceptance/module-instantiation_test.js
+++ b/api/tests/devcomp/acceptance/module-instantiation_test.js
@@ -2,11 +2,15 @@ import moduleDatasource from '../../../src/devcomp/infrastructure/datasources/le
 import { ElementForVerificationFactory } from '../../../src/devcomp/infrastructure/factories/element-for-verification-factory.js';
 import { ModuleFactory } from '../../../src/devcomp/infrastructure/factories/module-factory.js';
 import * as elementRepository from '../../../src/devcomp/infrastructure/repositories/element-repository.js';
-import { expect } from '../../test-helper.js';
+import { expect, nock } from '../../test-helper.js';
 
 const modules = await moduleDatasource.list();
 
 describe('Acceptance | Modules', function () {
+  beforeEach(function () {
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+  });
+
   describe('Verify modules', function () {
     modules.forEach((moduleData) => {
       it(`module ${moduleData.slug} should respect the domain`, async function () {

--- a/api/tests/devcomp/acceptance/module-instantiation_test.js
+++ b/api/tests/devcomp/acceptance/module-instantiation_test.js
@@ -9,9 +9,9 @@ const modules = await moduleDatasource.list();
 describe('Acceptance | Modules', function () {
   describe('Verify modules', function () {
     modules.forEach((moduleData) => {
-      it(`module ${moduleData.slug} should respect the domain`, function () {
+      it(`module ${moduleData.slug} should respect the domain`, async function () {
         try {
-          ModuleFactory.build(moduleData);
+          await ModuleFactory.build(moduleData);
 
           const elements = elementRepository.flattenModuleElements(moduleData);
           elements.forEach((element) => {

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -9,7 +9,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
   let modulesListAsJs;
 
   beforeEach(async function () {
-    modulesListAsJs = [ModuleFactory.build(moduleContent)];
+    modulesListAsJs = [await ModuleFactory.build(moduleContent)];
   });
 
   describe('#getElements', function () {

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -2,13 +2,14 @@ import sinon from 'sinon';
 
 import { getElements, getElementsListAsCsv } from '../../../../scripts/modulix/get-elements-csv.js';
 import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
-import { expect } from '../../../test-helper.js';
+import { expect, nock } from '../../../test-helper.js';
 import moduleContent from './test-module.json' with { type: 'json' };
 
 describe('Acceptance | Script | Get Elements as CSV', function () {
   let modulesListAsJs;
 
   beforeEach(async function () {
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     modulesListAsJs = [await ModuleFactory.build(moduleContent)];
   });
 

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -6,7 +6,7 @@ import moduleContent from './test-module.json' with { type: 'json' };
 describe('Acceptance | Script | Get Modules as CSV', function () {
   it(`should return modules list as CSV`, async function () {
     // Given
-    const modulesListAsJs = [ModuleFactory.build(moduleContent)];
+    const modulesListAsJs = [await ModuleFactory.build(moduleContent)];
 
     // When
     const modulesListAsCsv = await getModulesListAsCsv(modulesListAsJs);

--- a/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules-csv_test.js
@@ -1,11 +1,12 @@
 import { getModulesListAsCsv } from '../../../../scripts/modulix/get-modules-csv.js';
 import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
-import { expect } from '../../../test-helper.js';
+import { expect, nock } from '../../../test-helper.js';
 import moduleContent from './test-module.json' with { type: 'json' };
 
 describe('Acceptance | Script | Get Modules as CSV', function () {
   it(`should return modules list as CSV`, async function () {
     // Given
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     const modulesListAsJs = [await ModuleFactory.build(moduleContent)];
 
     // When

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -1,7 +1,7 @@
 import { ModuleStatus } from '../../../../../src/devcomp/application/api/models/ModuleStatus.js';
 import * as modulesApi from '../../../../../src/devcomp/application/api/modules-api.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, nock, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Devcomp | Application | Api | Modules', function () {
   let clock, now;
@@ -18,6 +18,7 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
   describe('#getModuleStatuses', function () {
     it('should return a list of Module statuses', async function () {
       // given
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
       const { id: userId } = databaseBuilder.factory.buildUser();
       const existingModuleIdWithoutRelatedPassage = '6282925d-4775-4bca-b513-4c3009ec5886';
       const existingModuleId2 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';

--- a/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/recommended-modules-api_test.js
@@ -2,7 +2,7 @@ import { RecommendableModule } from '../../../../../src/devcomp/application/api/
 import { RecommendedModule } from '../../../../../src/devcomp/application/api/models/RecommendedModule.js';
 import * as recommendedModulesApi from '../../../../../src/devcomp/application/api/recommended-modules-api.js';
 import { DomainError } from '../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, nock } from '../../../../test-helper.js';
 
 describe('Integration | Devcomp | Application | Api | RecommendedModules', function () {
   describe('#findByCampaignParticipationIds', function () {
@@ -52,6 +52,7 @@ describe('Integration | Devcomp | Application | Api | RecommendedModules', funct
   describe('#findByTargetProfileIds', function () {
     it('should return a list recommended modules', async function () {
       // given
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       const trainingId = databaseBuilder.factory.buildTraining({
         type: 'modulix',

--- a/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
+++ b/api/tests/devcomp/integration/domain/usecases/find-recommended-modules-by-campaign-participation-ids_test.js
@@ -1,6 +1,6 @@
 import { RecommendedModule } from '../../../../../src/devcomp/domain/read-models/RecommendedModule.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
-import { databaseBuilder, expect } from '../../../../test-helper.js';
+import { databaseBuilder, expect, nock } from '../../../../test-helper.js';
 
 describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCampaignParticipationIds', function () {
   it('it returns recommended modules for given participation ids', async function () {
@@ -43,6 +43,7 @@ describe('Integration | DevComp | Domain | Usecases | findRecommendedModulesByCa
   });
   it('ignores module when its slug does not pass regex', async function () {
     // given
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     const { id: campaignParticipationId1, userId } = databaseBuilder.factory.buildCampaignParticipation();
     const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
 

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -19,7 +19,7 @@ import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
 import { ModuleFactory } from '../../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
-import { catchErr, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, expect, nock, sinon } from '../../../../test-helper.js';
 import { validateFlashcards } from '../../../shared/validateFlashcards.js';
 
 describe('Integration | Devcomp | Infrastructure | Factories | Module ', function () {
@@ -200,6 +200,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
     it('should instantiate a Module with a grain containing components', async function () {
       // given
+      nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
       const version = Symbol('version');
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -405,6 +406,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
       it('should instantiate a Module with a ComponentElement which contains an Image Element', async function () {
         // given
+        nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
@@ -1287,6 +1289,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
     describe('With ComponentStepper', function () {
       it('should instantiate a Module with a ComponentStepper which contains an Image Element', async function () {
         // given
+        nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -19,14 +19,14 @@ import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
 import { ModuleFactory } from '../../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
-import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 import { validateFlashcards } from '../../../shared/validateFlashcards.js';
 
-describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
+describe('Integration | Devcomp | Infrastructure | Factories | Module ', function () {
   describe('#toDomain', function () {
     describe('when data is incorrect', function () {
       describe('when a component has an unknown type', function () {
-        it('should log the error', function () {
+        it('should log the error', async function () {
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -70,7 +70,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           sinon.stub(logger, 'warn').returns();
 
           // when
-          ModuleFactory.build(moduleData);
+          await ModuleFactory.build(moduleData);
 
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
@@ -81,7 +81,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       });
 
       describe('when an element has an unknown type', function () {
-        it('should log the error', function () {
+        it('should log the error', async function () {
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -125,7 +125,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           sinon.stub(logger, 'warn').returns();
 
           // when
-          ModuleFactory.build(moduleData);
+          await ModuleFactory.build(moduleData);
 
           // then
           expect(logger.warn).to.have.been.calledWithExactly({
@@ -136,7 +136,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       });
 
       describe('when a qrocm has an unknown proposal type', function () {
-        it('should log the error', function () {
+        it('should log the error', async function () {
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -190,7 +190,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
           sinon.stub(logger, 'warn').returns();
 
           // when
-          ModuleFactory.build(moduleData);
+          await ModuleFactory.build(moduleData);
 
           // then
           expect(logger.warn).to.have.been.calledWithExactly('Type de proposal inconnu: unknown');
@@ -198,7 +198,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       });
     });
 
-    it('should instantiate a Module with a grain containing components', function () {
+    it('should instantiate a Module with a grain containing components', async function () {
       // given
       const version = Symbol('version');
       const moduleData = {
@@ -243,7 +243,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       };
 
       // when
-      const module = ModuleFactory.build(moduleData);
+      const module = await ModuleFactory.build(moduleData);
 
       // then
       expect(module).to.be.an.instanceOf(Module);
@@ -256,7 +256,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
     });
 
     describe('With ComponentElement', function () {
-      it('should instantiate a Module with a ComponentElement which contains a Custom Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Custom Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -347,13 +347,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(CustomElement);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a CustomDraft Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a CustomDraft Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -397,13 +397,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(CustomDraft);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains an Image Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -448,13 +448,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Image);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Separator Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Separator Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -494,7 +494,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Separator);
@@ -505,7 +505,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         });
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Text Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Text Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -546,13 +546,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Text);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Video Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Video Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -597,7 +597,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Video);
@@ -613,7 +613,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         });
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Download Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Download Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -659,13 +659,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Download);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains an Embed Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains an Embed Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -709,13 +709,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(Embed);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QCU Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -770,13 +770,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCU);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QCUDeclarative Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QCUDeclarative Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -840,13 +840,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCUDeclarative);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QCUDiscovery Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QCUDiscovery Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -922,13 +922,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCUDiscovery);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QCM Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -997,13 +997,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QCM);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QROCM Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QROCM Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1087,13 +1087,13 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.an.instanceOf(QROCM);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1155,7 +1155,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         const flashcards = module.sections[0].grains[0].components[0].element;
@@ -1163,7 +1163,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         validateFlashcards(flashcards, expectedFlashcards);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Expand Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Expand Element', async function () {
         // given
         const givenData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1205,7 +1205,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(givenData);
+        const module = await ModuleFactory.build(givenData);
 
         // then
         const expand = module.sections[0].grains[0].components[0].element;
@@ -1216,7 +1216,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(expand.type).to.equal(expectedExpand.type);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a QAB Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a QAB Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1277,7 +1277,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0].element).to.be.instanceOf(QAB);
@@ -1285,7 +1285,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
     });
 
     describe('With ComponentStepper', function () {
-      it('should instantiate a Module with a ComponentStepper which contains an Image Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains an Image Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1334,7 +1334,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1342,7 +1342,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Image);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a Separator Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a Separator Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1388,7 +1388,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1396,7 +1396,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Separator);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a Text Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a Text Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1444,7 +1444,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1452,7 +1452,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a Video Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a Video Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1503,7 +1503,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1511,7 +1511,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a Download Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a Download Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1563,7 +1563,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1571,7 +1571,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Download);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains an Embed Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains an Embed Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1622,7 +1622,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1630,7 +1630,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Embed);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a QCU Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a QCU Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1692,7 +1692,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1700,7 +1700,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a QCUDeclarative Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a QCUDeclarative Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1770,7 +1770,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1778,7 +1778,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCUDeclarative);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a QCM Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a QCM Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1853,7 +1853,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1861,7 +1861,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCM);
       });
 
-      it('should instantiate a Module with a ComponentStepper which contains a QROCM Element', function () {
+      it('should instantiate a Module with a ComponentStepper which contains a QROCM Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -1947,7 +1947,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -1955,7 +1955,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QROCM);
       });
 
-      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', function () {
+      it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2023,7 +2023,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         const flashcards = module.sections[0].grains[0].components[0].steps[0].elements[0];
@@ -2031,7 +2031,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         validateFlashcards(flashcards, expectedFlashcards);
       });
 
-      it('should filter out unknown element type', function () {
+      it('should filter out unknown element type', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2084,7 +2084,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const module = ModuleFactory.build(moduleData);
+        const module = await ModuleFactory.build(moduleData);
 
         // then
         expect(module.sections[0].grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
@@ -2093,7 +2093,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.sections[0].grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
       });
 
-      it('should filter out steps with only unknown element type', function () {
+      it('should filter out steps with only unknown element type', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2150,14 +2150,14 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const error = catchErrSync(ModuleFactory.build)(moduleData);
+        const error = await catchErr(ModuleFactory.build)(moduleData);
 
         // then
         expect(error).to.be.an.instanceOf(ModuleInstantiationError);
         expect(error.message).to.deep.equal('A step should contain at least one element');
       });
 
-      it('should filter out stepper with only unknown element type', function () {
+      it('should filter out stepper with only unknown element type', async function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2204,7 +2204,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         };
 
         // when
-        const error = catchErrSync(ModuleFactory.build)(moduleData);
+        const error = await catchErr(ModuleFactory.build)(moduleData);
 
         // then
         expect(error).to.be.an.instanceOf(ModuleInstantiationError);
@@ -2212,7 +2212,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       });
     });
 
-    it('should filter out unknown component types', function () {
+    it('should filter out unknown component types', async function () {
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2261,7 +2261,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       };
 
       // when
-      const module = ModuleFactory.build(moduleData);
+      const module = await ModuleFactory.build(moduleData);
 
       // then
       expect(module).to.be.an.instanceOf(Module);
@@ -2270,7 +2270,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       expect(module.sections[0].grains[0].components[0].element).not.to.be.empty;
     });
 
-    it('should filter out component if element type is unknown', function () {
+    it('should filter out component if element type is unknown', async function () {
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -2319,7 +2319,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       };
 
       // when
-      const module = ModuleFactory.build(moduleData);
+      const module = await ModuleFactory.build(moduleData);
 
       // then
       expect(module).to.be.an.instanceOf(Module);

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -136,7 +136,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       };
       moduleDatasourceStub.getAllByIds
         .withArgs(notExistingModuleIds)
-        .throws(new ModuleDoesNotExistError(expectedErrorMessage));
+        .rejects(new ModuleDoesNotExistError(expectedErrorMessage));
 
       // when
       const error = await catchErr(moduleRepository.getAllByIds)({

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -1,5 +1,6 @@
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { PixAssetImageInfos } from '../../../../../../src/shared/domain/models/PixAssetImageInfos.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
@@ -13,6 +14,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
         alternativeText: 'alternativeText',
         legend: 'legend',
         licence: 'licence',
+        infos: new PixAssetImageInfos({ width: 400, height: 200 }),
       });
 
       // then
@@ -23,6 +25,31 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
       expect(image.legend).to.equal('legend');
       expect(image.licence).to.equal('licence');
       expect(image.type).to.equal('image');
+      expect(image.infos).to.deep.equal({ width: 400, height: 200 });
+    });
+
+    describe('without infos', function () {
+      it('should create an image and keep attributes', function () {
+        // when
+        const image = new Image({
+          id: 'id',
+          url: 'https://assets.pix.org/modules/placeholder-details.svg',
+          alt: 'alt',
+          alternativeText: 'alternativeText',
+          legend: 'legend',
+          licence: 'licence',
+        });
+
+        // then
+        expect(image.id).to.equal('id');
+        expect(image.url).to.equal('https://assets.pix.org/modules/placeholder-details.svg');
+        expect(image.alt).to.equal('alt');
+        expect(image.alternativeText).to.equal('alternativeText');
+        expect(image.legend).to.equal('legend');
+        expect(image.licence).to.equal('licence');
+        expect(image.type).to.equal('image');
+        expect(image.infos).to.be.undefined;
+      });
     });
   });
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -389,6 +389,7 @@ function getComponents() {
         alternativeText: 'alternativeText',
         licence: 'mon copyright',
         legend: 'ma légende',
+        infos: { width: 400, height: 200 },
       }),
     }),
     new ComponentElement({
@@ -594,6 +595,10 @@ function getAttributesComponents() {
         url: 'https://assets.pix.org/modules/placeholder-details.svg',
         legend: 'ma légende',
         licence: 'mon copyright',
+        infos: {
+          width: 400,
+          height: 200,
+        },
       },
     },
     {

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -4,7 +4,7 @@ import { CombinedCourseItem, ITEM_TYPE } from '../../../../../src/quest/domain/m
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
-import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, nock, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code', function () {
   let combinedCourseUrl, code;
@@ -18,6 +18,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
   });
 
   it('should return CombinedCourse for provided code', async function () {
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
     const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
     const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
@@ -129,6 +130,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
   });
 
   it('should return started combined course for given userId', async function () {
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
     const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
     const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });

--- a/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
@@ -4,7 +4,7 @@ import {
 } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
-import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { databaseBuilder, expect, knex, nock, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Quest | Domain | UseCases | update-combined-course', function () {
   let clock;
@@ -18,6 +18,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     clock.restore();
   });
   it('should update combined course if it is completed', async function () {
+    nock('https://assets.pix.org').head('/modules/bac-a-sable/ordi-spatial.svg').reply(200, {});
     const code = 'SOMETHING';
     const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
     const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();

--- a/api/tests/shared/integration/infrastructure/repositories/pix-assets-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/pix-assets-repository_test.js
@@ -1,0 +1,79 @@
+import { PixAssetImageInfos } from '../../../../../src/shared/domain/models/PixAssetImageInfos.js';
+import {
+  getAssetInfos,
+  getValidHostname,
+} from '../../../../../src/shared/infrastructure/repositories/pix-assets-repository.js';
+import { catchErr, expect, nock } from '../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Repository | PixAssets', function () {
+  const fakeAnswerContent = {
+    date: new Date('2025-09-12').toString(),
+    'content-type': 'image/svg+xml',
+    'content-length': 4660,
+    'x-request-id': 'e33deae7-a480-46af-886d-626adfa1dd43',
+    vary: 'Accept-Encoding',
+    'x-object-meta-optimized': 'true',
+    'x-object-meta-uploader': 'yann.bertrand@pix.fr',
+    'x-object-meta-comment': '',
+    'x-object-meta-width': 140,
+    'x-object-meta-height': 140,
+    etag: '5d000d7075553ddcc08bedfcc34dc2ae',
+    'last-modified': new Date('2025-09-11').toString(),
+    'x-timestamp': '1757611042.11464',
+    'accept-ranges': 'bytes',
+    'x-trans-id': 'tx44bf743653444a4d9e6aa-0068c41191',
+    'x-openstack-request-id': 'tx44bf743653444a4d9e6aa-0068c41191',
+    'x-iplb-request-id': '94FD60BE:9DF4_5762BBC9:01BB_68C41191_4BD0A3B5:4174',
+    'x-iplb-instance': 54408,
+    'access-control-allow-origin': '*',
+    'cache-control': 'public, max-age=172800',
+    'strict-transport-security': 'max-age=31536000',
+  };
+
+  describe('#getValidHostname', function () {
+    it('should return only valid hostname', function () {
+      // when
+      const validHostname = getValidHostname();
+
+      // then
+      expect(validHostname).to.equal('assets.pix.org');
+    });
+  });
+
+  describe('#getAssetInfos', function () {
+    describe('when not from assets.pix.org', function () {
+      it('should throw', async function () {
+        // when
+        const error = await catchErr(getAssetInfos)('https://images.pix.fr/modules/placeholder-details.svg');
+
+        // then
+        expect(error.message).to.equal(`Asset URL "images.pix.fr" hostname is not handled. Use "assets.pix.org"`);
+      });
+    });
+
+    it('should call pix-assets for asset informations', async function () {
+      // given
+      const assetPath = '/modules/placeholder-details.svg';
+      nock('https://assets.pix.org').head(assetPath).reply(200, '', fakeAnswerContent);
+
+      const expectedResult = new PixAssetImageInfos({ width: 140, height: 140, contentType: 'image/svg+xml' });
+
+      // when
+      const result = await getAssetInfos('https://assets.pix.org/modules/placeholder-details.svg');
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it('should return empty object if no info found', async function () {
+      const assetPath = '/modules/empty.svg';
+      nock('https://assets.pix.org').head(assetPath).reply(200, {});
+
+      // when
+      const result = await getAssetInfos('https://assets.pix.org/modules/empty.svg');
+
+      // then
+      expect(result).to.deep.equal({});
+    });
+  });
+});

--- a/api/tests/shared/unit/domain/models/PixAssetImageInfos_test.js
+++ b/api/tests/shared/unit/domain/models/PixAssetImageInfos_test.js
@@ -1,0 +1,68 @@
+import { PixAssetImageInfos } from '../../../../../src/shared/domain/models/PixAssetImageInfos.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
+  describe('#constructor', function () {
+    it('should get image infos and keep attributes', function () {
+      // when
+      const imageInfos = new PixAssetImageInfos({
+        width: 300,
+        height: 200,
+        contentType: 'image/svg+xml',
+      });
+
+      // then
+      expect(imageInfos.width).to.equal(300);
+      expect(imageInfos.height).to.equal(200);
+      expect(imageInfos.type).to.equal('vector');
+    });
+  });
+
+  describe('An image without width/height', function () {
+    it('should keep type attributes', function () {
+      // when
+      const imageInfos = new PixAssetImageInfos({ contentType: 'image/svg+xml' });
+
+      // then
+      expect(imageInfos.width).to.be.undefined;
+      expect(imageInfos.height).to.be.undefined;
+      expect(imageInfos.type).to.equal('vector');
+    });
+  });
+
+  describe('An image without contentType', function () {
+    it('should set width and height', function () {
+      // when
+      const imageInfos = new PixAssetImageInfos({ width: 300, height: 200 });
+
+      // then
+      expect(imageInfos.width).to.equal(300);
+      expect(imageInfos.height).to.equal(200);
+      expect(imageInfos.type).to.be.undefined;
+    });
+  });
+
+  describe('An image with unknown contentType', function () {
+    it('should not set type', function () {
+      // when
+      const imageInfos = new PixAssetImageInfos({ width: 300, height: 200, contentType: 'text/html' });
+
+      // then
+      expect(imageInfos.width).to.equal(300);
+      expect(imageInfos.height).to.equal(200);
+      expect(imageInfos.type).to.be.undefined;
+    });
+  });
+
+  describe('An image without nothing', function () {
+    it('should set no attributes', function () {
+      // when
+      const imageInfos = new PixAssetImageInfos({});
+
+      // then
+      expect(imageInfos.width).to.be.undefined;
+      expect(imageInfos.height).to.be.undefined;
+      expect(imageInfos.type).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Lors du processus d'affichage d'une image dans un navigateur, il essaye d'abord de déterminer l'espace nécessaire afin de réserver cet espace dans la page. En cas de mauvaise connexion, par exemple sur mobile dans le train, cet espace ne sera pas occupé tant que le navigateur n'a pas les informations des dimensions. Lors du chargement de l'image, l'espace devient réservé et le reste du contenu est décalé plus bas et donc une mauvaise UX. C'est ce qu'on appelle du [Layout shift](https://web.dev/articles/cls).

Exemple dans Modulix :
<img width="300" height="250" alt="avant le chargement" title="avant le chargement" src="https://github.com/user-attachments/assets/f43ff7e2-1d23-48fa-93c5-f28b0ccbc581" />

<img width="300" height="350" alt="après le chargement" title="après le chargement" src="https://github.com/user-attachments/assets/c6a072a0-db3a-4737-bf96-0f0b0c8f5f5e" />

## ⛱️ Proposition

Si l’asset est une image hébergée sur [assets.pix.org](http://assets.pix.org/), depuis https://github.com/1024pix/pix-assets-manager-tmp/pull/46, on peut trouver les champs `width` et `height` dans ses métadonnées. Si elles sont disponibles : les récupérer. Puis les renvoyer dans le endpoint `GET /modules/:slug`.

On peut aussi récupérer le type d'image (vectorielle ou matricielle), ce qui permet de savoir si l'image est extensible ou non.

Ces informations sont memoizées, lors de la première requête de l'asset. L'utilisateur qui arrive sur un nouveau container peut légèrement être impacté lors de la récupération d'un module pour la première fois.

## 🌊 Remarques

Il a fallu faire un gros refacto sur la `ModuleFactory` pour qu'elle devienne asynchrone.

J'ai du propager du `nock` à droite à gauche. Peut être qu'il y a moyen de faire plus propre...

## 🏄 Pour tester

Vérifier sur [un module](https://app-pr13558.review.pix.fr/api/modules/bac-a-sable) que les éléments `Image` contiennent un nouveau champ `infos` qui peut éventuellement contenir : 
- `width` la largeur de l'image en pixels,
- `height` la hauteur de l'image en pixels,
- `type` : `vector` ou `raster` selon le type d'image.
