### PR TITLE
[BUGFIX] Rectifier l'affichage d'infos de complémentaire en fonction des rôles (PIX-19514).

### DIFF
--- a/admin/app/components/complementary-certifications/item/framework.gjs
+++ b/admin/app/components/complementary-certifications/item/framework.gjs
@@ -10,6 +10,7 @@ import FrameworkDetails from './framework/framework-details';
 import FrameworkHistory from './framework/framework-history';
 
 export default class ComplementaryCertificationFramework extends Component {
+  @service currentUser;
   @service store;
   @service router;
   @tracked currentConsolidatedFramework;
@@ -39,21 +40,23 @@ export default class ComplementaryCertificationFramework extends Component {
   }
 
   <template>
-    <PixBlock @variant="admin">
-      {{#unless this.currentConsolidatedFramework}}
-        <PixNotificationAlert @withIcon={{true}} class="framework__no-current">
-          {{t "components.complementary-certifications.item.framework.no-current-framework"}}
-        </PixNotificationAlert>
-        <br />
-      {{/unless}}
+    {{#if this.currentUser.adminMember.isSuperAdmin}}
+      <PixBlock @variant="admin">
+        {{#unless this.currentConsolidatedFramework}}
+          <PixNotificationAlert @withIcon={{true}} class="framework__no-current">
+            {{t "components.complementary-certifications.item.framework.no-current-framework"}}
+          </PixNotificationAlert>
+          <br />
+        {{/unless}}
 
-      <PixButtonLink
-        class="framework__creation-button"
-        @route="authenticated.complementary-certifications.item.framework.new"
-      >
-        {{t "components.complementary-certifications.item.framework.create-button"}}
-      </PixButtonLink>
-    </PixBlock>
+        <PixButtonLink
+          class="framework__creation-button"
+          @route="authenticated.complementary-certifications.item.framework.new"
+        >
+          {{t "components.complementary-certifications.item.framework.create-button"}}
+        </PixButtonLink>
+      </PixBlock>
+    {{/if}}
 
     {{#if this.currentConsolidatedFramework}}
       <FrameworkDetails @currentConsolidatedFramework={{this.currentConsolidatedFramework}} />

--- a/admin/app/routes/authenticated/complementary-certifications/item.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item.js
@@ -4,6 +4,10 @@ import { service } from '@ember/service';
 export default class ItemRoute extends Route {
   @service store;
 
+  beforeModel() {
+    return this.store.findAll('complementary-certification');
+  }
+
   model(params) {
     return this.store.findRecord('complementary-certification', params.complementary_certification_id, {
       reload: true,

--- a/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
@@ -12,7 +12,7 @@ module('Integration | Component | complementary-certifications/item/framework', 
 
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:currentUser');
-    currentUser.adminMember = { isSuperAdmin: true };
+    currentUser.adminMember = { isCertif: true };
 
     store = this.owner.lookup('service:store');
 
@@ -31,42 +31,49 @@ module('Integration | Component | complementary-certifications/item/framework', 
     store.queryRecord = sinon.stub().resolves({});
   });
 
-  test('it should display a creation form button for framework', async function (assert) {
-    // given
-    store.findRecord = sinon.stub().returns();
+  module('when user has a super admin role', function (hooks) {
+    hooks.beforeEach(function () {
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true, isCertif: false };
+    });
 
-    // when
-    const screen = await render(<template><Framework /></template>);
-
-    // then
-    assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
-  });
-
-  module('when a current consolidated framework exists', function () {
-    test('it should display the details component', async function (assert) {
+    test('it should display a framework creation button', async function (assert) {
       // given
-      store.findRecord = sinon.stub().resolves({
-        hasMany: sinon.stub().returns({
-          value: sinon.stub().returns([]),
-        }),
-      });
+      store.findRecord = sinon.stub().returns();
 
       // when
       const screen = await render(<template><Framework /></template>);
 
       // then
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
-          }),
-        )
-        .exists();
+      assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
+    });
+
+    module('when there is no current consolidated framework', function () {
+      test('it should display the information and not the details component', async function (assert) {
+        // given
+        store.findRecord = sinon.stub().returns();
+
+        // when
+        const screen = await render(<template><Framework /></template>);
+
+        // then
+        assert
+          .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
+          .exists();
+
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: t('components.complementary-certifications.item.framework.details.title'),
+            }),
+          )
+          .doesNotExist();
+      });
     });
   });
 
-  module('when there is no current consolidated framework', function () {
-    test('it should display the information and not the details component', async function (assert) {
+  module('when user has another accepted role', function () {
+    test('it should not display a framework creation button', async function (assert) {
       // given
       store.findRecord = sinon.stub().returns();
 
@@ -75,53 +82,20 @@ module('Integration | Component | complementary-certifications/item/framework', 
 
       // then
       assert
-        .dom(screen.getByText(t('components.complementary-certifications.item.framework.no-current-framework')))
-        .exists();
-
-      assert
-        .dom(
-          screen.queryByRole('heading', {
-            name: t('components.complementary-certifications.item.framework.details.title'),
-          }),
-        )
+        .dom(screen.queryByText(t('components.complementary-certifications.item.framework.create-button')))
         .doesNotExist();
     });
   });
 
-  module('#frameworkHistory', function () {
-    module('when there is no existing framework history', function () {
-      test('it should not display the framework history', async function (assert) {
+  module('for all accepted roles', function () {
+    module('when a current consolidated framework exists', function () {
+      test('it should display the details component', async function (assert) {
         // given
         store.findRecord = sinon.stub().resolves({
           hasMany: sinon.stub().returns({
             value: sinon.stub().returns([]),
           }),
         });
-        store.queryRecord = sinon.stub().resolves({ history: [] });
-
-        // when
-        const screen = await render(<template><Framework /></template>);
-
-        // then
-        assert
-          .dom(
-            screen.queryByRole('heading', {
-              name: t('components.complementary-certifications.item.framework.history.title'),
-            }),
-          )
-          .doesNotExist();
-      });
-    });
-
-    module('when there are existing framework versions', function () {
-      test('it should display the framework history', async function (assert) {
-        // given
-        store.findRecord = sinon.stub().resolves({
-          hasMany: sinon.stub().returns({
-            value: sinon.stub().returns([]),
-          }),
-        });
-        store.queryRecord = sinon.stub().resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
 
         // when
         const screen = await render(<template><Framework /></template>);
@@ -130,10 +104,62 @@ module('Integration | Component | complementary-certifications/item/framework', 
         assert
           .dom(
             screen.getByRole('heading', {
-              name: t('components.complementary-certifications.item.framework.history.title'),
+              name: t('components.complementary-certifications.item.framework.details.title'),
             }),
           )
           .exists();
+      });
+    });
+
+    module('#frameworkHistory', function () {
+      module('when there is no existing framework history', function () {
+        test('it should not display the framework history', async function (assert) {
+          // given
+          store.findRecord = sinon.stub().resolves({
+            hasMany: sinon.stub().returns({
+              value: sinon.stub().returns([]),
+            }),
+          });
+          store.queryRecord = sinon.stub().resolves({ history: [] });
+
+          // when
+          const screen = await render(<template><Framework /></template>);
+
+          // then
+          assert
+            .dom(
+              screen.queryByRole('heading', {
+                name: t('components.complementary-certifications.item.framework.history.title'),
+              }),
+            )
+            .doesNotExist();
+        });
+      });
+
+      module('when there are existing framework versions', function () {
+        test('it should display the framework history', async function (assert) {
+          // given
+          store.findRecord = sinon.stub().resolves({
+            hasMany: sinon.stub().returns({
+              value: sinon.stub().returns([]),
+            }),
+          });
+          store.queryRecord = sinon
+            .stub()
+            .resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
+
+          // when
+          const screen = await render(<template><Framework /></template>);
+
+          // then
+          assert
+            .dom(
+              screen.getByRole('heading', {
+                name: t('components.complementary-certifications.item.framework.history.title'),
+              }),
+            )
+            .exists();
+        });
       });
     });
   });

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -138,11 +138,13 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
-            assign: 'hasRoleSuperAdmin',
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
         validate: {
@@ -153,7 +155,7 @@ const register = async function (server) {
         handler: complementaryCertificationController.getCurrentConsolidatedFramework,
         tags: ['api', 'admin'],
         notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin',
+          'Cette route est restreinte aux utilisateurs authentifiés avec un rôle Super Admin, Certif, Support ou Métier',
           'Elle permet de récupérer le référentiel cadre courant pour une complémentaire',
         ],
       },
@@ -169,6 +171,7 @@ const register = async function (server) {
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
@@ -181,7 +184,7 @@ const register = async function (server) {
         handler: complementaryCertificationController.getFrameworkHistory,
         tags: ['api', 'admin'],
         notes: [
-          'Cette route est restreinte aux utilisateurs authentifiés avec un de ces rôles : Super Admin, Certif ou Métier',
+          'Cette route est restreinte aux utilisateurs authentifiés avec un rôle Super Admin, Certif, Support ou Métier',
           "Elle permet de récupérer l'historique des référentiels d'une complémentaire",
         ],
       },

--- a/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
@@ -150,6 +150,30 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
         sinon.assert.notCalled(complementaryCertificationController.getCurrentConsolidatedFramework);
       });
     });
+
+    const authorizedRoles = ['SuperAdmin', 'Certif', 'Metier', 'Support'];
+    authorizedRoles.forEach((role) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should return 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, `checkAdminMemberHasRole${role}`).returns(true);
+          sinon.stub(complementaryCertificationController, 'getCurrentConsolidatedFramework').returns('ok');
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(
+            'GET',
+            `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/current-consolidated-framework`,
+          );
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(complementaryCertificationController.getCurrentConsolidatedFramework);
+        });
+      });
+    });
   });
 
   describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/framework-history', function () {
@@ -175,8 +199,7 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
       });
     });
 
-    const authorizedRoles = ['SuperAdmin', 'Certif', 'Metier'];
-
+    const authorizedRoles = ['SuperAdmin', 'Certif', 'Metier', 'Support'];
     authorizedRoles.forEach((role) => {
       describe(`when the user has ${role} role`, function () {
         it('should return 200 HTTP status code', async function () {


### PR DESCRIPTION
## 🔆 Problème

La partie référentiel cadre de la page Certifications complémentaires a été séparée de la logique habituelle de donner un accès soit en actions soit en lecture de données seule à toute la page.

Elle n’est  accessible en actions et en lecture de données qu’aux super-admins alors que les autres rôles devraient également avoir un accès en lecture des données.

## ⛱️ Proposition

Remettre en place la logique d’accès de la page Certifications complémentaires (y compris sur la partie référentiels de certifications/ex-cadres), à savoir : 

- rôle **SUPERADMIN** : action + lecture
- rôle **SUPPORT** : lecture
- rôle **METIER** : lecture
- rôle **CERTIF** : lecture

## 🏄 Pour tester

- Sur PixAdmin, se connecter avec chacun de ces rôles
- Visualiser le détail d'une complémentaire
- Seul le super-admin est censé avoir le bouton de création de nouveau référentiel
