### PR TITLE
[FEATURE] Copier l'event IMAGE_ALTERNATIVE_TEXT_OPENED du service metrics vers un passageEvent (PIX-18367)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -7,6 +7,7 @@ import {
   QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
+import { ImageAlternativeTextOpenedEvent } from '../models/passage-events/events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -38,6 +39,8 @@ class PassageEventFactory {
         return new GrainContinuedEvent(eventData);
       case 'GRAIN_SKIPPED':
         return new GrainSkippedEvent(eventData);
+      case 'IMAGE_ALTERNATIVE_TEXT_OPENED':
+        return new ImageAlternativeTextOpenedEvent(eventData);
       case 'STEPPER_NEXT_STEP':
         return new StepperNextStepEvent(eventData);
       case 'PASSAGE_STARTED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -1,0 +1,24 @@
+import { PassageEventWithElement } from './PassageEventWithElement.js';
+
+/**
+ * @class ImageAlternativeTextOpenedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user opens the alternative text of an image.
+ *
+ * */
+class ImageAlternativeTextOpenedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'IMAGE_ALTERNATIVE_TEXT_OPENED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+export { ImageAlternativeTextOpenedEvent };

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -9,6 +9,7 @@ import {
   QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
+import { ImageAlternativeTextOpenedEvent } from '../../../../../src/devcomp/domain/models/passage-events/events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -398,6 +399,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(QCUDiscoveryAnsweredEvent);
+      });
+    });
+
+    describe('when given an IMAGE_ALTERNATIVE_TEXT_OPENED event', function () {
+      it('should return an ImageAlternativeTextOpenedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'IMAGE_ALTERNATIVE_TEXT_OPENED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(ImageAlternativeTextOpenedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -185,6 +185,13 @@ export default class ModulePassage extends Component {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
+
+    this.passageEvents.record({
+      type: 'IMAGE_ALTERNATIVE_TEXT_OPENED',
+      data: {
+        elementId: imageElementId,
+      },
+    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -678,6 +678,42 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
 
+    test('should send an event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = {
+        id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+        type: 'image',
+        url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+        alt: "Dessin détaillé dans l'alternative textuelle",
+        alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        sections: [section],
+      });
+      const passage = store.createRecord('passage');
+
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      await click(screen.getByRole('button', { name: t('pages.modulix.buttons.element.alternativeText') }));
+
+      // then
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'IMAGE_ALTERNATIVE_TEXT_OPENED',
+        data: {
+          elementId: element.id,
+        },
+      });
+      assert.ok(true);
+    });
+
     module('when image is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given


### PR DESCRIPTION
## ⛱️ Proposition

Envoyer un event quand on ouvre le texte alternatif d'une image dans un Module.

## 🌊 Remarques

La métrique pour Plausible continue d'être envoyée.

## 🏄 Pour tester

- Ouvrir [le bac-a-sable](https://app-pr13573.review.pix.fr/modules/bac-a-sable)
- Afficher une image et ouvrir l'onglet "Réseau"
- Cliquer sur "Afficher le texte alternatif"
- Vérifier que la route /passage-events est appelée avec un retour 204
