### PR TITLE
[BUGFIX] Traductions défectueuses suite à l'extraction de la méthode translate de i18n (PIX-19565)

### DIFF
--- a/api/src/shared/infrastructure/i18n/i18n.js
+++ b/api/src/shared/infrastructure/i18n/i18n.js
@@ -45,6 +45,19 @@ export function getI18n(locale) {
     i18n.setLocale = () => {
       logger.warn('Cannot change i18n locale instance, use getI18n(locale) instead.');
     };
+    const originalI18nTranslate = i18n.__;
+    i18n.__ = (param1, param2) => {
+      if (_isTranslationKeyOnly(param1, param2)) {
+        return originalI18nTranslate({ phrase: param1, locale: baseLocale });
+      }
+
+      if (_hasTranslationParameter(param1, param2)) {
+        return originalI18nTranslate({ phrase: param1, locale: baseLocale }, param2);
+      }
+
+      return originalI18nTranslate(param1, param2);
+    };
+
     i18nInstances[baseLocale] = i18n;
   }
 
@@ -59,4 +72,12 @@ export function getI18n(locale) {
 export async function getI18nFromRequest(request) {
   const locale = request.query?.lang || (await getChallengeLocale(request));
   return getI18n(locale);
+}
+
+function _isTranslationKeyOnly(translationKey, translationParameter) {
+  return typeof translationKey === 'string' && translationParameter === undefined;
+}
+
+function _hasTranslationParameter(translationKey, translationParameter) {
+  return typeof translationKey === 'string' && translationParameter !== undefined;
 }

--- a/api/tests/shared/unit/infrastructure/i18n/i18n_test.js
+++ b/api/tests/shared/unit/infrastructure/i18n/i18n_test.js
@@ -37,6 +37,14 @@ describe('Unit | Shared | Infrastucture | i18n', function () {
       // then
       expect(result).to.equal('Hello Bob');
     });
+
+    it('interpolates parameter with single mustach when first argument is an object with explicit locale', async function () {
+      // when
+      const result = getI18n().__({ phrase: 'Hello {name}', locale: 'fr' }, { name: 'Bob' });
+
+      // then
+      expect(result).to.equal('Hello Bob');
+    });
   });
 
   describe('getI18n', function () {


### PR DESCRIPTION
## 🔆 Problème

Depuis #13170, les traductions dans le modèle du fichier de participants dans Pix Certif ne se font plus et les fichiers contiennent du français même si l’utilisateur a une locale/lang `en` et qu’il est en train de consulter Pix Certif suivant la locale/lang `en`.

## ⛱️ Proposition

Appeler la méthode i18n.__ (qui est la méthode de traduction qui prend une chaine de traduction et est censée la traduire avec la locale courante) avec en paramètres la chaine à traduire et la locale (transmise ici directement plutôt que récupérée automatiquement par le package i18n).

## 🌊 Remarques

Voir [la doc du paquet i18n](https://www.npmjs.com/package/i18n).

Pour se mettre dans un état où il n’y pas la régression, se mettre sur le commit précédant #13170 : 
```shell
git checkout 4002b56f76f653538a6b6a58941e46aaaf822adb
```
Pour se mettre dans un état où il y a la régression, se mettre sur le commit correspondant au merge de #13170 : 
```shell
git checkout 68c1612ada802363054a8706856d789f75466c4a
```

## 🏄 Pour tester

- Se rendre sur Pix Certif avec en paramètres ?locale=en
- Créer une session, aller sur l'onglet Candidats puis télécharger le modèle d'inscription des candidats
- Constater que l'ensemble de ce fichier est en anglais


