### PR TITLE
[BUMP] Mise à jour du package epreuves-components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -82,7 +82,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.4.4",
+        "@1024pix/epreuves-components": "^1.4.5",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -123,11 +123,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.4.tgz",
-      "integrity": "sha512-gHJsM+h9nHu7qtB07sUX/kqlYMAcgk27jE7nzFkivhpfXbtwf7PvJ/TGKHSH0gczMiXGbDWo6ZuoE53mfMOPkg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.5.tgz",
+      "integrity": "sha512-miGVlzhFrjsQLBbkt9CgL5lwHjwlvLEqmCltEihDuUF2ZurOm1HOwfHeKEqlJgMYjGX+uh86kqoCy753MLIskQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.4.4",
+    "@1024pix/epreuves-components": "^1.4.5",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -260,7 +260,7 @@
                   ],
                   "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                   "llmMessage": "On peut mettre du ",
-                  "wordsToAdd": ["beurre", "et", "du", "sucre"]
+                  "wordsToAdd": ["beurre", "et", "du ?"]
                 }
               }
             }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.4",
+        "@1024pix/epreuves-components": "^1.4.5",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,11 +101,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.4.tgz",
-      "integrity": "sha512-gHJsM+h9nHu7qtB07sUX/kqlYMAcgk27jE7nzFkivhpfXbtwf7PvJ/TGKHSH0gczMiXGbDWo6ZuoE53mfMOPkg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.5.tgz",
+      "integrity": "sha512-miGVlzhFrjsQLBbkt9CgL5lwHjwlvLEqmCltEihDuUF2ZurOm1HOwfHeKEqlJgMYjGX+uh86kqoCy753MLIskQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.4",
+    "@1024pix/epreuves-components": "^1.4.5",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.13",
-        "@1024pix/epreuves-components": "^1.4.4",
+        "@1024pix/epreuves-components": "^1.4.5",
         "@1024pix/eslint-plugin": "^2.1.11",
         "@1024pix/pix-ui": "^55.26.12",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -808,11 +808,10 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.4.tgz",
-      "integrity": "sha512-gHJsM+h9nHu7qtB07sUX/kqlYMAcgk27jE7nzFkivhpfXbtwf7PvJ/TGKHSH0gczMiXGbDWo6ZuoE53mfMOPkg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.4.5.tgz",
+      "integrity": "sha512-miGVlzhFrjsQLBbkt9CgL5lwHjwlvLEqmCltEihDuUF2ZurOm1HOwfHeKEqlJgMYjGX+uh86kqoCy753MLIskQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"
       }

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.13",
-    "@1024pix/epreuves-components": "^1.4.4",
+    "@1024pix/epreuves-components": "^1.4.5",
     "@1024pix/eslint-plugin": "^2.1.11",
     "@1024pix/pix-ui": "^55.26.12",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🔆 Problème
Il faut intégrer les derniers patchs sur les POI

## ⛱️ Proposition
Mettre à jour le package pour intégrer les derniers patchs sur les POI.

## 🌊 Remarques
RAS

## 🏄 Pour tester
Voir sur la page de démo modulix les dernières modifs (complete-phrase)
