### PR TITLE
[TECH] Ajouter des constantes pour les types d'item des parcours combinés et pour les urls des assets (PIX-19550)

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -6,6 +6,8 @@ import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
+import { CombinedCourseItemTypes } from '../../models/combined-course-item';
+
 const Content = <template>
   <div class="combined-course-item" ...attributes>
     <div class="combined-course-item__content">
@@ -50,7 +52,7 @@ const Duration = <template>
 </template>;
 
 <template>
-  {{#if (eq @item.type "FORMATION")}}
+  {{#if (eq @item.type CombinedCourseItemTypes.FORMATION)}}
     <Content
       @title={{t "pages.combined-courses.items.formation.title"}}
       @isLocked={{true}}

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -5,8 +5,7 @@ import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
-
-import { CombinedCourseItemTypes } from '../../models/combined-course-item';
+import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 
 const Content = <template>
   <div class="combined-course-item" ...attributes>

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -5,6 +5,11 @@ export const CombinedCourseItemTypes = {
   FORMATION: 'FORMATION',
   MODULE: 'MODULE',
 };
+
+export const CombinedCourseAssets = {
+  CAMPAIGN_ICON: 'https://assets.pix.org/combined-courses/campaign-icon.svg',
+  FORMATION_ICON: 'https://assets.pix.org/combined-courses/picto_formation_vector.svg',
+};
 export default class CombinedCourseItem extends Model {
   @attr('string') reference;
   @attr('string') title;
@@ -20,10 +25,8 @@ export default class CombinedCourseItem extends Model {
   }
 
   get iconUrl() {
-    if (this.type === CombinedCourseItemTypes.CAMPAIGN)
-      return 'https://assets.pix.org/combined-courses/campaign-icon.svg';
-    if (this.type === CombinedCourseItemTypes.FORMATION)
-      return 'https://assets.pix.org/combined-courses/picto_formation_vector.svg';
+    if (this.type === CombinedCourseItemTypes.CAMPAIGN) return CombinedCourseAssets.CAMPAIGN_ICON;
+    if (this.type === CombinedCourseItemTypes.FORMATION) return CombinedCourseAssets.FORMATION_ICON;
 
     return this.image;
   }

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -1,5 +1,10 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+export const CombinedCourseItemTypes = {
+  CAMPAIGN: 'CAMPAIGN',
+  FORMATION: 'FORMATION',
+  MODULE: 'MODULE',
+};
 export default class CombinedCourseItem extends Model {
   @attr('string') reference;
   @attr('string') title;
@@ -11,12 +16,14 @@ export default class CombinedCourseItem extends Model {
   @attr('string') image;
 
   get route() {
-    return this.type === 'CAMPAIGN' ? 'campaigns' : 'module';
+    return this.type === CombinedCourseItemTypes.CAMPAIGN ? 'campaigns' : 'module';
   }
 
   get iconUrl() {
-    if (this.type === 'CAMPAIGN') return 'https://assets.pix.org/combined-courses/campaign-icon.svg';
-    if (this.type === 'FORMATION') return 'https://assets.pix.org/combined-courses/picto_formation_vector.svg';
+    if (this.type === CombinedCourseItemTypes.CAMPAIGN)
+      return 'https://assets.pix.org/combined-courses/campaign-icon.svg';
+    if (this.type === CombinedCourseItemTypes.FORMATION)
+      return 'https://assets.pix.org/combined-courses/picto_formation_vector.svg';
 
     return this.image;
   }

--- a/mon-pix/tests/unit/models/combined-course-item-test.js
+++ b/mon-pix/tests/unit/models/combined-course-item-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from 'ember-qunit';
+import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 import { module, test } from 'qunit';
 
 module('Unit | Model | Combined Course Item', function (hooks) {
@@ -13,14 +14,14 @@ module('Unit | Model | Combined Course Item', function (hooks) {
   module('Type is CAMPAIGN', function () {
     test('return route campaign', function (assert) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
-        type: 'CAMPAIGN',
+        type: CombinedCourseItemTypes.CAMPAIGN,
       });
       assert.strictEqual(combinedCourseItem.route, 'campaigns');
     });
 
     test('return iconUrl related for campaign', function (assert) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
-        type: 'CAMPAIGN',
+        type: CombinedCourseItemTypes.CAMPAIGN,
       });
       assert.strictEqual(combinedCourseItem.iconUrl, 'https://assets.pix.org/combined-courses/campaign-icon.svg');
     });
@@ -29,14 +30,14 @@ module('Unit | Model | Combined Course Item', function (hooks) {
   module('Type is MODULE', function () {
     test('return route campaign', function (assert) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
-        type: 'MODULE',
+        type: CombinedCourseItemTypes.MODULE,
       });
       assert.strictEqual(combinedCourseItem.route, 'module');
     });
 
     test('return iconUrl related for campaign', function (assert) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
-        type: 'MODULE',
+        type: CombinedCourseItemTypes.MODULE,
         image: 'my-module-url',
       });
       assert.strictEqual(combinedCourseItem.iconUrl, 'my-module-url');
@@ -46,7 +47,7 @@ module('Unit | Model | Combined Course Item', function (hooks) {
   module('Type is FORMATION', function () {
     test('return iconUrl related for campaign', function (assert) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
-        type: 'FORMATION',
+        type: CombinedCourseItemTypes.FORMATION,
         image: 'my-module-url',
       });
       assert.strictEqual(

--- a/mon-pix/tests/unit/models/combined-course-item-test.js
+++ b/mon-pix/tests/unit/models/combined-course-item-test.js
@@ -1,5 +1,5 @@
 import { setupTest } from 'ember-qunit';
-import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
+import { CombinedCourseAssets, CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 import { module, test } from 'qunit';
 
 module('Unit | Model | Combined Course Item', function (hooks) {
@@ -23,7 +23,7 @@ module('Unit | Model | Combined Course Item', function (hooks) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
         type: CombinedCourseItemTypes.CAMPAIGN,
       });
-      assert.strictEqual(combinedCourseItem.iconUrl, 'https://assets.pix.org/combined-courses/campaign-icon.svg');
+      assert.strictEqual(combinedCourseItem.iconUrl, CombinedCourseAssets.CAMPAIGN_ICON);
     });
   });
 
@@ -50,10 +50,7 @@ module('Unit | Model | Combined Course Item', function (hooks) {
         type: CombinedCourseItemTypes.FORMATION,
         image: 'my-module-url',
       });
-      assert.strictEqual(
-        combinedCourseItem.iconUrl,
-        'https://assets.pix.org/combined-courses/picto_formation_vector.svg',
-      );
+      assert.strictEqual(combinedCourseItem.iconUrl, CombinedCourseAssets.FORMATION_ICON);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
Les types d'item pour les parcours combinés, ainsi que les urls des images qu'on utilise pour eux, sont écrits en dur.

## ⛱️ Proposition
On crée des constantes dans le fichier du model front.

## 🌊 Remarques
https://www.pix.assets.org mériterait de passer en urlBase() un de ces 4.
Les imports ne se font pas de la même manière dans les fichiers de tests et dans les autres, ça nous a fait perdre du temps.

## 🏄 Pour tester
Passer un combinix et vérifier que les icônes formation / campagne de diagnostic correspondent bien.