### PR TITLE
[BUGFIX] Corriger une coquille dans la consigne du QCU découverte (PIX-19526)

### DIFF
--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -279,7 +279,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     const screen = await render(<template><ModulixElement @element={{element}} /></template>);
 
     // then
-    assert.deepEqual(screen.getAllByText('Sélectionner la réponse qui vous semble la plus juste.').length, 2);
+    assert.deepEqual(screen.getAllByText('Sélectionnez la réponse qui vous semble la plus juste.').length, 2);
     assert.ok(screen.getByRole('button', { name: element.proposals[0].content }));
   });
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1798,7 +1798,7 @@
         "direction": "Sélectionnez une seule réponse."
       },
       "qcuDiscovery": {
-        "direction": "Sélectionner la réponse qui vous semble la plus juste."
+        "direction": "Sélectionnez la réponse qui vous semble la plus juste."
       },
       "qrocm": {
         "direction": "Remplissez {count, plural, =1 {le champ vide} other {les champs vides}}."


### PR DESCRIPTION
## 🔆 Problème

> La consigne est suivie du texte : "Sélectionne**r** la réponse qui vous semble la plus juste."  

## ⛱️ Proposition

> Ce devrait être "Sélectionne**z** la réponse qui vous semble la plus juste."

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur le [module bac à sable](https://app-pr13566.review.pix.fr/modules/bac-a-sable).
2. Aller jusqu'au QCU Découverte
3. Constater que la consigne est "Sélectionne**z** la réponse qui vous semble la plus juste."