### PR TITLE
[BUGFIX] Retours design Combinix (PIX-19559)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -29,7 +29,7 @@ test('pass a combined course as sco user and see the final result', async ({ pag
   });
 
   await test.step('Resume combined course', async function () {
-    await page.getByRole('button', { name: 'Reprendre mon parcours' }).click();
+    await page.getByRole('button', { name: 'Continuer mon parcours' }).click();
   });
 
   await test.step('Run module', async function () {

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -4,11 +4,14 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
-import { eq } from 'ember-truth-helpers';
+import { eq, or } from 'ember-truth-helpers';
 import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 
 const Content = <template>
-  <div class="combined-course-item" ...attributes>
+  <div
+    class="combined-course-item {{if (or @isCompleted @isLocked) 'combined-course-item--ended-locked-state'}}"
+    ...attributes
+  >
     <div class="combined-course-item__content">
       <div class="combined-course-item__icon">
         {{#if @iconUrl}}
@@ -18,12 +21,14 @@ const Content = <template>
       <div class="combined-course-item__text">
         <div class="combined-course-item__title">{{@title}}</div>
         <div class="combined-course-item__description">
-          {{yield to="description"}}
+          <span>{{yield to="description"}}</span>
+          <span class="combined-course-item__duration">
+            {{yield to="duration"}}
+          </span>
         </div>
+
       </div>
-      <div class="combined-course-item__duration">
-        {{yield to="duration"}}
-      </div>
+
     </div>
     {{#if @isLocked}}
       <div class="combined-course-item__indicator--locked">

--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -20,13 +20,14 @@ const Content = <template>
       </div>
       <div class="combined-course-item__text">
         <div class="combined-course-item__title">{{@title}}</div>
-        <div class="combined-course-item__description">
-          <span>{{yield to="description"}}</span>
-          <span class="combined-course-item__duration">
-            {{yield to="duration"}}
-          </span>
-        </div>
-
+        {{#if @displayDuration}}
+          <div class="combined-course-item__description">
+            <span>{{yield to="description"}}</span>
+            <span class="combined-course-item__duration">
+              {{yield to="duration"}}
+            </span>
+          </div>
+        {{/if}}
       </div>
 
     </div>
@@ -49,7 +50,7 @@ const Content = <template>
 </template>;
 
 const Duration = <template>
-  <PixIcon @name="time" class="combined-course-item__duration__icon" /><span>{{t
+  <PixIcon @name="acute" class="combined-course-item__duration__icon" /><span>{{t
       "pages.combined-courses.items.approximatelySymbol"
     }}{{@item.duration}}
     {{t "pages.combined-courses.items.durationUnit"}}</span>
@@ -62,6 +63,7 @@ const Duration = <template>
       @isLocked={{true}}
       @iconUrl={{@item.iconUrl}}
       class="combined-course-item--formation"
+      @displayDuration={{true}}
     >
       <:description>
         <p>{{t "pages.combined-courses.items.formation.description"}}</p>
@@ -69,7 +71,12 @@ const Duration = <template>
     </Content>
   {{else}}
     {{#if @isLocked}}
-      <Content @title={{@item.title}} @isLocked={{true}} @iconUrl={{@item.iconUrl}}>
+      <Content
+        @title={{@item.title}}
+        @isLocked={{true}}
+        @iconUrl={{@item.iconUrl}}
+        @displayDuration={{eq @item.type "MODULE"}}
+      >
         <:duration>
           {{#if @item.duration}}<Duration @item={{@item}} />{{/if}}
         </:duration>
@@ -82,7 +89,12 @@ const Duration = <template>
         @query={{hash redirection=@item.redirection}}
         disabled
       >
-        <Content @title={{@item.title}} @isCompleted={{@item.isCompleted}} @iconUrl={{@item.iconUrl}}>
+        <Content
+          @title={{@item.title}}
+          @isCompleted={{@item.isCompleted}}
+          @iconUrl={{@item.iconUrl}}
+          @displayDuration={{eq @item.type "MODULE"}}
+        >
           <:duration>
             {{#if @item.duration}}
               <Duration @item={{@item}} />
@@ -90,7 +102,7 @@ const Duration = <template>
           </:duration>
           <:blockEnd>
             {{#if @isNextItemToComplete}}
-              <PixTag @color="purple-light" class="combined-course-item__current-item-tag">{{t
+              <PixTag @color="purple-light" @plainIcon={{true}} class="combined-course-item__current-item-tag">{{t
                   "pages.combined-courses.items.tagText"
                 }}
                 <PixIcon @name="distance" @ariaHidden={{true}} /></PixTag>

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -25,6 +25,8 @@
   &__description {
     @extend %pix-body-l;
 
+    display: flex;
+    align-items: center;
     margin-bottom: var(--pix-spacing-6x);
   }
 
@@ -71,11 +73,16 @@
   margin-bottom: var(--pix-spacing-4x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: var(--pix-neutral-0);
-  border: 1px solid var(--pix-primary-100);
+  border: 6px solid var(--pix-primary-300);
   border-radius: var(--pix-spacing-4x);
 
   &--formation {
     background: color-mix(in srgb, var(--pix-primary-100) 20%, transparent);
+  }
+
+  &--ended-locked-state {
+  background: rgb(var(--pix-primary-300-inline), 0.20);
+  border: 1px solid var(--pix-primary-100);
   }
 
   &__content {
@@ -97,6 +104,11 @@
 
   &__description {
     @extend %pix-body-s;
+
+    display: inline-flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+    color: var(--pix-neutral-500);
   }
 
   &__indicator {
@@ -117,7 +129,7 @@
       display: flex;
       gap: var(--pix-spacing-2x);
       align-items: center;
-      color: var(--pix-primary-300);
+      color: var(--pix-primary-500);
       font-weight: var(--pix-font-bold);
 
       .combined-course-item__icon {
@@ -137,12 +149,12 @@
   }
 
   &__duration {
-    display: flex;
+    display: inline-flex;
     gap: var(--pix-spacing-1x);
-    align-self: center;
-    color: var(--pix-neutral-500);
-    font-size: 13px;
-    line-height: 18px;
+
+    @extend %pix-body-s;
+
+    align-items:center;
 
     &__icon {
       width: 16px;

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -81,7 +81,7 @@
   }
 
   &--ended-locked-state {
-  background: rgb(var(--pix-primary-300-inline), 0.20);
+  background: rgb(var(--pix-primary-100-inline), 0.20);
   border: 1px solid var(--pix-primary-100);
   }
 
@@ -95,7 +95,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: var(--pix-spacing-12x);
   }
 
   &__title {
@@ -160,5 +159,11 @@
       width: 16px;
       height: 16px;
     }
+  }
+
+  .combined-course-item__text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-1x);
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14,7 +14,7 @@
         "@1024pix/ember-testing-library": "^3.0.13",
         "@1024pix/epreuves-components": "^1.4.5",
         "@1024pix/eslint-plugin": "^2.1.11",
-        "@1024pix/pix-ui": "^55.26.12",
+        "@1024pix/pix-ui": "^55.27.0",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-proposal-decorators": "^7.24.7",
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "55.26.12",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-55.26.12.tgz",
-      "integrity": "sha512-EblU4iMru7Ab3n5n3H1L6VGoPbF1YTRO4cEo8izqOpnuxAKRYH5fBCNhtglpT8Ejttz9QEVBYtPM/d2X+it4eQ==",
+      "version": "55.27.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-55.27.0.tgz",
+      "integrity": "sha512-kGKokOcjcdnuTUcMVeGltvC93BWTX3b6YaDdcC3+wOyQCZy6mEQLjg9E/U64pkOlK0ibfnpY6hO9jQX8yeHd/A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -47,7 +47,7 @@
     "@1024pix/ember-testing-library": "^3.0.13",
     "@1024pix/epreuves-components": "^1.4.5",
     "@1024pix/eslint-plugin": "^2.1.11",
-    "@1024pix/pix-ui": "^55.26.12",
+    "@1024pix/pix-ui": "^55.27.0",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -368,7 +368,7 @@ module('Integration | Component | combined course', function (hooks) {
       <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
     // then
-    await click(screen.getByRole('button', { name: 'Reprendre mon parcours' }));
+    await click(screen.getByRole('button', { name: t('pages.combined-courses.content.resume-button') }));
     assert.ok(
       router.transitionTo.calledWith('module', 'mon-module', { queryParams: { redirection: 'une+url+chiffree' } }),
     );
@@ -407,7 +407,7 @@ module('Integration | Component | combined course', function (hooks) {
       <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
 
     // then
-    assert.ok(screen.getByRole('button', { name: 'Reprendre mon parcours' }));
+    assert.ok(screen.getByRole('button', { name: t('pages.combined-courses.content.resume-button') }));
     assert.notOk(screen.queryByRole('link', { name: 'mon module' }));
   });
   module('when participation is completed', function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1202,7 +1202,7 @@
     },
     "combined-courses": {
       "completed": {
-        "description": "Well done! You have taken an important step toward navigating the digital world safely.",
+        "description": "Well done! You have taken an important step toward navigating the digital world.",
         "title": "Congratulations! You're done!"
       },
       "content": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1202,7 +1202,7 @@
       },
       "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",
-        "description": "¡Bien hecho! Ha dado un paso importante para navegar con seguridad por el mundo digital."
+        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital."
       },
       "items": {
         "formation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1202,11 +1202,11 @@
     },
     "combined-courses": {
       "completed": {
-        "description": "Bien joué ! Vous avez franchi une étape importante pour naviguer en toute sécurité dans le monde numérique.",
+        "description": "Bien joué ! Vous avez franchi une étape importante pour naviguer dans le monde numérique.",
         "title": "Félicitations ! Vous avez terminé !"
       },
       "content": {
-        "resume-button": "Reprendre mon parcours",
+        "resume-button": "Continuer mon parcours",
         "start-button": "Commencer mon parcours"
       },
       "items": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1206,7 +1206,7 @@
       },
       "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",
-        "description": "Goed gedaan! Je hebt een belangrijke stap gezet om veilig door de digitale wereld te navigeren."
+        "description": "Bravo! Je hebt een belangrijke stap gezet om je weg te vinden in de digitale wereld."
       },
       "items": {
         "formation": {


### PR DESCRIPTION
## 🔆 Problème
Quelques points design nous ont été remontés sur les parcours combinés.

## 🏄 Pour tester
Se connecter avec attestation-blank@example.net. Entrer COMBINIX1 comme code de parcours combiné.
Vérifier que les différents retours présents dans le ticket ont bien été respectés. 

- [x] utiliser le bon token couleur pour “Complété” et la coche 
- [ ] le bloc diagnostic complété doit être en violet
- [ ] les modules verrouillés doivent être en violet 
- [ ] passer l’indication de durée du module sous le nom du module
- [ ] ajouter un contour sur l'étape en cours
- [ ] renommer le bouton “Reprendre mon parcours” en “Continuer mon parcours”
- [ ] changer le message de Félicitations pour “Bien joué ! Vous avez franchi une étape importante pour naviguer dans le me monde numérique.”
- [ ] L'icone n'est pas à la bonne taille, elle doit faire 42px de large
- [ ] Il a un pb de marge en dessous du titre du diag
- [ ] Il faut appliquer spacing-1x entre le titre et les infos secondaires
- [ ] Les couleurs des blocs doivent etre pix-primary-100 a 20% d'opacité
- [ ] L'icône doit etre utilisée en "plain"
- [ ] Utiliser l'icone "acute"