### PR TITLE
[FEATURE] Cacher le code campagne lorsqu'elles sont liées à un parcours combiné (PIX-19611).

### DIFF
--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1066,5 +1066,50 @@ describe('Integration | Repository | Campaign-Report', function () {
         });
       });
     });
+
+    context('when campaigns are related to combine course', function () {
+      it('should set isFromCombineCourse', async function () {
+        // given
+        const campaignInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
+        const campaignNotInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
+        databaseBuilder.factory.buildQuestForCombinedCourse({
+          code: 'ABCDE1234',
+          name: 'Mon parcours Combiné',
+          organizationId,
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: campaignInQuest.id,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { models } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({
+          organizationId,
+          filter,
+          page,
+        });
+
+        // then
+        expect(models.map(({ id, isFromCombinedCourse }) => ({ id, isFromCombinedCourse }))).to.have.deep.members([
+          {
+            id: campaignInQuest.id,
+            isFromCombinedCourse: true,
+          },
+          {
+            id: campaignNotInQuest.id,
+            isFromCombinedCourse: false,
+          },
+        ]);
+      });
+    });
   });
 });

--- a/orga/app/components/campaign/list.gjs
+++ b/orga/app/components/campaign/list.gjs
@@ -129,7 +129,9 @@ export default class List extends Component {
                 {{t "pages.campaigns-list.table.column.code"}}
               </:header>
               <:cell>
-                <span {{on "click" stopPropagation}}>{{campaign.code}}</span>
+                {{#unless campaign.isFromCombinedCourse}}
+                  <span {{on "click" stopPropagation}}>{{campaign.code}}</span>
+                {{/unless}}
               </:cell>
             </PixTableColumn>
 

--- a/orga/tests/integration/components/campaign/list-test.js
+++ b/orga/tests/integration/components/campaign/list-test.js
@@ -267,8 +267,40 @@ module('Integration | Component | Campaign::List', function (hooks) {
       );
 
       // then
-      assert.dom(screen.getByText('AAAAAA111')).exists();
-      assert.dom(screen.getByText('BBBBBB222')).exists();
+      assert.ok(screen.getByText('AAAAAA111'));
+      assert.ok(screen.getByText('BBBBBB222'));
+    });
+
+    test('it should not display the code when campaign is from combined course', async function (assert) {
+      const store = this.owner.lookup('service:store');
+
+      const campaign1 = store.createRecord('campaign', {
+        id: '1',
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        type: 'PROFILES_COLLECTION',
+      });
+      const campaign2 = store.createRecord('campaign', {
+        id: '2',
+        name: 'campagne 2',
+        code: 'BBBBBB222',
+        type: 'ASSESSMENT',
+        isFromCombinedCourse: true,
+      });
+      const campaigns = [campaign1, campaign2];
+      campaigns.meta = {
+        rowCount: 2,
+      };
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`,
+      );
+
+      // then
+      assert.ok(screen.getByText('AAAAAA111'));
+      assert.notOk(screen.queryByText('BBBBBB222'));
     });
 
     test('should hide campaign owner', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème

Nous ne souhaitons pas afficher le code campagne des campagnes liées à un parcours combinées, car elles n'ont pas vocation à être rejoindre autre que par le parcours combiné.

## ⛱️ Proposition

Cacher le code campagne

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Se connecter sur Pix Orga
- Aller sur l'orga attestation
- Constater que la campagne liée au parcours combiné n'a pas son code d'affichée. 