### PR TITLE
[FEATURE] Copier l'event EXPAND_CLOSED du service metrics vers un passageEvent (PIX-18372)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -8,6 +8,7 @@ import {
   QROCMAnsweredEvent,
 } from '../models/passage-events/answerable-element-events.js';
 import {
+  ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
@@ -33,6 +34,8 @@ class PassageEventFactory {
         return new EmbedAnsweredEvent(eventData);
       case 'EXPAND_OPENED':
         return new ExpandOpenedEvent(eventData);
+      case 'EXPAND_CLOSED':
+        return new ExpandClosedEvent(eventData);
       case 'FILE_DOWNLOADED':
         return new FileDownloadedEvent(eventData);
       case 'FLASHCARDS_CARD_AUTO_ASSESSED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -1,6 +1,26 @@
 import { PassageEventWithElement } from './PassageEventWithElement.js';
 
 /**
+ * @class ExpandClosedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user closes an expand.
+ */
+class ExpandClosedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'EXPAND_CLOSED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+/**
  * @class ExpandOpenedEvent
  * See PassageEventWithElement for more info.
  *
@@ -88,7 +108,6 @@ class VideoPlayedEvent extends PassageEventWithElement {
  * @class FileDownloadedEvent
  * See PassageEventWithElement for more info.
  *
- * This event is generated when the user downloads a file.
  * */
 class FileDownloadedEvent extends PassageEventWithElement {
   constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId, filename, format }) {
@@ -106,6 +125,7 @@ class FileDownloadedEvent extends PassageEventWithElement {
 }
 
 export {
+  ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -10,6 +10,7 @@ import {
   QROCMAnsweredEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/answerable-element-events.js';
 import {
+  ExpandClosedEvent,
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
@@ -58,6 +59,25 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
         // then
         expect(error).to.be.instanceof(DomainError);
         expect(error.message).to.equal('Passage event with type UNKNOWN does not exist');
+      });
+    });
+
+    describe('when given a EXPAND_CLOSED event', function () {
+      it('should return an ExpandClosedEvent instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 10,
+          sequenceNumber: 34,
+          elementId: 'f905e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'EXPAND_CLOSED',
+        };
+
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(ExpandClosedEvent);
       });
     });
 

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -220,19 +220,16 @@ export default class ModulePassage extends Component {
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
-
-    if (isOpen) {
-      this.passageEvents.record({
-        type: 'EXPAND_OPENED',
-        data: {
-          elementId,
-        },
-      });
-    }
-
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+    });
+
+    this.passageEvents.record({
+      type: isOpen ? 'EXPAND_OPENED' : 'EXPAND_CLOSED',
+      data: {
+        elementId,
+      },
     });
   }
 

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1506,5 +1506,50 @@ module('Integration | Component | Module | Passage', function (hooks) {
       });
       assert.ok(true);
     });
+
+    test('should send a passage-event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const expandElement = {
+        id: 'f5e7ce21-b71d-4054-8886-a4e9a17016ff',
+        type: 'expand',
+        isAnswerable: false,
+        title: 'Mon Expand',
+        content: "<p>Ceci est le contenu d'un expand dans mon module</p>",
+      };
+      const section = store.createRecord('section', {
+        id: 'section1',
+        type: 'blank',
+        grains: [
+          {
+            title: 'Grain title',
+            type: 'discovery',
+            id: '123-abc',
+            components: [{ type: 'element', element: expandElement }],
+          },
+        ],
+      });
+      const module = store.createRecord('module', {
+        title: 'Didacticiel',
+        slug: 'module-slug',
+        sections: [section],
+      });
+      const passage = store.createRecord('passage');
+
+      //  when
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+      const expandSummarySelector = '.modulix-expand__title';
+      await click(expandSummarySelector);
+      await click(expandSummarySelector);
+
+      // then
+      sinon.assert.calledWithExactly(passageEventRecordStub, {
+        type: 'EXPAND_CLOSED',
+        data: {
+          elementId: expandElement.id,
+        },
+      });
+      assert.ok(true);
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

On n'a pas de trace d'apprentissage pour la fermeture d'un élément expand.

## ⛱️ Proposition

Quand on ferme un expand, envoyer un passage-event ExpandClosedEvent

## 🌊 Remarques

Attention aux potentiels conflits avant merge 

## 🏄 Pour tester

- Ouvrir le module [galerie](https://app-pr13622.review.pix.fr/modules/galerie)
- Aller vers le bloc "expand"
- Ouvrir console développeur -> Réseau
- Cliquer sur le texte dépliable pour l'ouvrir, puis une seconde fois pour le fermer
- Vérifier que le deuxième appel api /passage-event retourne 204
