### PR TITLE
[TECH] Corriger le style de la page des Parcours Combiné sur PixApp (PIX-19521).

### DIFF
--- a/mon-pix/app/components/global/app-layout.gjs
+++ b/mon-pix/app/components/global/app-layout.gjs
@@ -12,7 +12,6 @@ import AppMainHeader from './app-main-header';
 import AppNavigation from './app-navigation';
 
 export default class AppLayout extends Component {
-  @service router;
   @service session;
   @service currentUser;
   @service media;
@@ -21,13 +20,25 @@ export default class AppLayout extends Component {
     return this.args.displayFullLayout && this.session.isAuthenticated && this.currentUser.user && !this.media.isMobile;
   }
 
+  get appLayoutClass() {
+    const cssClass = [];
+
+    if (!this.args.displayFullLayout) cssClass.push('page-without-navbar ');
+
+    if (this.args.isLoginPages) cssClass.push('page-without-navbar--login-page');
+
+    if (this.args.isFullWidth) cssClass.push('page-without-navbar--force-max-width');
+
+    return cssClass.join(' ');
+  }
+
   <template>
     {{#if @displayFullLayout}}
       <Skiplink @href="#main" @label={{t "common.skip-links.skip-to-content"}} />
       <Skiplink @href="#footer" @label={{t "common.skip-links.skip-to-footer"}} />
     {{/if}}
 
-    <PixAppLayout class="{{unless @displayFullLayout 'unauthenticated-page'}}">
+    <PixAppLayout class="{{this.appLayoutClass}}">
       <:banner>
         {{#if @displayFullLayout}}
           <DataProtectionPolicyInformationBanner />

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -201,14 +201,21 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use 'pages/certification-instructions' as *;
 @use 'pages/download-session-results' as *;
 
-.unauthenticated-page {
+.page-without-navbar {
+
+  &--login-page {
+    background-color: var(--pix-neutral-0);
+  }
+
+  &--force-max-width {
+    & > .pix-app-layout__main {
+      max-width: 100%;
+    }
+  }
+
   & > .pix-app-layout__main,
   .pix-app-layout__footer,
   .pix-app-layout__navigation {
     padding: 0;
-  }
-
-  & > .pix-app-layout__main {
-    max-width: 100%;
   }
 }

--- a/mon-pix/app/templates/application.gjs
+++ b/mon-pix/app/templates/application.gjs
@@ -25,6 +25,20 @@ export default class ApplicationTemplate extends Component {
     );
   }
 
+  get isLoginPages() {
+    return this.router.currentRouteName.startsWith('authentication.');
+  }
+
+  get isFullWidth() {
+    return (
+      this.router.currentRouteName.startsWith('assessments.') ||
+      this.router.currentRouteName === 'campaigns.assessment.tutorial' ||
+      this.router.currentRouteName.startsWith('module.') ||
+      this.router.currentRouteName === 'module-preview-existing' ||
+      this.router.currentRouteName === 'module-preview'
+    );
+  }
+
   <template>
     {{! template-lint-disable no-inline-styles }}
     {{pageTitle (t "navigation.pix")}}
@@ -35,7 +49,12 @@ export default class ApplicationTemplate extends Component {
     {{/in-element}}
 
     <div id="app">
-      <AppLayout @displayFullLayout={{this.displayFullLayout}} @banners={{@controller.model.informationBanner.banners}}>
+      <AppLayout
+        @displayFullLayout={{this.displayFullLayout}}
+        @isLoginPages={{this.isLoginPages}}
+        @isFullWidth={{this.isFullWidth}}
+        @banners={{@controller.model.informationBanner.banners}}
+      >
         {{outlet}}
       </AppLayout>
 

--- a/mon-pix/app/templates/fill-in-campaign-code.gjs
+++ b/mon-pix/app/templates/fill-in-campaign-code.gjs
@@ -4,14 +4,9 @@ import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import CampaignCodeForm from 'mon-pix/components/campaign-code-form';
-import DataProtectionPolicyInformationBanner from 'mon-pix/components/data-protection-policy-information-banner';
 
 <template>
   {{pageTitle (t "pages.fill-in-campaign-code.title")}}
-
-  <div class="pix-communication-banner">
-    <DataProtectionPolicyInformationBanner />
-  </div>
 
   <main id="main" class="main global-page-container" role="main">
     <CampaignCodeForm


### PR DESCRIPTION
## 🔆 Problème

Actuellement la page des parcours combiné prend toute la place de l'écran. Ce qui pose des problème de lecteur lorsque l'écran est trop grand

## ⛱️ Proposition

Modifier la manière dont on gère les page sans layouting ( login par exemple ainsi que les assessment )

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier que la page login est bien sur fond blanc complet et centré. 
Vérifier que la page COMBINIX1 en saisissant j'ai un code s'affiche de manière correct.
Vérifier que les page du parcours d'un assessment s'affiche correctement