### PR TITLE
[FEATURE] Supprimer la description d'un module sur Pix App (PIX-19538).

### DIFF
--- a/mon-pix/app/components/module/instruction/_details.scss
+++ b/mon-pix/app/components/module/instruction/_details.scss
@@ -108,20 +108,11 @@
   }
 }
 
-.module-details-infos-objectives,
-.module-details-infos-explanation {
+.module-details-infos-objectives {
   &__title {
     @extend %pix-title-s;
 
     margin-bottom: var(--pix-spacing-4x);
-  }
-}
-
-.module-details-infos-explanation {
-  &__text {
-    &:not(:last-child) {
-      margin-bottom: var(--pix-spacing-4x);
-    }
   }
 }
 

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -161,16 +161,6 @@ export default class ModulixDetails extends Component {
           <h2 class="module-details-infos-objectives__title">{{t "pages.modulix.details.objectives"}}</h2>
           <ModuleObjectives @objectives={{@module.details.objectives}} />
         </div>
-
-        <div class="module-details-infos__explanation">
-          <div class="module-details-infos-explanation__title">
-            <h2>{{t "pages.modulix.details.explanationTitle"}}</h2>
-          </div>
-          <p class="module-details-infos-explanation__text">{{t "pages.modulix.details.explanationText1"}}</p>
-          {{#if @module.isBeta}}
-            <p class="module-details-infos-explanation__text">{{t "pages.modulix.details.explanationText2"}}</p>
-          {{/if}}
-        </div>
       </div>
     </main>
   </template>

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -1,5 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
-import { click, findAll } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import ModulixDetails from 'mon-pix/components/module/instruction/details';
@@ -34,8 +34,6 @@ module('Integration | Component | Module | Details', function (hooks) {
     assert.ok(screen.getByText(`${module.details.duration} min`));
     assert.ok(screen.getByText(t(`pages.modulix.details.levels.${module.details.level}`)));
     assert.ok(screen.getByText(module.details.objectives[0]));
-    assert.ok(screen.getByRole('heading', { name: t('pages.modulix.details.explanationTitle'), level: 2 }));
-    assert.ok(findAll('.module-details-infos-explanation__title').length > 0);
   });
 
   module('When on desktop', function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1707,9 +1707,6 @@
       "details": {
         "duration": "Duration",
         "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'About '</span>'{duration} min",
-        "explanationText1": "The Pix learning modules are comprised of lessons and activities to practice and develop your digital skills. The lessons take the form of videos, audios, images and texts. The activities allow you to practice and verify your answers directly. Each module takes around 10 minutes to complete on a particular subject with a level of difficulty from beginner to expert.",
-        "explanationText2": "These learning modules are currently in beta test phase. You can send us your suggestions for improvement in the questionnaire at the end of each module.",
-        "explanationTitle": "What is a module?",
         "level": "Level",
         "levels": {
           "advanced": "Advanced",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1693,9 +1693,6 @@
       "details": {
         "duration": "Duración",
         "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Aproximadamente '</span>'{duration} min",
-        "explanationText1": "Los módulos de aprendizaje Pix se componen de lecciones y actividades para practicar y desarrollar tus competencias digitales. Las lecciones se presentan en forma de vídeos, audio, imágenes y texto. Las actividades permiten practicar y comprobar directamente las respuestas. Cada módulo tiene una duración aproximada de 10 minutos, sobre un tema específico, con un nivel de dificultad que va de principiante a experto.",
-        "explanationText2": "Estos módulos de aprendizaje se encuentran actualmente en fase de prueba beta. Puede enviarnos sus sugerencias de mejora a través del cuestionario que figura al final de cada módulo.",
-        "explanationTitle": "¿Qué es un módulo?",
         "level": "Nivel",
         "levels": {
           "advanced": "Avanzado",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1707,9 +1707,6 @@
       "details": {
         "duration": "Durée",
         "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Environ '</span>'{duration} min",
-        "explanationText1": "Les modules apprenants Pix sont composés de leçons et d’activités pour vous exercer et développer vos compétences numériques. Les leçons prennent la forme de vidéos, d'audios, d'images et de textes. Les activités vous permettent de vous entraîner et de vérifier directement vos réponses. Un module dure environ 10 minutes, sur un sujet précis, avec un niveau de difficulté allant de débutant à expert.",
-        "explanationText2": "Ces modules apprenants sont actuellement en phase de bêta-test. Vous pouvez nous envoyer toutes vos suggestions d’amélioration dans le questionnaire de fin de module.",
-        "explanationTitle": "C'est quoi un module ?",
         "level": "Niveau",
         "levels": {
           "advanced": "Avancé",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1697,9 +1697,6 @@
       "details": {
         "duration": "Duur",
         "durationValue": "≈{duration} min",
-        "explanationText1": "De Pix leermodules bestaan uit lessen en activiteiten om je digitale vaardigheden te oefenen en te ontwikkelen. De lessen bestaan uit video's, audio, afbeeldingen en tekst. Met de activiteiten kun je direct oefenen en je antwoorden controleren. Elke module duurt ongeveer 10 minuten, gaat over een specifiek onderwerp en heeft een moeilijkheidsgraad van beginner tot expert.",
-        "explanationText2": "Deze leermodules bevinden zich momenteel in de bètatestfase. Je kunt ons suggesties voor verbetering sturen via de vragenlijst aan het einde van elke module.",
-        "explanationTitle": "Wat is een module?",
         "level": "Niveau",
         "levels": {
           "advanced": "Gevorderd",


### PR DESCRIPTION
## 🔆 Problème

Actuellement nous avons sur la page de détails d'un module une explication de ce qu'est un module (+ mention de la bêta).
Avec l'intégration des modules au parcours combiné, cette information n'est plus pertinente.

## ⛱️ Proposition

Supprimer la description

## 🏄 Pour tester


- Se rendre sur : https://app-pr13577.review.pix.fr/modules/bac-a-sable
- Constater que la description n'existe plus 🔥 

<img width="1723" height="835" alt="Capture d’écran 2025-09-16 à 11 17 04" src="https://github.com/user-attachments/assets/0740703f-71cf-48a5-9f44-5cb969ef142a" />

