### PR TITLE
[FEATURE] Mise à jour du wording dans le bloc "Formation" des parcours combinés

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1214,8 +1214,8 @@
         "completed": "Completed!",
         "durationUnit": "min",
         "formation": {
-          "description": "Complete your test and unlock customised training modules! The number of modules will depend on your results.",
-          "title": "I am training myself"
+          "description": "Complete your assessment to unlock a programme of modules tailored to your results!",
+          "title": "Customised module programme"
         },
         "tagText": "You're at that point!"
       }

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1206,8 +1206,8 @@
       },
       "items": {
         "formation": {
-          "title": "Me estoy formando",
-          "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados."
+          "title": "Programa personalizado de módulos",
+          "description": "¡Completa tu diagnóstico para desbloquear un programa de módulos adaptado a tu resultado!"
         },
         "completed": "¡Completado!",
         "tagText": "¡Ya estás ahí!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1214,8 +1214,8 @@
         "completed": "Complété !",
         "durationUnit": "min",
         "formation": {
-          "description": "Terminez votre test et débloquez des modules de formation sur mesure ! Leur nombre dépendra de vos résultats.",
-          "title": "Je me forme"
+          "description": "Terminez votre diagnostic pour débloquer un programme de modules adapté à votre résultat !",
+          "title": "Programme personnalisé de modules"
         },
         "tagText": "Vous en êtes là !"
       }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1210,8 +1210,8 @@
       },
       "items": {
         "formation": {
-          "title": "Ik volg een opleiding",
-          "description": "Voltooi uw test en ontgrendel op maat gemaakte trainingsmodules! Het aantal modules hangt af van uw resultaten."
+          "title": "Gepersonaliseerd programma met modules",
+          "description": "Voltooi uw diagnose om een moduleprogramma te ontgrendelen dat is afgestemd op uw resultaat!"
         },
         "completed": "Voltooid!",
         "tagText": "U bent er nu!",


### PR DESCRIPTION
## 🔆 Problème
On veut modifier le wording du titre et de la description du bloc "Formation".

## 🏄 Pour tester
Commencer un parcours combiné et vérifier que le wording correspond à ce qui est attendu dans le ticket.