### PR TITLE
[FEATURE] Migrer l'event FILE_DOWNLOADED du service metrics vers un passageEvent (PIX-18370)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,7 @@ import {
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
+  FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
   VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
@@ -29,6 +30,8 @@ class PassageEventFactory {
     switch (eventData.type) {
       case 'EMBED_ANSWERED':
         return new EmbedAnsweredEvent(eventData);
+      case 'FILE_DOWNLOADED':
+        return new FileDownloadedEvent(eventData);
       case 'FLASHCARDS_CARD_AUTO_ASSESSED':
         return new FlashcardsCardAutoAssessedEvent(eventData);
       case 'FLASHCARDS_RECTO_REVIEWED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -63,4 +63,25 @@ class VideoPlayedEvent extends PassageEventWithElement {
   }
 }
 
-export { ImageAlternativeTextOpenedEvent, VideoPlayedEvent, VideoTranscriptionOpenedEvent };
+/**
+ * @class FileDownloadedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user downloads a file.
+ * */
+class FileDownloadedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, filename, format }) {
+    super({
+      type: 'FILE_DOWNLOADED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+      data: { filename, format },
+    });
+  }
+}
+
+export { FileDownloadedEvent, ImageAlternativeTextOpenedEvent, VideoPlayedEvent, VideoTranscriptionOpenedEvent };

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -10,6 +10,7 @@ import {
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
+  FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
   VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
@@ -457,6 +458,27 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(VideoPlayedEvent);
+      });
+    });
+
+    describe('when given a FILE_DOWNLOADED event', function () {
+      it('should return an FileDownloadedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 9,
+          sequenceNumber: 34,
+          elementId: 'd905e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'FILE_DOWNLOADED',
+          filename: 'my-file.pdf',
+          format: '.pdf',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(FileDownloadedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/element/download.gjs
+++ b/mon-pix/app/components/module/element/download.gjs
@@ -10,8 +10,10 @@ import ModuleElement from './module-element';
 
 export default class ModulixDownload extends ModuleElement {
   @action
-  onDownload(downloadedFormat) {
-    this.args.onDownload({ elementId: this.args.download.id, downloadedFormat });
+  onDownload(downloadedFile) {
+    const filename = downloadedFile.url.split('/').pop();
+    const format = downloadedFile.format;
+    this.args.onDownload({ elementId: this.args.download.id, format, filename });
   }
 
   <template>
@@ -33,7 +35,8 @@ export default class ModulixDownload extends ModuleElement {
                 @href="{{file.url}}"
                 aria-label="{{t 'pages.modulix.download.label' format=file.format}}"
                 download
-                {{on "click" (fn this.onDownload file.format)}}
+                target="_blank"
+                {{on "click" (fn this.onDownload file)}}
               >
                 {{t "pages.modulix.download.button"}}
               </PixButtonLink>

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -206,11 +206,14 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async onFileDownload({ elementId, downloadedFormat }) {
-    this.pixMetrics.trackEvent(`Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`, {
-      disabled: true,
-      category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+  async onFileDownload({ elementId, format, filename }) {
+    this.passageEvents.record({
+      type: 'FILE_DOWNLOADED',
+      data: {
+        elementId,
+        format,
+        filename,
+      },
     });
   }
 

--- a/mon-pix/tests/integration/components/module/download_test.gjs
+++ b/mon-pix/tests/integration/components/module/download_test.gjs
@@ -98,7 +98,8 @@ module('Integration | Component | Module | Element | Download', function (hooks)
       // then
       sinon.assert.calledWithExactly(onDownloadStub, {
         elementId: downloadElement.id,
-        downloadedFormat,
+        format: downloadedFormat,
+        filename: 'placeholder-doc.pdf',
       });
       assert.ok(true);
     });


### PR DESCRIPTION
## 🔆 Problème

On n'a pas de passage-event créé quand un utilisateur télécharge un fichier dans élément `download`

## ⛱️ Proposition

Générer un passage-event FILE_DOWNLOADED quand utilisateur télécharge un fichier, en appelant l'api.
Supprimer l'event Plausible.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr13584.review.pix.fr/modules/bac-a-sable)
- Afficher un élément download (où user doit télécharger un fichier)
- Ouvrir console développeur -> Réseau
- Cliquer sur "Télécharger un fichier"
- Vérifier que l'appel api /passage-event retourne 204
