### PR TITLE
[FEATURE] Remonter le nom du parcours combiné sur la page d'une campagne (PIX-19317)

### DIFF
--- a/api/src/prescription/campaign/domain/read-models/CampaignReport.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignReport.js
@@ -26,7 +26,6 @@ class CampaignReport {
     multipleSendings,
     targetProfileName,
   } = {}) {
-    this.isFromCombinedCourse = false;
     this.targetProfileName = targetProfileName;
     this.id = id;
     this.name = name;
@@ -72,8 +71,14 @@ class CampaignReport {
     return Boolean(this.archivedAt);
   }
 
-  setIsFromCombinedCourse(isFromCombinedCourse) {
-    this.isFromCombinedCourse = isFromCombinedCourse;
+  setCombinedCourse({ id, name } = {}) {
+    if (name && id) {
+      this.combinedCourse = { id, name };
+    }
+  }
+
+  get isFromCombinedCourse() {
+    return Boolean(this.combinedCourse);
   }
 
   setTargetProfileInformation(targetProfile) {

--- a/api/src/prescription/campaign/domain/usecases/get-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign.js
@@ -10,7 +10,11 @@ const getCampaign = async function ({
   const campaignReport = await campaignReportRepository.get(campaignId);
 
   const existingCombinedCourse = await findByCampaignId({ campaignId });
-  campaignReport.setIsFromCombinedCourse(existingCombinedCourse.length > 0);
+
+  if (existingCombinedCourse.length > 0) {
+    const { id, name } = existingCombinedCourse[0];
+    campaignReport.setCombinedCourse({ id, name });
+  }
 
   if (campaignReport.isAssessment || campaignReport.isExam) {
     const [badges, stageCollection, masteryRates] = await Promise.all([

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -145,7 +145,7 @@ const findPaginatedFilteredByOrganizationId = async function ({
   const campaignReports = await PromiseUtils.mapSeries(results, async (attributes) => {
     const campaignReport = new CampaignReport(attributes);
     const combinedCourseInfo = await combinedCourseRepo.findByCampaignId({ campaignId: campaignReport.id });
-    campaignReport.setIsFromCombinedCourse(combinedCourseInfo.length > 0);
+    campaignReport.setCombinedCourse(combinedCourseInfo[0]);
     return campaignReport;
   });
   return { models: campaignReports, meta: { ...pagination, hasCampaigns } };

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -4,11 +4,6 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (campaignReports, meta) {
   return new Serializer('campaign', {
-    transform: (record) => {
-      const campaign = Object.assign({}, record);
-      campaign.isArchived = record.isArchived;
-      return campaign;
-    },
     attributes: [
       'name',
       'code',
@@ -44,6 +39,7 @@ const serialize = function (campaignReports, meta) {
       'multipleSendings',
       'targetProfile',
       'isFromCombinedCourse',
+      'combinedCourse',
     ],
     stages: {
       ref: 'id',

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -22,9 +22,9 @@ describe('Integration | UseCase | get-campaign', function () {
       await databaseBuilder.commit();
     });
 
-    it('should defined isFromCombinedCourse to true when campaign register on combined course', async function () {
+    it('should return combinedCourse info when a combined course is associated with a campaign', async function () {
       // given
-      databaseBuilder.factory.buildQuestForCombinedCourse({
+      const combinedCourseId = databaseBuilder.factory.buildQuestForCombinedCourse({
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,
@@ -40,7 +40,7 @@ describe('Integration | UseCase | get-campaign', function () {
             },
           },
         ],
-      });
+      }).id;
       await databaseBuilder.commit();
 
       // when
@@ -49,17 +49,20 @@ describe('Integration | UseCase | get-campaign', function () {
       });
 
       // then
-      expect(resultCampaign.isFromCombinedCourse).true;
+      expect(resultCampaign.combinedCourse).deep.equal({
+        id: combinedCourseId,
+        name: 'Mon parcours Combiné',
+      });
     });
 
-    it('should defined isFromCombinedCourse to false when campaign is not register on combined course', async function () {
+    it('should not return combinedCourse info when a combined course is not associated with a campaign', async function () {
       // when
       const resultCampaign = await usecases.getCampaign({
         campaignId: campaign.id,
       });
 
       // then
-      expect(resultCampaign.isFromCombinedCourse).false;
+      expect(resultCampaign.combinedCourse).undefined;
     });
   });
   context('Type ASSESSMENT', function () {

--- a/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -36,6 +36,8 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
         ],
       });
 
+      report.setCombinedCourse({ id: 123, name: 'Mon combinix' });
+
       report.setTargetProfileInformation({
         tubeCount: 3,
         thematicResultCount: 2,
@@ -130,6 +132,7 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function ()
             'reached-stage': report.reachedStage,
             'total-stage': report.totalStage,
             'is-from-combined-course': report.isFromCombinedCourse,
+            'combined-course': report.combinedCourse,
           },
         },
         included: [

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -120,27 +120,35 @@ describe('Unit | Domain | Models | CampaignReport', function () {
     });
   });
 
-  describe('#setIsFromCombinedCourse', function () {
-    it('should define isFromCombinedCourse to false by default', function () {
+  describe('isFromCombinedCourse', function () {
+    it('should return false by default', function () {
       const campaignReport = new CampaignReport();
 
       expect(campaignReport.isFromCombinedCourse).false;
     });
 
-    it('should define isFromCombinedCourse to false when not combined course defined', function () {
+    it('should be false when there is no combined course defined', function () {
       const campaignReport = new CampaignReport();
 
-      campaignReport.setIsFromCombinedCourse(false);
+      campaignReport.setCombinedCourse();
 
       expect(campaignReport.isFromCombinedCourse).false;
     });
 
-    it('should define isFromCombinedCourse to true when combined course defined', function () {
+    it('should be true when a combined course is set', function () {
       const campaignReport = new CampaignReport();
 
-      campaignReport.setIsFromCombinedCourse(true);
+      campaignReport.setCombinedCourse({ id: 123, name: 'combinix' });
 
       expect(campaignReport.isFromCombinedCourse).true;
+    });
+
+    it('should return combined course info when a combined course is set', function () {
+      const campaignReport = new CampaignReport();
+
+      campaignReport.setCombinedCourse({ id: 123, name: 'combinix' });
+
+      expect(campaignReport.combinedCourse).deep.equal({ id: 123, name: 'combinix' });
     });
   });
 });

--- a/orga/app/components/campaign/header/title.gjs
+++ b/orga/app/components/campaign/header/title.gjs
@@ -52,6 +52,14 @@ export default class Header extends Component {
         <CampaignType @big={{true}} @campaignType={{@campaign.type}} @hideLabel={{true}} />
         <span class="page-title__name">{{@campaign.name}}</span>
       </:title>
+      <:subtitle>
+        {{#if @campaign.isFromCombinedCourse}}
+          <p class="campaign-page__page-subtext">{{t
+              "pages.campaign.included-in-combined-course"
+              name=@campaign.combinedCourse.name
+            }}</p>
+        {{/if}}
+      </:subtitle>
       <:tools>
         <dl class="campaign-header-title__details">
           <div class="campaign-header-title__detail-item hide-on-mobile">

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -26,6 +26,7 @@ export default class Campaign extends Model {
   @attr('boolean') targetProfileHasStage;
   @attr('boolean') targetProfileAreKnowledgeElementsResettable;
   @attr('boolean') isFromCombinedCourse;
+  @attr() combinedCourse;
   @attr('number') participationsCount;
   @attr('number') sharedParticipationsCount;
   @attr('number') averageResult;

--- a/orga/app/styles/pages/authenticated/campaigns/campaign.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/campaign.scss
@@ -1,6 +1,12 @@
+@use 'pix-design-tokens/typography';
+
 .campaign-page {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
+
+  &__page-subtext {
+    @extend %pix-body-s;
+  }
 }

--- a/orga/tests/integration/components/campaign/header/title-test.js
+++ b/orga/tests/integration/components/campaign/header/title-test.js
@@ -32,6 +32,44 @@ module('Integration | Component | Campaign::Header::Title', function (hooks) {
     assert.ok(screen.getByText('14/04/2021'));
   });
 
+  test('it should display combined course name if campaign is from combined course', async function (assert) {
+    // given
+    this.campaign = {
+      name: 'campagne 1',
+      code: '1234PixTest',
+      createdAt: new Date('2021-04-14'),
+      ownerFullName: 'Mulan Fa',
+      type: 'ASSESSMENT',
+      isFromCombinedCourse: true,
+      combinedCourse: { id: '1', name: 'COMBINIX' },
+    };
+
+    // when
+    const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+    // then
+    assert.ok(screen.getByText(t('pages.campaign.included-in-combined-course', { name: 'COMBINIX' })));
+  });
+
+  test('it should not display combined course name if campaign is not from combined course', async function (assert) {
+    // given
+    this.campaign = {
+      name: 'campagne 1',
+      code: '1234PixTest',
+      createdAt: new Date('2021-04-14'),
+      ownerFullName: 'Mulan Fa',
+      type: 'ASSESSMENT',
+      isFromCombinedCourse: false,
+      combinedCourse: { id: '1', name: 'ABC123' },
+    };
+
+    // when
+    const screen = await render(hbs`<Campaign::Header::Title @campaign={{this.campaign}} />`);
+
+    // then
+    assert.notOk(screen.queryByText(t('pages.campaign.included-in-combined-course', { name: 'ABC123' })));
+  });
+
   module('campaign code display', function () {
     test('it should display campaign code when campaign is not from combined course', async function (assert) {
       // given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -602,6 +602,7 @@
       "created-on": "Created on",
       "empty-state": "No participants yet!",
       "empty-state-with-copy-link": "No participants yet! Share with them the following link to join this campaign.",
+      "included-in-combined-course": "This assessment campaign is included in the {name} course.",
       "multiple-sendings": {
         "status": {
           "disabled": "No",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -602,6 +602,7 @@
       "created-on": "Créée le",
       "empty-state": "Aucun participant pour l’instant !",
       "empty-state-with-copy-link": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
+      "included-in-combined-course": "Cette campagne d'évaluation est incluse dans le parcours {name}.",
       "multiple-sendings": {
         "status": {
           "disabled": "Non",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -602,6 +602,7 @@
       "created-on": "Gemaakt op",
       "empty-state": "Geen deelnemers op het moment",
       "empty-state-with-copy-link": "Geen deelnemers op het moment! Stuur ze de volgende link om mee te doen aan je campagne.",
+      "included-in-combined-course": "Deze evaluatiecampagne maakt deel uit van het {name}-traject.",
       "multiple-sendings": {
         "status": {
           "disabled": "Nee",
@@ -1399,7 +1400,8 @@
         "campaign-status": "Status:",
         "campaign-type": "Type:",
         "participation-SHARED-status": "Ontvangen",
-        "participation-STARTED-status": "Bezig"      }
+        "participation-STARTED-status": "Bezig"
+      }
     },
     "places": {
       "before-date": "op",


### PR DESCRIPTION
## 🔆 Problème

Actuellement on ne sait pas quand une campagne fait partie d'un parcours combiné.

## ⛱️ Proposition

Afficher le nom du parcours combiné pour le campagnes concernées.

## 🏄 Pour tester

- Se connecter avec admin-orga
- Aller sur l'organisation Attestation
- Aller sur la campagne CODE123
- Voir le nom du parcours combiné (COMBINIX) 
