### PR TITLE
[BUGFIX] Supprimer l'appel dupliqué à buildParenthoodQuest dans build-quests.js

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -715,7 +715,6 @@ export const buildQuests = async (databaseBuilder) => {
   // Create quests
   buildSixthGradeQuests(databaseBuilder, rewardId, targetProfiles);
   const parenthoodAttestationId = buildParenthoodQuest(databaseBuilder);
-  buildParenthoodQuest(databaseBuilder);
   buildProCombinedCourseQuest(databaseBuilder, PRO_ORGANIZATION_ID);
   buildCombinedCourseQuest(databaseBuilder, organization.id);
 


### PR DESCRIPTION
## Summary
• Suppression de l'appel dupliqué à `buildParenthoodQuest(databaseBuilder)` dans le fichier de seeds
• Correction d'une duplication qui pouvait causer des problèmes lors de la génération des données de test

## Test plan
- [ ] Vérifier que les seeds se chargent correctement
- [ ] S'assurer qu'aucune régression n'est introduite dans les quêtes de parentalité

🤖 Generated with [Claude Code](https://claude.ai/code)