### PR TITLE
[FEATURE] Ajouter une carte pour reprendre un parcours combiné dans "Mes parcours" (PIX-19479)

### DIFF
--- a/api/db/database-builder/factory/build-quest.js
+++ b/api/db/database-builder/factory/build-quest.js
@@ -55,10 +55,12 @@ const buildQuestForCombinedCourse = function ({
   organizationId,
   description = 'Le but de ma quête',
   illustration = 'images/illustration.svg',
+  rewardId = null,
+  rewardType = null,
   ...args
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
-  return buildQuest({ ...args, code, name, organizationId, description, illustration });
+  return buildQuest({ ...args, code, name, organizationId, description, illustration, rewardId, rewardType });
 };
 
 export { buildQuest, buildQuestForCombinedCourse };

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -149,12 +149,9 @@ const getCampaignParticipationOverviews = async function (
   const userCampaignParticipationOverviews = await usecases.findUserCampaignParticipationOverviews({
     userId: authenticatedUserId,
     states: query.filter.states,
-    page: query.page,
   });
 
-  return dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList(
-    userCampaignParticipationOverviews,
-  );
+  return dependencies.campaignParticipationOverviewSerializer.serialize(userCampaignParticipationOverviews);
 };
 
 const getAnonymisedCampaignAssessments = async function (

--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -282,10 +282,6 @@ const register = async function (server) {
             filter: Joi.object({
               states: Joi.array().required(),
             }).required(),
-            page: Joi.object({
-              number: Joi.number().integer().empty('').allow(null).optional(),
-              size: Joi.number().integer().max(200).empty('').allow(null).optional(),
-            }).default({}),
           }),
         },
         handler: campaignParticipationController.getCampaignParticipationOverviews,

--- a/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js
@@ -27,6 +27,7 @@ class CampaignParticipationOverview {
     isCampaignMultipleSendings,
     isOrganizationLearnerDisabled,
     campaignType,
+    updatedAt,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -49,6 +50,7 @@ class CampaignParticipationOverview {
     this.isCampaignMultipleSendings = isCampaignMultipleSendings;
     this.isOrganizationLearnerDisabled = isOrganizationLearnerDisabled;
     this.campaignType = campaignType;
+    this.updatedAt = updatedAt;
     this.canRetry = this.computeCanRetry();
   }
 

--- a/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
@@ -1,7 +1,6 @@
 const findUserCampaignParticipationOverviews = async function ({
   userId,
   states,
-  page,
   stageRepository,
   stageAcquisitionRepository,
   campaignParticipationOverviewRepository,
@@ -9,12 +8,10 @@ const findUserCampaignParticipationOverviews = async function ({
 }) {
   const concatenatedStates = states ? [].concat(states) : undefined;
 
-  const { campaignParticipationOverviews, pagination } =
-    await campaignParticipationOverviewRepository.findByUserIdWithFilters({
-      userId,
-      states: concatenatedStates,
-      page,
-    });
+  const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+    userId,
+    states: concatenatedStates,
+  });
 
   // We deduplicate targetProfileIds in the case where several campaigns belong to the same target profile
   const targetProfileIds = [...new Set(campaignParticipationOverviews.map(({ targetProfileId }) => targetProfileId))];
@@ -45,7 +42,7 @@ const findUserCampaignParticipationOverviews = async function ({
     },
   );
 
-  return { campaignParticipationOverviews: campaignParticipationOverviewsWithStages, pagination };
+  return campaignParticipationOverviewsWithStages;
 };
 
 export { findUserCampaignParticipationOverviews };

--- a/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/find-user-campaign-participation-overviews.js
@@ -12,9 +12,14 @@ const findUserCampaignParticipationOverviews = async function ({
     userId,
     states: concatenatedStates,
   });
-
   // We deduplicate targetProfileIds in the case where several campaigns belong to the same target profile
-  const targetProfileIds = [...new Set(campaignParticipationOverviews.map(({ targetProfileId }) => targetProfileId))];
+  const targetProfileIds = [
+    ...new Set(
+      campaignParticipationOverviews
+        .filter((participation) => participation.campaignType !== 'COMBINED_COURSE')
+        .map(({ targetProfileId }) => targetProfileId),
+    ),
+  ];
   const campaignParticipationIds = campaignParticipationOverviews.map(({ id }) => id);
 
   const [stages, acquiredStages] = await Promise.all([

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,11 +1,10 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 
-const findByUserIdWithFilters = async function ({ userId, states, page }) {
+const findByUserIdWithFilters = async function ({ userId, states }) {
   const queryBuilder = _getQueryBuilder(function (qb) {
     qb.where('campaign-participations.userId', userId).whereNotExists(function () {
       this.select(knex.raw('1'))
@@ -20,16 +19,10 @@ const findByUserIdWithFilters = async function ({ userId, states, page }) {
     _filterByStates(queryBuilder, states);
   }
 
-  const { results, pagination } = await fetchPage({
-    queryBuilder,
-    paginationParams: page,
-  });
-  return {
-    campaignParticipationOverviews: results.map(
-      (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),
-    ),
-    pagination,
-  };
+  const results = await queryBuilder;
+  return results.map(
+    (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),
+  );
 };
 
 const findByOrganizationLearnerId = async ({ organizationLearnerId }) => {

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,11 +1,14 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { CombinedCourseParticipationStatuses } from '../../../../prescription/shared/domain/constants.js';
 import { constants } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 
 const findByUserIdWithFilters = async function ({ userId, states }) {
-  const queryBuilder = _getQueryBuilder(function (qb) {
+  const combinedCourseQueryBuilder = _getCombinedCoursesParticipations({ userId });
+
+  const campaignQueryBuilder = _getQueryBuilder(function (qb) {
     qb.where('campaign-participations.userId', userId).whereNotExists(function () {
       this.select(knex.raw('1'))
         .from('quests')
@@ -16,10 +19,12 @@ const findByUserIdWithFilters = async function ({ userId, states }) {
   });
 
   if (states && states.length > 0) {
-    _filterByStates(queryBuilder, states);
+    _filterByStates(campaignQueryBuilder, states);
+    _filterByStates(combinedCourseQueryBuilder, states);
   }
-
-  const results = await queryBuilder;
+  const campaignResults = await campaignQueryBuilder;
+  const combinedCourseResults = await combinedCourseQueryBuilder;
+  const results = [...combinedCourseResults, ...campaignResults];
   return results.map(
     (campaignParticipationOverview) => new CampaignParticipationOverview(campaignParticipationOverview),
   );
@@ -79,6 +84,32 @@ function _getQueryBuilder(callback) {
     .orderBy('createdAt', 'DESC');
 }
 
+function _getCombinedCoursesParticipations({ userId }) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn
+    .with('combined_course_participation_overviews', (qb) => {
+      qb.select({
+        id: 'combined_course_participations.id',
+        campaignCode: 'quests.code',
+        campaignTitle: 'quests.name',
+        organizationName: 'organizations.name',
+        status: 'combined_course_participations.status',
+        createdAt: 'combined_course_participations.createdAt',
+        participationState: _computeCombinedCourseParticipationState(),
+        updatedAt: 'combined_course_participations.updatedAt',
+        campaignType: knexConn.raw(`'COMBINED_COURSE'`),
+      })
+        .from('combined_course_participations')
+        .join('quests', 'combined_course_participations.questId', 'quests.id')
+        .join('organizations', 'quests.organizationId', 'organizations.id')
+        .whereIn('combined_course_participations.organizationLearnerId', function () {
+          this.select('id').from('organization-learners').where('userId', userId);
+        });
+    })
+    .from('combined_course_participation_overviews')
+    .orderByRaw(_computeCombinedCourseParticipationOrder());
+}
+
 function _computeCampaignParticipationState() {
   return knex.raw(
     `
@@ -93,6 +124,17 @@ function _computeCampaignParticipationState() {
   );
 }
 
+function _computeCombinedCourseParticipationState() {
+  return knex.raw(
+    `
+  CASE
+    WHEN combined_course_participations.status = ? THEN 'ONGOING'
+    WHEN combined_course_participations.status = ?  THEN 'ENDED'
+  END`,
+    [CombinedCourseParticipationStatuses.STARTED, CombinedCourseParticipationStatuses.COMPLETED],
+  );
+}
+
 function _computeCampaignParticipationOrder() {
   return `
   CASE
@@ -100,6 +142,14 @@ function _computeCampaignParticipationOrder() {
     WHEN "participationState" = 'ONGOING'  THEN 2
     WHEN "participationState" = 'ENDED'    THEN 3
     WHEN "participationState" = 'DISABLED' THEN 4
+  END`;
+}
+
+function _computeCombinedCourseParticipationOrder() {
+  return `
+  CASE
+    WHEN "participationState" = 'ONGOING'  THEN 1
+    WHEN "participationState" = 'ENDED'    THEN 2
   END`;
 }
 

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -2,12 +2,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serializeForPaginatedList = function (userCampaignParticipationOverviewsPaginatedList) {
-  const { campaignParticipationOverviews, pagination } = userCampaignParticipationOverviewsPaginatedList;
-  return this.serialize(campaignParticipationOverviews, pagination);
-};
-
-const serialize = function (campaignParticipationOverview, meta) {
+const serialize = function (campaignParticipationOverviews) {
   return new Serializer('campaign-participation-overview', {
     attributes: [
       'isShared',
@@ -23,8 +18,7 @@ const serialize = function (campaignParticipationOverview, meta) {
       'totalStagesCount',
       'canRetry',
     ],
-    meta,
-  }).serialize(campaignParticipationOverview);
+  }).serialize(campaignParticipationOverviews);
 };
 
-export { serialize, serializeForPaginatedList };
+export { serialize };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -17,6 +17,7 @@ const serialize = function (campaignParticipationOverviews) {
       'validatedStagesCount',
       'totalStagesCount',
       'canRetry',
+      'campaignType',
     ],
   }).serialize(campaignParticipationOverviews);
 };

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -57,7 +57,7 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews).to.have.lengthOf(2);
+      expect(result).to.have.lengthOf(2);
     });
 
     it('should return acquired stages', async function () {
@@ -67,10 +67,10 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews[0].totalStagesCount).to.equal(3);
-      expect(result.campaignParticipationOverviews[0].validatedStagesCount).to.equal(1);
-      expect(result.campaignParticipationOverviews[1].totalStagesCount).to.equal(5);
-      expect(result.campaignParticipationOverviews[1].validatedStagesCount).to.equal(1);
+      expect(result[0].totalStagesCount).to.equal(3);
+      expect(result[0].validatedStagesCount).to.equal(1);
+      expect(result[1].totalStagesCount).to.equal(5);
+      expect(result[1].validatedStagesCount).to.equal(1);
     });
   });
 
@@ -126,7 +126,7 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews).to.have.lengthOf(2);
+      expect(result).to.have.lengthOf(2);
     });
 
     it('should return acquired stages', async function () {
@@ -136,10 +136,10 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       });
 
       // then
-      expect(result.campaignParticipationOverviews[0].totalStagesCount).to.equal(3);
-      expect(result.campaignParticipationOverviews[0].validatedStagesCount).to.equal(1);
-      expect(result.campaignParticipationOverviews[1].totalStagesCount).to.equal(3);
-      expect(result.campaignParticipationOverviews[1].validatedStagesCount).to.equal(2);
+      expect(result[0].totalStagesCount).to.equal(3);
+      expect(result[0].validatedStagesCount).to.equal(1);
+      expect(result[1].totalStagesCount).to.equal(3);
+      expect(result[1].validatedStagesCount).to.equal(2);
     });
   });
 });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -1,21 +1,22 @@
+import _ from 'lodash';
+
+import * as campaignParticipationOverviewRepository
+  from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js';
+import {
+  CampaignParticipationStatuses,
+  CampaignTypes
+} from '../../../../../../src/prescription/shared/domain/constants.js';
+import { constants } from '../../../../../../src/shared/domain/constants.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import {
   databaseBuilder,
   expect,
   learningContentBuilder,
   mockLearningContent,
-  sinon,
+  sinon
 } from '../../../../../test-helper.js';
 
 const { campaignParticipationOverviewFactory } = databaseBuilder.factory;
-import _ from 'lodash';
-
-import * as campaignParticipationOverviewRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-overview-repository.js';
-import {
-  CampaignParticipationStatuses,
-  CampaignTypes,
-} from '../../../../../../src/prescription/shared/domain/constants.js';
-import { constants } from '../../../../../../src/shared/domain/constants.js';
-import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 
 let userId;
 
@@ -351,9 +352,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const {
-          campaignParticipationOverviews: [campaignParticipation],
-        } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const [campaignParticipation] = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipation).to.deep.include({
           id: participationId,
@@ -387,8 +388,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         campaignParticipationOverviewFactory.build();
         await databaseBuilder.commit();
 
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
         const campaignParticipationUserIds = _.map(campaignParticipationOverviews, 'id');
 
         expect(campaignParticipationUserIds).to.exactlyContain([participation1Id, participation2Id]);
@@ -412,8 +414,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
         await databaseBuilder.commit();
 
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
         const campaignParticipationUserIds = _.map(campaignParticipationOverviews, 'id');
 
         expect(campaignParticipationUserIds).to.exactlyContain([participation1Id, participation2Id]);
@@ -443,9 +446,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const {
-          campaignParticipationOverviews: [campaignParticipation],
-        } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const [campaignParticipation] = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipation.id).to.equal(participationId);
       });
@@ -475,9 +478,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const {
-          campaignParticipationOverviews: [campaignParticipation],
-        } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const [campaignParticipation] = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipation.status).to.equal(CampaignParticipationStatuses.TO_SHARE);
       });
@@ -500,9 +503,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const {
-          campaignParticipationOverviews: [campaignParticipation],
-        } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const [campaignParticipation] = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipation.disabledAt).to.deep.equal(deletedAt);
       });
@@ -525,37 +528,11 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const {
-          campaignParticipationOverviews: [campaignParticipation],
-        } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const [campaignParticipation] = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipation.disabledAt).to.deep.equal(archivedAt);
-      });
-
-      it('retrieves pagination information', async function () {
-        const { id: oldestParticipation } = campaignParticipationOverviewFactory.buildOnGoing({
-          userId,
-          createdAt: new Date('2020-01-01'),
-          campaignSkills: ['recSkillId1'],
-        });
-        campaignParticipationOverviewFactory.buildOnGoing({
-          userId,
-          createdAt: new Date('2020-01-02'),
-          campaignSkills: ['recSkillId1'],
-        });
-        await databaseBuilder.commit();
-        const page = { number: 2, size: 1 };
-
-        const { campaignParticipationOverviews, pagination } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, page });
-
-        expect(campaignParticipationOverviews[0].id).to.equal(oldestParticipation);
-        expect(pagination).to.deep.equal({
-          page: 2,
-          pageSize: 1,
-          rowCount: 2,
-          pageCount: 2,
-        });
       });
     });
 
@@ -610,8 +587,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       context('the filter is ONGOING', function () {
         it('returns participation with a started assessment', async function () {
           const states = ['ONGOING'];
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+            states,
+          });
 
           expect(campaignParticipationOverviews[0].id).to.equal(onGoingParticipation.id);
           expect(campaignParticipationOverviews).to.have.lengthOf(1);
@@ -621,8 +600,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       context('the filter is TO_SHARE', function () {
         it('returns participation with a completed assessment', async function () {
           const states = ['TO_SHARE'];
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+            states,
+          });
 
           expect(campaignParticipationOverviews[0].id).to.equal(toShareParticipation.id);
           expect(campaignParticipationOverviews).to.have.lengthOf(1);
@@ -632,8 +613,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       context('the filter is ENDED', function () {
         it('returns shared participation', async function () {
           const states = ['ENDED'];
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+            states,
+          });
 
           expect(campaignParticipationOverviews[0].id).to.equal(endedParticipation.id);
           expect(campaignParticipationOverviews).to.have.lengthOf(1);
@@ -643,8 +626,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       context('the filter is DISABLED', function () {
         it('returns participation where the campaign is archived or the participation deleted', async function () {
           const states = ['DISABLED'];
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+            states,
+          });
 
           expect(campaignParticipationOverviews).to.have.lengthOf(2);
           expect(campaignParticipationOverviews.map(({ id }) => id)).to.exactlyContain([
@@ -657,8 +642,10 @@ describe('Integration | Repository | Campaign Participation Overview', function 
       context('when there are several statuses given for the status filter', function () {
         it('returns only participations which matches with the given statuses', async function () {
           const states = ['ONGOING', 'TO_SHARE'];
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+            states,
+          });
 
           expect(_.map(campaignParticipationOverviews, 'id')).to.exactlyContain([
             onGoingParticipation.id,
@@ -689,8 +676,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           });
           await databaseBuilder.commit();
 
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+          });
           const campaignParticipationIds = _.map(campaignParticipationOverviews, 'id');
 
           expect(campaignParticipationIds).to.exactlyContainInOrder([
@@ -716,8 +704,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           });
           await databaseBuilder.commit();
 
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+          });
           const campaignParticipationIds = _.map(campaignParticipationOverviews, 'id');
 
           expect(campaignParticipationIds).to.exactlyContainInOrder([newestParticipation, oldestParticipation]);
@@ -747,8 +736,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
           await databaseBuilder.commit();
 
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+          });
           const campaignParticipationIds = _.map(campaignParticipationOverviews, 'id');
 
           expect(campaignParticipationIds).to.exactlyContainInOrder([
@@ -782,8 +772,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
           await databaseBuilder.commit();
 
-          const { campaignParticipationOverviews } =
-            await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+          const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+            userId,
+          });
           const campaignParticipationIds = _.map(campaignParticipationOverviews, 'id');
 
           expect(campaignParticipationIds).to.exactlyContainInOrder([
@@ -819,8 +810,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         });
         await databaseBuilder.commit();
 
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         expect(campaignParticipationOverviews).to.deep.equal([]);
       });
@@ -848,8 +840,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews).to.have.lengthOf(0);
@@ -876,8 +869,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews).to.have.lengthOf(0);
@@ -905,8 +899,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews).to.have.lengthOf(1);
@@ -968,8 +963,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews).to.have.lengthOf(1);
@@ -1007,8 +1003,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.true;
@@ -1043,8 +1040,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.false;
@@ -1080,8 +1078,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.false;
@@ -1117,8 +1116,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.false;
@@ -1153,8 +1153,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.true;
@@ -1189,8 +1190,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.false;
@@ -1225,8 +1227,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         await databaseBuilder.commit();
 
         // when
-        const { campaignParticipationOverviews } =
-          await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+        const campaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({
+          userId,
+        });
 
         // then
         expect(campaignParticipationOverviews[0].canRetry).to.be.false;

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -54,7 +54,6 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
     beforeEach(function () {
       const campaignParticipationOverviewSerializer = {
         serialize: sinon.stub(),
-        serializeForPaginatedList: sinon.stub(),
       };
       sinon.stub(usecases, 'findUserCampaignParticipationOverviews');
       dependencies = {
@@ -73,10 +72,10 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
         params: {
           id: userId,
         },
-        query: { filter: {}, page: {} },
+        query: { filter: {} },
       };
-      usecases.findUserCampaignParticipationOverviews.withArgs({ userId, states: undefined, page: {} }).resolves([]);
-      dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
+      usecases.findUserCampaignParticipationOverviews.withArgs({ userId, states: undefined }).resolves([]);
+      dependencies.campaignParticipationOverviewSerializer.serialize.withArgs([]).returns({
         id: 'campaignParticipationOverviews',
       });
 
@@ -91,7 +90,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       expect(response).to.deep.equal({
         id: 'campaignParticipationOverviews',
       });
-      expect(dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
+      expect(dependencies.campaignParticipationOverviewSerializer.serialize).to.have.been.calledOnce;
     });
 
     it('should forward state and page query parameters', async function () {
@@ -109,13 +108,10 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
           filter: {
             states: 'ONGOING',
           },
-          page: { number: 1, size: 10 },
         },
       };
-      usecases.findUserCampaignParticipationOverviews
-        .withArgs({ userId, states: 'ONGOING', page: { number: 1, size: 10 } })
-        .resolves([]);
-      dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
+      usecases.findUserCampaignParticipationOverviews.withArgs({ userId, states: 'ONGOING' }).resolves([]);
+      dependencies.campaignParticipationOverviewSerializer.serialize.withArgs([]).returns({
         id: 'campaignParticipationOverviews',
       });
 
@@ -130,7 +126,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       expect(response).to.deep.equal({
         id: 'campaignParticipationOverviews',
       });
-      expect(dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
+      expect(dependencies.campaignParticipationOverviewSerializer.serialize).to.have.been.calledOnce;
     });
   });
 

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -12,10 +12,7 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       compare: sinon.stub().returns([]),
     };
     campaignParticipationOverviewRepository = {
-      findByUserIdWithFilters: sinon.stub().resolves({
-        campaignParticipationOverviews: [],
-        pagination: {},
-      }),
+      findByUserIdWithFilters: sinon.stub().resolves([]),
     };
     stageRepository = { getByTargetProfileIds: sinon.stub().resolves([]) };
     stageAcquisitionRepository = { getByCampaignParticipations: sinon.stub().resolves([]) };
@@ -39,7 +36,6 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
 
       // then
       sinon.assert.calledWith(campaignParticipationOverviewRepository.findByUserIdWithFilters, {
-        page: undefined,
         userId,
         states,
       });
@@ -51,13 +47,11 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       // given
       const states = 'ONGOING';
       const userId = 1;
-      const page = {};
 
       // when
       await findUserCampaignParticipationOverviews({
         userId,
         states,
-        page,
         compareStagesAndAcquiredStages,
         campaignParticipationOverviewRepository,
         stageRepository,
@@ -66,7 +60,6 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
 
       // then
       sinon.assert.calledWith(campaignParticipationOverviewRepository.findByUserIdWithFilters, {
-        page,
         userId,
         states: ['ONGOING'],
       });
@@ -78,13 +71,11 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
       // given
       const states = ['ONGOING'];
       const userId = 1;
-      const page = {};
 
       // when
       await findUserCampaignParticipationOverviews({
         userId,
         states,
-        page,
         compareStagesAndAcquiredStages,
         campaignParticipationOverviewRepository,
         stageRepository,
@@ -93,7 +84,6 @@ describe('Unit | UseCase | find-user-campaign-participation-overviews', function
 
       // then
       sinon.assert.calledWith(campaignParticipationOverviewRepository.findByUserIdWithFilters, {
-        page,
         userId,
         states: ['ONGOING'],
       });

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,12 +1,15 @@
-import { CampaignParticipationOverview } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
-import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
+import {
+  CampaignParticipationOverview
+} from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
+import * as serializer
+  from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
 import {
   CampaignParticipationStatuses,
-  CampaignTypes,
+  CampaignTypes
 } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
-const { SHARED, STARTED } = CampaignParticipationStatuses;
+const { SHARED } = CampaignParticipationStatuses;
 
 describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializer', function () {
   describe('#serialize', function () {
@@ -100,105 +103,6 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
 
       // then
       expect(json.data.attributes['can-retry']).to.be.false;
-    });
-  });
-
-  describe('#serializeForPaginatedList', function () {
-    it('should call serialize method by destructuring passed parameter', function () {
-      // given
-      const campaignParticipationOverviews = [
-        new CampaignParticipationOverview({
-          id: 6,
-          status: STARTED,
-          sharedAt: new Date('2018-02-07T17:15:44Z'),
-          createdAt: new Date('2018-02-06T17:15:44Z'),
-          organizationName: 'My organization 1',
-          campaignCode: '4567',
-          campaignTitle: 'My campaign 1',
-          campaignArchivedAt: null,
-          masteryRate: null,
-          totalStagesCount: 0,
-          validatedStagesCount: null,
-          isCampaignMultipleSendings: false,
-          isOrganizationLearnerActive: true,
-          campaignType: CampaignTypes.ASSESSMENT,
-        }),
-
-        new CampaignParticipationOverview({
-          id: 7,
-          status: STARTED,
-          sharedAt: new Date('2018-02-10T17:30:44Z'),
-          createdAt: new Date('2018-02-09T13:15:44Z'),
-          organizationName: 'My organization 2',
-          campaignCode: '4567',
-          campaignTitle: 'My campaign 2',
-          campaignArchivedAt: null,
-          masteryRate: null,
-          totalStagesCount: 0,
-          validatedStagesCount: null,
-          isCampaignMultipleSendings: false,
-          isOrganizationLearnerActive: true,
-          campaignType: CampaignTypes.ASSESSMENT,
-        }),
-      ];
-      const pagination = {
-        page: {
-          number: 1,
-          pageSize: 2,
-        },
-      };
-      const parameters = { campaignParticipationOverviews, pagination };
-
-      // when
-      const result = serializer.serializeForPaginatedList(parameters);
-
-      // then
-      expect(result).to.deep.equal({
-        data: [
-          {
-            attributes: {
-              status: STARTED,
-              'campaign-code': '4567',
-              'campaign-title': 'My campaign 1',
-              'created-at': new Date('2018-02-06T17:15:44Z'),
-              'is-shared': false,
-              'organization-name': 'My organization 1',
-              'shared-at': new Date('2018-02-07T17:15:44Z'),
-              'mastery-rate': null,
-              'disabled-at': null,
-              'validated-stages-count': null,
-              'total-stages-count': 0,
-              'can-retry': false,
-            },
-            id: '6',
-            type: 'campaign-participation-overviews',
-          },
-          {
-            attributes: {
-              status: STARTED,
-              'campaign-code': '4567',
-              'campaign-title': 'My campaign 2',
-              'created-at': new Date('2018-02-09T13:15:44Z'),
-              'is-shared': false,
-              'organization-name': 'My organization 2',
-              'shared-at': new Date('2018-02-10T17:30:44Z'),
-              'mastery-rate': null,
-              'disabled-at': null,
-              'validated-stages-count': null,
-              'total-stages-count': 0,
-              'can-retry': false,
-            },
-            id: '7',
-            type: 'campaign-participation-overviews',
-          },
-        ],
-        meta: {
-          page: {
-            number: 1,
-            pageSize: 2,
-          },
-        },
-      });
     });
   });
 });

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -1,11 +1,8 @@
-import {
-  CampaignParticipationOverview
-} from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
-import * as serializer
-  from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
+import { CampaignParticipationOverview } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/CampaignParticipationOverview.js';
+import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js';
 import {
   CampaignParticipationStatuses,
-  CampaignTypes
+  CampaignTypes,
 } from '../../../../../../../src/prescription/shared/domain/constants.js';
 import { expect } from '../../../../../../test-helper.js';
 
@@ -50,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'validated-stages-count': 2,
             'total-stages-count': 3,
             'can-retry': false,
+            'campaign-type': CampaignTypes.ASSESSMENT,
           },
         },
       };

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.gjs
@@ -1,12 +1,12 @@
 import PixBlock from '@1024pix/pix-ui/components/pix-block';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixStars from '@1024pix/pix-ui/components/pix-stars';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
+import { eq } from 'ember-truth-helpers';
 
 export default class Ended extends Component {
   <template>
@@ -25,31 +25,34 @@ export default class Ended extends Component {
         </time>
       </div>
       <section class="campaign-participation-overview-card-content">
-        <div class="campaign-participation-overview-card-content__content">
-          {{#if this.hasStages}}
-            <PixStars
-              @count={{this.count}}
-              @total={{this.total}}
-              @alt={{t "pages.campaign-participation-overview.card.stages" count=this.count total=this.total}}
-              @color="yellow"
-            />
-          {{else}}
-            <p>
-              {{t "pages.campaign-participation-overview.card.results" result=@model.masteryRate}}
-            </p>
-          {{/if}}
-        </div>
-        <PixButton
+        {{#unless (eq @model.campaignType "COMBINED_COURSE")}}
+          <div class="campaign-participation-overview-card-content__content">
+            {{#if this.hasStages}}
+              <PixStars
+                @count={{this.count}}
+                @total={{this.total}}
+                @alt={{t "pages.campaign-participation-overview.card.stages" count=this.count total=this.total}}
+                @color="yellow"
+              />
+            {{else}}
+              <p>
+                {{t "pages.campaign-participation-overview.card.results" result=@model.masteryRate}}
+              </p>
+            {{/if}}
+          </div>
+        {{/unless}}
+        <PixButtonLink
           class="campaign-participation-overview-card-content__action"
+          @route={{if (eq @model.campaignType "COMBINED_COURSE") "combined-courses" "campaigns.entry-point"}}
+          @model={{@model.campaignCode}}
           @variant={{if @model.canRetry "primary" "secondary"}}
-          @triggerAction={{this.onClick}}
         >
           {{#if @model.canRetry}}
             {{t "pages.campaign-participation-overview.card.retry"}}
           {{else}}
             {{t "pages.campaign-participation-overview.card.see-more"}}
           {{/if}}
-        </PixButton>
+        </PixButtonLink>
       </section>
     </PixBlock>
   </template>
@@ -66,15 +69,5 @@ export default class Ended extends Component {
 
   get total() {
     return this.args.model.totalStagesCount - 1;
-  }
-
-  @action
-  onClick() {
-    this.pixMetrics.trackEvent(`Voir le détail d'une participation partagée`, {
-      disabled: true,
-      category: 'Campaign participation',
-      action: `Voir le détail d'une participation partagée`,
-    });
-    this.router.transitionTo('campaigns.entry-point', this.args.model.campaignCode);
   }
 }

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.gjs
@@ -3,6 +3,8 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
 import t from 'ember-intl/helpers/t';
+import { eq } from 'ember-truth-helpers';
+
 <template>
   <PixBlock class="campaign-participation-overview-card" role="article">
     <div class="campaign-participation-overview-card__header">
@@ -21,7 +23,7 @@ import t from 'ember-intl/helpers/t';
     <section class="campaign-participation-overview-card-content">
       <PixButtonLink
         class="campaign-participation-overview-card-content__action"
-        @route="campaigns.entry-point"
+        @route={{if (eq @model.campaignType "COMBINED_COURSE") "combined-courses" "campaigns.entry-point"}}
         @model={{@model.campaignCode}}
         @variant="success"
         aria-label={{t

--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -14,9 +14,10 @@ export default class CampaignParticipationOverviews extends Model {
   @attr('number') totalStagesCount;
   @attr('number') validatedStagesCount;
   @attr('boolean') canRetry;
+  @attr('string') campaignType;
 
   get cardStatus() {
-    if (this.isShared) return 'ENDED';
+    if (this.isShared || this.status === 'COMPLETED') return 'ENDED';
     else if (this.disabledAt) return 'DISABLED';
     else if (this.status === 'TO_SHARE') return 'TO_SHARE';
     else return 'ONGOING';

--- a/mon-pix/app/routes/authenticated/user-dashboard.js
+++ b/mon-pix/app/routes/authenticated/user-dashboard.js
@@ -8,11 +8,8 @@ export default class UserDashboard extends Route {
 
   async model() {
     const user = this.currentUser.user;
-    const maximumDisplayed = 9;
     const queryParams = {
       userId: user.id,
-      'page[number]': 1,
-      'page[size]': maximumDisplayed,
       'filter[states]': ['ONGOING', 'TO_SHARE'],
     };
     const campaignParticipationOverviews = await this.store.query('campaign-participation-overview', queryParams);

--- a/mon-pix/app/routes/authenticated/user-tests.js
+++ b/mon-pix/app/routes/authenticated/user-tests.js
@@ -10,11 +10,8 @@ export default class UserTestsRoute extends Route {
 
   async model() {
     const user = this.currentUser.user;
-    const maximumDisplayed = 100;
     const queryParams = {
       userId: user.id,
-      'page[number]': 1,
-      'page[size]': maximumDisplayed,
       'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED', 'DISABLED'],
     };
     const campaignParticipationOverviews = await this.store.query('campaign-participation-overview', queryParams);

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing-test.js
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -31,5 +32,73 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ongoing
     assert.dom(screen.getByText('My campaign')).exists();
     assert.dom(screen.getByText('En cours')).exists();
     assert.dom(screen.getByText('Commencé le 10/12/2020')).exists();
+  });
+
+  module('Conditional Button', function () {
+    test('should redirect to campaigns', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.owner.lookup('service:router');
+      const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+        isShared: false,
+        createdAt: '2020-12-10T15:16:20.109Z',
+        sharedAt: null,
+        status: 'STARTED',
+        campaignTitle: 'My campaign',
+        campaignType: 'CAMPAIGN',
+        campaignCode: '12345',
+        organizationName: 'My organization',
+      });
+      this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card::Ongoing @model={{this.campaignParticipationOverview}} />`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('link', {
+            name: t('pages.campaign-participation-overview.card.resume.extra-information', {
+              campaignTitle: 'My campaign',
+            }),
+          }),
+        )
+        .hasAttribute('href', '/campagnes/12345');
+    });
+
+    test('should redirect to combined courses', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.owner.lookup('service:router');
+      const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+        isShared: false,
+        createdAt: '2020-12-10T15:16:20.109Z',
+        sharedAt: null,
+        status: 'STARTED',
+        campaignTitle: 'My campaign',
+        campaignType: 'COMBINED_COURSE',
+        campaignCode: '12345',
+        organizationName: 'My organization',
+      });
+      this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card::Ongoing @model={{this.campaignParticipationOverview}} />`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('link', {
+            name: t('pages.campaign-participation-overview.card.resume.extra-information', {
+              campaignTitle: 'My campaign',
+            }),
+          }),
+        )
+        .hasAttribute('href', '/parcours/12345');
+    });
   });
 });

--- a/mon-pix/tests/unit/adapters/campaign-participation-overview-test.js
+++ b/mon-pix/tests/unit/adapters/campaign-participation-overview-test.js
@@ -17,14 +17,10 @@ module('Unit | Adapters | campaign-participation-overviews', function (hooks) {
       // given
       const params = {
         userId: 1,
-        'page[number]': 1,
-        'page[size]': 5,
         'filter[states][]': 'ONGOING',
       };
 
       const paramsAfterQuery = {
-        'page[number]': 1,
-        'page[size]': 5,
         'filter[states][]': 'ONGOING',
       };
 

--- a/mon-pix/tests/unit/routes/authenticated/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/authenticated/user-tests-test.js
@@ -21,8 +21,6 @@ module('Unit | Route | User-Tests', function (hooks) {
       store.query
         .withArgs('campaign-participation-overview', {
           userId: '1',
-          'page[number]': 1,
-          'page[size]': 100,
           'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED', 'DISABLED'],
         })
         .returns(campaignParticipationOverviews);


### PR DESCRIPTION
## 🔆 Problème
A l'image de ce qui se fait pour les campagnes, on veut une carte pour pouvoir reprendre un parcours combiné en cours.

## ⛱️ Proposition
On garde la même route que pour les campagnes (campaign-participation-overview) et on agrège deux requêtes.

## 🌊 Remarques
- Ajouté par rapport au ticket
On a supprimé la pagination qui existait côté back et qui n'était pas exploitée côté front.

Si le statut de la participation au combined course est terminé, on ne l'affiche pas sur la page d'accueil. Et dans la page "Mes parcours", on a supprimé le visuel avec le mastery Rate

- Points à revoir :
* Créer un nouveau model ParticipationOverview qui prendrait uniquement en compte les données nécessaires en commun aux campagnes et aux parcours combinés, se poser la question de dissocier les usages
* On a un mapping dans le model front get cardStatus qu'il faudrait faire sauter 

## 🏄 Pour tester
Passer un parcours combiné (code COMBINIX1) et cliquer sur "Quitter".
Passer une campagne PROASSMUL et cliquer sur "Quitter".
Se rendre sur la page d'accueil et la page "Mes parcours" et vérifier que le visuel correspond aux attentes.