### PR TITLE
[FEATURE] Migrer l'évènement VIDEO_PLAYED du service metrics vers un passageEvent (PIX-18369)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -7,7 +7,11 @@ import {
   QCUDiscoveryAnsweredEvent,
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
-import { ImageAlternativeTextOpenedEvent, VideoTranscriptionOpenedEvent } from '../models/passage-events/events.js';
+import {
+  ImageAlternativeTextOpenedEvent,
+  VideoPlayedEvent,
+  VideoTranscriptionOpenedEvent,
+} from '../models/passage-events/events.js';
 import {
   FlashcardsCardAutoAssessedEvent,
   FlashcardsRectoReviewedEvent,
@@ -63,6 +67,8 @@ class PassageEventFactory {
         return new QCUDiscoveryAnsweredEvent(eventData);
       case 'VIDEO_TRANSCRIPTION_OPENED':
         return new VideoTranscriptionOpenedEvent(eventData);
+      case 'VIDEO_PLAYED':
+        return new VideoPlayedEvent(eventData);
       default:
         throw new DomainError(`Passage event with type ${eventData.type} does not exist`);
     }

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -42,4 +42,25 @@ class VideoTranscriptionOpenedEvent extends PassageEventWithElement {
   }
 }
 
-export { ImageAlternativeTextOpenedEvent, VideoTranscriptionOpenedEvent };
+/**
+ * @class VideoPlayedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user plays a video.
+ *
+ * */
+class VideoPlayedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'VIDEO_PLAYED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+export { ImageAlternativeTextOpenedEvent, VideoPlayedEvent, VideoTranscriptionOpenedEvent };

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -11,6 +11,7 @@ import {
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
   ImageAlternativeTextOpenedEvent,
+  VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/events.js';
 import {
@@ -438,6 +439,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(VideoTranscriptionOpenedEvent);
+      });
+    });
+
+    describe('when given an VIDEO_PLAYED event', function () {
+      it('should return an VideoPlayed instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'VIDEO_PLAYED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(VideoPlayedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -30,7 +30,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "image")}}
       <ImageElement @image={{@element}} @onAlternativeTextOpen={{@onImageAlternativeTextOpen}} />
     {{else if (eq @element.type "video")}}
-      <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} @onPlay={{@onVideoPlay}} />
+      <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
     {{else if (eq @element.type "download")}}
       <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}

--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -59,7 +59,6 @@ export default class ModulixStep extends Component {
               @getLastCorrectionForElement={{@getLastCorrectionForElement}}
               @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
-              @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
               @onExpandToggle={{@onExpandToggle}}
             />

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -216,7 +216,6 @@ export default class ModulixStepper extends Component {
                 @isHidden={{this.stepIsHidden index}}
                 @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                 @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
-                @onVideoPlay={{@onVideoPlay}}
                 @onFileDownload={{@onFileDownload}}
                 @onExpandToggle={{@onExpandToggle}}
                 @onNextButtonClick={{this.displayNextStep}}
@@ -242,7 +241,6 @@ export default class ModulixStepper extends Component {
               @isHidden={{false}}
               @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
-              @onVideoPlay={{@onVideoPlay}}
               @onFileDownload={{@onFileDownload}}
               @onExpandToggle={{@onExpandToggle}}
               @onNextButtonClick={{this.displayNextStep}}

--- a/mon-pix/app/components/module/element/video.gjs
+++ b/mon-pix/app/components/module/element/video.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -13,6 +14,8 @@ import player_fr from '../plyr-translation/player_fr';
 
 export default class ModulixVideoElement extends Component {
   @tracked modalIsOpen = false;
+  @service passageEvents;
+
   videoWasStarted = false;
 
   get hasSubtitles() {
@@ -52,6 +55,13 @@ export default class ModulixVideoElement extends Component {
     }
     this.videoWasStarted = true;
     this.args.onPlay({ elementId: this.args.video.id });
+
+    this.passageEvents.record({
+      type: 'VIDEO_PLAYED',
+      data: {
+        elementId: this.args.video.id,
+      },
+    });
   }
 
   <template>

--- a/mon-pix/app/components/module/element/video.gjs
+++ b/mon-pix/app/components/module/element/video.gjs
@@ -54,7 +54,6 @@ export default class ModulixVideoElement extends Component {
       return;
     }
     this.videoWasStarted = true;
-    this.args.onPlay({ elementId: this.args.video.id });
 
     this.passageEvents.record({
       type: 'VIDEO_PLAYED',

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -276,7 +276,6 @@ export default class ModuleGrain extends Component {
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
                   @onElementAnswer={{this.onElementAnswer}}
                   @onElementRetry={{@onElementRetry}}
-                  @onVideoPlay={{@onVideoPlay}}
                   @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
@@ -294,7 +293,6 @@ export default class ModuleGrain extends Component {
                   @onStepperNextStep={{@onStepperNextStep}}
                   @onImageAlternativeTextOpen={{@onImageAlternativeTextOpen}}
                   @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
-                  @onVideoPlay={{@onVideoPlay}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
                   @direction={{this.stepperDirection}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -206,15 +206,6 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  async onVideoPlay({ elementId }) {
-    this.pixMetrics.trackEvent(`Click sur le bouton Play : ${elementId}`, {
-      disabled: true,
-      category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
-    });
-  }
-
-  @action
   async onFileDownload({ elementId, downloadedFormat }) {
     this.pixMetrics.trackEvent(`Click sur le bouton Télécharger au format ${downloadedFormat} de ${elementId}`, {
       disabled: true,
@@ -274,7 +265,6 @@ export default class ModulePassage extends Component {
             @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
             @hasJustAppeared={{this.hasGrainJustAppeared index}}
             @onModuleTerminate={{this.onModuleTerminate}}
-            @onVideoPlay={{this.onVideoPlay}}
             @onFileDownload={{this.onFileDownload}}
             @onExpandToggle={{this.onExpandToggle}}
           />

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -196,7 +196,6 @@ export default class ModulixPreview extends Component {
                 @shouldDisplayTerminateButton={{false}}
                 @onModuleTerminate={{this.noop}}
                 @hasJustAppeared={{false}}
-                @onVideoPlay={{this.noop}}
                 @onFileDownload={{this.noop}}
               />
             {{/each}}

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1,6 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
-// eslint-disable-next-line no-restricted-imports
-import { click, find, findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ApplicationAdapter from 'mon-pix/adapters/application';
 import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
@@ -1149,110 +1148,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
           // then
           assert.dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.grain.terminate') })).exists();
         });
-      });
-    });
-  });
-
-  module('when a video element is played', function () {
-    test('should push an event', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const metrics = this.owner.lookup('service:pix-metrics');
-      metrics.trackEvent = sinon.stub();
-
-      const videoElement = {
-        id: 'id',
-        url: 'https://videos.pix.fr/modulix/placeholder-video.mp4',
-        title: 'title',
-        subtitles: 'subtitles',
-        type: 'video',
-        transcription: '',
-      };
-      const section = store.createRecord('section', {
-        id: 'section1',
-        type: 'blank',
-        grains: [
-          {
-            id: '123',
-            components: [{ type: 'element', element: videoElement }],
-          },
-        ],
-      });
-
-      const module = store.createRecord('module', {
-        id: '1',
-        slug: 'module-slug',
-        title: 'Module title',
-        sections: [section],
-      });
-      const passage = store.createRecord('passage');
-
-      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-      const video = find(`#${videoElement.id}`);
-
-      //  when
-      const event = new Event('play');
-      video.dispatchEvent(event);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
-        category: 'Modulix',
-        disabled: true,
-        action: `Passage du module : ${module.slug}`,
-      });
-      assert.ok(true);
-    });
-
-    module('when video is in a stepper', function () {
-      test('should push metrics event', async function (assert) {
-        // given
-        const metrics = this.owner.lookup('service:pix-metrics');
-        metrics.trackEvent = sinon.stub();
-
-        // given
-        const store = this.owner.lookup('service:store');
-        const videoElement = {
-          id: 'a9f2269-99ba-4631-b6fd-6802c88d5c26',
-          type: 'video',
-          title: 'Vidéo de présentation de Pix',
-          url: 'https://videos.pix.fr/modulix/didacticiel/presentation.mp4',
-          subtitles: '',
-          transcription: '<p>transcription</p>',
-        };
-        const section = store.createRecord('section', {
-          id: 'section1',
-          type: 'blank',
-          grains: [
-            {
-              title: 'Grain title',
-              components: [{ type: 'element', element: videoElement }],
-            },
-          ],
-        });
-        const module = store.createRecord('module', {
-          id: 'module-id',
-          slug: 'module-slug',
-          title: 'Module title',
-          sections: [section],
-        });
-        const passage = store.createRecord('passage');
-        await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
-        const video = find(`#${videoElement.id}`);
-
-        //  when
-        const event = new Event('play');
-        video.dispatchEvent(event);
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Play : ${videoElement.id}`, {
-          category: 'Modulix',
-          disabled: true,
-
-          action: `Passage du module : ${module.slug}`,
-        });
-        assert.ok(true);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/video_test.gjs
+++ b/mon-pix/tests/integration/components/module/video_test.gjs
@@ -144,58 +144,6 @@ module('Integration | Component | Module | Video', function (hooks) {
   });
 
   module('when the video is played', function () {
-    test('should call onPlay prop with right argument', async function (assert) {
-      // given
-      const videoElement = {
-        id: 'id',
-        url: 'https://videos.pix.fr/modulix/placeholder-video.mp4',
-        title: 'title',
-        subtitles: 'subtitles',
-        transcription: '',
-        poster: 'https://example.org/modulix/video-poster.jpg',
-      };
-      const onVideoPlayStub = sinon.stub();
-      await render(<template><ModulixVideoElement @video={{videoElement}} @onPlay={{onVideoPlayStub}} /></template>);
-      const video = find(`#${videoElement.id}`);
-
-      //  when
-      const event = new Event('play');
-      video.dispatchEvent(event);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // then
-      sinon.assert.calledWithExactly(onVideoPlayStub, {
-        elementId: videoElement.id,
-      });
-      assert.ok(true);
-    });
-
-    test('should call onPlay prop only once', async function (assert) {
-      // given
-      const videoElement = {
-        id: 'id',
-        url: 'https://videos.pix.fr/modulix/placeholder-video.mp4',
-        title: 'title',
-        subtitles: 'subtitles',
-        transcription: '',
-        poster: 'https://example.org/modulix/video-poster.jpg',
-      };
-      const onVideoPlayStub = sinon.stub();
-      await render(<template><ModulixVideoElement @video={{videoElement}} @onPlay={{onVideoPlayStub}} /></template>);
-      const video = find(`#${videoElement.id}`);
-
-      //  when
-      const event = new Event('play');
-      video.dispatchEvent(event);
-      video.dispatchEvent(event);
-      video.dispatchEvent(event);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // then
-      sinon.assert.calledOnce(onVideoPlayStub);
-      assert.ok(true);
-    });
-
     test('should record a passage event', async function (assert) {
       // given
       const videoElement = {
@@ -206,8 +154,7 @@ module('Integration | Component | Module | Video', function (hooks) {
         transcription: '',
         poster: 'https://example.org/modulix/video-poster.jpg',
       };
-      const onVideoPlayStub = sinon.stub();
-      await render(<template><ModulixVideoElement @video={{videoElement}} @onPlay={{onVideoPlayStub}} /></template>);
+      await render(<template><ModulixVideoElement @video={{videoElement}} /></template>);
       const video = find(`#${videoElement.id}`);
 
       //  when
@@ -218,6 +165,7 @@ module('Integration | Component | Module | Video', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // then
+      sinon.assert.calledOnce(passageEventRecordStub);
       sinon.assert.calledWithExactly(passageEventRecordStub, {
         type: 'VIDEO_PLAYED',
         data: {


### PR DESCRIPTION
## ⛱️ Proposition

- Enregistrer une trace d'apprentissage quand on joue une vidéo dans un Module.
- Ne plus enregistrer le même évènement dans Plausible

## 🌊 Remarques

Comme on supprime l'évènement Plausible plus besoin de remonter jusqu'à passage, j'ai géré le passage event directement dans l'élément `Video`.

## 🏄 Pour tester

- Ouvrir [le bac-a-sable](https://app-pr13587.review.pix.fr/modules/bac-a-sable)
- Aller à la vidéo et ouvrir l'onglet "Réseau"
- Cliquer sur le bouton de lecture de la vidéo
- Vérifier que la route `/passage-events` est appelée avec le bon type et l'id de l'élément
- Vérifier en base que l'évènement apparaît dans la table `passage-events`
- Constater qu'aucun évènement n'est envoyé à Plausible
