### PR TITLE
[FEATURE] Ajouter un champ `instruction` au custom elements (PIX-18990)

### DIFF
--- a/api/src/devcomp/domain/models/element/CustomElement.js
+++ b/api/src/devcomp/domain/models/element/CustomElement.js
@@ -5,13 +5,18 @@ class CustomElement extends Element {
   /**
    * @param{object} params
    * @param{string} params.id
+   * @param{string} params.instruction
    * @param{string} params.tagName
    * @param{string} params.props
    */
-  constructor({ id, tagName, props }) {
+  constructor({ id, instruction, tagName, props }) {
     super({ id, type: 'custom' });
+
+    assertNotNullOrUndefined(instruction, 'The instruction is required for a CustomElement element');
     assertNotNullOrUndefined(tagName, 'The tagName is required for a CustomElement element');
     assertNotNullOrUndefined(props, 'The props are required for a CustomElement element');
+
+    this.instruction = instruction;
     this.tagName = tagName;
     this.props = props;
   }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -666,6 +666,7 @@
               "element": {
                 "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae39",
                 "type": "custom",
+                "instruction": "Extrait de conversation",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Confessions nocturnes",
@@ -755,6 +756,7 @@
               "element": {
                 "id": "cfec5a0e-2ed5-462f-8974-e5ca25faae38",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "image-quiz",
                 "props": {
                   "name": "Liste d'applications",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -45,6 +45,7 @@
               "element": {
                 "id": "2ef9874d-e137-40e0-bc64-1210ff66b9c0",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Conversation entre Naomi et Mickaël à propos d’une adresse mail",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -34,6 +34,7 @@
               "element": {
                 "id": "4b7eb96e-134c-4b65-9513-cd57d9ed1e89",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "capacity-calculation",
                 "props": {
                   "titleLevel": 2,
@@ -82,6 +83,7 @@
               "element": {
                 "id": "6251f379-2a39-4731-a19a-fde17151c889",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "calcul-impact",
                 "props": {
                   "titleLevel": 2
@@ -108,6 +110,7 @@
               "element": {
                 "id": "dfa8ac80-86ba-4278-9e02-a160b9c38c3b",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "clickable-image",
                 "props": {
                   "image": {
@@ -173,6 +176,7 @@
               "element": {
                 "id": "9fb9c98c-50e1-4338-9128-521e48060ad7",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "complete-phrase",
                 "props": {
                   "titleLevel": 2,
@@ -284,6 +288,7 @@
               "element": {
                 "id": "c1af1c71-cde4-47bb-9880-dfb0f4118ee1",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "flip-cards",
                 "props": {
                   "name": "Exemples d’utilisation de la reconnaissance d'image dans différents secteurs d'activité",
@@ -297,25 +302,25 @@
                     {
                       "name": "Santé",
                       "description": "Analyse de radios pour détecter des signes de cancer",
-                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-heart.svg",
+                      "icon": "https://assets.pix.org/modules/flip-cards/icon-heart.svg",
                       "image": "https://assets.pix.org/modules/flip-cards/transport.png"
                     },
                     {
                       "name": "Culture",
                       "description": "Reconnaissance des textes pour classer des documents dans une bibliothèque",
-                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-palette.svg",
+                      "icon": "https://assets.pix.org/modules/flip-cards/icon-palette.svg",
                       "image": "https://assets.pix.org/modules/flip-cards/transport.png"
                     },
                     {
                       "name": "Agriculture",
                       "description": "Survol de champs et prise de photos pour détecter un manque d’eau",
-                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-tractor.svg",
+                      "icon": "https://assets.pix.org/modules/flip-cards/icon-tractor.svg",
                       "image": "https://assets.pix.org/modules/flip-cards/transport.png"
                     },
                     {
                       "name": "Sécurité",
                       "description": "Reconnaissance des visages pour identifier des personnes autorisées",
-                      "icon":  "https://assets.pix.org/modules/flip-cards/icon-shield.svg",
+                      "icon": "https://assets.pix.org/modules/flip-cards/icon-shield.svg",
                       "image": "https://assets.pix.org/modules/flip-cards/transport.png"
                     }
                   ]
@@ -342,6 +347,7 @@
               "element": {
                 "id": "835cbd72-783a-4306-9317-74b39fcdc8a2",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Confessions nocturnes",
@@ -415,6 +421,7 @@
               "element": {
                 "id": "88265c48-3647-4868-a9ac-4ece1595eab0",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "image-quiz",
                 "props": {
                   "name": "nouveau_motdepasse.name",
@@ -495,6 +502,7 @@
               "element": {
                 "id": "02bacda6-2b76-49fd-a266-3a9bb16c20c9",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "image-quiz",
                 "props": {
                   "name": "Liste d’applications santé",
@@ -598,6 +606,7 @@
               "element": {
                 "id": "6fe94e2e-11db-4858-98ab-0466a9f49ef9",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "image-quizzes",
                 "props": {
                   "quizzes": [
@@ -754,6 +763,7 @@
               "element": {
                 "id": "af2a348f-666c-4935-83df-eeb32224ddba",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-compare-messages",
                 "props": {
                   "conversation1": {
@@ -818,6 +828,7 @@
               "element": {
                 "id": "03bacda5-2b76-49fd-a266-3a9bb16c20c9",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-messages",
                 "props": {
                   "messages": [
@@ -873,6 +884,7 @@
               "element": {
                 "id": "11b959b2-1894-4dc4-bf09-7de6c6c156a3",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-prompt-select",
                 "props": {
                   "messages": [
@@ -918,6 +930,7 @@
               "element": {
                 "id": "9cf6927d-a2a0-4eab-9a64-013630397b85",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-article",
                 "props": {
                   "titleLevel": 2,
@@ -953,6 +966,7 @@
               "element": {
                 "id": "b04ef581-48f2-4543-9bf4-e1e87c4fa396",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "aspectRatio": 1.84,
@@ -1041,6 +1055,7 @@
               "element": {
                 "id": "b04ef581-48f2-4543-9bf4-e1e8784fa396",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-cursor",
                 "props": {
                   "options": [
@@ -1087,6 +1102,7 @@
               "element": {
                 "id": "d58e3796-5c02-4587-9d19-39f7b808a82f",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "qcm-deepfake",
                 "props": {
                   "titleLevel": 2,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -64,6 +64,7 @@
               "element": {
                 "id": "fe68ec1f-acca-4bb5-902b-9f9a6a5b3ca9",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Confessions nocturnes",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -605,6 +605,7 @@
               "element": {
                 "id": "52a8dfa1-da92-46cf-903d-bfc7d593c4d9",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-article",
                 "props": {
                   "titleLevel": 2,
@@ -697,10 +698,7 @@
                           "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "3"
-                      ]
+                      "solutions": ["1", "3"]
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes.json
@@ -200,6 +200,7 @@
               "element": {
                 "id": "7a1b82fa-1e06-468d-922a-07b8f004f144",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "qcm-deepfake",
                 "props": {
                   "titleLevel": 0,
@@ -624,6 +625,7 @@
               "element": {
                 "id": "97fc69e7-1028-4b41-a97e-a4a9954c15d2",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-article",
                 "props": {
                   "titleLevel": 2,
@@ -716,10 +718,7 @@
                           "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "3"
-                      ]
+                      "solutions": ["1", "3"]
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-dit-ia.json
@@ -54,6 +54,7 @@
               "element": {
                 "id": "8ac18d0a-b0ec-4fa0-8107-3c655ddfe845",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-cursor",
                 "props": {
                   "options": [
@@ -260,6 +261,7 @@
               "element": {
                 "id": "a74745c7-0e8c-4024-9e4e-ab014c843f8d",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "clickable-image",
                 "props": {
                   "image": {
@@ -352,9 +354,7 @@
                     "ariaLabel": "nombre d'utilisation de l'IA",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": [
-                      6
-                    ]
+                    "solutions": [6]
                   }
                 ],
                 "feedbacks": {
@@ -404,6 +404,7 @@
               "element": {
                 "id": "aeeaae8f-72c4-4940-8163-49036e578b1e",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "flip-cards",
                 "props": {
                   "name": "flip card ia dit ia ",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-hallu.json
@@ -38,6 +38,7 @@
               "element": {
                 "id": "35c7d03b-8c62-40e6-a31d-5111e8dcc46a",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Nathan et Asma",
@@ -115,6 +116,7 @@
                     {
                       "id": "a2084553-6928-4931-b9e3-da97a0c799ed",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "llm-messages",
                       "props": {
                         "messages": [
@@ -137,6 +139,7 @@
                     {
                       "id": "665456ec-39dd-4caa-babc-ef3be6a778ea",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "pix-cursor",
                       "props": {
                         "options": [
@@ -178,6 +181,7 @@
                     {
                       "id": "7658ffd4-cf56-45ae-8700-c7abc8d256a3",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "llm-messages",
                       "props": {
                         "messages": [
@@ -200,6 +204,7 @@
                     {
                       "id": "9980a9f9-2ab7-40f1-81d5-c20054bf47dd",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "pix-cursor",
                       "props": {
                         "options": [
@@ -241,6 +246,7 @@
                     {
                       "id": "dac60e1e-dce0-4c4f-9862-071fd607acec",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "llm-messages",
                       "props": {
                         "messages": [
@@ -263,6 +269,7 @@
                     {
                       "id": "32dbbfcb-22ee-469f-8ca8-58b1a8d69bae",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "pix-cursor",
                       "props": {
                         "options": [
@@ -304,6 +311,7 @@
                     {
                       "id": "558833ee-bd2e-400c-8da2-9479b29f30c9",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "llm-messages",
                       "props": {
                         "messages": [
@@ -326,6 +334,7 @@
                     {
                       "id": "99933780-e248-4aeb-a718-9344a809e839",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "pix-cursor",
                       "props": {
                         "options": [
@@ -511,6 +520,7 @@
               "element": {
                 "id": "4a6674be-8c5a-4c01-852e-ccc1c9c80138",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-compare-messages",
                 "props": {
                   "conversation1": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-premier-prompt.json
@@ -30,6 +30,7 @@
               "element": {
                 "id": "09245327-cd08-4874-b006-1018c3b6b419",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Asso Yoga à Roulette",
@@ -182,6 +183,7 @@
               "element": {
                 "id": "14db3b92-0b6a-4bf7-966a-17798f0bedd1",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-prompt-select",
                 "props": {
                   "messages": [
@@ -292,6 +294,7 @@
               "element": {
                 "id": "19a2c102-618f-497d-b68f-48a9bb72d1d7",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-prompt-select",
                 "props": {
                   "messages": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -759,6 +759,7 @@
               "element": {
                 "id": "c7e69b60-f1ae-41b8-9cbc-80f22c6f634a",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/les-ia-consomment.json
@@ -44,6 +44,7 @@
               "element": {
                 "id": "d6a611ae-9e90-402b-8b35-03dcdc5e3faf",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Discussion intro",
@@ -113,6 +114,7 @@
               "element": {
                 "id": "f2081d5f-2054-477d-86d8-942e2b72c511",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",
@@ -318,6 +320,7 @@
               "element": {
                 "id": "92f6e0bb-fa86-4734-be11-d8f3d016e005",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Discussion ressources",
@@ -361,6 +364,7 @@
               "element": {
                 "id": "d281c4c1-9718-4e6d-a6b0-508f4489fcae",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",
@@ -513,6 +517,7 @@
               "element": {
                 "id": "9fc41408-a61d-4e6c-aee4-7f0ede9102a4",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Discussion supercalculateurs",
@@ -556,6 +561,7 @@
               "element": {
                 "id": "c0e5914e-2508-4b40-aae1-2797c0247b8c",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "capacity-calculation",
                 "props": {
                   "titleLevel": 0,
@@ -755,6 +761,7 @@
               "element": {
                 "id": "9cddd982-33fa-4b0f-8283-16daf5666a7b",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "transition bons usages",
@@ -1151,6 +1158,7 @@
               "element": {
                 "id": "6a18255a-eb6c-411f-9989-78fb97cf69e7",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "calcul-impact",
                 "props": {
                   "titleLevel": 0

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/prompt-intermediaire.json
@@ -45,6 +45,7 @@
               "element": {
                 "id": "f49a0fed-c65d-467e-a30d-73445381c61c",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Conversation d'introduction",
@@ -128,12 +129,7 @@
                     "diagnosis": "<p>Il faut donner le plus de précisions possible. Plus l'IA a d'informations sur la situation, meilleure sera sa réponse.&nbsp;<br></p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "2",
-                  "3",
-                  "4"
-                ]
+                "solutions": ["1", "2", "3", "4"]
               }
             }
           ]
@@ -163,6 +159,7 @@
               "element": {
                 "id": "01fc936a-bc83-4b86-8896-6b9289560128",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-prompt-select",
                 "props": {
                   "speed": 0,
@@ -402,10 +399,7 @@
                           "diagnosis": "<p>Ici, le format est le plan détaillé et le contexte correspond à l’heure d'entraînement pour des enfants de 6 à 8 ans débutant.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2"
-                      ]
+                      "solutions": ["1", "2"]
                     }
                   ]
                 },
@@ -444,11 +438,7 @@
                           "diagnosis": "<p>Ici, le format est le formulaire d’inscription, le ton est formel et le contexte correspond à toutes les informations sur l’association, son public et la fréquence des cours.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2",
-                        "3"
-                      ]
+                      "solutions": ["1", "2", "3"]
                     }
                   ]
                 },
@@ -487,10 +477,7 @@
                           "diagnosis": "<p>Ici, le format est le dialogue et le contexte, celui du match de volley.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2"
-                      ]
+                      "solutions": ["1", "2"]
                     }
                   ]
                 },
@@ -529,10 +516,7 @@
                           "diagnosis": "<p>Ici, le <strong>format </strong>est un court <strong>discours</strong>, le <strong>ton </strong>est <strong>amusant</strong>. Le <strong>contexte </strong>est le <strong>pot de départ </strong>d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2",
-                        "3"
+                      "solutions": ["1", "2", "3"
                       ]
                     }
                   ]
@@ -609,6 +593,7 @@
               "element": {
                 "id": "0fffc82c-48f2-40b4-9a75-335ea9f62f82",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-def-ia-supervise.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-def-ia-supervise.json
@@ -37,6 +37,7 @@
               "element": {
                 "id": "dad28e9d-425d-4637-b848-052231cb225f",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Arthur demande à Lila comment reconnaître l'ail des ours",
@@ -598,9 +599,7 @@
                         "content": "Etiquette"
                       }
                     ],
-                    "solutions": [
-                      "1"
-                    ]
+                    "solutions": ["1"]
                   },
                   {
                     "type": "text",
@@ -806,6 +805,7 @@
               "element": {
                 "id": "c9e931ea-9eba-4cd2-b2ff-a6812c4a88f8",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-bias-ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-bias-ind.json
@@ -30,6 +30,7 @@
               "element": {
                 "id": "510015d3-8fb4-4024-8632-9b7ca6ec1187",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Conversation à propos des biais",
@@ -703,6 +704,7 @@
               "element": {
                 "id": "cc1559a4-2f33-45b3-9c07-bdf018e9fafb",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "pix-carousel",
                 "props": {
                   "type": "image",
@@ -824,10 +826,7 @@
                     "diagnosis": "<p>Vous avez peut-être oublié un exemple, ou bien vu un détail qui n’était pas forcément un biais.</p><p>Voici un indice&nbsp;: les exemples qui comportent des biais renforcent des stéréotypes. N’hésitez pas à recommencer.</p>"
                   }
                 },
-                "solutions": [
-                  "2",
-                  "4"
-                ]
+                "solutions": ["2", "4"]
               }
             }
           ]
@@ -875,10 +874,7 @@
                     "diagnosis": "<p>Les biais de confirmation sont des erreurs humaines qui nous poussent à croire les choses que nous pensons déjà. C’est le cas pour plusieurs des personnes ci-dessus. N’hésitez pas à réessayer.</p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "3"
-                ]
+                "solutions": ["1", "3"]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-fonctionnement-debut.json
@@ -243,6 +243,7 @@
                     {
                       "id": "4c1b444d-2e5a-4e50-926f-8a73b8259181",
                       "type": "custom",
+                      "instruction": "",
                       "tagName": "complete-phrase",
                       "props": {
                         "titleLevel": 2,
@@ -314,12 +315,7 @@
                         ],
                         "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                         "llmMessage": "On peut mettre du ",
-                        "wordsToAdd": [
-                          "beurre",
-                          "et",
-                          "du",
-                          "sucre"
-                        ]
+                        "wordsToAdd": ["beurre", "et", "du", "sucre"]
                       }
                     },
                     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp-ia-int-mgo.json
@@ -37,6 +37,7 @@
               "element": {
                 "id": "55bb2043-0489-4faa-81cf-de3c39286c2d",
                 "type": "custom",
+                "instruction": "",
                 "tagName": "llm-prompt-select",
                 "props": {
                   "messages": [

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -158,6 +158,7 @@ export class ModuleFactory {
   static #buildCustom(element) {
     return new CustomElement({
       id: element.id,
+      instruction: element.instruction,
       tagName: element.tagName,
       props: element.props,
     });

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -110,7 +110,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"4ce2a31a-6584-4dae-87c6-d08b58d0f3b9"\t"c23436d4-6261-49f1-b50d-13a547529c29"\t"qrocm"\t"Connaissez-vous bien Pix"\t7\t14\t"<p>Compléter le texte suivant :</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb4"\t"0e3315fd-98ad-492f-9046-4aa867495d84"\t"embed"\t"Embed non-auto"\t8\t15\t"<p>Vous participez à la visioconférence ci-dessous.</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"f00133f5-0653-425b-a25f-3c9604820529"\t"custom-draft"\t"Elément custom"\t9\t16\t"<p>Retournez les cartes.</p>"
-"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t17\t
+"6282925d-4775-4bca-b513-4c3009ec5886"\t"46577fb1-aadb-49ba-b3fd-721a11da8eb5"\t"0e3315fd-98ad-492f-9046-4aa867495d85"\t"custom"\t"Elément custom"\t9\t17\t"Voici un extrait de conversation"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"cf436761-f56d-4b01-83f9-942afe9ce72c"\t"ed795d29-5f04-499c-a9c8-4019125c5cb1"\t"qab"\t"test qab"\t10\t18\t"<p><strong>Maintenant, entraînez-vous sur des exemples concrets !</strong> </p> <p> Pour chaque exemple, choisissez si l’affirmation est <strong>vraie</strong> ou <strong>fausse</strong>.</p>"
 "6282925d-4775-4bca-b513-4c3009ec5886"\t"cef7d350-008b-410b-8a6a-39b56efdbe8d"\t"0c397035-a940-441f-8936-050db7f997af"\t"qcu-discovery"\t"test qcu-discovery"\t11\t19\t"<p>Quel est le dessert classique idéal lors d’un goûter&nbsp;?</p>"`);
     });

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -407,6 +407,7 @@
               "element": {
                 "id": "0e3315fd-98ad-492f-9046-4aa867495d85",
                 "type": "custom",
+                "instruction": "Voici un extrait de conversation",
                 "tagName": "message-conversation",
                 "props": {
                   "title": "Confessions nocturnes",

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -287,6 +287,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                       element: {
                         id: 'cfec5a0e-2ed5-462f-8974-e5ca25faae39',
                         type: 'custom',
+                        instruction: 'Instruction',
                         tagName: 'message-conversation',
                         props: {
                           title: 'Confessions nocturnes',

--- a/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/CustomElement_test.js
@@ -8,6 +8,7 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function 
       // given
       const attributes = {
         id: '5ce0ddf1-8620-43b5-9e43-cd9b2ffaca17',
+        instruction: 'Instruction',
         tagName: 'qcu-image',
         props: {
           name: "Liste d'applications",
@@ -63,9 +64,24 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function 
 
       // then
       expect(result.id).to.equal(attributes.id);
+      expect(result.instruction).to.equal(attributes.instruction);
       expect(result.tagName).to.equal(attributes.tagName);
       expect(result.props).to.deep.equal(attributes.props);
       expect(result.type).to.equal('custom');
+    });
+  });
+
+  describe('A CustomElement without a instruction', function () {
+    it('should throw an error', function () {
+      const attributes = {
+        id: '5ce0ddf1-8620-43b5-9e43-cd9b2ffaca17',
+      };
+      // when
+      const error = catchErrSync(() => new CustomElement(attributes))();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The instruction is required for a CustomElement element');
     });
   });
 
@@ -73,6 +89,7 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function 
     it('should throw an error', function () {
       const attributes = {
         id: '5ce0ddf1-8620-43b5-9e43-cd9b2ffaca17',
+        instruction: 'Instruction',
       };
       // when
       const error = catchErrSync(() => new CustomElement(attributes))();
@@ -87,6 +104,7 @@ describe('Unit | Devcomp | Domain | Models | Element | CustomElement', function 
     it('should throw an error', function () {
       const attributes = {
         id: '5ce0ddf1-8620-43b5-9e43-cd9b2ffaca17',
+        instruction: 'Instruction',
         tagName: 'qcu-image',
       };
       // when

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/custom-element-schema.js
@@ -1,11 +1,12 @@
 import { schema as componentsSchema } from '@1024pix/epreuves-components/schema';
 import Joi from 'joi';
 
-import { uuidSchema } from '../utils.js';
+import { htmlSchema, uuidSchema } from '../utils.js';
 
 export const customElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('custom').required(),
+  instruction: htmlSchema.allow('').required(),
   tagName: Joi.string()
     .valid(...Object.keys(componentsSchema))
     .required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -26,6 +26,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
           const sample = {
             id: randomUUID(),
             type: 'custom',
+            instruction: 'Hello world',
             tagName: 'message-conversation',
             props: {
               title: 'Conversation entre Naomi et Mickaël à propos d’une adresse mail',

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -5,6 +5,11 @@ message-conversation::part(conversation) {
 }
 
 .element-custom {
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-bold);
+  }
+
   &__container {
     padding: var(--pix-spacing-2x);
     border: 2px dashed var(--pix-primary-700);

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -4,6 +4,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
 import ModuleElement from './module-element';
@@ -40,8 +41,18 @@ export default class ModulixCustomElement extends ModuleElement {
     }
   }
 
+  get hasInstruction() {
+    return this.args.component.instruction?.length > 0;
+  }
+
   <template>
     <div class="element-custom">
+      {{#if this.hasInstruction}}
+        <div class="element-custom__instruction">
+          {{htmlUnsafe @component.instruction}}
+        </div>
+      {{/if}}
+
       {{#if this.isInteractive}}
         <fieldset class="element-custom__container">
           <legend class="element-custom__legend">

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -14,6 +14,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     const element = {
       id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
       type: 'custom',
+      instruction: 'Instruction',
       tagName: 'qcu-image',
       props: {
         name: "Liste d'applications",


### PR DESCRIPTION
## 🔆 Problème
Il manque un champ d'`instruction` en gras sur les éléments `custom`.

## ⛱️ Proposition

Ajouter ce champ.

Penser à màj Modulix Editor.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Vérifier dans le [bac à sable](https://app-pr13599.review.pix.fr/modules/bac-a-sable/passage) que le premier custom element affiché à une instruction et que le suivant non.
