### PR TITLE
[FEATURE] Modifier le contenu de la bannière sur Pix App (PIX-19554).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1654,7 +1654,7 @@
       "title": "Create your Account"
     },
     "modulix": {
-      "beta-banner": "This module is in beta version. You can send us your feedback at the end of this module to help us improve it.",
+      "beta-banner": "This module is in beta version. Changes may be made over time.",
       "buttons": {
         "activity": {
           "retry": "Retry",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1640,7 +1640,7 @@
       "title": "Conectarse a Pix"
     },
     "modulix": {
-      "beta-banner": "Este módulo está en versión beta. Puede enviarnos sus comentarios al final de este módulo para ayudarnos a mejorarlo.",
+      "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
       "buttons": {
         "activity": {
           "retry": "Volver a intentarlo",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1654,7 +1654,7 @@
       "title": "Créez votre compte Pix"
     },
     "modulix": {
-      "beta-banner": "Ce module est en version bêta. Vous pourrez faire vos retours à la fin de ce module pour nous permettre de l’améliorer.",
+      "beta-banner": "Ce module est en version bêta. Des évolutions pourront être apportées au fil du temps.",
       "buttons": {
         "activity": {
           "retry": "Réessayer",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1644,7 +1644,7 @@
       "title": "Verbinding maken met Pix"
     },
     "modulix": {
-      "beta-banner": "Deze module is in bètaversie. Je kunt ons feedback sturen aan het einde van deze module om ons te helpen deze te verbeteren.",
+      "beta-banner": "Deze module is in bètaversie. In de loop van de tijd kunnen er wijzigingen worden aangebracht.",
       "buttons": {
         "activity": {
           "retry": "Probeer het opnieuw",


### PR DESCRIPTION
## 🔆 Problème

Sur Pix App, le bouton de feedback a été supprimé à la fin d'un module pour les besoins du parcours combinés.
Le bandeau de la beta, visible dans tout le parcours du module, mentionne encore la possibilité de feedback.

## ⛱️ Proposition

Modifier le contenu de la bannière

## 🏄 Pour tester

- Se rendre sur https://app-pr13590.review.pix.fr/modules/bac-a-sable/details
- Constater que la bannière retourne le message suivant :  "Ce module est en version bêta. Des évolutions pourront être apportées au fil du temps."
