### PR TITLE
[FEATURE] Améliorer la gestion de la locale lors de l'initialisation des applications (PIX-19511)

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -7,13 +7,11 @@ export default class ApplicationRoute extends Route {
   @service currentUser;
   @service locale;
 
-  async beforeModel() {
+  async beforeModel(transition) {
+    const queryParams = transition?.to?.queryParams;
+    this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-
     await this.featureToggles.load();
-
     await this.currentUser.load();
-
-    this.locale.setBestLocale({ user: this.currentUser.user });
   }
 }

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -6,13 +6,17 @@ import ENV from 'pix-certif/config/environment';
 export default class ApplicationRoute extends Route {
   @service featureToggles;
   @service currentDomain;
+  @service currentUser;
+  @service locale;
   @service session;
   @service store;
 
   async beforeModel(transition) {
+    const queryParams = transition?.to?.queryParams;
+    this.locale.setBestLocale({ queryParams });
     await this.session.setup();
     await this.featureToggles.load();
-    await this.session.loadCurrentUserAndSetLocale(transition);
+    await this.currentUser.load();
   }
 
   async model() {

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -4,11 +4,10 @@ import SessionService from 'ember-simple-auth/services/session';
 
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
-  @service locale;
   @service featureToggles;
 
   async handleAuthentication() {
-    await this.loadCurrentUserAndSetLocale();
+    await this.currentUser.load();
 
     const isCurrentUserMemberOfACertificationCenter =
       this.currentUser.certificationPointOfContact.isMemberOfACertificationCenter;
@@ -16,13 +15,6 @@ export default class CurrentSessionService extends SessionService {
       ? 'authenticated'
       : 'login-session-supervisor';
     super.handleAuthentication(routeAfterAuthentication);
-  }
-
-  async loadCurrentUserAndSetLocale(transition) {
-    await this.currentUser.load();
-
-    const queryParams = transition?.to?.queryParams;
-    this.locale.setBestLocale({ queryParams });
   }
 
   handleInvalidation() {

--- a/certif/tests/unit/services/session-test.js
+++ b/certif/tests/unit/services/session-test.js
@@ -17,17 +17,15 @@ module('Unit | Service | session', function (hooks) {
 
     service = this.owner.lookup('service:session');
     service.currentUser = { load: sinon.stub(), certificationPointOfContact: user };
-    service.locale = { setBestLocale: sinon.stub(), isSupportedLocale: sinon.stub().returns(true) };
   });
 
   module('#handleAuthentication', function () {
-    test('loads current user and sets locale', async function (assert) {
+    test('loads current user', async function (assert) {
       // when
       await service.handleAuthentication();
 
       // then
       sinon.assert.calledOnce(service.currentUser.load);
-      sinon.assert.calledWith(service.locale.setBestLocale, { queryParams: undefined });
       assert.ok(true);
     });
   });
@@ -47,40 +45,6 @@ module('Unit | Service | session', function (hooks) {
 
       // then
       assert.true(service.store.clear.calledOnce);
-    });
-  });
-
-  module('#loadCurrentUserAndSetLocale', function () {
-    module('when locale is supported', function () {
-      test('loads the current user, sets locale', async function (assert) {
-        // given
-        const queryParams = { lang: 'fr' };
-
-        // when
-        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
-
-        // then
-        sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
-        assert.ok(true);
-      });
-    });
-
-    module('when locale is not supported', function () {
-      test('loads the current user, sets locale', async function (assert) {
-        // given
-        const queryParams = { lang: 'es' };
-
-        service.locale.isSupportedLocale = sinon.stub().returns(false);
-
-        // when
-        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
-
-        // then
-        sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
-        assert.ok(true);
-      });
     });
   });
 

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -13,6 +13,8 @@ export default class ApplicationRoute extends Route {
   @service pixMetrics;
   @service store;
   @service router;
+  @service currentUser;
+  @service locale;
 
   constructor() {
     super(...arguments);
@@ -31,15 +33,13 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    const queryParams = transition?.to?.queryParams;
+    this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-
     await this.featureToggles.load().catch();
-
     await this.oidcIdentityProviders.load().catch();
-
     await this.authentication.handleAnonymousAuthentication(transition);
-
-    await this.session.handleUserLanguageAndLocale(transition);
+    await this.currentUser.load();
   }
 
   async model() {

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -53,11 +53,6 @@ export default class CurrentSessionService extends SessionService {
     super.handleInvalidation(routeAfterInvalidation);
   }
 
-  async handleUserLanguageAndLocale(transition = null) {
-    const queryParams = transition?.to?.queryParams;
-    await this._loadCurrentUserAndLocale(queryParams);
-  }
-
   get redirectionUrl() {
     const baseUrl = window.location.protocol + '//' + window.location.host;
 

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -11,7 +11,6 @@ export default class CurrentSessionService extends SessionService {
   @service url;
   @service router;
   @service oidcIdentityProviders;
-  @service locale;
 
   routeAfterAuthentication = 'authenticated.user-dashboard';
 
@@ -23,7 +22,7 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleAuthentication() {
-    await this._loadCurrentUserAndLocale();
+    await this.currentUser.load();
 
     const nextURL = this.data.nextURL;
     const isFromIdentityProviderLoginPage = this.oidcIdentityProviders.list.some((identityProvider) => {
@@ -109,11 +108,6 @@ export default class CurrentSessionService extends SessionService {
   revokeGarAuthenticationContext() {
     externalUserTokenFromGarStorage.remove();
     userIdForLearnerAssociationStorage.remove();
-  }
-
-  async _loadCurrentUserAndLocale(queryParams) {
-    await this.currentUser.load();
-    this.locale.setBestLocale({ user: this.currentUser.user, queryParams });
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -14,7 +14,6 @@ module('Unit | Services | session', function (hooks) {
   hooks.beforeEach(function () {
     sessionService = this.owner.lookup('service:session');
     sessionService.currentUser = { load: sinon.stub(), user: null };
-    sessionService.locale = { setBestLocale: sinon.stub() };
     sessionService._getRouteAfterInvalidation = sinon.stub();
 
     routerService = this.owner.lookup('service:router');
@@ -83,17 +82,12 @@ module('Unit | Services | session', function (hooks) {
       this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
     });
 
-    test('loads current user and sets user locale', async function (assert) {
-      // given
-      const user = { id: 1 };
-      sessionService.currentUser.user = user;
-
-      // when
+    test('loads current user', async function (assert) {
+      // given // when
       await sessionService.handleAuthentication();
 
       // then
       sinon.assert.calledOnce(sessionService.currentUser.load);
-      sinon.assert.calledWith(sessionService.locale.setBestLocale, { user, queryParams: undefined });
       assert.ok(true);
     });
 

--- a/mon-pix/tests/unit/services/session-test.js
+++ b/mon-pix/tests/unit/services/session-test.js
@@ -139,23 +139,6 @@ module('Unit | Services | session', function (hooks) {
     });
   });
 
-  module('#handleUserLanguageAndLocale', function () {
-    test('loads the current user and sets the language from query param', async function (assert) {
-      // given
-      const user = { id: 1 };
-      sessionService.currentUser.user = user;
-      const transition = { to: { queryParams: { lang: 'es' } } };
-
-      // when
-      await sessionService.handleUserLanguageAndLocale(transition);
-
-      // then
-      sinon.assert.calledOnce(sessionService.currentUser.load);
-      sinon.assert.calledWith(sessionService.locale.setBestLocale, { queryParams: { lang: 'es' }, user });
-      assert.ok(true);
-    });
-  });
-
   module('#requireAuthenticationAndApprovedTermsOfService', function () {
     module('when user is authenticated and must validate the terms of service', function () {
       test('should redirect user to terms of service page', async function (assert) {

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -27,9 +27,11 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    const queryParams = transition?.to?.queryParams;
+    this.locale.setBestLocale({ queryParams });
     await this.session.setup();
     await this.featureToggles.load();
-    await this.session.loadCurrentUserAndSetLocale(transition);
+    await this.currentUser.load();
   }
 
   async model() {

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -4,22 +4,14 @@ import SessionService from 'ember-simple-auth/services/session';
 
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
-  @service locale;
   @service url;
 
   routeAfterAuthentication = 'authenticated';
 
   async handleAuthentication() {
-    await this.loadCurrentUserAndSetLocale();
-
-    super.handleAuthentication(this.routeAfterAuthentication);
-  }
-
-  async loadCurrentUserAndSetLocale(transition) {
     await this.currentUser.load();
 
-    const queryParams = transition?.to?.queryParams;
-    this.locale.setBestLocale({ queryParams });
+    super.handleAuthentication(this.routeAfterAuthentication);
   }
 
   handleInvalidation() {

--- a/orga/tests/unit/services/session-test.js
+++ b/orga/tests/unit/services/session-test.js
@@ -17,17 +17,15 @@ module('Unit | Service | session', function (hooks) {
 
     service = this.owner.lookup('service:session');
     service.currentUser = { load: sinon.stub(), prescriber: user };
-    service.locale = { setBestLocale: sinon.stub(), isSupportedLocale: sinon.stub().returns(true) };
   });
 
   module('#handleAuthentication', function () {
-    test('loads current user and sets locale', async function (assert) {
+    test('loads current user', async function (assert) {
       // when
       await service.handleAuthentication();
 
       // then
       sinon.assert.calledOnce(service.currentUser.load);
-      sinon.assert.calledWith(service.locale.setBestLocale, { queryParams: undefined });
       assert.ok(true);
     });
   });
@@ -47,39 +45,6 @@ module('Unit | Service | session', function (hooks) {
 
       // then
       assert.true(service.store.clear.calledOnce);
-    });
-  });
-
-  module('#loadCurrentUserAndSetLocale', function () {
-    module('when locale is supported', function () {
-      test('loads the current user, sets locale', async function (assert) {
-        // given
-        const queryParams = { lang: 'es' };
-
-        // when
-        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
-
-        // then
-        sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
-        assert.ok(true);
-      });
-    });
-
-    module('when locale is not supported', function () {
-      test('loads the current user, sets locale', async function (assert) {
-        // given
-        const queryParams = { lang: 'es' };
-        service.locale.isSupportedLocale = sinon.stub().returns(false);
-
-        // when
-        await service.loadCurrentUserAndSetLocale({ to: { queryParams } });
-
-        // then
-        sinon.assert.calledOnce(service.currentUser.load);
-        sinon.assert.calledWith(service.locale.setBestLocale, { queryParams });
-        assert.ok(true);
-      });
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

La locale est initialisée trop tard dans le cycle de l'application. Il faut la détecter au plus tôt pour éviter les incohérences. De plus, plusieurs appels à setBestLocale sont faits dans différents modules ; cette redondance est inutile.

## ⛱️ Proposition

admin : Initialiser la détection des locales au plus tôt (setBestLocale) dans */app/routes/application.js

mon-pix : Initialiser la détection des locales au plus tôt (setBestLocale) dans */app/routes/application.js  et revoir handleUserLanguageAndLocale pour ne plus set la locale

orga et certif : Initialiser la détection des locales au plus tôt (setBestLocale) dans */app/routes/application.js et revoir loadCurrentUserAndSetLocale pour ne plus set la locale


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- pour tester la route application
non régression : faire les tests de https://github.com/1024pix/pix/pull/13482 
- pour tester la route authentification
-- faire une authentification simple sur chaque application, vérifier que la locale posée à l'initialisation de l'application est conservée, sauf action de l'utilisateur sur le domaine org.
-- faire une authentification par SSO, une authentification après parcours anonyme et vérifier que la locale posée à l'initialisation de l'application est conservée, sauf action de l'utilisateur sur le domaine org.