### PR TITLE
[BUGFIX] Corriger les marges sur les pages de PixApp (PIX-19568).

### DIFF
--- a/mon-pix/app/components/global/app-layout.gjs
+++ b/mon-pix/app/components/global/app-layout.gjs
@@ -23,9 +23,7 @@ export default class AppLayout extends Component {
   get appLayoutClass() {
     const cssClass = [];
 
-    if (!this.args.displayFullLayout) cssClass.push('page-without-navbar ');
-
-    if (this.args.isLoginPages) cssClass.push('page-without-navbar--login-page');
+    if (!this.args.displayFullLayout) cssClass.push('page-without-navbar');
 
     if (this.args.isFullWidth) cssClass.push('page-without-navbar--force-max-width');
 

--- a/mon-pix/app/templates/application.gjs
+++ b/mon-pix/app/templates/application.gjs
@@ -25,18 +25,30 @@ export default class ApplicationTemplate extends Component {
     );
   }
 
-  get isLoginPages() {
-    return this.router.currentRouteName.startsWith('authentication.');
-  }
-
   get isFullWidth() {
-    return (
+    const isAccessPages =
+      this.router.currentRouteName.startsWith('authentication.') ||
+      this.router.currentRouteName.startsWith('inscription.') ||
+      this.router.currentRouteName.startsWith('account-recovery.') ||
+      ['not-connected', 'cgu', 'reset-password', 'password-reset-demand', 'update-expired-password'].includes(
+        this.router.currentRouteName,
+      );
+
+    const isEvaluationPages =
       this.router.currentRouteName.startsWith('assessments.') ||
       this.router.currentRouteName === 'campaigns.assessment.tutorial' ||
+      this.router.currentRouteName.startsWith('organizations.');
+
+    const isModulePages =
       this.router.currentRouteName.startsWith('module.') ||
       this.router.currentRouteName === 'module-preview-existing' ||
-      this.router.currentRouteName === 'module-preview'
+      this.router.currentRouteName === 'module-preview';
+
+    const isCertificationsPages = ['authenticated.certifications.information', 'companion'].includes(
+      this.router.currentRouteName,
     );
+
+    return isAccessPages || isEvaluationPages || isModulePages || isCertificationsPages;
   }
 
   <template>
@@ -51,7 +63,6 @@ export default class ApplicationTemplate extends Component {
     <div id="app">
       <AppLayout
         @displayFullLayout={{this.displayFullLayout}}
-        @isLoginPages={{this.isLoginPages}}
         @isFullWidth={{this.isFullWidth}}
         @banners={{@controller.model.informationBanner.banners}}
       >


### PR DESCRIPTION
## 🔆 Problème

En voulant modifier les margins sur les combinix, nous avons entrainer une regression sur un nombre incalculable de page.

## ⛱️ Proposition

Revoir les différentes route et s'assurer du bon affichage de celui-ci 

## 🌊 Remarques

Il y a un grosse repasse à faire sur les margin des pages pour éviter d'avoir des espaces de la taille du grand canyon. un exemple parmis tant d'autre. 

<img width="1668" height="573" alt="image" src="https://github.com/user-attachments/assets/e176ff69-a02f-4ed5-b2ad-fd320ef76b15" />
un layout interne a 80 rem alors que le DS nous a donnée un main a 93rem en max. ce qui fait un décalage entre le header login et le contenu des formations. 

## 🏄 Pour tester

Faire un tour sur les différentes pages et vérifier