### PR TITLE
[FEATURE] Copier l'event EXPAND_OPENED en passageEvent (PIX-18371).

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,7 @@ import {
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
+  ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
   VideoPlayedEvent,
@@ -30,6 +31,8 @@ class PassageEventFactory {
     switch (eventData.type) {
       case 'EMBED_ANSWERED':
         return new EmbedAnsweredEvent(eventData);
+      case 'EXPAND_OPENED':
+        return new ExpandOpenedEvent(eventData);
       case 'FILE_DOWNLOADED':
         return new FileDownloadedEvent(eventData);
       case 'FLASHCARDS_CARD_AUTO_ASSESSED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -1,6 +1,27 @@
 import { PassageEventWithElement } from './PassageEventWithElement.js';
 
 /**
+ * @class ExpandOpenedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user opens a fold-out text.
+ *
+ * */
+class ExpandOpenedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'EXPAND_OPENED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+/**
  * @class ImageAlternativeTextOpenedEvent
  * See PassageEventWithElement for more info.
  *
@@ -84,4 +105,10 @@ class FileDownloadedEvent extends PassageEventWithElement {
   }
 }
 
-export { FileDownloadedEvent, ImageAlternativeTextOpenedEvent, VideoPlayedEvent, VideoTranscriptionOpenedEvent };
+export {
+  ExpandOpenedEvent,
+  FileDownloadedEvent,
+  ImageAlternativeTextOpenedEvent,
+  VideoPlayedEvent,
+  VideoTranscriptionOpenedEvent,
+};

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -10,6 +10,7 @@ import {
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
+  ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
   VideoPlayedEvent,
@@ -479,6 +480,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(FileDownloadedEvent);
+      });
+    });
+
+    describe('when given a EXPAND_OPENED event', function () {
+      it('should return an ExpandOpenedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 9,
+          sequenceNumber: 34,
+          elementId: 'd905e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'EXPAND_OPENED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(ExpandOpenedEvent);
       });
     });
   });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -220,6 +220,16 @@ export default class ModulePassage extends Component {
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
+
+    if (isOpen) {
+      this.passageEvents.record({
+        type: 'EXPAND_OPENED',
+        data: {
+          elementId,
+        },
+      });
+    }
+
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1316,6 +1316,50 @@ module('Integration | Component | Module | Passage', function (hooks) {
   });
 
   module('when user opens Expand element', function () {
+    test('should send a passage-event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        type: 'expand',
+        isAnswerable: false,
+        title: 'Mon Expand',
+        content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            title: 'Grain title',
+            type: 'discovery',
+            id: '123-abc',
+            components: [{ type: 'element', element: expandElement }],
+          },
+        ],
+      });
+      const module = store.createRecord('module', {
+        title: 'Didacticiel',
+        slug: 'module-slug',
+        sections: [section],
+      });
+      const passage = store.createRecord('passage');
+
+      //  when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'EXPAND_OPENED',
+        data: {
+          elementId: expandElement.id,
+        },
+      });
+      assert.ok(true);
+    });
+
     test('should push metrics event with "Ouverture" event name', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## 🔆 Problème

On n'a pas de passage-event créé quand un utilisateur ouvre un texte dépliable

## ⛱️ Proposition

Générer un passage-event EXPAND_OPENED quand utilisateur ouvre un texte dépliable, en appelant l'api.

## 🏄 Pour tester

- Ouvrir le module [galerie](https://app-pr13619.review.pix.fr/modules/galerie)
- Aller vers le bloc "expand"
- Ouvrir console développeur -> Réseau
- Cliquer sur le texte dépliable
- Vérifier que l'appel api /passage-event retourne 204
