### PR TITLE
[TECH] :card_file_box:  Suppression de la colonne `hasComplementaryReferential` de la table `complementary-certifications` (Pix-19530)

### DIFF
--- a/api/db/migrations/20250916154116_remove-column-has-complementary-referential-from-complementary-certifications.js
+++ b/api/db/migrations/20250916154116_remove-column-has-complementary-referential-from-complementary-certifications.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME = 'hasComplementaryReferential';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME);
+  });
+
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'DROIT' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'EDU_1ER_DEGRE' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'EDU_2ND_DEGRE' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, true).where({ key: 'PRO_SANTE' });
+  await knex(TABLE_NAME).update(COLUMN_NAME, false).where({ key: 'CLEA' });
+
+  await knex.schema.alterTable(TABLE_NAME, async (table) => {
+    await table.boolean(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

La colonne `hasComplementaryReferential` n'est plus utilisée

## ⛱️ Proposition

Supprimer la colonne `hasComplementaryReferential` de la table `complementary-certifications`.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
