### PR TITLE
[FEATURE] Autoriser tous les utilisateurs connectés n'appartenant pas à une orga à import, à accéder aux parcours combinés (PIX-19228)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -12,6 +12,7 @@ import { temporaryStorage } from '../../../../src/shared/infrastructure/key-valu
 import {
   AEFE_TAG,
   FEATURE_ATTESTATIONS_MANAGEMENT_ID,
+  PRO_ORGANIZATION_ID,
   SCO_ORGANIZATION_ID,
   USER_ID_ADMIN_ORGANIZATION,
   USER_ID_MEMBER_ORGANIZATION,
@@ -23,6 +24,8 @@ const firstTrainingfrFRId = QUEST_OFFSET + 1;
 const secondTrainingfrFRId = QUEST_OFFSET + 2;
 const firstTrainingFRId = QUEST_OFFSET + 3;
 const secondTrainingFRId = QUEST_OFFSET + 4;
+const firstProTrainingfrFRId = QUEST_OFFSET + 5;
+const firstProTrainingFRId = QUEST_OFFSET + 6;
 
 function buildCombinedCourseQuest(databaseBuilder, organizationId) {
   const targetProfile = buildTargetProfile(databaseBuilder, { id: organizationId }, 0, TARGET_PROFILE_TUBES[0]);
@@ -167,6 +170,126 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
       type: 'prerequisite',
     }).id,
     databaseBuilder.factory.buildTrainingTrigger({ trainingId: secondTrainingFRId, threshold: 100, type: 'goal' }).id,
+  ];
+  trainingTriggerIds.forEach((trainingTriggerId) =>
+    TARGET_PROFILE_TUBES[0].map((tube) =>
+      databaseBuilder.factory.buildTrainingTriggerTube({ trainingTriggerId, tubeId: tube.id, level: tube.level }),
+    ),
+  );
+}
+
+function buildProCombinedCourseQuest(databaseBuilder, organizationId) {
+  const targetProfile = buildTargetProfile(databaseBuilder, { id: organizationId }, 0, TARGET_PROFILE_TUBES[0]);
+  const campaign = databaseBuilder.factory.buildCampaign({
+    name: 'Je teste mes compétences',
+    organizationId,
+    code: 'CODEABC',
+    targetProfileId: targetProfile.id,
+    customResultPageButtonText: 'Continuer',
+    customResultPageButtonUrl: '/parcours/COMBINIX2',
+  });
+  CAMPAIGN_SKILLS[0].map((skillId) =>
+    databaseBuilder.factory.buildCampaignSkill({
+      campaignId: campaign.id,
+      skillId,
+    }),
+  );
+
+  databaseBuilder.factory.buildQuestForCombinedCourse({
+    name: 'Combinix',
+    rewardType: null,
+    rewardId: null,
+    code: 'COMBINIX2',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
+    organizationId,
+    eligibilityRequirements: [],
+    successRequirements: [
+      {
+        requirement_type: 'campaignParticipations',
+        comparison: 'all',
+        data: {
+          campaignId: {
+            data: campaign.id,
+            comparison: 'equal',
+          },
+          status: {
+            data: 'SHARED',
+            comparison: 'equal',
+          },
+        },
+      },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: 'f32a2238-4f65-4698-b486-15d51935d335',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: 'ab82925d-4775-4bca-b513-4c3009ec5886',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+    ],
+  });
+
+  databaseBuilder.factory.buildTraining({
+    id: firstProTrainingfrFRId,
+    type: 'modulix',
+    title: 'Demo combinix 1',
+    link: '/modules/demo-combinix-1',
+    locale: 'fr-fr',
+  });
+  databaseBuilder.factory.buildTraining({
+    id: firstProTrainingFRId,
+    type: 'modulix',
+    title: 'Demo combinix 1',
+    link: '/modules/demo-combinix-1',
+    locale: 'FR',
+  });
+  const trainingTriggerIds = [
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: firstProTrainingfrFRId,
+      threshold: 0,
+      type: 'prerequisite',
+    }).id,
+    databaseBuilder.factory.buildTrainingTrigger({
+      trainingId: firstProTrainingFRId,
+      threshold: 0,
+      type: 'prerequisite',
+    }).id,
   ];
   trainingTriggerIds.forEach((trainingTriggerId) =>
     TARGET_PROFILE_TUBES[0].map((tube) =>
@@ -592,6 +715,8 @@ export const buildQuests = async (databaseBuilder) => {
   // Create quests
   buildSixthGradeQuests(databaseBuilder, rewardId, targetProfiles);
   const parenthoodAttestationId = buildParenthoodQuest(databaseBuilder);
+  buildParenthoodQuest(databaseBuilder);
+  buildProCombinedCourseQuest(databaseBuilder, PRO_ORGANIZATION_ID);
   buildCombinedCourseQuest(databaseBuilder, organization.id);
 
   // Create reward for success user

--- a/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
+++ b/api/src/quest/application/usecases/check-authorization-to-access-combined-course.js
@@ -1,8 +1,23 @@
+import * as organizationApi from '../../../../src/organizational-entities/application/api/organization-api.js';
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
+import * as organizationFeatureRepository from '../../../shared/infrastructure/repositories/organization-feature-repository.js';
 import * as combinedCourseParticipantRepository from '../../infrastructure/repositories/combined-course-participant-repository.js';
 import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
 
 const execute = async function ({ userId, code }) {
   const { organizationId } = await combinedCourseRepository.getByCode({ code });
+
+  const hasImportFeature = await organizationFeatureRepository.isFeatureEnabledForOrganization({
+    organizationId,
+    featureKey: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+  });
+
+  const organization = await organizationApi.getOrganization(organizationId);
+
+  if (!hasImportFeature && !organization.isManagingStudents) {
+    return true;
+  }
+
   const organizationLearner = await combinedCourseParticipantRepository.findOrganizationLearner({
     userId,
     organizationId,

--- a/api/src/quest/infrastructure/repositories/eligibility-repository.js
+++ b/api/src/quest/infrastructure/repositories/eligibility-repository.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Eligibility } from '../../domain/models/Eligibility.js';
 
 export const find = async ({ userId, organizationLearnerWithParticipationApi }) => {
@@ -13,7 +14,17 @@ export const findByUserIdAndOrganizationId = async ({
   moduleIds = [],
 }) => {
   const passages = await modulesApi.getUserModuleStatuses({ userId, moduleIds });
-  const result = await organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId({ userId, organizationId });
+  let result = { campaignParticipations: [] };
+  try {
+    result = await organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId({
+      userId,
+      organizationId,
+    });
+  } catch (err) {
+    if (!(err instanceof NotFoundError)) {
+      throw err;
+    }
+  }
   return toDomain({ ...result, passages });
 };
 

--- a/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
@@ -1,35 +1,73 @@
 import * as checkAuthorizationToAccessCombinedCourse from '../../../../../src/quest/application/usecases/check-authorization-to-access-combined-course.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Application | Usecases | checkAuthorizationToAccessCombinedCourse', function () {
-  it('should return true if user belongs to combined course organization', async function () {
-    // given
-    const code = 'COMBINIX1';
-    const userId = databaseBuilder.factory.buildUser().id;
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
-    databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
-    databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
-    await databaseBuilder.commit();
+  context('when user has organization learner in combined course organization', function () {
+    it('should return true', async function () {
+      // given
+      const code = 'COMBINIX1';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
+      await databaseBuilder.commit();
 
-    // when
-    const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+      // when
+      const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
 
-    // then
-    expect(authorized).to.be.true;
+      // then
+      expect(authorized).to.be.true;
+    });
   });
 
-  it('should return false otherwise', async function () {
-    // given
-    const code = 'COMBINIX1';
-    const userId = databaseBuilder.factory.buildUser().id;
-    const organizationId = databaseBuilder.factory.buildOrganization().id;
-    databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
-    await databaseBuilder.commit();
+  context('when user does not have any organization learner in combined course organization', function () {
+    it('should return true when the organization has no import feature and is not managing students ', async function () {
+      // given
+      const code = 'COMBINIX1';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      await databaseBuilder.commit();
 
-    // when
-    const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+      // when
+      const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
 
-    // then
-    expect(authorized).to.be.false;
+      // then
+      expect(authorized).to.be.true;
+    });
+    it('should return false when the organization is managing students', async function () {
+      // given
+      const code = 'COMBINIX1';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
+      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+
+      // then
+      expect(authorized).to.be.false;
+    });
+    it('should return false when the organization has import feature', async function () {
+      // given
+      const code = 'COMBINIX1';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const importFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId,
+        featureId: importFeature.id,
+      });
+      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const authorized = await checkAuthorizationToAccessCombinedCourse.execute({ code, userId });
+
+      // then
+      expect(authorized).to.be.false;
+    });
   });
 });

--- a/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | repositories | eligibility', function () {
@@ -82,6 +83,29 @@ describe('Quest | Unit | Infrastructure | repositories | eligibility', function 
       expect(result.organizationLearner.id).to.equal(organizationLearnerId);
       expect(result.campaignParticipations[0].targetProfileId).to.equal(targetProfileId);
       expect(result.passages).to.deep.equal([{ moduleId: 1, isTerminated: true }]);
+    });
+    it('should ignore not found error', async function () {
+      // given
+      const organizationId = 1;
+      const userId = 2;
+      const organizationLearnerWithParticipationApi = {
+        getByUserIdAndOrganizationId: sinon.stub(),
+      };
+      organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId
+        .withArgs({ userId, organizationId })
+        .rejects(new NotFoundError());
+
+      const modulesApi = { getUserModuleStatuses: sinon.stub() };
+      modulesApi.getUserModuleStatuses.withArgs({ userId, moduleIds: [] }).resolves([{ id: 1, status: 'COMPLETED' }]);
+
+      // when
+      const result = await repositories.eligibilityRepository.findByUserIdAndOrganizationId({
+        userId,
+        organizationId,
+        organizationLearnerWithParticipationApi,
+        modulesApi,
+      });
+      expect(result).to.be.an.instanceof(Eligibility);
     });
   });
 });

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -658,6 +658,14 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
     });
 
     it('should return an error if connected user is not allowed to access given combined course', async function () {
+      // given
+      const importFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId,
+        featureId: importFeature.id,
+      });
+
+      await databaseBuilder.commit();
       // when
       const response = await server.inject(options);
 


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir donner l'accès aux parcours combinés aux utilisateurs appartenant à des organisations PRO ou qui n'ont pas la feature "import".
Or, actuellement, nos routes d'accès au parcours combiné sont conditionnées par l'existence d'un organization learner. 

## ⛱️ Proposition
Les 3 routes suivantes sont appelées au premier accès à un Combinix :
'api/combined-courses'
'/api/combined-courses/{code}/start'
'/api/combined-courses/{code}/reassess-status'

On modifie donc le prehandler de ces trois routes pour vérifier si la feature "import" existe sur l'organisation de l'apprenant. Si elle n'existe pas, l'utilisateur - nécessairement connecté - est autorisé à accéder au parcours.

## 🌊 Remarques
Pas besoin de rajouter une contrainte sur l'authentification parce que toutes les routes ont un accès restreint aux utilisateurs authentifiés par défaut (sinon elles sont en auth: false).

## 🏄 Pour tester
Test de non-régression avec attestation-blank@example.net / COMBINIX1
Test d'accès pour un profil pro avec le code COMBINIX2