### PR TITLE
[TECH] Corriger deux tests flaky sur le campaign participation overviews (PIX-19628).

### DIFF
--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -31,10 +31,12 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       const campaign1Participation1 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign1.id,
         userId: user.id,
+        createdAt: new Date('2025-02-01'),
       });
       const campaign2Participation2 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign2.id,
         userId: user.id,
+        createdAt: new Date('2025-01-01'),
       });
 
       databaseBuilder.factory.buildStageAcquisition({
@@ -95,10 +97,12 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
       const campaign1Participation1 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign1.id,
         userId: user.id,
+        createdAt: new Date('2025-02-01'),
       });
       const campaign2Participation2 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign2.id,
         userId: user.id,
+        createdAt: new Date('2025-01-01'),
       });
 
       databaseBuilder.factory.buildStageAcquisition({


### PR DESCRIPTION
## 🔆 Problème

le usecase tri les participation par date de création descendante, sauf que nos jeux de données de tests utilise la même date de création (merci les valeur des défaut des factory)

## ⛱️ Proposition

Définir la date de création dans le bon ordre. 

## 🌊 Remarques

Deux tests impacté dans le même fichier. c'est un comme un bon shampoing deux en un

## 🏄 Pour tester

Ci au vert. 