### PR TITLE
[BUGFIX] Correction de l'export CSV avec gestion des locales (PIX-19551)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,7 +1,6 @@
 import stream from 'node:stream';
 
-import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';
-import { escapeFileName } from '../../../shared/infrastructure/utils/request-response-utils.js';
+import { escapeFileName, getUserLocale } from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { CampaignParticipationStatuses } from '../../shared/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as campaignDetailsManagementSerializer from '../infrastructure/serializers/jsonapi/campaign-management-serializer.js';
@@ -71,7 +70,7 @@ const findPaginatedFilteredCampaigns = async function (request, _, dependencies 
 };
 
 const getCsvAssessmentResults = async function (request, h) {
-  const i18n = await getI18nFromRequest(request);
+  const locale = getUserLocale(request);
 
   const { campaignId } = request.params;
 
@@ -80,7 +79,7 @@ const getCsvAssessmentResults = async function (request, h) {
   const { fileName } = await usecases.startWritingCampaignAssessmentResultsToStream({
     campaignId,
     writableStream,
-    i18n,
+    locale,
   });
   const escapedFileName = escapeFileName(fileName);
 
@@ -96,7 +95,7 @@ const getCsvAssessmentResults = async function (request, h) {
 };
 
 const getCsvProfilesCollectionResults = async function (request, h) {
-  const i18n = await getI18nFromRequest(request);
+  const locale = getUserLocale(request);
 
   const { campaignId } = request.params;
 
@@ -105,7 +104,7 @@ const getCsvProfilesCollectionResults = async function (request, h) {
   const { fileName } = await usecases.startWritingCampaignProfilesCollectionResultsToStream({
     campaignId,
     writableStream,
-    i18n,
+    locale,
   });
   const escapedFileName = escapeFileName(fileName);
 

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -5,12 +5,13 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 import { CampaignTypeError } from '../../../../shared/domain/errors.js';
+import { getI18n } from '../../../../shared/infrastructure/i18n/i18n.js';
 import { CampaignProfilesCollectionExport } from '../../infrastructure/serializers/csv/campaign-profiles-collection-export.js';
 
 const startWritingCampaignProfilesCollectionResultsToStream = async function ({
   campaignId,
   writableStream,
-  i18n,
+  locale,
   campaignRepository,
   competenceRepository,
   campaignParticipationRepository,
@@ -20,7 +21,7 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
   organizationLearnerImportFormatRepository,
 }) {
   const campaign = await campaignRepository.get(campaignId);
-  const translate = i18n.__;
+  const i18n = getI18n(locale);
   let additionalHeaders = [];
 
   if (!campaign.isProfilesCollection) {
@@ -47,7 +48,7 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
     organization,
     campaign,
     competences: allPixCompetences,
-    translate,
+    locale,
     additionalHeaders,
   });
 
@@ -65,7 +66,7 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
       throw error;
     });
 
-  const fileName = translate('campaign-export.common.file-name', {
+  const fileName = i18n.__('campaign-export.common.file-name', {
     name: campaign.name,
     id: campaign.id,
     date: dayjs().tz('Europe/Berlin').format('YYYY-MM-DD-HHmm'),

--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-assessment-result-line.js
@@ -9,8 +9,10 @@ import _ from 'lodash';
 
 const STATS_COLUMNS_COUNT = 3;
 
+import { getI18n } from '../../../../../shared/infrastructure/i18n/i18n.js';
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import * as campaignParticipationService from '../../../domain/services/campaign-participation-service.js';
+
 class CampaignAssessmentResultLine {
   constructor({
     organization,
@@ -25,7 +27,7 @@ class CampaignAssessmentResultLine {
     participantKnowledgeElementsByCompetenceId,
     acquiredBadges,
     acquiredStages,
-    translate,
+    locale,
   }) {
     this.organization = organization;
     this.additionalHeaders = additionalHeaders;
@@ -43,9 +45,9 @@ class CampaignAssessmentResultLine {
     this.acquiredStages = acquiredStages;
     this.acquiredBadges = acquiredBadges;
     this.campaignParticipationService = campaignParticipationService;
-    this.translate = translate;
+    this.i18n = getI18n(locale);
 
-    this.emptyContent = translate('campaign-export.common.not-available');
+    this.emptyContent = this.i18n.__('campaign-export.common.not-available');
 
     // To have the good `this` in _getStatsForCompetence, it is necessary to bind it
     this._getStatsForCompetence = this._getStatsForCompetence.bind(this);
@@ -158,7 +160,7 @@ class CampaignAssessmentResultLine {
   }
 
   _makeYesNoColumns(isTrue) {
-    return isTrue ? this.translate('campaign-export.common.yes') : this.translate('campaign-export.common.no');
+    return isTrue ? this.i18n.__('campaign-export.common.yes') : this.i18n.__('campaign-export.common.no');
   }
 
   _makeNotSharedColumns() {
@@ -181,9 +183,9 @@ class CampaignAssessmentResultLine {
 
     return knowledgeElementForSkill
       ? knowledgeElementForSkill.isValidated
-        ? this.translate('campaign-export.assessment.status.ok')
-        : this.translate('campaign-export.assessment.status.ko')
-      : this.translate('campaign-export.assessment.status.not-tested');
+        ? this.i18n.__('campaign-export.assessment.status.ok')
+        : this.i18n.__('campaign-export.assessment.status.ko')
+      : this.i18n.__('campaign-export.assessment.status.not-tested');
   }
 
   _countValidatedKnowledgeElementsForCompetence(competenceId) {

--- a/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/src/prescription/campaign/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -5,6 +5,7 @@ import utc from 'dayjs/plugin/utc.js';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+import { getI18n } from '../../../../../shared/infrastructure/i18n/i18n.js';
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 
 const EMPTY_ARRAY = [];
@@ -16,7 +17,7 @@ class CampaignProfilesCollectionResultLine {
     campaignParticipationResult,
     competences,
     placementProfile,
-    translate,
+    locale,
     additionalHeaders,
   }) {
     this.organization = organization;
@@ -24,10 +25,10 @@ class CampaignProfilesCollectionResultLine {
     this.campaignParticipationResult = campaignParticipationResult;
     this.competences = competences;
     this.placementProfile = placementProfile;
-    this.translate = translate;
+    this.i18n = getI18n(locale);
     this.additionalHeaders = additionalHeaders;
 
-    this.notShared = translate('campaign-export.common.not-available');
+    this.notShared = this.i18n.__('campaign-export.common.not-available');
   }
 
   toCsvLine() {
@@ -110,7 +111,7 @@ class CampaignProfilesCollectionResultLine {
   }
 
   _yesOrNo(value) {
-    return this.translate(`campaign-export.common.${value ? 'yes' : 'no'}`);
+    return this.i18n.__(`campaign-export.common.${value ? 'yes' : 'no'}`);
   }
 
   _competenceColumns() {

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-assessment-export.js
@@ -4,6 +4,7 @@ import {
   CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
   CONCURRENCY_HEAVY_OPERATIONS,
 } from '../../../../../shared/infrastructure/constants.js';
+import { getI18n } from '../../../../../shared/infrastructure/i18n/i18n.js';
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { PromiseUtils } from '../../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignAssessmentResultLine } from '../../exports/campaigns/campaign-assessment-result-line.js';
@@ -16,7 +17,7 @@ class CampaignAssessmentExport {
     learningContent,
     stageCollection,
     campaign,
-    translate,
+    locale,
     additionalHeaders = [],
   }) {
     this.stream = outputStream;
@@ -28,7 +29,8 @@ class CampaignAssessmentExport {
     this.externalIdLabel = campaign.externalIdLabel;
     this.competences = learningContent.competences;
     this.areas = learningContent.areas;
-    this.translate = translate;
+    this.locale = locale;
+    this.i18n = getI18n(locale);
     this.additionalHeaders = additionalHeaders;
   }
 
@@ -88,33 +90,33 @@ class CampaignAssessmentExport {
     const extraHeaders = this.additionalHeaders.map((header) => header.columnName);
 
     const headers = [
-      this.translate('campaign-export.common.organization-name'),
-      this.translate('campaign-export.common.campaign-id'),
-      this.translate('campaign-export.common.campaign-code'),
-      this.translate('campaign-export.common.campaign-name'),
-      this.translate('campaign-export.assessment.target-profile-name'),
-      this.translate('campaign-export.common.participant-lastname'),
-      this.translate('campaign-export.common.participant-firstname'),
+      this.i18n.__('campaign-export.common.organization-name'),
+      this.i18n.__('campaign-export.common.campaign-id'),
+      this.i18n.__('campaign-export.common.campaign-code'),
+      this.i18n.__('campaign-export.common.campaign-name'),
+      this.i18n.__('campaign-export.assessment.target-profile-name'),
+      this.i18n.__('campaign-export.common.participant-lastname'),
+      this.i18n.__('campaign-export.common.participant-firstname'),
       ...extraHeaders,
-      ...(displayDivision ? [this.translate('campaign-export.common.participant-division')] : []),
-      ...(forSupStudents ? [this.translate('campaign-export.common.participant-group')] : []),
-      ...(forSupStudents ? [this.translate('campaign-export.common.participant-student-number')] : []),
+      ...(displayDivision ? [this.i18n.__('campaign-export.common.participant-division')] : []),
+      ...(forSupStudents ? [this.i18n.__('campaign-export.common.participant-group')] : []),
+      ...(forSupStudents ? [this.i18n.__('campaign-export.common.participant-student-number')] : []),
       ...(this.campaign.externalIdLabel ? [this.campaign.externalIdLabel] : []),
 
-      ...(this.campaign.isAssessment ? [this.translate('campaign-export.assessment.progress')] : []),
-      this.translate('campaign-export.assessment.started-on'),
-      this.translate('campaign-export.assessment.is-shared'),
-      this.translate('campaign-export.assessment.shared-on'),
+      ...(this.campaign.isAssessment ? [this.i18n.__('campaign-export.assessment.progress')] : []),
+      this.i18n.__('campaign-export.assessment.started-on'),
+      this.i18n.__('campaign-export.assessment.is-shared'),
+      this.i18n.__('campaign-export.assessment.shared-on'),
 
       ...(this.stageCollection.hasStage
-        ? [this.translate('campaign-export.assessment.success-rate', { value: this.stageCollection.totalStages - 1 })]
+        ? [this.i18n.__('campaign-export.assessment.success-rate', { value: this.stageCollection.totalStages - 1 })]
         : []),
 
       ..._.flatMap(this.targetProfile.badges, (badge) => [
-        this.translate('campaign-export.assessment.thematic-result-name', { name: badge.title }),
+        this.i18n.__('campaign-export.assessment.thematic-result-name', { name: badge.title }),
       ]),
 
-      this.translate('campaign-export.assessment.mastery-percentage-target-profile'),
+      this.i18n.__('campaign-export.assessment.mastery-percentage-target-profile'),
 
       ...this.#competenceColumnHeaders(),
       ...this.#areaColumnHeaders(),
@@ -130,17 +132,17 @@ class CampaignAssessmentExport {
 
   #competenceColumnHeaders() {
     return _.flatMap(this.competences, (competence) => [
-      this.translate('campaign-export.assessment.skill.mastery-percentage', { name: competence.name }),
-      this.translate('campaign-export.assessment.skill.total-items', { name: competence.name }),
-      this.translate('campaign-export.assessment.skill.items-successfully-completed', { name: competence.name }),
+      this.i18n.__('campaign-export.assessment.skill.mastery-percentage', { name: competence.name }),
+      this.i18n.__('campaign-export.assessment.skill.total-items', { name: competence.name }),
+      this.i18n.__('campaign-export.assessment.skill.items-successfully-completed', { name: competence.name }),
     ]);
   }
 
   #areaColumnHeaders() {
     return _.flatMap(this.areas, (area) => [
-      this.translate('campaign-export.assessment.competence-area.mastery-percentage', { name: area.title }),
-      this.translate('campaign-export.assessment.competence-area.total-items', { name: area.title }),
-      this.translate('campaign-export.assessment.competence-area.items-successfully-completed', { name: area.title }),
+      this.i18n.__('campaign-export.assessment.competence-area.mastery-percentage', { name: area.title }),
+      this.i18n.__('campaign-export.assessment.competence-area.total-items', { name: area.title }),
+      this.i18n.__('campaign-export.assessment.competence-area.items-successfully-completed', { name: area.title }),
     ]);
   }
 
@@ -179,7 +181,7 @@ class CampaignAssessmentExport {
         acquiredBadges && acquiredBadges[campaignParticipationInfo.campaignParticipationId]
           ? acquiredBadges[campaignParticipationInfo.campaignParticipationId].map((badge) => badge.title)
           : [],
-      translate: this.translate,
+      locale: this.locale,
     }).toCsvLine();
   }
 

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -4,18 +4,20 @@ import {
   CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
   CONCURRENCY_HEAVY_OPERATIONS,
 } from '../../../../../shared/infrastructure/constants.js';
+import { getI18n } from '../../../../../shared/infrastructure/i18n/i18n.js';
 import * as csvSerializer from '../../../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { PromiseUtils } from '../../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignProfilesCollectionResultLine } from '../../exports/campaigns/campaign-profiles-collection-result-line.js';
 
 class CampaignProfilesCollectionExport {
-  constructor({ outputStream, organization, campaign, competences, translate, additionalHeaders = [] }) {
+  constructor({ outputStream, organization, campaign, competences, locale, additionalHeaders = [] }) {
     this.stream = outputStream;
     this.organization = organization;
     this.campaign = campaign;
     this.externalIdLabel = campaign.externalIdLabel;
     this.competences = competences;
-    this.translate = translate;
+    this.locale = locale;
+    this.i18n = getI18n(locale);
     this.additionalHeaders = additionalHeaders;
   }
 
@@ -54,22 +56,22 @@ class CampaignProfilesCollectionExport {
     const extraHeaders = this.additionalHeaders.map((header) => header.columnName);
 
     const header = [
-      this.translate('campaign-export.common.organization-name'),
-      this.translate('campaign-export.common.campaign-id'),
-      this.translate('campaign-export.common.campaign-code'),
-      this.translate('campaign-export.common.campaign-name'),
-      this.translate('campaign-export.common.participant-lastname'),
-      this.translate('campaign-export.common.participant-firstname'),
+      this.i18n.__('campaign-export.common.organization-name'),
+      this.i18n.__('campaign-export.common.campaign-id'),
+      this.i18n.__('campaign-export.common.campaign-code'),
+      this.i18n.__('campaign-export.common.campaign-name'),
+      this.i18n.__('campaign-export.common.participant-lastname'),
+      this.i18n.__('campaign-export.common.participant-firstname'),
       ...extraHeaders,
-      displayGroup && this.translate('campaign-export.common.participant-group'),
-      displayDivision && this.translate('campaign-export.common.participant-division'),
-      displayStudentNumber && this.translate('campaign-export.common.participant-student-number'),
+      displayGroup && this.i18n.__('campaign-export.common.participant-group'),
+      displayDivision && this.i18n.__('campaign-export.common.participant-division'),
+      displayStudentNumber && this.i18n.__('campaign-export.common.participant-student-number'),
       this.externalIdLabel,
-      this.translate('campaign-export.profiles-collection.is-sent'),
-      this.translate('campaign-export.profiles-collection.sent-on'),
-      this.translate('campaign-export.profiles-collection.pix-score'),
-      this.translate('campaign-export.profiles-collection.is-certifiable'),
-      this.translate('campaign-export.profiles-collection.certifiable-skills'),
+      this.i18n.__('campaign-export.profiles-collection.is-sent'),
+      this.i18n.__('campaign-export.profiles-collection.sent-on'),
+      this.i18n.__('campaign-export.profiles-collection.pix-score'),
+      this.i18n.__('campaign-export.profiles-collection.is-certifiable'),
+      this.i18n.__('campaign-export.profiles-collection.certifiable-skills'),
       ...this._competenceColumnHeaders(),
     ];
 
@@ -114,7 +116,7 @@ class CampaignProfilesCollectionExport {
         additionalHeaders: this.additionalHeaders,
         competences: this.competences,
         placementProfile,
-        translate: this.translate,
+        locale: this.locale,
       });
 
       return line.toCsvLine();
@@ -125,8 +127,8 @@ class CampaignProfilesCollectionExport {
 
   _competenceColumnHeaders() {
     return _.flatMap(this.competences, (competence) => [
-      this.translate('campaign-export.profiles-collection.skill-level', { name: competence.name }),
-      this.translate('campaign-export.profiles-collection.skill-ranking', { name: competence.name }),
+      this.i18n.__('campaign-export.profiles-collection.skill-level', { name: competence.name }),
+      this.i18n.__('campaign-export.profiles-collection.skill-ranking', { name: competence.name }),
     ]);
   }
 }


### PR DESCRIPTION
## 🔆 Problème

Le système d'internationalisation (i18n) pour les exports CSV de campagnes présentait un problème de localisation. Le code utilisait directement l'objet `i18n` passé depuis les contrôleurs, mais cette approche ne permettait pas de garantir que la bonne locale soit utilisée pour les traductions dans les différentes couches de l'application.

```js
  const i18n = getI18n('en');
  const translate = i18n.__;

  console.log(i18n.__('email-sender-name.pix-app'));
  // PIX - Noreply
  console.log(translate('email-sender-name.pix-app'));
  // PIX - Ne pas répondre
```

## ⛱️ Proposition

Refactorisation du système d'internationalisation pour les exports CSV :

1. **Remplacement de l'objet `i18n` par la `locale`** : Les contrôleurs passent maintenant directement la locale (string) au lieu de l'objet i18n complet
2. **Création locale de l'objet i18n** : Chaque couche qui a besoin de traductions créé son propre objet i18n avec `getI18n(locale)`
3. **Cohérence dans l'utilisation des traductions** : Utilisation systématique de `i18n.__()` au lieu de `translate()`

**Fichiers modifiés :**
- `campaign-detail-controller.js` : Récupération de la locale via `getUserLocale()` au lieu de `getI18nFromRequest()`
- Use cases d'export : Création locale de l'objet i18n avec la bonne locale
- Classes d'export CSV : Réception de la locale et création de l'objet i18n en interne
- Lignes de résultat : Utilisation cohérente de `this.i18n.__()` pour toutes les traductions

## 🌊 Remarques

Cette approche améliore :
- La séparation des responsabilités entre les couches
- La garantie que la bonne locale est utilisée partout
- La testabilité du code (plus facile de mocker une locale qu'un objet i18n)
- La cohérence dans l'API des traductions

## 🏄 Pour tester

1. Utiliser une campagne d'évaluation avec des participants
2. Exporter les résultats en CSV avec différentes locales
3. Vérifier que les en-têtes et contenus du CSV sont traduits dans la bonne langue
4. Répéter avec une campagne de collecte de profils
5. S'assurer que tous les éléments traduits (statuts, labels, noms de fichiers) utilisent la bonne locale
