### PR TITLE
[FEATURE] Ajouter un sélecteur d'équipe à la création d'une organisation (PIX-19505).

### DIFF
--- a/admin/app/adapters/administration-team.js
+++ b/admin/app/adapters/administration-team.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class AdministrationTeam extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -3,18 +3,44 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import Card from '../card';
 
 export default class OrganizationCreationForm extends Component {
+  @service store;
+
+  @tracked administrationTeams = [];
+
   organizationTypes = [
     { value: 'PRO', label: 'Organisation professionnelle' },
     { value: 'SCO', label: 'Établissement scolaire' },
     { value: 'SUP', label: 'Établissement supérieur' },
     { value: 'SCO-1D', label: 'Établissement scolaire du premier degré' },
   ];
+
+  constructor() {
+    super(...arguments);
+    this.#onMount();
+  }
+
+  async #onMount() {
+    this.administrationTeams = await this.store.findAll('administration-team');
+  }
+
+  get administrationTeamsOptions() {
+    const options = [];
+    this.administrationTeams?.forEach((administrationTeam) =>
+      options.push({
+        value: administrationTeam.id,
+        label: administrationTeam.name,
+      }),
+    );
+    return options;
+  }
 
   @action
   handleOrganizationTypeSelectionChange(value) {
@@ -24,6 +50,11 @@ export default class OrganizationCreationForm extends Component {
   @action
   handleOrganizationNameChange(event) {
     this.args.organization.name = event.target.value;
+  }
+
+  @action
+  handleAdministrationTeamSelectionChange(value) {
+    this.args.organization.administrationTeamId = value;
   }
 
   @action
@@ -53,7 +84,6 @@ export default class OrganizationCreationForm extends Component {
 
   <template>
     <form class="admin-form" {{on "submit" @onSubmit}}>
-
       <section class="admin-form__content admin-form__content--with-counters">
         <Card class="admin-form__card" @title="Information générique">
           <PixInput
@@ -76,6 +106,17 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>Sélectionner un type d'organisation</:label>
             <:default as |organizationType|>{{organizationType.label}}</:default>
+          </PixSelect>
+
+          <PixSelect
+            @onChange={{this.handleAdministrationTeamSelectionChange}}
+            @options={{this.administrationTeamsOptions}}
+            @placeholder={{t "components.organizations.creation.administration-team.selector.placeholder"}}
+            @hideDefaultOption={{true}}
+            @value={{@organization.administrationTeamId}}
+            aria-required={{false}}
+          >
+            <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>
         </Card>
 

--- a/admin/app/models/administration-team.js
+++ b/admin/app/models/administration-team.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AdministrationTeam extends Model {
+  @attr('string') name;
+}

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -26,6 +26,8 @@ export default class Organization extends Model {
   @attr('nullable-string') code;
   @attr() parentOrganizationId;
   @attr('nullable-string') parentOrganizationName;
+  //TODO REMOVE nullable-string BEFORE THE END OF EPIX
+  @attr('nullable-string') administrationTeamId;
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;
 

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -644,6 +644,26 @@ function routes() {
   });
 
   this.post('/admin/campaigns', async () => new Response(204));
+  this.get('/admin/administration-teams', async () => {
+    return {
+      data: [
+        {
+          type: 'administration-team',
+          id: '2',
+          attributes: {
+            name: 'Équipe 2',
+          },
+        },
+        {
+          type: 'administration-team',
+          id: '1',
+          attributes: {
+            name: 'Équipe 1',
+          },
+        },
+      ],
+    };
+  });
 
   this.get('/admin/oidc/identity-providers', () => {
     return {

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -1,6 +1,7 @@
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
@@ -25,7 +26,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
   });
 
   module('when an organization is created', function () {
-    test('it redirects the user on the organization details page with the tags tab opened', async function (assert) {
+    test('it redirects the user on the organization details page on tags tab', async function (assert) {
       // given
       const screen = await visit('/organizations/new');
       await fillByLabel('Nom', 'Stark Corp.');
@@ -34,7 +35,14 @@ module('Acceptance | Organizations | Create', function (hooks) {
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
+      await click(
+        screen.getByRole('button', { name: t('components.organizations.creation.administration-team.selector.label') }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByText('Équipe 2'));
+
       await fillByLabel('Crédits', 120);
+
       await fillByLabel('Prénom du DPO', 'Justin');
       await fillByLabel('Nom du DPO', 'Ptipeu');
       await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -1,5 +1,6 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import CreationForm from 'pix-admin/components/organizations/creation-form';
 import { module, test } from 'qunit';
 
@@ -12,6 +13,11 @@ module('Integration | Component | organizations/creation-form', function (hooks)
 
   test('it renders', async function (assert) {
     const store = this.owner.lookup('service:store');
+    store.findAll = () =>
+      Promise.resolve([
+        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+      ]);
     const organization = store.createRecord('organization', { type: '' });
 
     // when
@@ -25,6 +31,9 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
     assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
+    assert
+      .dom(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')))
+      .exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
   });
@@ -32,6 +41,11 @@ module('Integration | Component | organizations/creation-form', function (hooks)
   module('#selectOrganizationType', function () {
     test('should update attribute organization.type', async function (assert) {
       const store = this.owner.lookup('service:store');
+      store.findAll = () =>
+        Promise.resolve([
+          store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+          store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+        ]);
       const organization = store.createRecord('organization', { type: '' });
 
       // given
@@ -51,8 +65,42 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     });
   });
 
+  module('#handlePixTeamSelectionChange', function () {
+    test('should update attribute organization Administration team', async function (assert) {
+      const store = this.owner.lookup('service:store');
+      store.findAll = () =>
+        Promise.resolve([
+          store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+          store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+        ]);
+      const organization = store.createRecord('organization', { type: '' });
+
+      // given
+      const screen = await render(
+        <template>
+          <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+        </template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', { name: t('components.organizations.creation.administration-team.selector.label') }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Équipe 2' }));
+
+      // then
+      assert.strictEqual(organization.administrationTeamId, 'team-2');
+    });
+  });
+
   test('Adds data protection officer information', async function (assert) {
     const store = this.owner.lookup('service:store');
+    store.findAll = () =>
+      Promise.resolve([
+        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+      ]);
     const organization = store.createRecord('organization', { type: '' });
 
     // given
@@ -76,6 +124,11 @@ module('Integration | Component | organizations/creation-form', function (hooks)
   test('Credits can be added', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
+    store.findAll = () =>
+      Promise.resolve([
+        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+      ]);
     const organization = store.createRecord('organization', { type: '' });
 
     //when

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -553,6 +553,14 @@
         },
         "table-name": "List of children organisations"
       },
+      "creation": {
+        "administration-team": {
+          "selector" : {
+            "label": "Choose an administration team",
+            "placeholder": "Administration team"
+          }
+        }
+      },
       "information-section-view": {
         "child-organization": "Child organization of",
         "features": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -554,6 +554,14 @@
         },
         "table-name": "Liste des organisations filles"
       },
+      "creation": {
+        "administration-team": {
+          "selector" : {
+            "label": "Sélectionner une équipe en charge",
+            "placeholder": "Équipe en charge"
+          }
+        }
+      },
       "information-section-view": {
         "child-organization": "Organisation fille de",
         "features": {


### PR DESCRIPTION
## 🔆 Problème

L'utilisateur de Pix Admin qui crée une nouvelle organisation doit pouvoir séléctionner un champ "Equipe en charge"


## ⛱️ Proposition

Afficher un champ "Equipe en charge" dans le formulaire de création d'une nouvelle organisation

- BACK la route /administration-teams doit être appelée au moment du clic sur “nouvelle orga” pour renseigner le contenu de la liste déroulante

- FRONT dans les informations génériques, après “Sélectionner un type d'organisation”, placer un nouveau champ :

    nom du label : Sélectionner un équipe en charge
    nom du champ/placeholder : Equipe en charge
    une liste déroulante (10 options), 
    une seule possible, 
    (champ obligatoire) > à réserver pour la fin de l’epix, pour l’instant non obligatoire

## 🌊 Remarques

RAS

## 🏄 Pour tester

Créer une nouvelle organisation sur Pix Admin, vérifier dans le formulaire qu'il est possible d'afficher et de sélectionner un champ "Equipe en charge"
