### PR TITLE
[TECH] Renommer la table "pix-teams" en "administration-teams" (PIX-19553)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -21,7 +21,7 @@ const buildOrganization = function buildOrganization({
   archivedAt = null,
   identityProviderForCampaigns = null,
   parentOrganizationId = null,
-  pixTeamId = null,
+  administrationTeamId = null,
 } = {}) {
   const values = {
     id,
@@ -44,7 +44,7 @@ const buildOrganization = function buildOrganization({
     archivedAt,
     identityProviderForCampaigns,
     parentOrganizationId,
-    pixTeamId,
+    administrationTeamId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20250917091232_rename-pix-teams-table.js
+++ b/api/db/migrations/20250917091232_rename-pix-teams-table.js
@@ -1,0 +1,62 @@
+const FORMER_TABLE_NAME = 'pix-teams';
+const NEW_TABLE_NAME = 'administration_teams';
+const FORMER_COLUMN_NAME = 'pixTeamId';
+const NEW_COLUMN_NAME = 'administrationTeamId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable('organizations', async (table) => {
+    table.dropColumn(FORMER_COLUMN_NAME);
+  });
+
+  await knex.schema.dropTable(FORMER_TABLE_NAME);
+
+  await knex.schema.createTable(NEW_TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.string('name').notNullable().comment('Team name');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.alterTable('organizations', async (table) => {
+    table
+      .integer(NEW_COLUMN_NAME)
+      .unsigned()
+      .index()
+      .references(`${NEW_TABLE_NAME}.id`)
+      .comment("Reference to the organization's administration team");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable('organizations', async (table) => {
+    table.dropColumn(NEW_COLUMN_NAME);
+  });
+
+  await knex.schema.dropTable(NEW_TABLE_NAME);
+
+  await knex.schema.createTable(FORMER_TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.string('name').notNullable().comment('Team name');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.alterTable('organizations', async (table) => {
+    table
+      .integer(FORMER_COLUMN_NAME)
+      .unsigned()
+      .index()
+      .references(`${FORMER_TABLE_NAME}.id`)
+      .comment("Reference to the organization's pix team");
+  });
+};
+
+export { down, up };

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -32,7 +32,7 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
     'parentOrganizationId',
     'schoolCode',
     'sessionExpirationDate',
-    'pixTeamId',
+    'administrationTeamId',
   ];
 
   let clock;


### PR DESCRIPTION
## 🔆 Problème

Le nom de la table "pix-teams" n'est pas correct

## ⛱️ Proposition

- Renommer la table “pix-teams” en “administration-teams”

- Modifier la relation “pixTeamId” en “administrationTeamId” dans la table “organization”

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Verifier en base que les changements ont bien été pris en compte