### PR TITLE
[FEATURE] Créer une route pour récupérer toutes les équipes d'administration (PIX-19495)

### DIFF
--- a/api/db/database-builder/factory/build-administration-team.js
+++ b/api/db/database-builder/factory/build-administration-team.js
@@ -1,0 +1,22 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildAdministrationTeam = function ({
+  id = databaseBuffer.getNextId(),
+  name = 'Équipe Alpha',
+  createdAt = new Date('2020-01-01'),
+  updatedAt = new Date('2020-01-02'),
+} = {}) {
+  const values = {
+    id,
+    name,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'administration_teams',
+    values,
+  });
+};
+
+export { buildAdministrationTeam };

--- a/api/db/seeds/data/team-acces/build-administration-teams.js
+++ b/api/db/seeds/data/team-acces/build-administration-teams.js
@@ -1,0 +1,11 @@
+function _buildAdministrationTeam(databaseBuilder, { name }) {
+  databaseBuilder.factory.buildAdministrationTeam({
+    name,
+  });
+}
+
+export function buildAdministrationTeams(databaseBuilder) {
+  _buildAdministrationTeam(databaseBuilder, { name: 'Team Rocket' });
+  _buildAdministrationTeam(databaseBuilder, { name: 'Team Alpha' });
+  _buildAdministrationTeam(databaseBuilder, { name: 'Team Solo' });
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -1,3 +1,4 @@
+import { buildAdministrationTeams } from './build-administration-teams.js';
 import { buildArchivedOrganizations } from './build-archived-organizations.js';
 import { buildBlockedUsers } from './build-blocked-users.js';
 import { buildCertificationCenters } from './build-certification-centers.js';
@@ -23,6 +24,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   await buildCertificationCenters(databaseBuilder);
   await buildOidcProviders(databaseBuilder);
   buildOrganizations(databaseBuilder);
+  buildAdministrationTeams(databaseBuilder);
   buildLtiPlatformRegistrations(databaseBuilder);
 }
 

--- a/api/src/organizational-entities/application/administration-team/administration-team.admin.controller.js
+++ b/api/src/organizational-entities/application/administration-team/administration-team.admin.controller.js
@@ -1,0 +1,11 @@
+import { usecases } from '../../domain/usecases/index.js';
+import * as administrationTeamSerializer from '../../infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
+
+const findAllAdministrationTeams = async function (request, h, dependencies = { administrationTeamSerializer }) {
+  const administrationTeams = await usecases.findAllAdministrationTeams();
+  return dependencies.administrationTeamSerializer.serialize(administrationTeams);
+};
+
+const administrationTeamsController = { findAllAdministrationTeams };
+
+export { administrationTeamsController };

--- a/api/src/organizational-entities/application/administration-team/administration-team.admin.route.js
+++ b/api/src/organizational-entities/application/administration-team/administration-team.admin.route.js
@@ -1,0 +1,35 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { administrationTeamsController } from './administration-team.admin.controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/administration-teams',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => administrationTeamsController.findAllAdministrationTeams(request, h),
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Renvoie toutes les administration teams.',
+        ],
+        tags: ['api', 'administration-teams'],
+      },
+    },
+  ]);
+};
+
+const name = 'administration-teams-admin-api';
+
+export { name, register };

--- a/api/src/organizational-entities/application/routes.js
+++ b/api/src/organizational-entities/application/routes.js
@@ -1,7 +1,13 @@
+import * as administrationTeamAdminRoutes from './administration-team/administration-team.admin.route.js';
 import * as certificationCenterAdminRoutes from './certification-center/certification-center.admin.route.js';
 import * as organizationAdminRoutes from './organization/organization.admin.route.js';
 import * as tagAdminRoutes from './tag/tag.admin.route.js';
 
-const organizationalEntitiesRoutes = [certificationCenterAdminRoutes, organizationAdminRoutes, tagAdminRoutes];
+const organizationalEntitiesRoutes = [
+  certificationCenterAdminRoutes,
+  organizationAdminRoutes,
+  administrationTeamAdminRoutes,
+  tagAdminRoutes,
+];
 
 export { organizationalEntitiesRoutes };

--- a/api/src/organizational-entities/domain/models/AdministrationTeam.js
+++ b/api/src/organizational-entities/domain/models/AdministrationTeam.js
@@ -1,0 +1,8 @@
+class AdministrationTeam {
+  constructor({ id, name }) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+export { AdministrationTeam };

--- a/api/src/organizational-entities/domain/usecases/find-all-administration-teams.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/find-all-administration-teams.usecase.js
@@ -1,0 +1,5 @@
+const findAllAdministrationTeams = async function ({ administrationTeamRepository }) {
+  return administrationTeamRepository.findAll();
+};
+
+export { findAllAdministrationTeams };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as codeGenerator from '../../../shared/domain/services/code-generator.j
 import { adminMemberRepository } from '../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
+import * as administrationTeamRepository from '../../infrastructure/repositories/administration-team-repository.js';
 import * as certificationCenterRepository from '../../infrastructure/repositories/certification-center.repository.js';
 import { certificationCenterApiRepository } from '../../infrastructure/repositories/certification-center-api.repository.js';
 import * as certificationCenterForAdminRepository from '../../infrastructure/repositories/certification-center-for-admin.repository.js';
@@ -31,13 +32,14 @@ import * as organizationValidator from '../validators/organization-with-tags-and
  * @typedef {import ('../../infrastructure/repositories/organization-for-admin.repository.js')} OrganizationForAdminRepository
  * @typedef {import ('../../infrastructure/repositories/tag.repository.js')} TagRepository
  * @typedef {import ('../../infrastructure/repositories/target-profile-share-repository.js')} TargetProfileShareRepository
-
+ * @typedef {import ('../../infrastructure/repositories/pix-team-repository.js')} PixTeamRepository
  * @typedef {import ('../../../shared/infrastructure/repositories/organization-repository.js')} OrganizationRepository
  * @typedef {import ('../../../school/infrastructure/repositories/school-repository.js')} SchoolRepository
  * @typedef {import ('../validators/organization-creation-validator.js')} OrganizationCreationValidator
  */
 
 const repositories = {
+  administrationTeamRepository,
   adminMemberRepository,
   organizationValidator,
   organizationCreationValidator,
@@ -71,6 +73,7 @@ import { createCertificationCenter } from './create-certification-center.usecase
 import { createOrganization } from './create-organization.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizations-with-tags-and-target-profiles.usecase.js';
 import { createTag } from './create-tag.js';
+import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
 import { findOrganizationFeatures } from './find-organization-features.js';
@@ -102,6 +105,7 @@ const usecasesWithoutInjectedDependencies = {
   findOrganizationFeatures,
   findPaginatedFilteredCertificationCenters,
   findPaginatedFilteredOrganizations,
+  findAllAdministrationTeams,
   getCenterForAdmin,
   getOrganizationById,
   getOrganizationDetails,

--- a/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
@@ -1,0 +1,16 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { AdministrationTeam } from '../../domain/models/AdministrationTeam.js';
+
+const findAll = async function () {
+  const administrationTeams = await knex.select('id', 'name').from('administration_teams').orderBy('name', 'asc');
+
+  return administrationTeams.map(_toDomain);
+};
+
+const _toDomain = function (administrationTeamDTO) {
+  return new AdministrationTeam({
+    ...administrationTeamDTO,
+  });
+};
+
+export { findAll };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (administrationTeam) {
+  return new Serializer('administration-teams', {
+    attributes: ['name'],
+  }).serialize(administrationTeam);
+};
+
+export { serialize };

--- a/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/administration-team/administration-team.admin.route.test.js
@@ -1,0 +1,48 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Organizational Entities | Application | Route | Admin | AdministrationTeam', function () {
+  describe('GET /api/admin/administration-teams', function () {
+    it('returns a list of administration teams with 200 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+      const team1 = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team1' });
+      const team2 = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team2' });
+      await databaseBuilder.commit();
+      const userId = (await insertUserWithRoleSuperAdmin()).id;
+      const options = {
+        method: 'GET',
+        url: '/api/admin/administration-teams',
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+      };
+      const expectedTeams = [
+        {
+          attributes: {
+            name: team1.name,
+          },
+          id: team1.id.toString(),
+          type: 'administration-teams',
+        },
+        {
+          attributes: {
+            name: team2.name,
+          },
+          id: team2.id.toString(),
+          type: 'administration-teams',
+        },
+      ];
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal(expectedTeams);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/domain/usecases/find-all-administration-teams.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/find-all-administration-teams.test.js
@@ -1,0 +1,38 @@
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | UseCases | find-all-administration-teams', function () {
+  context('when there are administration teams', function () {
+    it('should return all administration teams ordered by name', async function () {
+      // given
+      const firstAdministrationTeam = databaseBuilder.factory.buildAdministrationTeam({
+        name: 'Équipe B',
+        createdAt: new Date('2020-01-01'),
+      });
+      const secondAdministrationTeam = databaseBuilder.factory.buildAdministrationTeam({
+        name: 'Équipe A',
+        createdAt: new Date('2021-01-02'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await usecases.findAllAdministrationTeams();
+
+      // then
+      expect(result).to.have.deep.members([
+        domainBuilder.buildAdministrationTeam({ id: secondAdministrationTeam.id, name: 'Équipe A' }),
+        domainBuilder.buildAdministrationTeam({ id: firstAdministrationTeam.id, name: 'Équipe B' }),
+      ]);
+    });
+  });
+
+  context('when there is no administration team', function () {
+    it('should return an empty array', async function () {
+      // when
+      const result = await usecases.findAllAdministrationTeams();
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
@@ -1,0 +1,36 @@
+import * as administrationTeamRepository from '../../../../../src/organizational-entities/infrastructure/repositories/administration-team-repository.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Repository | administration-team-repository', function () {
+  describe('#findAll', function () {
+    it('should return all administration teams ordered by name', async function () {
+      // given
+      const firstAdministrationTeam = databaseBuilder.factory.buildAdministrationTeam({
+        name: 'Équipe B',
+        createdAt: new Date('2020-01-01'),
+      });
+      const secondAdministrationTeam = databaseBuilder.factory.buildAdministrationTeam({
+        name: 'Équipe A',
+        createdAt: new Date('2021-01-02'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await administrationTeamRepository.findAll();
+
+      // then
+      expect(result).to.have.deep.members([
+        domainBuilder.buildAdministrationTeam({ id: secondAdministrationTeam.id, name: 'Équipe A' }),
+        domainBuilder.buildAdministrationTeam({ id: firstAdministrationTeam.id, name: 'Équipe B' }),
+      ]);
+    });
+
+    it('should return an empty array if there is no pix team', async function () {
+      // when
+      const result = await administrationTeamRepository.findAll();
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/administration-team/administration-team.admin.controller.test.js
+++ b/api/tests/organizational-entities/unit/application/administration-team/administration-team.admin.controller.test.js
@@ -1,0 +1,23 @@
+import { administrationTeamsController } from '../../../../../src/organizational-entities/application/administration-team/administration-team.admin.controller.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Application | Controller | Admin | AdministrationTeam', function () {
+  describe('#findAllAdministrationTeams', function () {
+    it('calls findAllAdministrationTeams usecase and AdministrationTeam serializer', async function () {
+      // given
+      const team1 = domainBuilder.buildAdministrationTeam({ id: 1, name: 'Team1' });
+      const team2 = domainBuilder.buildAdministrationTeam({ id: 2, name: 'Team2' });
+      const teams = [team1, team2];
+      sinon.stub(usecases, 'findAllAdministrationTeams').resolves(teams);
+      const administrationTeamSerializer = { serialize: sinon.stub() };
+
+      // when
+      await administrationTeamsController.findAllAdministrationTeams({}, hFake, { administrationTeamSerializer });
+
+      // then
+      expect(usecases.findAllAdministrationTeams).to.have.been.calledOnce;
+      expect(administrationTeamSerializer.serialize).to.have.been.calledWithExactly(teams);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/administration-team-serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/administration-team-serializer.test.js
@@ -1,0 +1,30 @@
+import * as serializer from '../../../../../../src/organizational-entities/infrastructure/serializers/jsonapi/administration-team/administration-team-serializer.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Serializer | JSONAPI | administration-team', function () {
+  describe('#serialize', function () {
+    it('converts a administration team model to JSON', function () {
+      // given
+      const administrationTeam = domainBuilder.buildAdministrationTeam({
+        id: 42,
+        name: 'Team Rocket',
+      });
+
+      const expectedSerializedTeam = {
+        data: {
+          attributes: {
+            name: 'Team Rocket',
+          },
+          id: '42',
+          type: 'administration-teams',
+        },
+      };
+
+      // when
+      const json = serializer.serialize(administrationTeam);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedTeam);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-administration-team.js
+++ b/api/tests/tooling/domain-builder/factory/build-administration-team.js
@@ -1,0 +1,7 @@
+import { AdministrationTeam } from '../../../../src/organizational-entities/domain/models/AdministrationTeam.js';
+
+const buildAdministrationTeam = function ({ id = 1, name = 'Équipe Pix' } = {}) {
+  return new AdministrationTeam({ id, name });
+};
+
+export { buildAdministrationTeam };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -5,6 +5,7 @@ import { buildAccountRecoveryDemand } from './build-account-recovery-demand.js';
 import { buildActivity } from './build-activity.js';
 import { buildActivityAnswer } from './build-activity-answer.js';
 import { buildAdminMember } from './build-admin-member.js';
+import { buildAdministrationTeam } from './build-administration-team.js';
 import { buildAllowedCertificationCenterAccess } from './build-allowed-certification-center-access.js';
 import { buildAnswer } from './build-answer.js';
 import { buildArea } from './build-area.js';
@@ -341,6 +342,7 @@ export {
   buildAccountRecoveryDemand,
   buildActivity,
   buildActivityAnswer,
+  buildAdministrationTeam,
   buildAdminMember,
   buildAllowedCertificationCenterAccess,
   buildAnswer,


### PR DESCRIPTION
## 🔆 Problème

Dans le formulaire de création d'une organisation, on a besoin d'afficher une liste d'équipe

## ⛱️ Proposition

Créer un endpoint GET admin/administration-teams pour charger la liste des équipes

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
- Lancer la commande et vérifier que l'on reçoit bien une liste d'équipes
 
```
TOKEN=$(curl --insecure 'https://admin-pr13567.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin'  -H 'x-forwarded-host: admin' -H 'x-forwarded-proto: HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr13567.review.pix.fr/api/admin/administration-teams \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X GET \

```