### PR TITLE
[FEATURE] Améliorer la position de l'illustration dans les détails du module (PIX-19520)

### DIFF
--- a/mon-pix/app/components/module/instruction/_details.scss
+++ b/mon-pix/app/components/module/instruction/_details.scss
@@ -1,3 +1,4 @@
+@use 'pix-design-tokens/breakpoints';
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/shadows';
 
@@ -5,15 +6,23 @@
   margin: 0 auto;
   padding-bottom: var(--pix-spacing-12x);
 
-  &__image {
-    background-color: var(--pix-primary-100);
-  }
-
   &__content {
     @extend %pix-shadow-sm;
 
     position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     background-color: var(--pix-primary-10);
+
+    &__image {
+      width: 100%;
+      padding: var(--pix-spacing-8x);
+
+      @include breakpoints.device-is('tablet') {
+        width: auto;
+      }
+    }
   }
 
   &__infos {
@@ -29,14 +38,12 @@
     width: auto;
     max-height: 100%;
     margin: 0 auto;
-    padding-top: var(--pix-spacing-6x);
   }
 }
 
 .module-details-content {
   &__layout {
     max-width: var(--modulix-max-content-width);
-    margin: 0 auto;
     padding: var(--pix-spacing-10x) var(--pix-spacing-6x);
   }
 }

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -71,11 +71,12 @@ export default class ModulixDetails extends Component {
     {{pageTitle @module.title}}
 
     <main id="main" class="module-details" role="main">
-      <div class="module-details__image">
-        <img alt="" class="module-details-image__illustration" src={{@module.details.image}} height="150" />
-      </div>
 
       <div class="module-details__content">
+        <div class="module-details__content__image">
+          <img alt="" class="module-details-image__illustration" src={{@module.details.image}} height="150" />
+        </div>
+
         <div class="module-details-content__layout">
           <h1 class="module-details-content-layout__title">{{@module.title}}</h1>
 


### PR DESCRIPTION
## 🔆 Problème

L'illustration dans les détails du module n'est pas correctement placée.

## ⛱️ Proposition

La positionner au-dessus sur petit écran, à gauche sur grand écran.

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur [la page de détails du module bac à sable](https://app-pr13563.review.pix.fr/modules/bac-a-sable)
2. Constater que l'illustration s'affiche à gauche du titre
3. Simuler un petit écran
4. Constater que l'illustration s'affiche au-dessus du titre