### PR TITLE
[TECH] :card_file_box: Autorise la valeur `null` pour la colonne `hasComplementaryReferential` de la table `complementary-certifications` (PIX-19527)

### DIFF
--- a/api/db/migrations/20250915000000_allow-null-has-complementary-referential-complementary-certifications.js
+++ b/api/db/migrations/20250915000000_allow-null-has-complementary-referential-complementary-certifications.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME = 'hasComplementaryReferential';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

La colonne `hasComplementaryReferential` n'est utilisé que pour signaler un complémentaire de type « CLÉA ». 
La certification CLÉA est plutôt une sorte de « double certification ». 
Pour clarifier cela, nous allons supprimer cette colonne et nous baser sur la clef de complémentaire `CLEA`.

## ⛱️ Proposition

Dans un premier temps, autoriser la valeur `null` dans la colonne `hasComplementaryReferential`


## 🌊 Remarques

Il y aura 2 PR à suivre :
- une pour arrêté de se servir de cette colonne dans le code,
- une autre pour réaliser la suppression de la colonne.

C'est Claude qui a fait le code. J'ai relu et fait la PR.

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
