### PR TITLE
[BUGFIX] Correction clé de traduction manquante sur la cartes de la page Mes Parcours (PIX-19582)

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/deleted.gjs
+++ b/mon-pix/app/components/campaign-participation-overview/card/deleted.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 function getStatusWording(state) {
   const statusKey = {
     started: 'started-at',
+    aborted: 'started-at',
     completed: 'finished-at',
   };
   return `pages.campaign-participation-overview.card.${statusKey[state]}`;


### PR DESCRIPTION
## 🔆 Problème

Une clé de texte sur le statut d'un parcours est manquante quand un parcours est à un `state: aborted` dans la page des parcours.

## ⛱️ Proposition

Aucun texte n'étant défini pour ce `state` et ne sachant pas s'il s'agit de parcours anonymisés, on utilise la clé pour le `state: started-at` à la place.

## 🏄 Pour tester

- Afficher la page Mes Parcours via le compte recette de Géraldine pour avoir des parcours à l'état aborted.
(Une reproduction des données tel quel en local n'a pas été possible)
