### PR TITLE
[FEATURE] Supprimer le lien questionnaire de fin de module (PIX-19510)

### DIFF
--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -42,18 +42,5 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
       {{/if}}
 
     </div>
-
-    {{#if @module.isBeta}}
-      <div class="module-recap__link-form">
-        <PixButtonLink
-          @size="large"
-          @variant="tertiary"
-          target="_blank"
-          @href="https://form-eu.123formbuilder.com/82940/votre-avis-sur-les-modules-de-formation-pix?3285978={{@passage.id}}"
-        >
-          {{t "pages.modulix.recap.goToForm"}}
-        </PixButtonLink>
-      </div>
-    {{/if}}
   </main>
 </template>

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -60,22 +60,6 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       assert.ok(screen.getByRole('heading', { level: 1, name: t('pages.modulix.recap.title') }));
     });
 
-    module('when module has status beta', function () {
-      test('should display the links to homepage button and to form builder', async function (assert) {
-        // when
-        const formLink = screen.getByRole('link', { name: t('pages.modulix.recap.goToForm') });
-
-        // then
-        const passage = server.schema.passages.all().models[0];
-        assert.ok(formLink);
-        assert.ok(screen.queryByRole('link', { name: t('pages.modulix.recap.goToHomepage') }));
-        assert.strictEqual(
-          formLink.getAttribute('href'),
-          `https://form-eu.123formbuilder.com/82940/votre-avis-sur-les-modules-de-formation-pix?3285978=${passage.id}`,
-        );
-      });
-    });
-
     test('should navigate to homepage by clicking on go to homepage button', async function (assert) {
       // when
       await click(screen.getByRole('link', { name: t('pages.modulix.recap.goToHomepage') }));

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -27,25 +27,6 @@ module('Integration | Component | Module | Recap', function (hooks) {
       // then
       assert.dom(screen.getByRole('alert')).exists();
     });
-
-    test('should display link to user form', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-        description: '<p>Description</p>',
-        duration: 12,
-        level: 'novice',
-        objectives: ['Objectif 1'],
-      };
-      const module = store.createRecord('module', { title: 'Module title', isBeta: true, details });
-
-      // when
-      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
-
-      // then
-      assert.dom(screen.getByRole('link', { name: 'Répondre au questionnaire' })).exists();
-    });
   });
 
   module('when module does not have beta status', function () {
@@ -66,25 +47,6 @@ module('Integration | Component | Module | Recap', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('alert')).doesNotExist();
-    });
-
-    test('should not display link to user form', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-        description: '<p>Description</p>',
-        duration: 12,
-        level: 'novice',
-        objectives: ['Objectif 1'],
-      };
-      const module = store.createRecord('module', { title: 'Module title', isBeta: false, details });
-
-      // when
-      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
-
-      // then
-      assert.dom(screen.queryByRole('link', { name: 'Répondre au questionnaire' })).doesNotExist();
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1805,7 +1805,6 @@
       },
       "recap": {
         "backToModuleDetails": "Quit",
-        "goToForm": "Answer the questionnaire",
         "goToHomepage": "Continue",
         "subtitle": "You have worked on the following objectives:",
         "title": "Module completed!"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1792,7 +1792,6 @@
       "recap": {
         "backToModuleDetails": "Deje de",
         "goToHomepage": "Continuar",
-        "goToForm": "Responder al cuestionario",
         "subtitle": "Has trabajado en los siguientes objetivos:",
         "title": "¡Módulo completado!"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1805,7 +1805,6 @@
       },
       "recap": {
         "backToModuleDetails": "Quitter",
-        "goToForm": "Répondre au questionnaire",
         "goToHomepage": "Continuer",
         "subtitle": "Vous avez travaillé les objectifs suivants :",
         "title": "Module terminé !"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1796,7 +1796,6 @@
       "recap": {
         "backToModuleDetails": "Stoppen met",
         "goToHomepage": "Voortzetten",
-        "goToForm": "Beantwoord de vragenlijst",
         "subtitle": "Je hebt aan de volgende doelstellingen gewerkt:",
         "title": "Module voltooid!"
       },


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre de l’expérimentation du 22/09 un autre questionnaire va être mis en place en fin de parcours combiné + protocole de tests physique.

## ⛱️ Proposition

Supprimer le lien existant sur la page récap.

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13568.review.pix.fr/modules/bac-a-sable)
2. Terminer le module
3. Constater que le lien vers le formulaire n'apparaît pas
