### PR TITLE
[FEATURE] Réactiver le tracking des events modulix/contenu formatif/tuto sur Pix App (PIX-18995).

### DIFF
--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -26,7 +26,6 @@ export default class ModulixDetails extends Component {
   @action
   onModuleStart() {
     this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage`, {
-      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -36,7 +35,6 @@ export default class ModulixDetails extends Component {
   @action
   onModuleStartUsingSmallScreen() {
     this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage en petit écran`, {
-      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -46,7 +44,6 @@ export default class ModulixDetails extends Component {
   @action
   onSmallScreenModalOpen() {
     this.pixMetrics.trackEvent(`Ouvre la modale d'alerte de largeur d'écran`, {
-      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -56,7 +53,6 @@ export default class ModulixDetails extends Component {
   @action
   onSmallScreenModalClose() {
     this.pixMetrics.trackEvent(`Ferme la modale d'alerte de largeur d'écran`, {
-      disabled: true,
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -115,7 +115,6 @@ export default class ModulePassage extends Component {
     this.pixMetrics.trackEvent(
       `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
       {
-        disabled: true,
         category: 'Modulix',
         action: `Passage du module : ${this.args.module.slug}`,
       },
@@ -146,7 +145,6 @@ export default class ModulePassage extends Component {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
     this.pixMetrics.trackEvent(`Click sur le bouton Terminer du grain : ${grainId}`, {
-      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -172,7 +170,6 @@ export default class ModulePassage extends Component {
   @action
   async onElementRetry(answerData) {
     this.pixMetrics.trackEvent(`Click sur le bouton réessayer de l'élément : ${answerData.element.id}`, {
-      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -181,7 +178,6 @@ export default class ModulePassage extends Component {
   @action
   async onImageAlternativeTextOpen(imageElementId) {
     this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle : ${imageElementId}`, {
-      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -197,7 +193,6 @@ export default class ModulePassage extends Component {
   @action
   async onVideoTranscriptionOpen(videoElementId) {
     this.pixMetrics.trackEvent(`Click sur le bouton transcription : ${videoElementId}`, {
-      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });
@@ -232,7 +227,6 @@ export default class ModulePassage extends Component {
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
-      disabled: true,
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
     });

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -105,7 +105,6 @@ export default class Card extends Component {
   @action
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le cf : ${this.args.training.title}`, {
-      disabled: true,
       category: 'Accès Contenu Formatif',
       action: `Click depuis : ${this.router.currentRouteName}`,
     });

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -154,7 +154,6 @@ export default class Card extends Component {
   @action
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le tutoriel : ${this.args.tutorial.title}`, {
-      disabled: true,
       category: 'Accès tuto',
       action: `Click depuis : ${this.router.currentRouteName}`,
     });

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -50,7 +50,6 @@ module('Integration | Component | Module | Details', function (hooks) {
         sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
           category: 'Modulix',
           action: `Détails du module : ${module.slug}`,
-          disabled: true,
         });
         assert.ok(true);
       });
@@ -84,7 +83,6 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
             category: 'Modulix',
-            disabled: true,
             action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
@@ -118,7 +116,6 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre la modale d'alerte de largeur d'écran`, {
             category: 'Modulix',
-            disabled: true,
             action: `Détails du module : ${module.slug}`,
           });
           assert.ok(true);
@@ -167,7 +164,6 @@ module('Integration | Component | Module | Details', function (hooks) {
               `Click sur le bouton Commencer un passage en petit écran`,
               {
                 category: 'Modulix',
-                disabled: true,
                 action: `Détails du module : ${module.slug}`,
               },
             );
@@ -214,7 +210,6 @@ module('Integration | Component | Module | Details', function (hooks) {
             // then
             sinon.assert.calledWithExactly(metrics.trackEvent, `Ferme la modale d'alerte de largeur d'écran`, {
               category: 'Modulix',
-              disabled: true,
               action: `Détails du module : ${module.slug}`,
             });
             assert.ok(true);

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -630,7 +630,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer de l'élément : ${element.id}`, {
         category: 'Modulix',
-        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -672,7 +671,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle : ${element.id}`, {
         category: 'Modulix',
-        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -758,7 +756,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
           `Click sur le bouton alternative textuelle : ${imageElement.id}`,
           {
             category: 'Modulix',
-            disabled: true,
             action: `Passage du module : ${module.slug}`,
           },
         );
@@ -803,7 +800,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${element.id}`, {
         category: 'Modulix',
-        disabled: true,
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -889,7 +885,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${videoElement.id}`, {
           category: 'Modulix',
-          disabled: true,
           action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
@@ -938,7 +933,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
         `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
         {
           category: 'Modulix',
-          disabled: true,
           action: `Passage du module : ${module.slug}`,
         },
       );
@@ -1425,8 +1419,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer du grain : ${grain.id}`, {
         category: 'Modulix',
-        disabled: true,
-
         action: `Passage du module : ${module.slug}`,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
@@ -1478,8 +1470,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
         category: 'Modulix',
-        disabled: true,
-
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);
@@ -1529,8 +1519,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
           category: 'Modulix',
-          disabled: true,
-
           action: `Passage du module : ${module.slug}`,
         });
         assert.ok(true);
@@ -1583,8 +1571,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand : ${expandElement.id}`, {
         category: 'Modulix',
-        disabled: true,
-
         action: `Passage du module : ${module.slug}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -205,7 +205,6 @@ module('Unit | Component | Training | card', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf : ${trainingTitle}`, {
         category: 'Accès Contenu Formatif',
-        disabled: true,
         action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -224,7 +224,6 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel : ${tutorialTitle}`, {
         category: 'Accès tuto',
-        disabled: true,
         action: `Click depuis : ${currentRouteName}`,
       });
       assert.ok(true);


### PR DESCRIPTION
## 🔆 Problème

On a besoin d'avoir accès aux données des comportements utilisateurs sur Plausible. 
Seulement la grande majorité des évènements ont été désactivés lors de la migration vers le nouvel outil.

## ⛱️ Proposition

Réactiver les évènements lié au passage d'un module, de l'accès aux tutos etc...

## 🌊 Remarques

Les event contenants des variables dans le nom devront être modifiés (ex: `Click sur le bouton réessayer de l'élément : ${answerData.element.id}`).
En effet pour qu'un event soit affiché sur Plausible, il nous faut créer à la main un goal sur l'application (event = goal)

Il n'est donc pas possible d'y inclure les variables.
En revanche, si on veut garder ces données, il est possible de les passer en paramètres de l'event.
Il faudra penser à créer un Custom Properties sur Plausible pour qu'il s'affiche dans le dashboard.

## 🏄 Pour tester

- Se rendre sur https://app-pr13598.review.pix.fr/modules/bac-a-sable/details

- En parallèle, se connecter sur https://plausible.io/review.pix.fr (identifiants sur lockself)

- Tester toutes les actions impliquant l'envoi des évènements que nous avons réactivés : 

- [x] Commencer un passage
- [x] Commencer un passage en petit écran
- [x] Ouvrir la modale d'alerte de largeur d'écran
- [x] Fermer la modale d'alerte de largeur d'écran
- [x] Cliquer sur le bouton suivant du stepper dans un grain
- [x] Cliquer sur le bouton "Terminer" du module
- [x] Cliquer sur le bouton "Réessayer" d'un élément
- [x] Cliquer sur le bouton alternative textuelle
- [x] Cliquer sur le bouton transcription
- [x] Dévoiler un indice
- [ ] Ouvrir un contenu formatif ( prérequis passer une campagne et avoir un score pour y avoir accès)
- [ ] Ouvrir un tutoriel

