### PR TITLE
[FEATURE] Autoriser l'ajout d'une description et d'une illustration dans la création de Parcours Combiné (PIX-19525).

### DIFF
--- a/api/db/migrations/20250915123625_alter-table-quest-column-illustration.js
+++ b/api/db/migrations/20250915123625_alter-table-quest-column-illustration.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'quests';
+const COLUMN_NAME = 'illustration';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).alter();
+  });
+};
+
+export { down, up };

--- a/api/src/quest/domain/models/CombinedCourseTemplate.js
+++ b/api/src/quest/domain/models/CombinedCourseTemplate.js
@@ -6,8 +6,10 @@ import { buildRequirement, COMPARISONS, TYPES } from './Requirement.js';
 export class CombinedCourseTemplate {
   #quest;
   #name;
+  #description;
+  #illustration;
 
-  constructor({ name, successRequirements }) {
+  constructor({ name, successRequirements, description, illustration }) {
     const now = new Date();
     this.#name = name;
     this.#quest = new Quest({
@@ -18,6 +20,8 @@ export class CombinedCourseTemplate {
       eligibilityRequirements: [],
       successRequirements,
     });
+    this.#description = description;
+    this.#illustration = illustration;
   }
 
   get targetProfileIds() {
@@ -28,7 +32,10 @@ export class CombinedCourseTemplate {
 
   toCombinedCourse(code, organizationId, campaigns) {
     const quest = this.toCombinedCourseQuestFormat(campaigns);
-    return new CombinedCourse({ name: this.#name, code, organizationId }, quest);
+    return new CombinedCourse(
+      { name: this.#name, code, organizationId, description: this.#description, illustration: this.#illustration },
+      quest,
+    );
   }
 
   toCombinedCourseQuestFormat(campaigns) {

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -58,6 +58,8 @@ const _toDTO = (combinedCourse) => {
     name: combinedCourse.name,
     eligibilityRequirements: JSON.stringify([]),
     successRequirements: JSON.stringify(questDTO.successRequirements),
+    description: combinedCourse.description,
+    illustration: combinedCourse.illustration,
   };
 };
 

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -35,7 +35,7 @@ describe('Quest | Acceptance | Application | Combined course Route ', function (
         await databaseBuilder.commit();
 
         const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${organizationId};"{""name"":""Combinix"",""successRequirements"":[]}";${userId}`;
+${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}`;
 
         const options = {
           method: 'POST',
@@ -54,6 +54,8 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[]}";${userId}
 
         expect(createdQuest.code).not.to.be.null;
         expect(createdQuest.name).to.equal('Combinix');
+        expect(createdQuest.description).to.equal('ma description');
+        expect(createdQuest.illustration).to.equal('mon_illu.svg');
         expect(createdQuest.successRequirements).to.deep.equal([]);
       });
     });

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -22,7 +22,7 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     await databaseBuilder.commit();
 
     const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
 ${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
 `;
 
@@ -94,6 +94,8 @@ ${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requi
         },
         ...expectedModules,
       ],
+      description: 'ma description',
+      illustration: 'mon_illu.svg',
     };
     const expectedSecondQuestForFirstOrganization = {
       name: 'Combinix',
@@ -142,6 +144,8 @@ ${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requi
         },
         ...expectedModules,
       ],
+      description: 'ma description',
+      illustration: 'mon_illu.svg',
     };
 
     // then
@@ -152,27 +156,45 @@ ${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requi
       .where('organizationId', secondOrganizationId)
       .first();
 
+    // 1st Organization
+    // Quest
     expect(firstCreatedQuestForFirstOrganization.code).not.to.be.null;
     expect(firstCreatedQuestForFirstOrganization.name).to.equal(expectedFirstQuestForFirstOrganization.name);
     expect(firstCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
       expectedFirstQuestForFirstOrganization.successRequirements,
     );
+    expect(firstCreatedQuestForFirstOrganization.description).to.equal(
+      expectedFirstQuestForFirstOrganization.description,
+    );
+    expect(firstCreatedQuestForFirstOrganization.illustration).to.equal(
+      expectedFirstQuestForFirstOrganization.illustration,
+    );
+    //Campaign
     expect(firstCreatedCampaignForFirstOrganization.name).to.equal(targetProfile.internalName);
     expect(firstCreatedCampaignForFirstOrganization.title).to.equal(targetProfile.name);
 
+    // Quest
     expect(secondCreatedQuestForFirstOrganization.code).not.to.be.null;
     expect(secondCreatedQuestForFirstOrganization.name).to.equal(expectedSecondQuestForFirstOrganization.name);
     expect(secondCreatedQuestForFirstOrganization.successRequirements).to.deep.equal(
       secondCreatedQuestForFirstOrganization.successRequirements,
     );
+    expect(secondCreatedQuestForFirstOrganization.description).null;
+    expect(secondCreatedQuestForFirstOrganization.illustration).null;
+    //Campaign
     expect(secondCreatedCampaignForFirstOrganization.name).to.equal(targetProfile.internalName);
     expect(secondCreatedCampaignForFirstOrganization.title).to.equal(targetProfile.name);
 
+    // 2nd Organization
+    // Quest
     expect(createdQuestForSecondOrganization.code).not.to.be.null;
     expect(createdQuestForSecondOrganization.name).to.equal(expectedQuestForSecondOrganization.name);
     expect(createdQuestForSecondOrganization.successRequirements).to.deep.equal(
       expectedQuestForSecondOrganization.successRequirements,
     );
+    expect(createdQuestForSecondOrganization.description).to.equal(expectedQuestForSecondOrganization.description);
+    expect(createdQuestForSecondOrganization.illustration).to.equal(expectedQuestForSecondOrganization.illustration);
+    // Campaign
     expect(createdCampaignForSecondOrganization.name).to.equal(targetProfile.internalName);
     expect(createdCampaignForSecondOrganization.title).to.equal(targetProfile.name);
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -153,6 +153,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
           name: 'firstCombinedCourse',
           code: 'firstCode',
           organizationId: firstOrganizationId,
+          illustration: 'mon_illu.svg',
+          description: 'ma description',
         },
         quest,
       );
@@ -174,9 +176,13 @@ describe('Quest | Integration | Repository | combined-course', function () {
 
       expect(firstSavedCombinedCourse.name).to.equal('firstCombinedCourse');
       expect(firstSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
+      expect(firstSavedCombinedCourse.description).equal('ma description');
+      expect(firstSavedCombinedCourse.illustration).equal('mon_illu.svg');
 
       expect(secondSavedCombinedCourse.name).to.equal('secondCombinedCourse');
       expect(secondSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
+      expect(secondSavedCombinedCourse.description).null;
+      expect(secondSavedCombinedCourse.illustration).null;
     });
   });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
@@ -104,11 +104,15 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
           },
         },
       ];
+      const description = 'bla bla bla';
+      const illustration = 'illu.svg';
 
       // when
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name,
         successRequirements,
+        description,
+        illustration,
       });
       const combinedCourse = combinedCourseTemplate.toCombinedCourse(code, organizationId, campaigns);
 
@@ -166,6 +170,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
 
       expect(combinedCourse.quest.toDTO().successRequirements).to.deep.equal(questDTO.successRequirements);
       expect(combinedCourse.name).to.equal(name);
+      expect(combinedCourse.description).to.equal(description);
+      expect(combinedCourse.illustration).to.equal(illustration);
       expect(combinedCourse.code).to.equal(code);
       expect(combinedCourse.organizationId).to.equal(organizationId);
     });

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -54,7 +54,7 @@ export default class CombinedCourses extends Component {
             </PixButton>
           {{/if}}
         </div>
-        <img alt="" role="presentation" src={{@combinedCourse.illustration}} />
+        <img alt="" role="presentation" src={{@combinedCourse.illustration}} width="320" />
       </header>
       <div class="combined-course__divider" />
       {{#each @combinedCourse.items as |item|}}

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -13,6 +13,7 @@
   &__header {
     display: flex;
     gap: var(--pix-spacing-8x);
+    justify-content: space-between;
 
     h1 {
       @extend %pix-title-m;


### PR DESCRIPTION
## 🔆 Problème

On a ajouté deux colonnes, mais nous ne pouvons pas rajouter les description / illustration lors de la création via csv

## ⛱️ Proposition

Permettre l'ajout de la description illustration lors de la création de parcours combiné

## 🌊 Remarques

Modification de la migration pour changer le string en text pour l'illustration. en effet une url pourrait faire plus de 255 caractèress.

## 🏄 Pour tester

Aller sur PixAdmin , faire une création de parcours combiné avec description / illustration 
Et valider que tout s'affiche correctement.