### PR TITLE
[TECH] Ajouter des candidats aux certifications des seeds (PIX-18448).

### DIFF
--- a/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
+++ b/api/db/seeds/data/team-certification/cases/sup-certification-centre-with-habilitations.js
@@ -40,7 +40,7 @@ export class SupWithHabilitationsSeed {
 
   async create() {
     const { certificationCenter, certificationCenterMember } = await this.#addCertificationCenter();
-    const certifiableUser = await this.#addCertifiableUser();
+    const certifiableUsers = await this.#addCertifiableUsers();
 
     /**
      * Session Pix+Edu 1er degré with candidate ready to start his certification
@@ -52,16 +52,21 @@ export class SupWithHabilitationsSeed {
       description: 'Pix+Edu 1er degré session with candidate ready to start',
       forceSessionId: STARTED_PIX_EDU_1ER_DEGRE_CERTIFICATION_SESSION,
     });
-    await this.#addCandidateToSession({
-      pixAppUser: certifiableUser,
-      session: sessionDroitReadyToStart,
-      subscriptions: [
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+
+    await Promise.all(
+      certifiableUsers.map((certifiableUser) =>
+        this.#addCandidateToSession({
+          pixAppUser: certifiableUser,
+          session: sessionDroitReadyToStart,
+          subscriptions: [
+            Subscription.buildComplementary({
+              certificationCandidateId: null,
+              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_EDU_1ER_DEGRE,
+            }),
+          ],
         }),
-      ],
-    });
+      ),
+    );
 
     /**
      * Session Pix+Droit with candidate ready to start his certification
@@ -73,16 +78,20 @@ export class SupWithHabilitationsSeed {
       description: 'Pix+Droit session with candidate ready to start',
       forceSessionId: STARTED_PIX_DROIT_CERTIFICATION_SESSION,
     });
-    await this.#addCandidateToSession({
-      pixAppUser: certifiableUser,
-      session: sessionEduReadyToStart,
-      subscriptions: [
-        Subscription.buildComplementary({
-          certificationCandidateId: null,
-          complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+    await Promise.all(
+      certifiableUsers.map((certifiableUser) =>
+        this.#addCandidateToSession({
+          pixAppUser: certifiableUser,
+          session: sessionEduReadyToStart,
+          subscriptions: [
+            Subscription.buildComplementary({
+              certificationCandidateId: null,
+              complementaryCertificationKey: ComplementaryCertificationKeys.PIX_PLUS_DROIT,
+            }),
+          ],
         }),
-      ],
-    });
+      ),
+    );
   }
 
   async #addCertificationCenter() {
@@ -112,9 +121,9 @@ export class SupWithHabilitationsSeed {
     return { certificationCenter, certificationCenterMember };
   }
 
-  async #addCertifiableUser() {
-    const { certifiableUser } = await CommonCertifiableUser.getInstance({ databaseBuilder: this.databaseBuilder });
-    return certifiableUser;
+  async #addCertifiableUsers() {
+    const { certifiableUsers } = await CommonCertifiableUser.getInstance({ databaseBuilder: this.databaseBuilder });
+    return certifiableUsers;
   }
 
   async #addReadyToStartSession({

--- a/api/db/seeds/data/team-certification/shared/common-certifiable-user.js
+++ b/api/db/seeds/data/team-certification/shared/common-certifiable-user.js
@@ -6,7 +6,7 @@ import { CERTIFIABLE_SUCCESS_USER_ID } from './constants.js';
  *    - Pix Orga user   : certif-success@example.net
  */
 export class CommonCertifiableUser {
-  certifiableUser;
+  certifiableUsers = [];
 
   constructor({ databaseBuilder }) {
     this.databaseBuilder = databaseBuilder;
@@ -21,22 +21,24 @@ export class CommonCertifiableUser {
   }
 
   async #init() {
-    const user = this.databaseBuilder.factory.buildUser.withRawPassword({
-      id: CERTIFIABLE_SUCCESS_USER_ID,
-      firstName: 'Max',
-      lastName: 'Lagagne',
-      email: 'certif-success@example.net',
-      cgu: true,
-      lang: 'fr',
-      lastTermsOfServiceValidatedAt: new Date(),
-    });
+    for (let i = 0; i < 3; i++) {
+      const user = this.databaseBuilder.factory.buildUser.withRawPassword({
+        id: CERTIFIABLE_SUCCESS_USER_ID + i,
+        firstName: ['Max', 'Maxime', 'Maxou'][i],
+        lastName: 'Lagagne',
+        email: `certif-success${i > 0 ? `-${i}` : ''}@example.net`,
+        cgu: true,
+        lang: 'fr',
+        lastTermsOfServiceValidatedAt: new Date(),
+      });
 
-    await createCertifiableProfile({
-      databaseBuilder: this.databaseBuilder,
-      userId: user.id,
-    });
+      await createCertifiableProfile({
+        databaseBuilder: this.databaseBuilder,
+        userId: user.id,
+      });
 
-    this.certifiableUser = user;
+      this.certifiableUsers = [...this.certifiableUsers, user];
+    }
 
     return this;
   }

--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -22,93 +22,100 @@ import { FRENCH_SPOKEN } from '../../../../../src/shared/domain/services/locale-
 export default async function publishSessionWithValidatedCertification({
   databaseBuilder,
   sessionId,
-  candidateId,
+  candidatesIds,
   pixScoreTarget,
 }) {
   const session = await enrolmentUseCases.getSession({ sessionId });
-  const candidate = await enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
 
-  const { certificationCourse } = await evaluationUseCases.retrieveLastOrCreateCertificationCourse({
-    sessionId,
-    accessCode: session.accessCode,
-    userId: candidate.userId,
-    locale: 'fr',
-  });
+  const reports = [];
 
-  const assessment = certificationCourse._assessment;
+  for (const candidateId of candidatesIds) {
+    const candidate = await enrolmentUseCases.getCandidate({ certificationCandidateId: candidateId });
 
-  // We simulate a certification in order to get the right capacity for a specific pix score
-  const { capacity } = await scoringUseCases.simulateCapacityFromScore({
-    score: pixScoreTarget,
-    date: new Date(),
-  });
-  const pickAnswerStatus = pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
-  const pickChallenge = pickChallengeService.getChallengePicker(
-    config.v3Certification.defaultProbabilityToPickChallenge,
-  );
-
-  // stopAtChallenge helps to simulate less answer to trigger degradation, and a check reports at finalization
-  const simulatedCertification = await flashUseCases.simulateFlashAssessmentScenario({
-    locale: FRENCH_SPOKEN,
-    initialCapacity: config.v3Certification.defaultCandidateCapacity,
-    stopAtChallenge: config.v3Certification.numberOfChallengesPerCourse - 1,
-    pickChallenge,
-    pickAnswerStatus,
-  });
-
-  let timePad = 1;
-  let challengeDate = dayjs();
-  const getNewSecondPad = () => {
-    challengeDate = challengeDate.add(`${timePad++ % 60}`, 'seconds');
-    return challengeDate;
-  };
-  for (const simulatedChallenge of simulatedCertification) {
-    databaseBuilder.factory.buildCertificationChallenge({
-      associatedSkillName: simulatedChallenge.challenge.skill.name,
-      associatedSkillId: simulatedChallenge.challenge.skill.id,
-      challengeId: simulatedChallenge.challenge.id,
-      competenceId: simulatedChallenge.challenge.skill.competenceId,
-      courseId: certificationCourse._id,
-      createdAt: getNewSecondPad(),
-      updatedAt: getNewSecondPad(),
-      isNeutralized: false,
-      hasBeenSkippedAutomatically: false,
-      certifiableBadgeKey: null,
-      difficulty: simulatedChallenge.challenge.difficulty,
-      discriminant: simulatedChallenge.challenge.discriminant,
+    const { certificationCourse } = await evaluationUseCases.retrieveLastOrCreateCertificationCourse({
+      sessionId,
+      accessCode: session.accessCode,
+      userId: candidate.userId,
+      locale: 'fr',
     });
 
-    databaseBuilder.factory.buildAnswer({
-      value: 'dummy value',
-      result: simulatedChallenge.answerStatus,
-      assessmentId: assessment.id,
-      challengeId: simulatedChallenge.challenge.id,
-      createdAt: getNewSecondPad(),
-      updatedAt: getNewSecondPad(),
-      timeout: null,
-      resultDetails: 'dummy value',
-      timeSpent: 10,
+    const assessment = certificationCourse._assessment;
+
+    // We simulate a certification in order to get the right capacity for a specific pix score
+    const { capacity } = await scoringUseCases.simulateCapacityFromScore({
+      score: pixScoreTarget,
+      date: new Date(),
     });
+    const pickAnswerStatus = pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
+    const pickChallenge = pickChallengeService.getChallengePicker(
+      config.v3Certification.defaultProbabilityToPickChallenge,
+    );
+
+    // stopAtChallenge helps to simulate less answer to trigger degradation, and a check reports at finalization
+    const simulatedCertification = await flashUseCases.simulateFlashAssessmentScenario({
+      locale: FRENCH_SPOKEN,
+      initialCapacity: config.v3Certification.defaultCandidateCapacity,
+      stopAtChallenge: config.v3Certification.numberOfChallengesPerCourse - 1,
+      pickChallenge,
+      pickAnswerStatus,
+    });
+
+    let timePad = 1;
+    let challengeDate = dayjs();
+    const getNewSecondPad = () => {
+      challengeDate = challengeDate.add(`${timePad++ % 60}`, 'seconds');
+      return challengeDate;
+    };
+    for (const simulatedChallenge of simulatedCertification) {
+      databaseBuilder.factory.buildCertificationChallenge({
+        associatedSkillName: simulatedChallenge.challenge.skill.name,
+        associatedSkillId: simulatedChallenge.challenge.skill.id,
+        challengeId: simulatedChallenge.challenge.id,
+        competenceId: simulatedChallenge.challenge.skill.competenceId,
+        courseId: certificationCourse._id,
+        createdAt: getNewSecondPad(),
+        updatedAt: getNewSecondPad(),
+        isNeutralized: false,
+        hasBeenSkippedAutomatically: false,
+        certifiableBadgeKey: null,
+        difficulty: simulatedChallenge.challenge.difficulty,
+        discriminant: simulatedChallenge.challenge.discriminant,
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        value: 'dummy value',
+        result: simulatedChallenge.answerStatus,
+        assessmentId: assessment.id,
+        challengeId: simulatedChallenge.challenge.id,
+        createdAt: getNewSecondPad(),
+        updatedAt: getNewSecondPad(),
+        timeout: null,
+        resultDetails: 'dummy value',
+        timeSpent: 10,
+      });
+    }
+
+    await databaseBuilder.commit();
+
+    const report = new CertificationReport({
+      certificationCourseId: certificationCourse._id,
+      isCompleted: false,
+      abortReason: ABORT_REASONS.TECHNICAL,
+    });
+
+    reports.push(report);
+
+    databaseBuilder.factory.buildCertificationReport({ sessionId, ...report });
+
+    await databaseBuilder.commit();
   }
-
-  await databaseBuilder.commit();
-
-  const report = new CertificationReport({
-    certificationCourseId: certificationCourse._id,
-    isCompleted: false,
-    abortReason: ABORT_REASONS.TECHNICAL,
-  });
-
-  databaseBuilder.factory.buildCertificationReport({ sessionId, ...report });
-
-  await databaseBuilder.commit();
 
   const sessionFinalized = await sessionManagementUseCases.finalizeSession({
     sessionId,
     examinerGlobalComment: 'dummy comment',
     hasIncident: false,
     hasJoiningIssue: false,
-    certificationReports: [report],
+    certificationReports: reports,
   });
 
   await sessionManagementUseCases.processAutoJury({ sessionId: sessionFinalized.sessionId });


### PR DESCRIPTION
## ⛱️ Proposition

Il est plus pratique d'avoir 3 candidats aux certifications (SCO / PRO / CleA) présentes dans les seeds.

## 🏄 Pour tester

En plus de **Max Lagagne** (`certif-success@example.net`), les nouveaux utilisateurs sont : 
- **Maxime Lagagne** (`certif-success-1@example.net`)
- **Maxou Lagagne** (`certif-success-2@example.net`)

Ils partagent les mêmes dates de naissance.