### PR TITLE
[TECH] epreuves-components: update du package

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -82,7 +82,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.4.2",
+        "@1024pix/epreuves-components": "^1.4.3",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
-      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.3.tgz",
+      "integrity": "sha512-9qbdzo/tESAHAPOWEO4yYldxgtF6Lwjnfh2+VaPOOEj3MlU0HaqWVXCquTelSKa+4299d/aVPe8L0qvgkUeCew==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.4.2",
+    "@1024pix/epreuves-components": "^1.4.3",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.2",
+        "@1024pix/epreuves-components": "^1.4.3",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
-      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.3.tgz",
+      "integrity": "sha512-9qbdzo/tESAHAPOWEO4yYldxgtF6Lwjnfh2+VaPOOEj3MlU0HaqWVXCquTelSKa+4299d/aVPe8L0qvgkUeCew==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.2",
+    "@1024pix/epreuves-components": "^1.4.3",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.2",
+        "@1024pix/epreuves-components": "^1.4.3",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.2.tgz",
-      "integrity": "sha512-GCtLNkq/Mz3BKPcOQu26FykZpjENonRt8hqZX0LTFJL7GXIahxxO16E7rysLpdyAOQwzy2Jzk73F1BnMebD8CQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.3.tgz",
+      "integrity": "sha512-9qbdzo/tESAHAPOWEO4yYldxgtF6Lwjnfh2+VaPOOEj3MlU0HaqWVXCquTelSKa+4299d/aVPe8L0qvgkUeCew==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.2",
+    "@1024pix/epreuves-components": "^1.4.3",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🔆 Problème
POI qcm-deepfake avait besoin de changements de wording

## ⛱️ Proposition
appliquer les changements et mettre à jour le package `epreuves-components`

## 🌊 Remarques
RAS

## 🏄 Pour tester
Aller sur la page de démo et constater les modifs sur qcm-deepfake (le plus visible étant que tant qu'on n'a pas cliqué sur le bouton, il n'y a plus le titre "SORTIE" à droite)