### PR TITLE
[TECH] Ajouter la relation pixTeamId dans la table organizations (PIX-19513)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -21,6 +21,7 @@ const buildOrganization = function buildOrganization({
   archivedAt = null,
   identityProviderForCampaigns = null,
   parentOrganizationId = null,
+  pixTeamId = null,
 } = {}) {
   const values = {
     id,
@@ -43,6 +44,7 @@ const buildOrganization = function buildOrganization({
     archivedAt,
     identityProviderForCampaigns,
     parentOrganizationId,
+    pixTeamId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20250915081044_add-pixTeamId-relationship-on-organizations.js
+++ b/api/db/migrations/20250915081044_add-pixTeamId-relationship-on-organizations.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'pixTeamId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .defaultTo(null)
+      .nullable()
+      .references('pix-teams.id')
+      .index()
+      .comment("Reference to the organization's PIX team");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -32,6 +32,7 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
     'parentOrganizationId',
     'schoolCode',
     'sessionExpirationDate',
+    'pixTeamId',
   ];
 
   let clock;


### PR DESCRIPTION
## 🔆 Problème

Nous avons besoin de mettre en place une nouvelle table pix-teams pour référencer les équipes Pix et permettre de lier une organisation à une équipe via une clé étrangère optionnelle

## ⛱️ Proposition

Ajouter une colonne `pixTeamId` sur la table `organizations` qui pointera vers `pix-teams.id`

## 🌊 Remarques

Non

## 🏄 Pour tester

- Vérifier la présence en base de la nouvelle colonne sur `organizations`
