### PR TITLE
[FEATURE] Retirer les variables des évènements Plausible

### DIFF
--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -27,7 +27,7 @@ export default class ModulixDetails extends Component {
   onModuleStart() {
     this.pixMetrics.trackEvent(`Clic sur le bouton Commencer un passage`, {
       category: 'Modulix',
-      action: `Détails du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
     });
     this.router.transitionTo('module.passage', this.args.module.slug);
   }
@@ -36,7 +36,7 @@ export default class ModulixDetails extends Component {
   onModuleStartUsingSmallScreen() {
     this.pixMetrics.trackEvent(`Clic sur le bouton Commencer un passage en petit écran`, {
       category: 'Modulix',
-      action: `Détails du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
     });
     this.router.transitionTo('module.passage', this.args.module.slug);
   }
@@ -45,7 +45,7 @@ export default class ModulixDetails extends Component {
   onSmallScreenModalOpen() {
     this.pixMetrics.trackEvent(`Ouvre la modale d'alerte de largeur d'écran`, {
       category: 'Modulix',
-      action: `Détails du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
     });
     this.isSmallScreenModalOpen = true;
   }
@@ -54,7 +54,7 @@ export default class ModulixDetails extends Component {
   onSmallScreenModalClose() {
     this.pixMetrics.trackEvent(`Ferme la modale d'alerte de largeur d'écran`, {
       category: 'Modulix',
-      action: `Détails du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
     });
     this.isSmallScreenModalOpen = false;
   }

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -25,7 +25,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStart() {
-    this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton Commencer un passage`, {
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });
@@ -34,7 +34,7 @@ export default class ModulixDetails extends Component {
 
   @action
   onModuleStartUsingSmallScreen() {
-    this.pixMetrics.trackEvent(`Click sur le bouton Commencer un passage en petit écran`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton Commencer un passage en petit écran`, {
       category: 'Modulix',
       action: `Détails du module : ${this.args.module.slug}`,
     });

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -112,15 +112,12 @@ export default class ModulePassage extends Component {
       },
     });
 
-    this.pixMetrics.trackEvent(
-      `Click sur le bouton suivant du stepper`,
-      {
-        category: 'Modulix',
-        action: `Passage du module : ${this.args.module.slug}`,
-        grainId: currentGrain.id,
-        step: currentStepPosition,
-      },
-    );
+    this.pixMetrics.trackEvent(`Clic sur le bouton suivant du stepper`, {
+      category: 'Modulix',
+      action: `Passage du module : ${this.args.module.slug}`,
+      grainId: currentGrain.id,
+      step: currentStepPosition,
+    });
   }
 
   addNextGrainToDisplay() {
@@ -146,7 +143,7 @@ export default class ModulePassage extends Component {
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
-    this.pixMetrics.trackEvent(`Click sur le bouton Terminer`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton Terminer`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
       grainId: grainId,
@@ -172,7 +169,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onElementRetry(answerData) {
-    this.pixMetrics.trackEvent(`Click sur le bouton réessayer`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton réessayer`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
       elementId: answerData.element.id,
@@ -181,7 +178,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onImageAlternativeTextOpen(imageElementId) {
-    this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton alternative textuelle`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
       elementId: imageElementId,
@@ -197,7 +194,7 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoTranscriptionOpen(videoElementId) {
-    this.pixMetrics.trackEvent(`Click sur le bouton transcription`, {
+    this.pixMetrics.trackEvent(`Clic sur le bouton transcription`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
       elementId: videoElementId,

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -114,7 +114,7 @@ export default class ModulePassage extends Component {
 
     this.pixMetrics.trackEvent(`Clic sur le bouton suivant du stepper`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       grainId: currentGrain.id,
       step: currentStepPosition,
     });
@@ -145,7 +145,7 @@ export default class ModulePassage extends Component {
     await adapter.terminate({ passageId: this.args.passage.id });
     this.pixMetrics.trackEvent(`Clic sur le bouton Terminer`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       grainId: grainId,
     });
     this.passageEvents.record({
@@ -171,7 +171,7 @@ export default class ModulePassage extends Component {
   async onElementRetry(answerData) {
     this.pixMetrics.trackEvent(`Clic sur le bouton réessayer`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       elementId: answerData.element.id,
     });
   }
@@ -180,7 +180,7 @@ export default class ModulePassage extends Component {
   async onImageAlternativeTextOpen(imageElementId) {
     this.pixMetrics.trackEvent(`Clic sur le bouton alternative textuelle`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       elementId: imageElementId,
     });
 
@@ -196,7 +196,7 @@ export default class ModulePassage extends Component {
   async onVideoTranscriptionOpen(videoElementId) {
     this.pixMetrics.trackEvent(`Clic sur le bouton transcription`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       elementId: videoElementId,
     });
 
@@ -225,7 +225,7 @@ export default class ModulePassage extends Component {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
     this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand`, {
       category: 'Modulix',
-      action: `Passage du module : ${this.args.module.slug}`,
+      moduleId: this.args.module.id,
       elementId: elementId,
     });
 

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -113,10 +113,12 @@ export default class ModulePassage extends Component {
     });
 
     this.pixMetrics.trackEvent(
-      `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
+      `Click sur le bouton suivant du stepper`,
       {
         category: 'Modulix',
         action: `Passage du module : ${this.args.module.slug}`,
+        grainId: currentGrain.id,
+        step: currentStepPosition,
       },
     );
   }
@@ -144,9 +146,10 @@ export default class ModulePassage extends Component {
   async onModuleTerminate({ grainId }) {
     const adapter = this.store.adapterFor('passage');
     await adapter.terminate({ passageId: this.args.passage.id });
-    this.pixMetrics.trackEvent(`Click sur le bouton Terminer du grain : ${grainId}`, {
+    this.pixMetrics.trackEvent(`Click sur le bouton Terminer`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+      grainId: grainId,
     });
     this.passageEvents.record({
       type: 'PASSAGE_TERMINATED',
@@ -169,17 +172,19 @@ export default class ModulePassage extends Component {
 
   @action
   async onElementRetry(answerData) {
-    this.pixMetrics.trackEvent(`Click sur le bouton réessayer de l'élément : ${answerData.element.id}`, {
+    this.pixMetrics.trackEvent(`Click sur le bouton réessayer`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+      elementId: answerData.element.id,
     });
   }
 
   @action
   async onImageAlternativeTextOpen(imageElementId) {
-    this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle : ${imageElementId}`, {
+    this.pixMetrics.trackEvent(`Click sur le bouton alternative textuelle`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+      elementId: imageElementId,
     });
 
     this.passageEvents.record({
@@ -192,9 +197,10 @@ export default class ModulePassage extends Component {
 
   @action
   async onVideoTranscriptionOpen(videoElementId) {
-    this.pixMetrics.trackEvent(`Click sur le bouton transcription : ${videoElementId}`, {
+    this.pixMetrics.trackEvent(`Click sur le bouton transcription`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+      elementId: videoElementId,
     });
 
     this.passageEvents.record({
@@ -220,9 +226,10 @@ export default class ModulePassage extends Component {
   @action
   async onExpandToggle({ elementId, isOpen }) {
     const eventToggle = isOpen ? 'Ouverture' : 'Fermeture';
-    this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand : ${elementId}`, {
+    this.pixMetrics.trackEvent(`${eventToggle} de l'élément Expand`, {
       category: 'Modulix',
       action: `Passage du module : ${this.args.module.slug}`,
+      elementId: elementId,
     });
 
     this.passageEvents.record({

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -106,7 +106,7 @@ export default class Card extends Component {
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le cf`, {
       category: 'Accès Contenu Formatif',
-      action: `Click depuis : ${this.router.currentRouteName}`,
+      action: `Clic depuis : ${this.router.currentRouteName}`,
       title: this.args.training.title,
     });
   }

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -104,9 +104,10 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.pixMetrics.trackEvent(`Ouvre le cf : ${this.args.training.title}`, {
+    this.pixMetrics.trackEvent(`Ouvre le cf`, {
       category: 'Accès Contenu Formatif',
       action: `Click depuis : ${this.router.currentRouteName}`,
+      title: this.args.training.title,
     });
   }
 }

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -153,9 +153,10 @@ export default class Card extends Component {
 
   @action
   trackAccess() {
-    this.pixMetrics.trackEvent(`Ouvre le tutoriel : ${this.args.tutorial.title}`, {
+    this.pixMetrics.trackEvent(`Ouvre le tutoriel`, {
       category: 'Accès tuto',
       action: `Click depuis : ${this.router.currentRouteName}`,
+      title: this.args.tutorial.title,
     });
   }
 }

--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -155,7 +155,7 @@ export default class Card extends Component {
   trackAccess() {
     this.pixMetrics.trackEvent(`Ouvre le tutoriel`, {
       category: 'Accès tuto',
-      action: `Click depuis : ${this.router.currentRouteName}`,
+      action: `Clic depuis : ${this.router.currentRouteName}`,
       title: this.args.tutorial.title,
     });
   }

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -47,7 +47,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Commencer un passage`, {
           category: 'Modulix',
           action: `Détails du module : ${module.slug}`,
         });
@@ -81,7 +81,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Commencer un passage`, {
+          sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Commencer un passage`, {
             category: 'Modulix',
             action: `Détails du module : ${module.slug}`,
           });
@@ -161,7 +161,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             // then
             sinon.assert.calledWithExactly(
               metrics.trackEvent,
-              `Click sur le bouton Commencer un passage en petit écran`,
+              `Clic sur le bouton Commencer un passage en petit écran`,
               {
                 category: 'Modulix',
                 action: `Détails du module : ${module.slug}`,

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -49,7 +49,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Commencer un passage`, {
           category: 'Modulix',
-          action: `Détails du module : ${module.slug}`,
+          moduleId: module.id,
         });
         assert.ok(true);
       });
@@ -83,7 +83,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Commencer un passage`, {
             category: 'Modulix',
-            action: `Détails du module : ${module.slug}`,
+            moduleId: module.id,
           });
           assert.ok(true);
         });
@@ -116,7 +116,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           // then
           sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre la modale d'alerte de largeur d'écran`, {
             category: 'Modulix',
-            action: `Détails du module : ${module.slug}`,
+            moduleId: module.id,
           });
           assert.ok(true);
         });
@@ -164,7 +164,7 @@ module('Integration | Component | Module | Details', function (hooks) {
               `Clic sur le bouton Commencer un passage en petit écran`,
               {
                 category: 'Modulix',
-                action: `Détails du module : ${module.slug}`,
+                moduleId: module.id,
               },
             );
             assert.ok(true);
@@ -210,7 +210,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             // then
             sinon.assert.calledWithExactly(metrics.trackEvent, `Ferme la modale d'alerte de largeur d'écran`, {
               category: 'Modulix',
-              action: `Détails du module : ${module.slug}`,
+              moduleId: module.id,
             });
             assert.ok(true);
           });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -627,7 +627,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(retryButton);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton réessayer`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
         elementId: element.id,
@@ -669,7 +669,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName("Afficher l'alternative textuelle");
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton alternative textuelle`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
         elementId: element.id,
@@ -752,15 +752,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName("Afficher l'alternative textuelle");
 
         // then
-        sinon.assert.calledWithExactly(
-          metrics.trackEvent,
-          `Click sur le bouton alternative textuelle`,
-          {
-            category: 'Modulix',
-            action: `Passage du module : ${module.slug}`,
-            elementId: imageElement.id,
-          },
-        );
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton alternative textuelle`, {
+          category: 'Modulix',
+          action: `Passage du module : ${module.slug}`,
+          elementId: imageElement.id,
+        });
         assert.ok(true);
       });
     });
@@ -800,7 +796,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName('Afficher la transcription');
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton transcription`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
         elementId: element.id,
@@ -886,7 +882,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName('Afficher la transcription');
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription`, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton transcription`, {
           category: 'Modulix',
           action: `Passage du module : ${module.slug}`,
           elementId: videoElement.id,
@@ -932,16 +928,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(onStepperNextStepButtonName);
 
       // then
-      sinon.assert.calledWithExactly(
-        metrics.trackEvent,
-        `Click sur le bouton suivant du stepper`,
-        {
-          category: 'Modulix',
-          action: `Passage du module : ${module.slug}`,
-          grainId: grain.id,
-          step: 1,
-        },
-      );
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton suivant du stepper`, {
+        category: 'Modulix',
+        action: `Passage du module : ${module.slug}`,
+        grainId: grain.id,
+        step: 1,
+      });
       assert.ok(true);
     });
 
@@ -1311,7 +1303,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.grain.terminate'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Terminer`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
         grainId: grain.id,

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -629,7 +629,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton réessayer`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         elementId: element.id,
       });
       assert.ok(true);
@@ -671,7 +671,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton alternative textuelle`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         elementId: element.id,
       });
       assert.ok(true);
@@ -754,7 +754,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton alternative textuelle`, {
           category: 'Modulix',
-          action: `Passage du module : ${module.slug}`,
+          moduleId: module.id,
           elementId: imageElement.id,
         });
         assert.ok(true);
@@ -798,7 +798,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton transcription`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         elementId: element.id,
       });
       assert.ok(true);
@@ -884,7 +884,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton transcription`, {
           category: 'Modulix',
-          action: `Passage du module : ${module.slug}`,
+          moduleId: module.id,
           elementId: videoElement.id,
         });
         assert.ok(true);
@@ -930,7 +930,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton suivant du stepper`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         grainId: grain.id,
         step: 1,
       });
@@ -1305,7 +1305,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Clic sur le bouton Terminer`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         grainId: grain.id,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
@@ -1401,7 +1401,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         elementId: expandElement.id,
       });
       assert.ok(true);
@@ -1451,7 +1451,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand`, {
           category: 'Modulix',
-          action: `Passage du module : ${module.slug}`,
+          moduleId: module.id,
           elementId: expandElement.id,
         });
         assert.ok(true);
@@ -1504,7 +1504,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand`, {
         category: 'Modulix',
-        action: `Passage du module : ${module.slug}`,
+        moduleId: module.id,
         elementId: expandElement.id,
       });
       assert.ok(true);

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -627,9 +627,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(retryButton);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer de l'élément : ${element.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton réessayer`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        elementId: element.id,
       });
       assert.ok(true);
     });
@@ -668,9 +669,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName("Afficher l'alternative textuelle");
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle : ${element.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton alternative textuelle`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        elementId: element.id,
       });
       assert.ok(true);
     });
@@ -752,10 +754,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
         // then
         sinon.assert.calledWithExactly(
           metrics.trackEvent,
-          `Click sur le bouton alternative textuelle : ${imageElement.id}`,
+          `Click sur le bouton alternative textuelle`,
           {
             category: 'Modulix',
             action: `Passage du module : ${module.slug}`,
+            elementId: imageElement.id,
           },
         );
         assert.ok(true);
@@ -797,9 +800,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName('Afficher la transcription');
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${element.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        elementId: element.id,
       });
       assert.ok(true);
     });
@@ -882,9 +886,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await clickByName('Afficher la transcription');
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription : ${videoElement.id}`, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton transcription`, {
           category: 'Modulix',
           action: `Passage du module : ${module.slug}`,
+          elementId: videoElement.id,
         });
         assert.ok(true);
       });
@@ -892,7 +897,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
   });
 
   module('when user clicks on next step button', function () {
-    test('should push event', async function (assert) {
+    test('should push metrics event', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
@@ -929,10 +934,12 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       sinon.assert.calledWithExactly(
         metrics.trackEvent,
-        `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
+        `Click sur le bouton suivant du stepper`,
         {
           category: 'Modulix',
           action: `Passage du module : ${module.slug}`,
+          grainId: grain.id,
+          step: 1,
         },
       );
       assert.ok(true);
@@ -1304,9 +1311,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await clickByName(t('pages.modulix.buttons.grain.terminate'));
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer du grain : ${grain.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Click sur le bouton Terminer`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        grainId: grain.id,
       });
       sinon.assert.calledWithExactly(passageEventsService.record, {
         type: 'PASSAGE_TERMINATED',
@@ -1399,9 +1407,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        elementId: expandElement.id,
       });
       assert.ok(true);
     });
@@ -1448,9 +1457,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
         await click(expandSummarySelector);
 
         // then
-        sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand : ${expandElement.id}`, {
+        sinon.assert.calledWithExactly(metrics.trackEvent, `Ouverture de l'élément Expand`, {
           category: 'Modulix',
           action: `Passage du module : ${module.slug}`,
+          elementId: expandElement.id,
         });
         assert.ok(true);
       });
@@ -1500,9 +1510,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       await click(expandSummarySelector);
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand : ${expandElement.id}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Fermeture de l'élément Expand`, {
         category: 'Modulix',
         action: `Passage du module : ${module.slug}`,
+        elementId: expandElement.id,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -205,7 +205,7 @@ module('Unit | Component | Training | card', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf`, {
         category: 'Accès Contenu Formatif',
-        action: `Click depuis : ${currentRouteName}`,
+        action: `Clic depuis : ${currentRouteName}`,
         title: trainingTitle,
       });
       assert.ok(true);

--- a/mon-pix/tests/unit/components/training/card-test.js
+++ b/mon-pix/tests/unit/components/training/card-test.js
@@ -203,9 +203,10 @@ module('Unit | Component | Training | card', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf : ${trainingTitle}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le cf`, {
         category: 'Accès Contenu Formatif',
         action: `Click depuis : ${currentRouteName}`,
+        title: trainingTitle,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -222,9 +222,10 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       component.trackAccess();
 
       // then
-      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel : ${tutorialTitle}`, {
+      sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel`, {
         category: 'Accès tuto',
         action: `Click depuis : ${currentRouteName}`,
+        title: tutorialTitle,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -224,7 +224,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       // then
       sinon.assert.calledWithExactly(metrics.trackEvent, `Ouvre le tutoriel`, {
         category: 'Accès tuto',
-        action: `Click depuis : ${currentRouteName}`,
+        action: `Clic depuis : ${currentRouteName}`,
         title: tutorialTitle,
       });
       assert.ok(true);


### PR DESCRIPTION
## 🔆 Problème

Les évènements envoyés dans Plausible nécessitent d'être ajoutés manuellement dans l'interface avant d'apparaître dans les statistiques. On veut donc minimiser le nombre d'évènements différents. Or, certains évènements sont créés avec des variables dans leur nom ce qui implique un nombre d'évènements infini.

## ⛱️ Proposition

Utiliser un nom d'évènement fixe pour chaque type d'évènement et tirer partie des propriétés pour envoyer les variables.

## 🌊 Remarques

Tant qu'à revoir les évènements, j'en profite aussi pour :
- corriger "Click" en "Clic" dans les noms d'évènements
- remplacer les propriétés `action` qui ont pour valeur `Passage du module : {slug}` par des propriétés `moduleId` qui sont plus pérennes et faciliteront le filtrage.

## 🏄 Pour tester

Non régression fonctionnelle sur les envois d'évènements Plausible
