### PR TITLE
[TECH] Renommer checkDomainIsValid en assertEmailDomainHasMx pour indiquer clairement ce qui est fait

### DIFF
--- a/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
+++ b/api/src/certification/enrolment/domain/services/certification-candidates-ods-service.js
@@ -88,7 +88,7 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
 
     if (resultRecipientEmail) {
       try {
-        await mailCheck.checkDomainIsValid(resultRecipientEmail);
+        await mailCheck.assertEmailDomainHasMx(resultRecipientEmail);
       } catch {
         throw new CertificationCandidatesError({
           code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID.code,
@@ -99,7 +99,7 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
 
     if (email) {
       try {
-        await mailCheck.checkDomainIsValid(email);
+        await mailCheck.assertEmailDomainHasMx(email);
       } catch {
         throw new CertificationCandidatesError({
           code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code,

--- a/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
+++ b/api/src/certification/enrolment/domain/services/sessions-import-validation-service.js
@@ -274,7 +274,7 @@ function _hasSessionInfo(session) {
 async function _validateEmail({ email, mailCheck, errorCode, certificationCandidateErrors, line }) {
   if (email) {
     try {
-      await mailCheck.checkDomainIsValid(email);
+      await mailCheck.assertEmailDomainHasMx(email);
     } catch {
       return _addToErrorList({
         errorList: certificationCandidateErrors,

--- a/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-candidate-to-session.js
@@ -95,7 +95,7 @@ export async function addCandidateToSession({
 
   if (candidate.resultRecipientEmail) {
     try {
-      await mailCheck.checkDomainIsValid(candidate.resultRecipientEmail);
+      await mailCheck.assertEmailDomainHasMx(candidate.resultRecipientEmail);
     } catch {
       throw new CertificationCandidatesError({
         code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID.code,
@@ -105,7 +105,7 @@ export async function addCandidateToSession({
   }
   if (candidate.email) {
     try {
-      await mailCheck.checkDomainIsValid(candidate.email);
+      await mailCheck.assertEmailDomainHasMx(candidate.email);
     } catch {
       throw new CertificationCandidatesError({
         code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code,

--- a/api/src/shared/mail/infrastructure/services/mail-check.js
+++ b/api/src/shared/mail/infrastructure/services/mail-check.js
@@ -6,7 +6,7 @@ const resolver = new Resolver();
 
 let resolveMx = resolver.resolveMx.bind(resolver);
 
-const checkDomainIsValid = function (emailAddress) {
+const assertEmailDomainHasMx = function (emailAddress) {
   const domain = emailAddress.replace(/.*@/g, '');
   return resolveMx(domain).then(() => true);
 };
@@ -19,4 +19,4 @@ const clearResolveMx = function () {
   resolveMx = resolver.resolveMx.bind(resolver);
 };
 
-export { checkDomainIsValid, clearResolveMx, setResolveMx };
+export { assertEmailDomainHasMx, clearResolveMx, setResolveMx };

--- a/api/src/shared/mail/infrastructure/services/mail-check.js
+++ b/api/src/shared/mail/infrastructure/services/mail-check.js
@@ -7,8 +7,8 @@ const resolver = new Resolver();
 let resolveMx = resolver.resolveMx.bind(resolver);
 
 const assertEmailDomainHasMx = function (emailAddress) {
-  const domain = emailAddress.replace(/.*@/g, '');
-  return resolveMx(domain).then(() => true);
+  const domainName = emailAddress.replace(/.*@/g, '');
+  return resolveMx(domainName).then(() => true);
 };
 
 const setResolveMx = function (resolveMxFn) {

--- a/api/src/shared/mail/infrastructure/services/mail-check.js
+++ b/api/src/shared/mail/infrastructure/services/mail-check.js
@@ -1,6 +1,4 @@
-import { promises } from 'node:dns';
-
-const { Resolver } = promises;
+import { Resolver } from 'node:dns/promises';
 
 const resolver = new Resolver();
 

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -35,7 +35,7 @@ class Mailer {
     }
 
     try {
-      await this.dependencies.mailCheck.checkDomainIsValid(options.to);
+      await this.dependencies.mailCheck.assertEmailDomainHasMx(options.to);
     } catch (err) {
       logger.warn({ err }, `Email is not valid '${options.to}'`);
       return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_DOMAIN);

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -63,7 +63,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     await databaseBuilder.commit();
 
-    mailCheck = { checkDomainIsValid: sinon.stub() };
+    mailCheck = { assertEmailDomainHasMx: sinon.stub() };
 
     candidateList = _buildCandidateList({ sessionId });
   });
@@ -72,7 +72,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     // given
     const odsFilePath = `${__dirname}/attendance_sheet_extract_mandatory_ko_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    mailCheck.checkDomainIsValid.resolves();
+    mailCheck.assertEmailDomainHasMx.resolves();
 
     // when
     const error = await catchErr(
@@ -99,7 +99,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     // given
     const odsFilePath = `${__dirname}/attendance_sheet_extract_birth_ko_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    mailCheck.checkDomainIsValid.resolves();
+    mailCheck.assertEmailDomainHasMx.resolves();
 
     // when
     const error = await catchErr(
@@ -125,7 +125,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     // given
     const odsFilePath = `${__dirname}/attendance_sheet_extract_recipient_email_ko_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    mailCheck.checkDomainIsValid.withArgs('jack@d.it').throws();
+    mailCheck.assertEmailDomainHasMx.withArgs('jack@d.it').throws();
 
     // when
     const error = await catchErr(
@@ -211,7 +211,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
   context('when certification center has habilitations', function () {
     it('should return extracted and validated certification candidates with complementary certification', async function () {
       // given
-      mailCheck.checkDomainIsValid.resolves();
+      mailCheck.assertEmailDomainHasMx.resolves();
 
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
@@ -263,7 +263,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     it('should throw an error if candidate is registered for multiple complementary certifications', async function () {
       // given
-      mailCheck.checkDomainIsValid.resolves();
+      mailCheck.assertEmailDomainHasMx.resolves();
 
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
@@ -309,7 +309,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
   it('should return extracted and validated certification candidates with billing information', async function () {
     // given
-    mailCheck.checkDomainIsValid.resolves();
+    mailCheck.assertEmailDomainHasMx.resolves();
     const isSco = false;
 
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
@@ -340,7 +340,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     const isSco = true;
     const odsFilePath = `${__dirname}/attendance_sheet_extract_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    mailCheck.checkDomainIsValid.resolves();
+    mailCheck.assertEmailDomainHasMx.resolves();
 
     // when
     const actualCandidates =

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -418,7 +418,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // given
         const certificationCandidate = _buildValidCandidateData();
         const mailCheckStub = {
-          checkDomainIsValid: sinon.stub().throws(),
+          assertEmailDomainHasMx: sinon.stub().throws(),
         };
 
         // when
@@ -441,7 +441,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // given
         const certificationCandidate = _buildValidCandidateData();
         const mailCheckStub = {
-          checkDomainIsValid: sinon.stub().resolves(),
+          assertEmailDomainHasMx: sinon.stub().resolves(),
         };
 
         // when

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-candidate-to-session_test.js
@@ -54,7 +54,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
         }),
       ]),
     };
-    mailCheck = { checkDomainIsValid: sinon.stub() };
+    mailCheck = { assertEmailDomainHasMx: sinon.stub() };
     centerRepository.getById.resolves(domainBuilder.certification.enrolment.buildCenter());
     normalizeStringFnc = (str) => str;
     dependencies = {
@@ -229,8 +229,8 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                   email: 'jesuisunemail@incorrect.fr',
                   resultRecipientEmail: 'jesuisunemail@correct.fr',
                 });
-                mailCheck.checkDomainIsValid.withArgs('jesuisunemail@incorrect.fr').throws();
-                mailCheck.checkDomainIsValid.withArgs('jesuisunemail@correct.fr').resolves();
+                mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@incorrect.fr').throws();
+                mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@correct.fr').resolves();
 
                 // when
                 const error = await catchErr(addCandidateToSession)({
@@ -257,8 +257,8 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
                   email: 'jesuisunemail@correct.fr',
                   resultRecipientEmail: 'jesuisunemail@incorrect.fr',
                 });
-                mailCheck.checkDomainIsValid.withArgs('jesuisunemail@incorrect.fr').throws();
-                mailCheck.checkDomainIsValid.withArgs('jesuisunemail@correct.fr').resolves();
+                mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@incorrect.fr').throws();
+                mailCheck.assertEmailDomainHasMx.withArgs('jesuisunemail@correct.fr').resolves();
 
                 // when
                 const error = await catchErr(addCandidateToSession)({
@@ -281,7 +281,7 @@ describe('Certification | Enrolment | Unit | UseCase | add-candidate-to-session'
 
           context('when emails validations succeed', function () {
             beforeEach(function () {
-              mailCheck.checkDomainIsValid.resolves();
+              mailCheck.assertEmailDomainHasMx.resolves();
             });
 
             it('should insert the candidate and return the ID', async function () {

--- a/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
@@ -14,7 +14,7 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
 
   beforeEach(function () {
     mailCheck = {
-      checkDomainIsValid: sinon.stub(),
+      assertEmailDomainHasMx: sinon.stub(),
     };
     sinon.stub(mailing, 'provider').value('brevo');
   });
@@ -80,7 +80,7 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
         it('should send email and return a success status', async function () {
           // given
           _enableMailing();
-          mailCheck.checkDomainIsValid.withArgs(recipient).resolves();
+          mailCheck.assertEmailDomainHasMx.withArgs(recipient).resolves();
 
           const from = 'no-reply@example.net';
           const options = {
@@ -108,7 +108,7 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
           _enableMailing();
 
           const expectedError = new Error('fail');
-          mailCheck.checkDomainIsValid.withArgs(recipient).rejects(expectedError);
+          mailCheck.assertEmailDomainHasMx.withArgs(recipient).rejects(expectedError);
 
           sinon.stub(logger, 'warn');
           const mailer = new Mailer({ dependencies: { mailCheck } });
@@ -132,7 +132,7 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
         it('should log a warning and return an error status', async function () {
           // given
           _enableMailing();
-          mailCheck.checkDomainIsValid.withArgs(recipient).resolves();
+          mailCheck.assertEmailDomainHasMx.withArgs(recipient).resolves();
 
           sinon.stub(logger, 'warn');
           const mailer = new Mailer({ dependencies: { mailCheck } });
@@ -157,7 +157,7 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
             // Given
             _enableMailing();
             const invalidEmailRecipient = 'invalid@email.net';
-            mailCheck.checkDomainIsValid.withArgs(invalidEmailRecipient).resolves();
+            mailCheck.assertEmailDomainHasMx.withArgs(invalidEmailRecipient).resolves();
 
             const mailer = new Mailer({ dependencies: { mailCheck } });
             const mailingProvider = _mockMailingProvider(mailer);


### PR DESCRIPTION
## 🔆 Problème

Le nom de la fonction `checkDomainIsValid` de `api/src/shared/mail/infrastructure/services/mail-check.js` porte à confusion car il fait penser : 
* que la fonction retourne un booléen, alors que ce n’est pas le cas
* que la fonction vérifie si le domaine existe, alors que ce n’est pas le cas


## ⛱️ Proposition

Renommer la fonction `checkDomainIsValid` en `assertEmailDomainHasMx`, de manière à signifier : 
* qu’il s’agit d’une assertion et que la fonction fait un `throw` en cas de condition non-conforme
* que c’est l’existence d’un MX record dans la configuration du domaine qui est particulièrement recherchée, en plus bien sûr de la disponibilité en ligne du domaine

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Configurer `MAILING_ENABLED=true` dans le `.env`
2. Aller dans Pix Admin et inviter une adresse email pour laquelle le domaine n’existe pas (par exemple `toto@cedomainenexistevraimentvraimentpas.niet`)
3. Constater que cet envoi produit une erreur
4. Toujours dans Pix Admin, inviter cette fois une adresse email pour laquelle le domaine existe avec un MX (par exemple votre adresse email)
5. Constater que cet envoi ne produit pas d’erreur

PS : On n’est pas obligé de tester le cas d’un domaine sans MX car il faudrait pouvoir en trouver un, ce qui n’est pas évident sauf à créer un nom de domaine bidon pour l’occasion.