### PR TITLE
[TECH] :recycle: Simplifie le mécanisme de vérification d'accès d'un utilisateur à un centre de certification (PIX-19614)

### DIFF
--- a/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
+++ b/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
@@ -7,7 +7,7 @@ const findPaginatedCertificationCenterSessionSummaries = async function ({
   sessionSummaryRepository,
   userRepository,
 }) {
-  const hasAccess = await userRepository.isUserCanAccededToThisCertificationCenter(userId, certificationCenterId);
+  const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(userId, certificationCenterId);
   if (!hasAccess) {
     throw new ForbiddenAccess(`User ${userId} is not a member of certification center ${certificationCenterId}`);
   }

--- a/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
+++ b/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
@@ -7,7 +7,7 @@ const findPaginatedCertificationCenterSessionSummaries = async function ({
   sessionSummaryRepository,
   userRepository,
 }) {
-  const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(userId, certificationCenterId);
+  const hasAccess = await userRepository.isUserAllowedToAccessCertificationCenter(userId, certificationCenterId);
   if (!hasAccess) {
     throw new ForbiddenAccess(`User ${userId} is not a member of certification center ${certificationCenterId}`);
   }

--- a/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
+++ b/api/src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js
@@ -7,8 +7,8 @@ const findPaginatedCertificationCenterSessionSummaries = async function ({
   sessionSummaryRepository,
   userRepository,
 }) {
-  const user = await userRepository.getWithCertificationCenterMemberships(userId);
-  if (!user.hasAccessToCertificationCenter(certificationCenterId)) {
+  const hasAccess = await userRepository.isUserCanAccededToThisCertificationCenter(userId, certificationCenterId);
+  if (!hasAccess) {
     throw new ForbiddenAccess(`User ${userId} is not a member of certification center ${certificationCenterId}`);
   }
 

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -120,10 +120,6 @@ class User {
     return this.memberships.length > 0;
   }
 
-  isLinkedToCertificationCenters() {
-    return this.certificationCenterMemberships.length > 0;
-  }
-
   hasAccessToOrganization(organizationId) {
     return this.memberships.some((membership) => membership.organization.id === organizationId);
   }

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -33,7 +33,6 @@ class User {
       locale,
       isAnonymous,
       memberships = [],
-      certificationCenterMemberships = [],
       pixScore,
       scorecards = [],
       updatedAt,
@@ -68,7 +67,6 @@ class User {
     this.isAnonymous = isAnonymous;
     this.pixScore = pixScore;
     this.memberships = memberships;
-    this.certificationCenterMemberships = certificationCenterMemberships;
     this.scorecards = scorecards;
     this.updatedAt = updatedAt;
     this.campaignParticipations = campaignParticipations;

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -6,7 +6,7 @@ import * as localeService from '../../../shared/domain/services/locale-service.j
 import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/date-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
-const { toLower, isNil } = lodash;
+const { toLower } = lodash;
 
 class User {
   constructor(
@@ -126,14 +126,6 @@ class User {
 
   hasAccessToOrganization(organizationId) {
     return this.memberships.some((membership) => membership.organization.id === organizationId);
-  }
-
-  hasAccessToCertificationCenter(certificationCenterId) {
-    return this.certificationCenterMemberships.some(
-      (certificationCenterMembership) =>
-        certificationCenterMembership.certificationCenter.id === certificationCenterId &&
-        isNil(certificationCenterMembership.disabledAt),
-    );
   }
 
   markEmailAsValid() {

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -199,7 +199,7 @@ const getWithMemberships = async function (userId) {
   return _toDomainFromDTO({ userDTO, membershipsDTO });
 };
 
-const isUserCanAccededToThisCertificationCenter = async function (userId, certificationCenterId) {
+const isUserAllowedToAccessThisCertificationCenter = async function (userId, certificationCenterId) {
   const user = await knex('users').where({ id: userId }).first();
   if (!user) throw new UserNotFoundError(`User not found for ID ${userId}`);
 
@@ -431,7 +431,7 @@ const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
  * @property {function} getForObfuscation
  * @property {function} getFullById
  * @property {function} getUserDetailsForAdmin
- * @property {function} isUserCanAccededToThisCertificationCenter
+ * @property {function} isUserAllowedToAccessThisCertificationCenter
  * @property {function} getWithMemberships
  * @property {function} isUserExistingByEmail
  * @property {function} isUsernameAvailable
@@ -465,7 +465,7 @@ export {
   getFullById,
   getUserDetailsForAdmin,
   getWithMemberships,
-  isUserCanAccededToThisCertificationCenter,
+  isUserAllowedToAccessThisCertificationCenter,
   isUserExistingByEmail,
   isUsernameAvailable,
   update,

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -11,7 +11,6 @@ import {
   AlreadyRegisteredUsernameError,
   UserNotFoundError,
 } from '../../../shared/domain/errors.js';
-import { CertificationCenterMembership } from '../../../shared/domain/models/CertificationCenterMembership.js';
 import { Membership } from '../../../shared/domain/models/Membership.js';
 import { fetchPage, isUniqConstraintViolated } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
@@ -41,16 +40,12 @@ const getFullById = async function (userId) {
   }
 
   const membershipsDTO = await knex('memberships').where({ userId: userDTO.id, disabledAt: null });
-  const certificationCenterMembershipsDTO = await knex('certification-center-memberships').where({
-    userId: userDTO.id,
-    disabledAt: null,
-  });
   const authenticationMethodsDTO = await knex('authentication-methods').where({
     userId: userDTO.id,
     identityProvider: 'PIX',
   });
 
-  return _toDomainFromDTO({ userDTO, membershipsDTO, certificationCenterMembershipsDTO, authenticationMethodsDTO });
+  return _toDomainFromDTO({ userDTO, membershipsDTO, authenticationMethodsDTO });
 };
 
 const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
@@ -64,16 +59,12 @@ const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
   }
 
   const membershipsDTO = await knex('memberships').where({ userId: userDTO.id, disabledAt: null });
-  const certificationCenterMembershipsDTO = await knex('certification-center-memberships').where({
-    userId: userDTO.id,
-    disabledAt: null,
-  });
   const authenticationMethodsDTO = await knex('authentication-methods').where({
     userId: userDTO.id,
     identityProvider: 'PIX',
   });
 
-  return _toDomainFromDTO({ userDTO, membershipsDTO, certificationCenterMembershipsDTO, authenticationMethodsDTO });
+  return _toDomainFromDTO({ userDTO, membershipsDTO, authenticationMethodsDTO });
 };
 
 /**
@@ -579,17 +570,11 @@ function _fromKnexDTOToUserDetailsForAdmin({
 /**
  * @param userDTO
  * @param membershipsDTO
- * @param certificationCenterMembershipsDTO
  * @param authenticationMethodsDTO
  * @return {User}
  * @private
  */
-function _toDomainFromDTO({
-  userDTO,
-  membershipsDTO = [],
-  certificationCenterMembershipsDTO = [],
-  authenticationMethodsDTO = [],
-}) {
+function _toDomainFromDTO({ userDTO, membershipsDTO = [], authenticationMethodsDTO = [] }) {
   const memberships = membershipsDTO.map((membershipDTO) => {
     let organization;
     if (membershipDTO.organizationName) {
@@ -603,9 +588,6 @@ function _toDomainFromDTO({
     }
     return new Membership({ ...membershipDTO, organization });
   });
-  const certificationCenterMemberships = certificationCenterMembershipsDTO.map(
-    (certificationCenterMembershipDTO) => new CertificationCenterMembership(certificationCenterMembershipDTO),
-  );
   return new User({
     id: userDTO.id,
     cgu: userDTO.cgu,
@@ -630,7 +612,6 @@ function _toDomainFromDTO({
     scorecards: userDTO.scorecards,
     campaignParticipations: userDTO.campaignParticipations,
     memberships,
-    certificationCenterMemberships,
     authenticationMethods: authenticationMethodsDTO,
   });
 }

--- a/api/src/identity-access-management/infrastructure/repositories/user.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/user.repository.js
@@ -199,7 +199,7 @@ const getWithMemberships = async function (userId) {
   return _toDomainFromDTO({ userDTO, membershipsDTO });
 };
 
-const isUserAllowedToAccessThisCertificationCenter = async function (userId, certificationCenterId) {
+const isUserAllowedToAccessCertificationCenter = async function (userId, certificationCenterId) {
   const user = await knex('users').where({ id: userId }).first();
   if (!user) throw new UserNotFoundError(`User not found for ID ${userId}`);
 
@@ -211,7 +211,7 @@ const isUserAllowedToAccessThisCertificationCenter = async function (userId, cer
     .whereNull('disabledAt')
     .first();
 
-  return !!userIsMemberOfThisCertificationCenter;
+  return Boolean(userIsMemberOfThisCertificationCenter);
 };
 
 const getBySamlId = async function (samlId) {
@@ -431,7 +431,7 @@ const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
  * @property {function} getForObfuscation
  * @property {function} getFullById
  * @property {function} getUserDetailsForAdmin
- * @property {function} isUserAllowedToAccessThisCertificationCenter
+ * @property {function} isUserAllowedToAccessCertificationCenter
  * @property {function} getWithMemberships
  * @property {function} isUserExistingByEmail
  * @property {function} isUsernameAvailable
@@ -465,7 +465,7 @@ export {
   getFullById,
   getUserDetailsForAdmin,
   getWithMemberships,
-  isUserAllowedToAccessThisCertificationCenter,
+  isUserAllowedToAccessCertificationCenter,
   isUserExistingByEmail,
   isUsernameAvailable,
   update,

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-for-admin.serializer.js
@@ -21,7 +21,6 @@ const serialize = function (users, meta) {
       'lang',
       'isAnonymous',
       'memberships',
-      'certificationCenterMemberships',
       'pixScore',
       'scorecards',
       'profile',
@@ -33,10 +32,6 @@ const serialize = function (users, meta) {
       'hasSeenOtherChallengesTooltip',
     ],
     memberships: {
-      ref: 'id',
-      ignoreRelationshipData: true,
-    },
-    certificationCenterMemberships: {
       ref: 'id',
       ignoreRelationshipData: true,
     },

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-session_test.js
@@ -5,7 +5,6 @@ import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 describe('Unit | UseCase | create-session', function () {
   let centerRepository;
   let sessionRepository;
-  let userWithMemberships;
   const userId = 'userId';
   const certificationCenterId = 123;
   const certificationCenterName = 'certificationCenterName';
@@ -14,7 +13,6 @@ describe('Unit | UseCase | create-session', function () {
   beforeEach(function () {
     centerRepository = { getById: sinon.stub() };
     sessionRepository = { save: sinon.stub() };
-    userWithMemberships = { hasAccessToCertificationCenter: sinon.stub() };
   });
 
   describe('#save', function () {
@@ -47,10 +45,8 @@ describe('Unit | UseCase | create-session', function () {
         accessCode = Symbol('accessCode');
         sessionValidatorStub = { validate: sinon.stub().returns() };
         sessionCodeServiceStub = { getNewSessionCode: sinon.stub().returns(accessCode) };
-        userWithMemberships.hasAccessToCertificationCenter = sinon.stub();
         centerRepository.getById = sinon.stub();
         sessionRepository.save = sinon.stub();
-        userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
         sessionRepository.save.resolves();
       });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
@@ -8,18 +8,18 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   };
 
   const userRepository = {
-    isUserAllowedToAccessThisCertificationCenter: () => undefined,
+    isUserAllowedToAccessCertificationCenter: () => undefined,
   };
 
   beforeEach(function () {
     sessionSummaryRepository.findPaginatedByCertificationCenterId = sinon.stub();
-    userRepository.isUserAllowedToAccessThisCertificationCenter = sinon.stub();
+    userRepository.isUserAllowedToAccessCertificationCenter = sinon.stub();
   });
 
   context('when user is not a member of the certification center', function () {
     it('should throw a Forbidden Access error', async function () {
       // given
-      userRepository.isUserAllowedToAccessThisCertificationCenter.withArgs(123, 456).resolves(false);
+      userRepository.isUserAllowedToAccessCertificationCenter.withArgs(123, 456).resolves(false);
       sessionSummaryRepository.findPaginatedByCertificationCenterId.rejects(new Error('should not be called'));
 
       // when
@@ -40,7 +40,7 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   context('when user is a member of the certification center', function () {
     it('should return session summaries', async function () {
       // given
-      userRepository.isUserAllowedToAccessThisCertificationCenter.withArgs(123, 456).resolves(true);
+      userRepository.isUserAllowedToAccessCertificationCenter.withArgs(123, 456).resolves(true);
       const sessionSummaries = Symbol('session-summaries');
       const meta = Symbol('meta');
       sessionSummaryRepository.findPaginatedByCertificationCenterId

--- a/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
@@ -8,18 +8,18 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   };
 
   const userRepository = {
-    isUserCanAccededToThisCertificationCenter: () => undefined,
+    isUserAllowedToAccessThisCertificationCenter: () => undefined,
   };
 
   beforeEach(function () {
     sessionSummaryRepository.findPaginatedByCertificationCenterId = sinon.stub();
-    userRepository.isUserCanAccededToThisCertificationCenter = sinon.stub();
+    userRepository.isUserAllowedToAccessThisCertificationCenter = sinon.stub();
   });
 
   context('when user is not a member of the certification center', function () {
     it('should throw a Forbidden Access error', async function () {
       // given
-      userRepository.isUserCanAccededToThisCertificationCenter.withArgs(123, 456).resolves(false);
+      userRepository.isUserAllowedToAccessThisCertificationCenter.withArgs(123, 456).resolves(false);
       sessionSummaryRepository.findPaginatedByCertificationCenterId.rejects(new Error('should not be called'));
 
       // when
@@ -40,7 +40,7 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   context('when user is a member of the certification center', function () {
     it('should return session summaries', async function () {
       // given
-      userRepository.isUserCanAccededToThisCertificationCenter.withArgs(123, 456).resolves(true);
+      userRepository.isUserAllowedToAccessThisCertificationCenter.withArgs(123, 456).resolves(true);
       const sessionSummaries = Symbol('session-summaries');
       const meta = Symbol('meta');
       sessionSummaryRepository.findPaginatedByCertificationCenterId

--- a/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/find-paginated-certification-center-session-summaries_test.js
@@ -1,6 +1,6 @@
 import { findPaginatedCertificationCenterSessionSummaries } from '../../../../../../src/certification/session-management/domain/usecases/find-paginated-certification-center-session-summaries.js';
 import { ForbiddenAccess } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | find-paginated-certification-center-session-summaries', function () {
   const sessionSummaryRepository = {
@@ -8,25 +8,18 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   };
 
   const userRepository = {
-    getWithCertificationCenterMemberships: () => undefined,
+    isUserCanAccededToThisCertificationCenter: () => undefined,
   };
 
   beforeEach(function () {
     sessionSummaryRepository.findPaginatedByCertificationCenterId = sinon.stub();
-    userRepository.getWithCertificationCenterMemberships = sinon.stub();
+    userRepository.isUserCanAccededToThisCertificationCenter = sinon.stub();
   });
 
   context('when user is not a member of the certification center', function () {
     it('should throw a Forbidden Access error', async function () {
       // given
-      const user = domainBuilder.buildUser();
-      const certificationCenter = domainBuilder.buildCertificationCenter({ id: 789 });
-      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
-        user,
-        certificationCenter,
-      });
-      user.certificationCenterMemberships = [certificationCenterMembership];
-      userRepository.getWithCertificationCenterMemberships.withArgs(123).resolves(user);
+      userRepository.isUserCanAccededToThisCertificationCenter.withArgs(123, 456).resolves(false);
       sessionSummaryRepository.findPaginatedByCertificationCenterId.rejects(new Error('should not be called'));
 
       // when
@@ -47,14 +40,7 @@ describe('Unit | Domain | Use Cases | find-paginated-certification-center-sessio
   context('when user is a member of the certification center', function () {
     it('should return session summaries', async function () {
       // given
-      const user = domainBuilder.buildUser();
-      const certificationCenter = domainBuilder.buildCertificationCenter({ id: 456 });
-      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
-        user,
-        certificationCenter,
-      });
-      user.certificationCenterMemberships = [certificationCenterMembership];
-      userRepository.getWithCertificationCenterMemberships.withArgs(123).resolves(user);
+      userRepository.isUserCanAccededToThisCertificationCenter.withArgs(123, 456).resolves(true);
       const sessionSummaries = Symbol('session-summaries');
       const meta = Symbol('meta');
       sessionSummaryRepository.findPaginatedByCertificationCenterId

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -971,7 +971,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
     });
 
-    describe('#isUserAllowedToAccessThisCertificationCenter', function () {
+    describe('#isUserAllowedToAccessCertificationCenter', function () {
       it('returns true when user has access to the certification center', async function () {
         // given
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
@@ -983,7 +983,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -999,7 +999,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -1020,7 +1020,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -1036,7 +1036,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const result = await catchErr(userRepository.isUserAllowedToAccessThisCertificationCenter)(
+        const result = await catchErr(userRepository.isUserAllowedToAccessCertificationCenter)(
           unknownUserId,
           certificationCenter.id,
         );

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/user.repository.test.js
@@ -971,7 +971,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       });
     });
 
-    describe('#isUserCanAccededToThisCertificationCenter', function () {
+    describe('#isUserAllowedToAccessThisCertificationCenter', function () {
       it('returns true when user has access to the certification center', async function () {
         // given
         const userInDB = databaseBuilder.factory.buildUser(userToInsert);
@@ -983,7 +983,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserCanAccededToThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -999,7 +999,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserCanAccededToThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -1020,7 +1020,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const hasAccess = await userRepository.isUserCanAccededToThisCertificationCenter(
+        const hasAccess = await userRepository.isUserAllowedToAccessThisCertificationCenter(
           userInDB.id,
           certificationCenter.id,
         );
@@ -1036,7 +1036,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         await databaseBuilder.commit();
 
         // when
-        const result = await catchErr(userRepository.isUserCanAccededToThisCertificationCenter)(
+        const result = await catchErr(userRepository.isUserAllowedToAccessThisCertificationCenter)(
           unknownUserId,
           certificationCenter.id,
         );

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -190,32 +190,6 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     });
   });
 
-  describe('isLinkedToCertificationCenters', function () {
-    it('should be true if user has a role in a certification center', function () {
-      // given
-      const user = domainBuilder.buildUser({
-        certificationCenterMemberships: [domainBuilder.buildCertificationCenterMembership()],
-      });
-
-      // when
-      const isLinked = user.isLinkedToCertificationCenters();
-
-      // then
-      expect(isLinked).to.be.true;
-    });
-
-    it('should be false if user has no role in certification center', function () {
-      // given
-      const user = new User(undefined);
-
-      // when
-      const isLinked = user.isLinkedToCertificationCenters();
-
-      // then
-      expect(isLinked).to.be.false;
-    });
-  });
-
   describe('hasAccessToOrganization', function () {
     it('should be false is user has no access to no organizations', function () {
       // given

--- a/api/tests/identity-access-management/unit/domain/models/User.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/User.test.js
@@ -258,67 +258,6 @@ describe('Unit | Identity Access Management | Domain | Model | User', function (
     });
   });
 
-  describe('hasAccessToCertificationCenter', function () {
-    it('should be false if user has no access to given certification center', function () {
-      // given
-      const user = new User(undefined);
-      const certificationCenterId = 12345;
-
-      // when
-      const hasAccess = user.hasAccessToCertificationCenter(certificationCenterId);
-
-      // then
-      expect(hasAccess).to.be.false;
-    });
-
-    it('should be false if user has access to many CertificationCenters, but not the given one', function () {
-      // given
-      const certificationCenterId = 12345;
-      const user = domainBuilder.buildUser();
-      user.certificationCenterMemberships.push(domainBuilder.buildCertificationCenterMembership());
-      user.certificationCenterMemberships[0].certificationCenter.id = 93472;
-      user.certificationCenterMemberships[1].certificationCenter.id = 74569;
-
-      // when
-      const hasAccess = user.hasAccessToCertificationCenter(certificationCenterId);
-
-      //then
-      expect(hasAccess).to.be.false;
-    });
-
-    it('should be true if the user has an access to the given CertificationCenterId', function () {
-      // given
-      const certificationCenterId = 12345;
-      const user = domainBuilder.buildUser();
-      user.certificationCenterMemberships[0].certificationCenter.id = 12345;
-
-      // when
-      const hasAccess = user.hasAccessToCertificationCenter(certificationCenterId);
-
-      //then
-      expect(hasAccess).to.be.true;
-    });
-
-    it('should be false if the user has a disabled access to the given CertificationCenterId', function () {
-      // given
-      const certificationCenterId = 12345;
-      const now = new Date();
-      const user = domainBuilder.buildUser();
-      user.certificationCenterMemberships = [
-        domainBuilder.buildCertificationCenterMembership({
-          certificationCenter: { id: certificationCenterId },
-          disabledAt: now,
-        }),
-      ];
-
-      // when
-      const hasAccess = user.hasAccessToCertificationCenter(certificationCenterId);
-
-      //then
-      expect(hasAccess).to.be.false;
-    });
-  });
-
   describe('#email', function () {
     it('should normalize email', function () {
       // given

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-for-admin.serializer.test.js
@@ -50,7 +50,6 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | user-for-ad
             },
             relationships: {
               memberships: {},
-              'certification-center-memberships': {},
               'pix-score': {},
               profile: {
                 links: {


### PR DESCRIPTION
## 🔆 Problème

Nous construisons tout un tas d'objet pour vérifier un simple accès.

## ⛱️ Proposition

Utilise une requête SQL simple pour vérifier l'accès d'un utilisateur à un centre de certification.

Et supprime tous les usages devenu inutile autour des centres de certification de l'utilisateur.

## 🌊 Remarques

C'est en observant les usages du modèle `CertificationCenterMembership` que j'ai découvert qu'il était utilisé dans `src/team/` et dans `src/identity-access-management/`. Aussi, je suis allé explorer comment ce modèle est utilisé dans ces deux domaines pour comprendre où le déplacer. C'est à ce moment-là que j'ai découvert cette pile de code qui à priori pouvait être simplifié.

## 🏄 Pour tester

Aller sur la page des sessions de certifications de pixCertif et s'assurer que l'on accède bien uniquement aux sessions du centre de certification courant.
Changer de centre et s'assurer que l'on continue à ne voir que les sessions du centre courant.
