### PR TITLE
[FEATURE] Copier l'event VIDEO_TRANSCRIPTION_OPENED du service metrics vers un passageEvent (PIX-18368)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -7,7 +7,7 @@ import {
   QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
-import { ImageAlternativeTextOpenedEvent } from '../models/passage-events/events.js';
+import { ImageAlternativeTextOpenedEvent, VideoTranscriptionOpenedEvent } from '../models/passage-events/events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -61,6 +61,8 @@ class PassageEventFactory {
         return new QCUDeclarativeAnsweredEvent(eventData);
       case 'QCU_DISCOVERY_ANSWERED':
         return new QCUDiscoveryAnsweredEvent(eventData);
+      case 'VIDEO_TRANSCRIPTION_OPENED':
+        return new VideoTranscriptionOpenedEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -21,4 +21,25 @@ class ImageAlternativeTextOpenedEvent extends PassageEventWithElement {
   }
 }
 
-export { ImageAlternativeTextOpenedEvent };
+/**
+ * @class VideoTranscriptionOpenedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user opens the transcription of a video.
+ *
+ * */
+class VideoTranscriptionOpenedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'VIDEO_TRANSCRIPTION_OPENED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+export { ImageAlternativeTextOpenedEvent, VideoTranscriptionOpenedEvent };

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -9,7 +9,10 @@ import {
   QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
-import { ImageAlternativeTextOpenedEvent } from '../../../../../src/devcomp/domain/models/passage-events/events.js';
+import {
+  ImageAlternativeTextOpenedEvent,
+  VideoTranscriptionOpenedEvent,
+} from '../../../../../src/devcomp/domain/models/passage-events/events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -417,6 +420,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(ImageAlternativeTextOpenedEvent);
+      });
+    });
+
+    describe('when given an VIDEO_TRANSCRIPTION_OPENED event', function () {
+      it('should return an VideoTranscriptionOpened instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'VIDEO_TRANSCRIPTION_OPENED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(VideoTranscriptionOpenedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -201,6 +201,13 @@ export default class ModulePassage extends Component {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
+
+    this.passageEvents.record({
+      type: 'VIDEO_TRANSCRIPTION_OPENED',
+      data: {
+        elementId: videoElementId,
+      },
+    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -809,6 +809,44 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
 
+    test('should record a passage event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = {
+        id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+        type: 'video',
+        title: 'Vidéo de présentation de Pix',
+        url: 'https://videos.pix.fr/modulix/didacticiel/presentation.mp4',
+        subtitles: '',
+        transcription: '<p>transcription</p>',
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [{ title: 'Grain title', components: [{ type: 'element', element }] }],
+      });
+      const module = store.createRecord('module', {
+        id: 'module-id',
+        slug: 'module-slug',
+        title: 'Module title',
+        sections: [section],
+      });
+      const passage = store.createRecord('passage');
+
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
+
+      // then
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'VIDEO_TRANSCRIPTION_OPENED',
+        data: {
+          elementId: element.id,
+        },
+      });
+      assert.ok(true);
+    });
+
     module('when video is in a stepper', function () {
       test('should push metrics event', async function (assert) {
         // given


### PR DESCRIPTION
## ⛱️ Proposition

Enregistrer une trace d'apprentissage quand on ouvre la transcription d'une vidéo dans un Module.

## 🌊 Remarques

PR à merger après https://github.com/1024pix/pix/pull/13573

## 🏄 Pour tester

- Ouvrir [le bac-a-sable](https://app-pr13578.review.pix.fr/modules/bac-a-sable)
- Aller à la vidéo et ouvrir l'onglet "Réseau"
- Cliquer sur "Afficher la transcription"
- Vérifier que la route `/passage-events` est appelée avec le bon type et l'id de l'élément
- Vérifier en base que l'évènement apparaît dans la table `passage-events`
