### PR TITLE
[FEATURE] - Ajout du bouton Répondre au questionnaire sur les parcours combinés (PIX-19609)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -74,4 +74,11 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['team-acces'],
   },
+  isSurveyEnabledForCombinedCourses: {
+    type: 'boolean',
+    description: 'Enables survey button at the end of the combined courses',
+    defaultValue: false,
+    devDefaultValues: { test: true, reviewApp: true },
+    tags: ['frontend', 'team-prescription'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-auto-share-enabled': false,
             'is-filtering-recommended-training-by-organizations-enabled': false,
+            'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -44,7 +45,7 @@ const Header = <template>
         </PixButton>
       {{/if}}
       {{#if (and (eq @combinedCourse.status "COMPLETED") @isSurveyEnabled)}}
-        <PixTooltip @id="tooltip-satisfaction-survey" @position="right" @isWide={{true}}>
+        <PixTooltip @id="tooltip-satisfaction-survey" @position="right" @isInline={{true}}>
           <:triggerElement>
             <PixButtonLink
               @href={{@surveyLink}}

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -4,4 +4,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isTextToSpeechButtonEnabled;
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isAutoShareEnabled;
+  @attr('boolean') isSurveyEnabledForCombinedCourses;
 }

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -10,18 +10,6 @@
     margin-bottom: var(--pix-spacing-2x);
   }
 
-  &__header {
-    display: flex;
-    gap: var(--pix-spacing-8x);
-    justify-content: space-between;
-
-    h1 {
-      @extend %pix-title-m;
-
-      margin-bottom: var(--pix-spacing-4x);
-    }
-  }
-
   &__description {
     @extend %pix-body-l;
 
@@ -34,7 +22,6 @@
     display: flex;
     gap: var(--pix-spacing-4x);
     align-items: center;
-    margin-bottom: var(--pix-spacing-8x);
     padding: var(--pix-spacing-6x);
     background: var(--pix-secondary-100);
     border: 1px solid var(--pix-secondary-500);
@@ -63,8 +50,32 @@
     margin: var(--pix-spacing-6x) 0;
     border-top: 1px solid var(--pix-neutral-100);
   }
+
 }
 
+.combined-course-header {
+    display: flex;
+    gap: var(--pix-spacing-8x);
+    justify-content: space-between;
+
+    h1 {
+      @extend %pix-title-m;
+    }
+
+    &__text {
+      display:flex;
+      flex-direction: column;
+      gap: var(--pix-spacing-8x);
+    }
+
+    button {
+    width: fit-content;
+    }
+
+    .survey-button {
+      width: fit-content;
+    }
+}
 .combined-course-item {
   display: flex;
   gap: var(--pix-spacing-4x);

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -75,7 +75,12 @@
     .survey-button {
       width: fit-content;
     }
+
+    .pix-tooltip {
+      width: fit-content;
+    }
 }
+
 .combined-course-item {
   display: flex;
   gap: var(--pix-spacing-4x);

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -122,6 +122,8 @@ module.exports = function (environment) {
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
       AUTO_SHARE_DISABLED_ORGANIZATION_IDS: JSON.parse(process.env.AUTO_SHARE_DISABLED_ORGANIZATION_IDS || '[]'),
+      COMBINIX_SURVEY_LINK:
+        'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
     },
 
     fontawesome: {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -123,6 +123,7 @@ module.exports = function (environment) {
       AUTO_SHARE_AFTER_DATE: process.env.AUTO_SHARE_AFTER_DATE || '2025-07-18',
       AUTO_SHARE_DISABLED_ORGANIZATION_IDS: JSON.parse(process.env.AUTO_SHARE_DISABLED_ORGANIZATION_IDS || '[]'),
       COMBINIX_SURVEY_LINK:
+        process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
     },
 

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -431,5 +431,33 @@ module('Integration | Component | combined course', function (hooks) {
       assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.completed.title') }));
       assert.notOk(screen.queryByText(t('pages.combined-courses.items.tagText')));
     });
+    test('should display survey cta', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isSurveyEnabledForCombinedCourses: true });
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.COMPLETED,
+        code: 'COMBINIX9',
+      });
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      const link = screen.getByRole('link', { name: t('pages.combined-courses.completed.survey-button') });
+      assert
+        .dom(link)
+        .hasAttribute(
+          'href',
+          'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
+        );
+      assert.dom(link).hasAttribute('target', '_blank');
+      assert.dom(link).hasAttribute('rel', 'noopener noreferrer');
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1204,6 +1204,7 @@
       "completed": {
         "description": "Well done! You have taken an important step toward navigating the digital world.",
         "survey-button": "Answer the survey",
+        "survey-button-description": "Complete the survey to give your opinion on the course.",
         "title": "Congratulations! You're done!"
       },
       "content": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1203,6 +1203,7 @@
     "combined-courses": {
       "completed": {
         "description": "Well done! You have taken an important step toward navigating the digital world.",
+        "survey-button": "Answer the survey",
         "title": "Congratulations! You're done!"
       },
       "content": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1202,7 +1202,8 @@
       },
       "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",
-        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital."
+        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
+        "survey-button": "Responder a la encuesta de satisfacción"
       },
       "items": {
         "formation": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1203,7 +1203,8 @@
       "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",
         "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
-        "survey-button": "Responder a la encuesta de satisfacción"
+        "survey-button": "Responder a la encuesta de satisfacción",
+        "survey-button-description": "Responda al cuestionario para dar su opinión sobre el recorrido."
       },
       "items": {
         "formation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1203,6 +1203,7 @@
     "combined-courses": {
       "completed": {
         "description": "Bien joué ! Vous avez franchi une étape importante pour naviguer dans le monde numérique.",
+        "survey-button": "Répondre au questionnaire",
         "title": "Félicitations ! Vous avez terminé !"
       },
       "content": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1204,6 +1204,7 @@
       "completed": {
         "description": "Bien joué ! Vous avez franchi une étape importante pour naviguer dans le monde numérique.",
         "survey-button": "Répondre au questionnaire",
+        "survey-button-description": "Répondez au questionnaire pour donner votre avis sur le parcours",
         "title": "Félicitations ! Vous avez terminé !"
       },
       "content": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1206,7 +1206,8 @@
       },
       "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",
-        "description": "Bravo! Je hebt een belangrijke stap gezet om je weg te vinden in de digitale wereld."
+        "description": "Bravo! Je hebt een belangrijke stap gezet om je weg te vinden in de digitale wereld.",
+        "survey-button": "De tevredenheidsenquête invullen"
       },
       "items": {
         "formation": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1207,7 +1207,8 @@
       "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",
         "description": "Bravo! Je hebt een belangrijke stap gezet om je weg te vinden in de digitale wereld.",
-        "survey-button": "De tevredenheidsenquête invullen"
+        "survey-button": "De tevredenheidsenquête invullen",
+        "survey-button-descritpion": "Beantwoord de vragenlijst om uw mening te geven over het parcours"
       },
       "items": {
         "formation": {


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir proposer une enquête de satisfaction à l'utilisateur en fin de parcours combiné.

## ⛱️ Proposition
On crée un bouton avec un lien externe (le lien s'ouvre dans un deuxième onglet).

## 🌊 Remarques
On le met derrière un feature toggle pour l'instant car ça ne doit pas être visible immédiatement.

## 🏄 Pour tester
La variable d'env est à true par défaut sur la review app.
On doit pouvoir voir le bouton "Répondre au questionnaire" après avoir complété tous les items du parcours.