### PR TITLE
[FEATURE] Ajouter la locale es-419 à Pix App (PIX-19592)

### DIFF
--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -20,7 +20,7 @@ const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
-const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const PIX_LANGUAGES = [
   { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -16,7 +16,7 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -55,6 +55,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   nl: 'https://pix.org/nl-be',
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
+  'es-419': 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -67,6 +68,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'algemene-gebruiksvoorwaarden',
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
+    'es-419': 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -76,6 +78,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'wettelijke-vermeldingen',
     en: 'legal-notice',
     es: 'legal-notice',
+    'es-419': 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -85,6 +88,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
+    'es-419': 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -94,6 +98,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid',
     en: 'accessibility',
     es: 'accessibility',
+    'es-419': 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -103,6 +108,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-orga',
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
+    'es-419': 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -112,6 +118,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-certif',
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
+    'es-419': 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -121,6 +128,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'support',
     en: 'support',
     es: 'support',
+    'es-419': 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -130,6 +138,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'mijn-certificeringsresultaten-begrijpen',
     en: 'understand-certification-results',
     es: 'understand-certification-results',
+    'es-419': 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
 };

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function (environment) {
       API_HOST: process.env.API_HOST || '',
       APPLICATION_NAME: process.env.APP || 'pix-app-local',
       DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
-      SUPPORTED_LOCALES: ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'],
+      SUPPORTED_LOCALES: ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'],
       FT_FOCUS_CHALLENGE_ENABLED: _isFeatureEnabled(process.env.FT_FOCUS_CHALLENGE_ENABLED) || false,
       isTimerCountdownEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -65,7 +65,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -310,7 +310,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixChallengeLocales = localeService.pixChallengeLocales;
 
       // then
-      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de']);
+      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de']);
     });
   });
 

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1,0 +1,2357 @@
+{
+  "api-error-messages": {
+    "join-error": {
+      "r11": "Ya dispones de una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R11)",
+      "r12": "Ya dispones de una cuenta Pix utilizada con el nombre de usuario con la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R12)",
+      "r13": "Ya dispones de una cuenta Pix a través del ENT en otro centro escolar.'<br><br>'Para continuar, ponte en contacto con un profesor para que te dé acceso a esa cuenta utilizando Pix Orga.'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R13)",
+      "r31": "Ya dispones de una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R31)",
+      "r32": "Ya dispones de una cuenta Pix utilizada con el nombre de usuario con la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de resolución de problemas' en Pix Orga > Documentación - Código R32)",
+      "r33": "Ya dispones de una cuenta Pix a través del ENT. Utilízala para unirte al test.",
+      "r70": "Se ha producido un error. Desconéctate y vuelve a intentarlo.",
+      "r90": {
+        "account-belonging-to-another-user": "Parece que un estudiante ya está utilizando esta cuenta.",
+        "details": {
+          "code": "(especificando el código R90)",
+          "contact-support": {
+            "link-text": " ponte en contacto con el servicio de asistencia ",
+            "link-url": "https://support.pix.org/fr/support/tickets/new"
+          },
+          "disconnect-user": "De lo contrario, desconéctate y únete a la campaña desde tu cuenta",
+          "if-account-belonging-to-user": "Si la cuenta es tuya,"
+        }
+      }
+    },
+    "register-error": {
+      "s50": "Este nombre de usuario ya existe",
+      "s51": "Ya dispones de una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R51)",
+      "s52": "Ya dispones de una cuenta Pix utilizada con el nombre de usuario con la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de resolución de problemas' en Pix Orga > Documentación - Código R52)",
+      "s53": "Ya tienes una cuenta Pix a través del ENT.'<br>'Úsala para unirte al test.",
+      "s61": "Ya dispones de una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, conéctate a esa cuenta o pide ayuda a un profesor'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R61)",
+      "s62": "Ya dispones de una cuenta Pix utilizada con el nombre de usuario con la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, conéctate a esta cuenta o pide ayuda a un profesor.'<br><br>'(Para el profesor: ver el 'Kit de resolución de problemas' en Pix Orga > Documentación - Código R62)",
+      "s63": "Ya dispones de una cuenta Pix a través del ENT en otro centro escolar.'<br><br>'Para continuar, ponte en contacto con un profesor para que te dé acceso a esa cuenta utilizando Pix Orga.'<br><br>'(Para el profesor: ver el 'Kit de solución de problemas' en Pix Orga > Documentación - Código R63)"
+    }
+  },
+  "application": {
+    "description": "Pix es una plataforma en línea para evaluar y certificar las competencias digitales de ciudadanos (alumnos/as, estudiantes, jóvenes que dejan la escuela, demandantes de empleo, personas mayores)"
+  },
+  "common": {
+    "actions": {
+      "back": "Volver",
+      "cancel": "Cancelar",
+      "close": "Cerrar",
+      "confirm": "Confirmar",
+      "download": "Descargar",
+      "lets-go": "¡Empecemos!",
+      "login": "Iniciar sesión",
+      "quit": "Salir",
+      "refresh-page": "Actualizar la página",
+      "show-less": "Mostrar menos",
+      "show-more": "Ver más",
+      "sign-out": "Desconectarse",
+      "stay": "Quedarse",
+      "validate": "Validar"
+    },
+    "api-error-messages": {
+      "bad-request-error": "Los datos que has enviado no están en el formato correcto.",
+      "gateway-timeout-error": "El servicio está experimentando ralentizaciones. Vuelve a intentarlo más tarde.",
+      "internal-server-error": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelve a intentarlo más tarde.",
+      "login-unauthorized-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
+      "login-unauthorized-remaining-attempts-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que su cuenta Pix sea bloqueada permanentemente.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Advertencia: le quedan {remainingAttempts, plural, =0 {0 intento} =1 {1 intento} other {# intentos}} antes de que su cuenta Pix sea bloqueada permanentemente.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión.",
+      "login-unauthorized-with-user-name-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión.",
+      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtelo de nuevo en unos momentos. Si el problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'póngase en contacto con nosotros'</a>'.",
+      "login-user-blocked-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de conexión. Para desbloquearla, '<'a href=\"{url}\"'>'ponte en contacto con nosotros'</a>'.",
+      "login-user-temporary-blocked-error": "Ha realizado demasiados intentos de inicio de sesión, su cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos. Inténtalo de nuevo más tarde o haz clic en '<'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla.",
+      "login-user-temporary-blocked-with-username-error": "Ha realizado demasiados intentos de inicio de sesión, su cuenta Pix está temporalmente bloqueada durante {blockingDurationMinutes} minutos.'<br>'Si olvidas tu contraseña, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecerla y/o recuperar tu inicio de sesión."
+    },
+    "cgu": {
+      "cgu": "condiciones de uso",
+      "data-protection-policy": "política de privacidad",
+      "error": "Debes aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
+      "label": "Acepto las condiciones de uso y la política de privacidad de Pix",
+      "message": "Acepto las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'política de privacidad'</a>' de Pix.",
+      "read-message": "Lee las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'política de privacidad'</a>'."
+    },
+    "companion": {
+      "check": {
+        "detected": {
+          "description": "Extensión Pix Companion{version}<br />instalada y activada.",
+          "version": " (versión {version})"
+        },
+        "not-detected": {
+          "description": "Extensión Pix Companion no instalada/activada o en una versión obsoleta,<br /> que ya no es compatible para el acceso a la sesión de certificación.",
+          "link": "Acceder a la documentación"
+        }
+      },
+      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
+      "not-detected": {
+        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el supervisor.",
+        "link": "Acceder a la documentación",
+        "title": "La extensión Pix Companion<br /> no se detecta"
+      }
+    },
+    "data-protection-policy-information-banner": {
+      "title": "Nuestra política de privacidad ha cambiado. Te invitamos a consultarla: ",
+      "url-label": "Política de protección de datos."
+    },
+    "error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+    "form": {
+      "error": "error",
+      "invisible-password": "ocultar la contraseña",
+      "mandatory": "obligatorio",
+      "mandatory-all-fields": "Todos los campos son obligatorios.",
+      "mandatory-fields": "Los campos marcados con '<abbr title=\"obligatorio\" class=\"mandatory-mark\">'*'</abbr>' son obligatorios",
+      "success": "correcto",
+      "visible-password": "Mostrar la contraseña"
+    },
+    "french-education-ministry": "Ministerio francés de Educación y Juventud. Libertad igualdad fraternidad",
+    "french-republic": "República Francesa. Libertad, igualdad, fraternidad.",
+    "languages": {
+      "en": "Inglés",
+      "fr": "Francés",
+      "nl": "Holandés"
+    },
+    "level": "nivel",
+    "no-level": "No nivel",
+    "loading": {
+      "default": "Cargando",
+      "results": "Preparación de tus resultados",
+      "test": "Tu prueba se está cargando"
+    },
+    "new-information-banner": {
+      "close-label": "Cerrar el banner"
+    },
+    "or": "o",
+    "pagination": {
+      "action": {
+        "next": "Ir a la página siguiente",
+        "previous": "Ir a la página anterior",
+        "select-page-size": "Número de elementos que mostrar por página"
+      },
+      "page-info": "{start, number}-{end, number} en {total, plural, =0 {0 elementos} =1 {1 elemento} other {{total, number} elementos}}",
+      "page-number": "Página {current, number} / {total, number}",
+      "page-results": "{total, plural, =0 {0 elementos} =1 {1 elemento} other {{total, number} elementos}}",
+      "result-by-page": "Ver"
+    },
+    "password": "Contraseña",
+    "pix": "pix",
+    "skip-links": {
+      "skip-to-content": "Ir al contenido",
+      "skip-to-footer": "Ir al final de la página"
+    },
+    "validation": {
+      "password": {
+        "error": "Ha introducido una contraseña incorrecta. Su contraseña debe tener más de 8 caracteres y contener al menos un número, una letra minúscula y una letra mayúscula.",
+        "rules": {
+          "contains-digit": "al menos un número",
+          "contains-lowercase": "al menos una letra minúscula",
+          "contains-uppercase": "al menos una letra mayúscula",
+          "min-length": "mínimo 8 caracteres"
+        }
+      }
+    }
+  },
+  "components": {
+    "attestations": {
+      "obtainedAt": "Fecha de emisión: {date}",
+      "title": {
+        "numeric-sensivity": "Certificado de sensibilización digital"
+      }
+    },
+    "authentication": {
+      "login-form": {
+        "fields": {
+          "login": {
+            "error": "No se ha introducido la dirección de correo electrónico o el nombre de usuario."
+          },
+          "password": {
+            "error": "No se ha introducido la contraseña."
+          }
+        }
+      },
+      "new-password-input": {
+        "completed-message": "{ rulesCompleted }  { rulesCount } en .",
+        "instructions-label": "Tu contraseña debe cumplir con los siguientes requisitos :",
+        "label": "Contraseña"
+      },
+      "oidc-provider-selector": {
+        "label": "Buscar una organización",
+        "placeholder": "Seleccione una organización",
+        "searchLabel": "Búsqueda por palabras clave"
+      },
+      "other-authentication-providers": {
+        "login": {
+          "heading": "Otros medios de conexión",
+          "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
+        },
+        "select-another-organization-link": "Elegir otra organización",
+        "signup": {
+          "heading": "Otros medios de registro",
+          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
+        }
+      },
+      "password-reset-demand-form": {
+        "actions": {
+          "receive-reset-button": "Reiniciar contraseña"
+        },
+        "contact-us-link": {
+          "link-text": "Contáctanos."
+        },
+        "fields": {
+          "email": {
+            "error-message-invalid": "Tu dirección de correo electrónico no es válida.",
+            "label": "Dirección de correo electrónico",
+            "placeholder": "ej. juan.perez@email.es"
+          }
+        },
+        "no-email-question": "¿No ingresaste una dirección de correo electrónico?",
+        "rule": "Todos los campos son obligatorios."
+      },
+      "password-reset-demand-received-info": {
+        "heading": "Comprueba tu correo electrónico",
+        "message": "Si tu dirección está asociada a una cuenta Pix, se te han enviado instrucciones por correo electrónico para restablecer tu contraseña.",
+        "no-email-received-question": "¿No has recibido un correo electrónico?",
+        "try-again": "Reenviar correo electrónico de restablecimiento"
+      },
+      "password-reset-form": {
+        "actions": {
+          "login": "Me conecto",
+          "submit": "He restablecido mi contraseña"
+        },
+        "errors": {
+          "expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, vuelve a intentarlo.",
+          "forbidden": "Se ha producido un error, ponte en contacto con el servicio de asistencia."
+        },
+        "fields": {
+          "password": {
+            "label": "Introduce tu nueva contraseña"
+          }
+        },
+        "success-info": {
+          "message": "Su contraseña ha sido restablecida."
+        }
+      },
+      "signup-form": {
+        "actions": {
+          "submit": "Crear cuenta"
+        },
+        "errors": {
+          "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada"
+        },
+        "fields": {
+          "email": {
+            "error": "Tu dirección de correo electrónico no es válida.",
+            "label": "Dirección de correo electrónico",
+            "placeholder": "ej. juan.perez@email.es"
+          },
+          "firstname": {
+            "error": "Su nombre de pila no está rellenado.",
+            "label": "Nombre",
+            "placeholder": "ej. Juan"
+          },
+          "lastname": {
+            "error": "No has indicado tus apellidos.",
+            "label": "Apellidos",
+            "placeholder": "ej. Pérez"
+          },
+          "legend": "Información necesaria para la inscripción."
+        }
+      },
+      "sso-selection-form": {
+        "should-display-account-recovery-banner": "¿Estudiante? Si aún no lo ha hecho, '<'a href=\"{url}\"'>'acceda a la página para recuperar su cuenta Pix'</a>' y mantenga su progreso."
+      }
+    },
+    "campaigns": {
+      "attestation-result": {
+        "computing": "Certificado en curso de cálculo",
+        "computing-description": "Un problema técnico nos ha impedido informarle de sus resultados. Por favor, conéctese de nuevo mañana en Pix, en la sección \"Mi curso\", para comprobar sus resultados. Le pedimos disculpas por las molestias ocasionadas.",
+        "not-obtained": "Certificado no obtenido :",
+        "obtained": "Certificado obtenido",
+        "title": {
+          "EDUCOLLAB": "Comunicar colaborar",
+          "EDUCULTURENUM": "Cultura digital",
+          "EDUDOC": "Adaptar documentos",
+          "EDUIA": "Datos, algoritmos e IA",
+          "EDUINCONTOURNABLES": "Lo esencial",
+          "EDURESSOURCES": "Gestión e intercambio de recursos",
+          "EDUSECU": "Digital y seguridad",
+          "EDUSUPPORT": "Crear materiales educativos",
+          "EDUVEILLE": "Realizar seguimiento",
+          "MINARM": "Base digital",
+          "PARENTHOOD": "Conciencia digital",
+          "SIXTH_GRADE": "Conciencia digital"
+        }
+      },
+      "results-loader": {
+        "steps": {
+          "competences": "Calcular las puntuaciones por competencias",
+          "rewards": "Entrega de premios",
+          "trainings": "Identificar cursos de formación útiles"
+        },
+        "subtitle": "¡Un momento, por favor! Seré tan rápido como pueda.",
+        "title": "Calcular su puntuación actual..."
+      },
+      "start-landing-page": {
+        "steps": {
+          "step1": {
+            "description": "Responde a preguntas adaptadas a tu nivel",
+            "title": "Evalúa tus habilidades"
+          },
+          "step2": {
+            "description": "Analiza tus puntos fuertes y tus áreas de mejora",
+            "title": "Descubre tus resultados"
+          },
+          "step3": {
+            "description": "Accede a contenidos adaptados a tus resultados para progresar",
+            "title": "Mejora"
+          }
+        }
+      }
+    },
+    "invited": {
+      "reconciliation": {
+        "error-message": {
+          "date-field": "Utilice el formato dd/mm/aaaa al introducir el campo {fieldName}",
+          "invalid-reconciliation-error": "Comprueba tus datos ({fields}) o ponte en contacto con un profesor.",
+          "mandatory-field": "Este campo es obligatorio"
+        },
+        "field": {
+          "birthdate": "Fecha de nacimiento",
+          "firstname": "Nombre",
+          "lastname": "Apellidos",
+          "sub-label": {
+            "date": "En formato (dd/mm/aaaa), por ejemplo : {dateFormat}"
+          }
+        },
+        "title": "Únete a la organización { organizationName }"
+      }
+    },
+    "locale-switcher": {
+      "label": "Selecciona un idioma"
+    }
+  },
+  "navigation": {
+    "back-to-homepage": "Volver a la página de inicio",
+    "back-to-profile": "Volver al perfil",
+    "copyrights": "©",
+    "error": "Error",
+    "external-link-title": "Abrir en una ventana nueva",
+    "footer": {
+      "a11y": "Accesibilidad: parcialmente conforme",
+      "data-protection-policy": "Política de protección de datos",
+      "eula": "CGU",
+      "help-center": "Centro de ayuda",
+      "label": "Menú secundario",
+      "legal-notice": "Información legal",
+      "server-status": "Estado del servicio",
+      "sitemap": "Mapa del sitio",
+      "student-data-protection-policy": "Política de protección de datos de los alumnos",
+      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+    },
+    "homepage": "Página de inicio de Pix",
+    "main": {
+      "attestations": "Mis títulos",
+      "code": "Tengo un código",
+      "dashboard": "Inicio",
+      "help": "Ayuda",
+      "label": "Menú principal",
+      "link-help": "https://support.pix.org/fr/support/home",
+      "skills": "Competencias",
+      "start-certification": "Certificación",
+      "trainings": "Mis formaciones",
+      "tutorials": "Mis tutoriales"
+    },
+    "mobile-button-title": "Abrir el menú",
+    "nav-bar": {
+      "aria-label": "navegación principal",
+      "close": "Cerrar la navegación",
+      "open": "Abrir la navegación"
+    },
+    "not-logged": {
+      "sign-in": "Conectarse",
+      "sign-up": "Inscribirse"
+    },
+    "pix": "Pix",
+    "showcase-homepage": "Página de inicio de Pix.{ tld }",
+    "user-logged-menu": {
+      "details": "Consultar mis datos"
+    },
+    "user": {
+      "account": "Mi cuenta",
+      "certifications": "Mis certificaciones",
+      "sign-out": "Desconectarse",
+      "tests": "Mis tests"
+    }
+  },
+  "pages": {
+    "attestations": {
+      "title": "Mis títulos",
+      "subtitle": "Acceda a todos sus certificados Pix y descárguelos."
+    },
+    "account-recovery": {
+      "errors": {
+        "account-exists": "Ya existe una cuenta con esta dirección de correo electrónico.",
+        "key-expired": "El enlace de restablecimiento ha caducado, ",
+        "key-expired-renew-demand-link": "renueva aquí tu solicitud.",
+        "key-invalid": "El enlace de restablecimiento no existe.",
+        "key-used": "Esta cuenta ya ha sido restablecida.",
+        "title": "¡Uy, se ha producido un error!"
+      },
+      "find-sco-record": {
+        "backup-email-confirmation": {
+          "ask-for-new-email-message": "de lo contrario, proporciona una nueva",
+          "email-already-exist-for-account-message": "La dirección de correo electrónico que aparece a continuación ya está asociada a tu cuenta:",
+          "email-is-needed-message": "{ firstName }, necesitamos tu dirección de correo electrónico",
+          "email-is-valid-message": "Si es válida,",
+          "email-reset-message": "restablece tu contraseña",
+          "email-sent-to-choose-password-message": "Te enviaremos un correo electrónico para que elijas una contraseña.",
+          "form": {
+            "actions": {
+              "cancel": "Cancelar",
+              "submit": "Empecemos"
+            },
+            "email": "Tu dirección de correo electrónico",
+            "error": {
+              "email-already-exist": {
+                "existing-email": "Ya tienes esta dirección de correo electrónico. Si es válida,",
+                "init-password": " restablece tu contraseña",
+                "new-email": ", de lo contrario, introduce una nueva."
+              },
+              "empty-email": "El campo de dirección de correo electrónico es obligatorio.",
+              "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada",
+              "new-backup-email": "Introduce una dirección de correo electrónico válida para restablecer tu cuenta",
+              "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando",
+              "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+            }
+          }
+        },
+        "confirmation-step": {
+          "buttons": {
+            "cancel": "Cancelar",
+            "confirm": "Confirmo"
+          },
+          "certify-account": "Certifico que la cuenta asociada a estos datos es mía.",
+          "contact-support": "Si observas un error o si estos datos no son tuyos, ",
+          "fields": {
+            "first-name": "Tu nombre",
+            "last-name": "Tus apellidos",
+            "latest-organization-name": "Tu último centro",
+            "username": "Tu nombre de usuario"
+          },
+          "found-account": "Hemos encontrado tu cuenta:",
+          "good-news": "¡Buenas noticias { firstName }!"
+        },
+        "conflict": {
+          "found-you-but": "{ firstName }te hemos encontrado, pero ...",
+          "title": "Conflicto",
+          "warning": "Por precaución, tenemos que comprobar juntos tus datos."
+        },
+        "contact-support": {
+          "link-text": "ponte en contacto con el servicio de asistencia.",
+          "link-url": "https://pix.fr/support/form/aide-recuperer-mon-compte"
+        },
+        "send-email-confirmation": {
+          "check-spam": "Si no ves este correo electrónico, comprueba tu carpeta de correo no deseado.",
+          "return": "Volver a Pix",
+          "send-email": "Acabamos de enviarte un correo electrónico para que puedas elegir una contraseña. Ya puedes consultar tu buzón.",
+          "title": "Restablecimiento de tu cuenta Pix"
+        },
+        "student-information": {
+          "errors": {
+            "empty-first-name": "El campo del nombre es obligatorio.",
+            "empty-ine-ina": "El campo INE es obligatorio.",
+            "empty-last-name": "El campo apellidos es obligatorio.",
+            "invalid-ine-ina-format": "El campo INE tiene un formato incorrecto.",
+            "not-found": "Pix no reconoce tus datos. Por favor, comprueba que son correctos, de lo contrario,"
+          },
+          "form": {
+            "birthdate": "Fecha de nacimiento",
+            "first-name": "Nombre",
+            "ine-ina": "INE (Identifiant National Élève)",
+            "label": {
+              "birth-day": "día de nacimiento",
+              "birth-month": "mes de nacimiento",
+              "birth-year": "año de nacimiento"
+            },
+            "last-name": "Apellidos",
+            "placeholder": {
+              "birth-day": "DD",
+              "birth-month": "MM",
+              "birth-year": "AAAA"
+            },
+            "submit": "¡Encuéntrame!",
+            "tooltip": "<strong>¿Dónde puedo encontrar mi INE?</strong> <p>Por lo general, este identificador figura en tu boletín de calificaciones. De lo contrario, tu antiguo centro te lo puede facilitar.</p>"
+          },
+          "mandatory-all-fields": "Todos los campos son obligatorios.",
+          "subtitle": {
+            "link": "restablece tu contraseña aquí.",
+            "text": "Si tienes una cuenta con una dirección de correo electrónico válida, "
+          },
+          "title": "Has salido del sistema escolar y deseas recuperar tu acceso a Pix"
+        },
+        "title": "Restablecer mi cuenta"
+      },
+      "support": {
+        "recover": " para obtener asistencia.",
+        "url": "https://support.pix.org/fr/support/tickets/new",
+        "url-text": "Ponte en contacto con el servicio de asistencia"
+      },
+      "update-sco-record": {
+        "fill-password": "¡Introduce tu contraseña y Pix será tuyo!",
+        "form": {
+          "authentication-methods-removal-notice": "Después de este paso, ya no podrá iniciar sesión utilizando { connections }.",
+          "choose-password": "Elige una contraseña para seguir disfrutando de Pix.",
+          "email-label": "Dirección de correo electrónico",
+          "errors": {
+            "empty-password": "El campo contraseña es obligatorio.",
+            "invalid-password": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito."
+          },
+          "login-button": "Iniciar sesión",
+          "new-connection-info": "No te preocupes, todo lo que tienes que hacer para volver a conectarte es utilizar tu dirección de correo electrónico y la contraseña que estableciste aquí.",
+          "password-label": "Contraseña",
+          "sco-connections": {
+            "gar": "el Mediacentre",
+            "username": "su identificación escolar Pix"
+          }
+        },
+        "welcome-message": "¡Te damos de nuevo la bienvenida, { firstName }!"
+      }
+    },
+    "assessment-banner": {
+      "modal": {
+        "actions": {
+          "quit": {
+            "extra-information": "Salir de la prueba y volver a la página de inicio"
+          }
+        },
+        "content": "Todos tus progresos se van registrando. Podrás continuar donde lo dejaste.",
+        "title": "¿Necesitas un descanso?"
+      },
+      "title": "Prueba para la evaluación: "
+    },
+    "assessment-results": {
+      "actions": {
+        "continue-pix-experience": "Continuar mi experiencia Pix",
+        "return-to-homepage": "Volver a la página de inicio"
+      },
+      "answers": {
+        "header": "Tus respuestas"
+      },
+      "title": "Fin de la prueba"
+    },
+    "authentication": {
+      "login": {
+        "signup-button": "Regístrate"
+      },
+      "sso-selection": {
+        "signin": {
+          "button": "Iniciar sesión",
+          "message": "{providerName} Será redirigido a la página de acceso \" \" para identificarse en Pix."
+        },
+        "signup": {
+          "button": "Crear cuenta",
+          "link": "Inscríbete",
+          "title": "¿No tiene una cuenta?"
+        },
+        "title": "Elegir otra organización"
+      }
+    },
+    "autonomous-course": {
+      "landing-page": {
+        "actions": {
+          "sign-in": "Ya tengo una cuenta, me conecto",
+          "start-anonymously": "Empiezo sin cuenta Pix",
+          "start-connected": "Empiezo"
+        },
+        "texts": {
+          "first-course": "¿Es tu primer test Pix?",
+          "legal-informations": "Con o sin cuenta Pix, la información relativa a tu progreso en el test nos llegará a nosotros.'<br>'Esta información la utiliza Pix para mejorar el servicio.",
+          "title": "Empieza el test:"
+        }
+      }
+    },
+    "campaign-landing": {
+      "assessment": {
+        "action": "Empiezo",
+        "announcement": "Inscríbete o conéctate a la plataforma Pix y comienza tu prueba.",
+        "certify": {
+          "description": "En función de tu situación y con ciertas condiciones, puedes acceder a la certificación Pix, reconocida en el ámbito profesional y que te permite destacar tus competencias digitales. Para más información, ponte en contacto con el organizador del test.",
+          "title": "Las respuestas validadas en este test contribuirán a mejorar tu perfil personal de competencias digitales en Pix."
+        },
+        "details": "Durante este test, tendrás la oportunidad de:",
+        "develop": {
+          "description": "Cada 5 preguntas, verás las respuestas correctas y obtendrás consejos y para mejorar tus competencias.",
+          "title": "Descubrir tus resultados a medida que vaya avanzando la prueba y consultar las pistas para mejorar."
+        },
+        "evaluate": {
+          "description": "Deberás realizar búsquedas en internet, utilizar tu entorno de trabajo digital, poner a prueba tus conocimientos, etc.",
+          "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
+        },
+        "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
+        "legal-with-autoshare": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "title": "Empieza tu test Pix",
+        "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
+      },
+      "profiles-collection": {
+        "action": "¡Empecemos!",
+        "announcement": "Inscríbete o conéctate a la plataforma Pix y envía tu perfil a la organización destinataria.",
+        "legal": "La información relativa a tu perfil PIX se enviará al organizador para que pueda ayudarte. Solo se transmitirá con tu consentimiento.",
+        "title": "Envía tu perfil",
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' envía tu perfil"
+      },
+      "title": "Presentación",
+      "warning-message": "¿No eres { firstName } { lastName }?",
+      "warning-message-logout": "Desconectarse"
+    },
+    "campaign-participation-overview": {
+      "card": {
+        "finished-at": "Finalizado el {date}",
+        "results": "{result, number, ::percent} de éxito",
+        "resume": {
+          "extra-information": "Retomar el test {campaignTitle}",
+          "information": "Retomar"
+        },
+        "retry": "Mejorarme a mí mismo",
+        "see-more": "Ver el detalle",
+        "send": "Enviar mis resultados",
+        "stages": "{count} { count, plural, =0 {estrellas} =1 {estrella} other {estrellas} } de {total}",
+        "started-at": "Empezado el {date}",
+        "tag": {
+          "completed": "Para enviar",
+          "deleted": "Inactivo",
+          "disabled": "Inactivo",
+          "finished": "Finalizado",
+          "started": "En curso"
+        },
+        "text-deleted": "Test desactivado por tu organización.'<br>'Ya no puedes actuar sobre este test.",
+        "text-disabled": "Test desactivado por tu organización.'<br>'Ya no puedes enviar tus resultados."
+      },
+      "title": "Test"
+    },
+    "campaign-participation": {
+      "title": "Test"
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "El test no está accesible para ti.",
+        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
+        "existing-participation-user-info": "Hay una participación asociada a nombre de ",
+        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
+        "not-accessible": "Uy, la página solicitada no está disponible."
+      }
+    },
+    "certificate": {
+      "congratulations": "¡Felicidades!",
+      "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        }
+      },
+      "certification-value": {
+        "paragraphs": {
+          "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
+          "2": "Your certified score has been calculated on the basis of your answers during the certification process. It may therefore differ from the number of pix shown in your profile.",
+          "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
+        }
+      },
+      "attestation": "Descargar mi certificado",
+      "back-link": "Volver a mis certificaciones",
+      "candidate-birth": "Nacido/a el {birthdate}",
+      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
+      "certification-center": "Centro de certificación :",
+      "delivered-at": "Fecha de emisión :",
+      "subtitle": "(niveles de {maxReachableLevel})",
+      "details": {
+        "competences": {
+          "description": "Tu puntuación Pix da una estimación de tu nivel en las 16 competencias digitales.",
+          "title": "Su perfil de competencias digitales"
+        }
+      },
+      "certification-date": "Fecha de examen :",
+      "candidate": "Candidato :",
+      "competences": {
+        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
+      },
+      "complementary": {
+        "alternative": "Certificación complementaria",
+        "title": "No hay ninguna certificación obtenida",
+        "clea": "Certificación CléA Numérique by Pix"
+      },
+      "exam-date": "Fecha de presentación:",
+      "hexagon-score": {
+        "certified": "certificados"
+      },
+      "issued-on": "Entregado el",
+      "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
+      "jury-title": "Observaciones del tribunal",
+      "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
+      "title": "Certificado Pix",
+      "verification-code": {
+        "share": "Share your certificate",
+        "information": "Your unique verification code",
+        "alt": "Copiar",
+        "copied": "¡Código copiado!",
+        "copy": "Copiar el código",
+        "title": "Código de comprobación",
+        "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
+      },
+      "learn-about-certification-results": "¿Cómo interpretar los resultados?"
+    },
+    "certification-ender": {
+      "candidate": {
+        "disconnect": "Desconectar mi cuenta",
+        "disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
+        "ended-by-supervisor": "El supervisor ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
+        "ended-due-to-finalization": "Tu centro de certificación ha finalizado la sesión. Ya no puedes continuar respondiendo a las preguntas.",
+        "remote-certification": "Si estás realizando tu certificación Pix de forma remota, asegúrate de desconectarte de la herramienta de supervisión una vez que hayas finalizado la prueba.",
+        "title": "¡Prueba finalizada!"
+      },
+      "results": {
+        "disclaimer": "Tus resultados, pendientes de validación por los equipos Pix, estarán pronto disponibles en tu cuenta Pix.",
+        "step-1": "Solo tienes que conectarte a tu cuenta Pix y podrás encontrar tus resultados en tu perfil, en «Mis certificaciones» (accesible haciendo clic en tu nombre en la esquina superior derecha de la pantalla).",
+        "step-2": "Podrás descargar tu certificado de certificación y compartirlo con otras personas, o incluso indicar el código de comprobación para utilizar en el sitio web de Pix.",
+        "title": "¿Consultar y compartir mis resultados de certificación?"
+      }
+    },
+    "certification-instructions": {
+      "buttons": {
+        "continuous": {
+          "aria-label": "Pasar a la pantalla siguiente",
+          "label": "Continuar",
+          "last-page": {
+            "aria-label": "Continuar a la página de entrada de la certificación"
+          }
+        },
+        "previous": {
+          "aria-label": "Volver a la pantalla anterior",
+          "label": "Anterior"
+        }
+      },
+      "steps": {
+        "1": {
+          "paragraphs": {
+            "1": "La Certificación Pix es un '<strong>'test adaptativo'</strong>' para evaluar tu nivel en el '<strong>'conjunto de 16 competencias digitales del marco de referencia Pix'</strong>'.",
+            "2": "La '<strong>'dificultad de las preguntas se adapta en tiempo real'</strong>' en función de las respuestas dadas.",
+            "3": "Si algunas preguntas le parecen difíciles, es porque la prueba de certificación pretende medir su nivel máximo. '<strong>'Si no puede responder a una pregunta, tiene la opción de \"saltársela\"'</strong>': no se le volverá a ofrecer durante la certificación y no será validada.",
+            "4": "Para obtener una puntuación lo más cercana posible a tu capacidad '<strong>'es necesario llegar hasta el final de la prueba'</strong>'."
+          },
+          "question": "¿Cómo funciona la prueba de certificación?",
+          "title": "Bienvenido a la certificación Pix"
+        },
+        "2": {
+          "legend": {
+            "strong-text": "32 PREGUNTAS",
+            "text": "1 H 45 min"
+          },
+          "paragraphs": {
+            "1": "La prueba de certificación consta de '<strong>'32 preguntas'</strong>'.",
+            "2": "Tienes un máximo de '<strong>'1h45'</strong>' para responder*.",
+            "3": "*excluyendo cualquier tiempo adicional",
+            "4": "Si completa '<strong>'menos de 20 preguntas, no podremos emitirle una puntuación'</strong>'."
+          },
+          "title": "¿Cómo funciona la prueba de certificación?"
+        },
+        "3": {
+          "images": {
+            "focus-challenge": "Modo enfoque",
+            "regular-challenge": "Modo libre"
+          },
+          "paragraphs": {
+            "1": {
+              "text": "Para preguntas en '<strong>'modo libre'</strong>', indicado con un icono verde: se le permitirá buscar en la web y utilizar el entorno digital a su disposición.",
+              "title": "Modo libre :"
+            },
+            "2": {
+              "text": "Para preguntas en '<strong>'modo de enfoque'</strong>', indicado con un icono amarillo: no se le permitirá salir de la página y buscar.",
+              "title": "Modo de enfoque :"
+            }
+          },
+          "title": "Dos tipos de preguntas"
+        },
+        "4": {
+          "list": {
+            "1": "Ir al final de la página",
+            "2": "Seleccione \"Informar de un problema con la pregunta\".",
+            "3": "Haga clic en \"Sí, estoy seguro\".",
+            "4": "Llama al supervisor que intervendrá para ayudarte"
+          },
+          "text": "'<strong>'En caso de problema técnico'</strong>' (por ejemplo, la imagen se niega a mostrarse), sigue estos pasos:",
+          "title": "¿Qué hacer en caso de problema?"
+        },
+        "5": {
+          "checkbox-label": "Al marcar esta casilla, reconozco que he leído estas normas y me comprometo a cumplirlas.",
+          "list": {
+            "1": "'<strong>'Comunicarse con otra persona'</strong>', dentro o fuera de la sala, por medios físicos o electrónicos.",
+            "2": "'<strong>'Utilizar un teléfono móvil o cualquier dispositivo electrónico conectado'</strong>' (que no sea el ordenador en el que está realizando la certificación).",
+            "3": "'<strong>'Utiliza un sistema de inteligencia artificial'</strong>' o un chatbot.",
+            "4": "'<strong>'Consulta un foro de autoayuda'</strong>' proporcionando directamente la respuesta a una pregunta.",
+            "5": "'<strong>'Movilizar cualquier otro medio que proporcione directamente la respuesta a la pregunta'</strong>', sin haber realizado el trabajo requerido por la instrucción.",
+            "6": "'<strong>'Utilice un navegador diferente'</strong>' al que está ejecutando su prueba de Certificación Pix.",
+            "7": "'<strong>'Suplantar'</strong>' a otra persona."
+          },
+          "pix-companion": "El acceso a determinados sitios está prohibido en el marco de la prueba de certificación, gracias a una extensión instalada en el navegador. Cualquier fraude probado (intento de eludir la extensión o incumplimiento de los comportamientos enumerados anteriormente) puede dar lugar a la invalidación de la certificación.",
+          "text": "En certificación, está prohibido :",
+          "title": "Normas que deben respetarse"
+        }
+      },
+      "title": "Explicación de la certificación",
+      "vocal-step-identifier": "{pageId} Página {pageCount}"
+    },
+    "certification-joiner": {
+      "congratulation-banner": {
+        "double-certification": {
+          "eligible": "También eres elegible a la certificación complementaria :",
+          "outdated": "<strong>Ya no eres elegible para la certificación {doubleCertificationName} después de su evolución.</strong><br />Ponte de nuevo en contacto con tu centro o la organización que te ofreció el test para realizar de nuevo una campaña y volver a ser elegible. Tu progreso se ha conservado y solo tendrás que hacer las pruebas nuevas, debería ir rápido."
+        },
+        "link": {
+          "text": "¿Cómo puedo obtener el certificado?",
+          "url": "https://pix.fr/se-certifier#slice-2"
+        },
+        "message": "Enhorabuena {fullName}, tu perfil Pix se puede certificar."
+      },
+      "error-messages": {
+        "generic": {
+          "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de inscripción.",
+          "check-session-number": "Comprueba el número de sesión.",
+          "disclaimer": "La información introducida no corresponde a ningún candidato inscrito en la sesión."
+        },
+        "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
+        "language-not-supported-link": "Mi cuenta",
+        "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
+        "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
+        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al supervisor.",
+        "wrong-account-sco-link": {
+          "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        },
+        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación."
+      },
+      "first-title": "Unirse a una sesión",
+      "form": {
+        "actions": {
+          "submit": "Continuar"
+        },
+        "fields-validation": {
+          "session-number-error": "El número de sesión se compone únicamente de dígitos."
+        },
+        "fields": {
+          "birth-date": "Fecha de nacimiento",
+          "birth-day": "día de nacimiento (DD)",
+          "birth-month": "mes de nacimiento (MM)",
+          "birth-name": "Apellido de nacimiento",
+          "birth-year": "año de nacimiento (AAAA)",
+          "first-name": "Nombre",
+          "session-number": "Número de sesión",
+          "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+        },
+        "placeholders": {
+          "birth-day": "DD",
+          "birth-month": "MM",
+          "birth-name": "ex: Dupont",
+          "birth-year": "YYYY",
+          "first-name": "ex: Jean",
+          "session-number": "ex: 123456"
+        }
+      },
+      "title": "Unirse a una sesión de certificación"
+    },
+    "certification-not-certifiable": {
+      "action": {
+        "back": "Volver a la página de inicio"
+      },
+      "text": "Para que tu perfil esté certificado, debes haber alcanzado un nivel superior a 0 en al menos 5 competencias.",
+      "title": "Tu perfil todavía no se puede certificar."
+    },
+    "certification-results": {
+      "action": {
+        "confirm": "Confirmo",
+        "logout": "Desconectarse"
+      },
+      "finished": {
+        "description": "Tus resultados estarán disponibles en breve en tu cuenta.",
+        "title": "¡Enhorabuena, has terminado!",
+        "warning-text": "Si no es tu ordenador, recuerda desconectarte."
+      },
+      "flag-alt": "Bandera",
+      "title": "Prueba finalizada"
+    },
+    "certification-start": {
+      "access-code": "Código de acceso comunicado por el supervisor",
+      "actions": {
+        "submit": "Empezar mi prueba"
+      },
+      "cgu": {
+        "contact": {
+          "email": "dpo@pix.fr",
+          "info": "De conformidad con la Ley francesa de «Informática y libertades», puedes ejercer tu derecho de acceso y rectificación de tus datos personales enviando un correo electrónico a "
+        },
+        "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el supervisor se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
+      },
+      "core-and-complementary-subscriptions": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
+      "error-messages": {
+        "access-code-error": "Este código no existe o ya no es válido.",
+        "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
+        "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al supervisor.",
+        "generic": "Acaba de producirse un error inesperado en el servidor.",
+        "missing-code": "You have not entered your access code.",
+        "session-not-accessible": "La sesión de certificación ya no está disponible.",
+        "unknown": {
+          "summary-label": "Ver más detalles:"
+        }
+      },
+      "first-title": "Estás a punto de empezar tu prueba de certificación",
+      "link-to-user-certification": "Ver mis certificaciones",
+      "non-eligible-subscription": "No eres elegible para {complementarySubscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",
+      "title": "Unirse a una sesión de certificación"
+    },
+    "certifications-list": {
+      "comment": "Comentario:",
+      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
+      "no-certification": {
+        "text": "Aún no tienes Pix certificación"
+      },
+      "buttons": {
+        "details": "Ver detalles",
+        "download-certificate": "Descargar certificado",
+        "download-attestation": "Descargar certificado"
+      },
+      "statuses": {
+        "cancelled": "Cancelado",
+        "rejected": "No obtenido",
+        "not-published": "Resultados pendientes",
+        "validated": "Obtenido"
+      },
+      "information": {
+        "certification-center": "Centro de certificación :",
+        "date": "Fecha del examen :"
+      },
+      "title": "Mis certificaciones"
+    },
+    "challenge": {
+      "actions": {
+        "continue": "Continuar",
+        "continue-go-to-next": "Continúo y voy a la siguiente pregunta",
+        "skip": "Paso",
+        "skip-go-to-next": "Paso y voy a la siguiente pregunta",
+        "validate": "Valido",
+        "validate-go-to-next": "Valido y voy a la siguiente pregunta",
+        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el supervisor"
+      },
+      "already-answered": "Ya has respondido a esta pregunta",
+      "answer-input": {
+        "numbered-label": "Respuesta {number}"
+      },
+      "certification": {
+        "banner": {
+          "certification-number": "N.º de certificación"
+        },
+        "title": "Certificación {certificationNumber}"
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Empezar",
+          "launch-label": "Empezar simulación",
+          "reset": "Restablecer",
+          "reset-label": "Reiniciar simulación"
+        },
+        "placeholder": "Cargando la aplicación"
+      },
+      "certification-feedback-panel": {
+        "actions": {
+          "no-send-feedback": "No, vuelvo a la prueba",
+          "open-close": "Informar de un problema con la pregunta",
+          "send-feedback": "Sí, estoy seguro/a"
+        },
+        "description": "¿Estás seguro/a de que quieres informar de un problema?",
+        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
+      },
+      "feedback-panel": {
+        "actions": {
+          "open-close": "Informar de un problema con la pregunta"
+        },
+        "description": "Pix siempre está dispuesto a escuchar tus comentarios para mejorar las pruebas que ofrecemos*.",
+        "form": {
+          "actions": {
+            "submit": "Enviar",
+            "submit-aria-label": "Enviar mi mensaje de aviso"
+          },
+          "fields": {
+            "category-selection": {
+              "label": "Tengo un problema con",
+              "options": {
+                "other": "Otro",
+                "accessibility": "La accesibilidad a la prueba",
+                "answer": "La respuesta",
+                "download": "El archivo que se debe descargar",
+                "embed": "El simulador/la aplicación",
+                "link": "El enlace indicado en la pregunta",
+                "picture": "La imagen",
+                "question": "La pregunta",
+                "tutorial": "El tutorial"
+              }
+            },
+            "detail-selection": {
+              "add-comment": "Añadir un comentario",
+              "aria-first": "Tengo un problema con",
+              "aria-secondary": "Seleccionar una opción para especificar el problema",
+              "label": "Seleccionar una opción para especificar el problema",
+              "options": {
+                "answer-not-accepted": "Mi respuesta es correcta, pero no ha sido validada",
+                "answer-not-agreed": "No estoy de acuerdo con la respuesta",
+                "download": {
+                  "other": "Tengo otro problema con el archivo",
+                  "edit-failure": {
+                    "label": "No puedo modificar el archivo",
+                    "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
+                  },
+                  "lost": {
+                    "label": "No encuentro el archivo descargado",
+                    "solution": "Por defecto, un archivo descargado se guarda en una carpeta «Descargas» o «Downloads». También puede que se haya descargado en la misma ubicación de tu última descarga…"
+                  },
+                  "open-failure": {
+                    "label": "No puedo abrir el archivo en un ordenador",
+                    "solution": "Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas."
+                  }
+                },
+                "embed-displayed-on-desktop-with-problems": {
+                  "label": "En un ordenador, aparece el simulador, pero tiene un problema",
+                  "solution": "Hacemos todo lo posible para que los simuladores funcionen en todos los dispositivos, todos los sistemas operativos y todos los navegadores, pero puede que estés utilizando un sistema concreto. Puedes detenerte aquí y retomar el test en otro ordenador.'<br>'Especifica tu problema indicando tu navegador y sistema operativo."
+                },
+                "embed-displayed-on-mobile-devices-with-problems": {
+                  "label": "En un teléfono o tableta, aparece el simulador, pero tiene un problema",
+                  "solution": "Hacemos todo lo posible para que los simuladores funcionen en todos los dispositivos, todos los sistemas operativos y todos los navegadores, pero es posible que estés utilizando un sistema concreto.'<br>'Especifica tu problema indicando el tipo de dispositivo (smartphone, tableta, etc.), el sistema operativo y navegador."
+                },
+                "embed-not-displayed": {
+                  "label": "No aparece el simulador/la aplicación",
+                  "solution": "Tu conexión a internet puede ser demasiado débil'<br>'Vuelve a cargar la página pulsando el botón de actualización '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' situado junto a la barra de direcciones. Espera un poco, puede que aparezca el simulado. '<br><br>'Si no es así, ¿puedes volver a intentarlo en otro momento o desde otro lugar con mejor conexión?"
+                },
+                "embed-other": "El simulador/la aplicación tiene otro problema",
+                "link-other": "El enlace no funciona o tiene otro problema",
+                "link-unauthorized": {
+                  "label": "El enlace está bloqueado por mi organización/centro...",
+                  "solution": "Es posible que pertenezcas a una organización (centro escolar, universidad, empresa, administración, asociación, etc.) que protege a sus usuarios y equipos limitando las páginas de internet a las que tienes acceso.'<br>'"
+                },
+                "other-challenge-proposal": "Tengo una (brillante) idea para sugerir una prueba",
+                "other-difficulty": "Tengo otro problema",
+                "other-site-improvement": "Tengo una sugerencia para mejorar la plataforma",
+                "picture-not-displayed": {
+                  "label": "La imagen no aparece",
+                  "solution": "Tu conexión a internet puede ser demasiado débil'<br>'Vuelve a cargar la página pulsando el botón de actualización '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' situado junto a la barra de direcciones. Espera un poco, puede que aparezca la imagen. '<br><br>'Si no es así, ¿puedes volver a intentarlo en otro momento o desde otro lugar con mejor conexión?"
+                },
+                "picture-other": "La imagen tiene otro problema",
+                "question-improvement": "Me gustaría proponer una mejora para la pregunta",
+                "question-not-understood": "No entiendo la pregunta",
+                "tutorial-link-error": "El enlace al tutorial lleva a otra página o a una página de error",
+                "tutorial-not-accepted": "El tutorial no es adecuado",
+                "tutorial-proposal": "Tengo un tutorial que proponeros"
+              },
+              "problem-suggestion-description": "Describe tu problema o sugerencia"
+            }
+          },
+          "status": {
+            "error": {
+              "empty-message": "Debes introducir un mensaje.",
+              "max-characters": "Tu mensaje está limitado a 10 000 caracteres."
+            },
+            "success": "'<p>'Tu comentario ha sido enviado al equipo del proyecto Pix.'</p><p>'Gracix!'</p>'"
+          }
+        },
+        "information": {
+          "data-usage": "'<p>'Pix trata los datos en este ámbito para gestionar y analizar la dificultad identificada y beneficiarse de tus comentarios. Puedes ejercer tus derechos en relación con tus datos dirigiéndote a: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Para obtener más información sobre la protección de tus datos y tus derechos.'</a></p>'",
+          "guidance": "'<p>'* Ten cuidado con lo que escribes en esta área: mantén la objetividad y los hechos en tu propio beneficio y en el de los demás.'</p><p>'En particular, no introduzcas ninguna información, que te concierna a ti o a terceros, sobre salud, religión, opiniones políticas, sindicales o filosóficas, orígenes étnicos o sanciones y condenas.'</p>'"
+        },
+        "modal": {
+          "content": "'<p><strong>'¿Estás seguro de que deseas informar de este problema?'</strong></p><p>'Gracias por tu informe, que será revisado cuidadosamente por el equipo de Pix. Tenemos en cuenta todos los comentarios para mejorar continuamente nuestros servicios y la experiencia del usuario. No podremos darte una respuesta personalizada. Gracias por tu colaboración.'</p>'",
+          "title": "Confirmación del aviso"
+        }
+      },
+      "has-focused-out-of-window": {
+        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor y responde a la pregunta en su presencia.",
+        "default": "Hemos detectado un cambio de página.",
+        "v3-accessible-certification": "Hemos detectado un cambio de página. Si has tenido que cambiar de página para utilizar una herramienta de accesibilidad digital (como un lector de pantalla o un teclado virtual), responde a la pregunta de todos modos.",
+        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor para que pueda constatarlo e informar de ello, dado el caso."
+      },
+      "illustration": {
+        "placeholder": "Cargando la imagen"
+      },
+      "is-focused-challenge": {
+        "info-alert": {
+          "adjusted-course-title": "Responde a esta pregunta sin utilizar Internet ni ninguna aplicación.",
+          "subtitle": " ",
+          "title": "Responde a esta pregunta sin buscar en internet ni utilizar ningún programa informático."
+        }
+      },
+      "live-alerts": {
+        "challenge": {
+          "message": "Avisa al supervisor para que identifique el problema."
+        },
+        "companion": {
+          "message": "Póngase en contacto con su supervisor para confirmar la presencia de la extensión."
+        },
+        "refresh": "Actualizar la página",
+        "waiting-information": "Esperando al supervisor..."
+      },
+      "parts": {
+        "answer-input": "Tu respuesta",
+        "answer-instructions": {
+          "qcm": "Selecciona varias respuestas.",
+          "qcu": "Selecciona una sola respuesta."
+        },
+        "feedback": "Informar de un problema",
+        "feedback-v3": "Informar de un problema con la pregunta",
+        "instruction": "Instrucciones de la prueba",
+        "progress": "Tu progreso",
+        "validation": "Validar o saltar la prueba"
+      },
+      "progress-bar": {
+        "label": "Pregunta"
+      },
+      "skip-error-message": {
+        "qcm": "Para validar, selecciona al menos dos respuestas. De lo contrario, puedes pasar.",
+        "qcu": "Para validar, selecciona una respuesta. De lo contrario, puedes pasar.",
+        "qroc": "Para validar, rellena el campo de texto. De lo contrario, puedes pasar.",
+        "qroc-auto-reply": "«Puedes validar» aparece cuando se supera la prueba. Inténtalo de nuevo o puedes pasar.",
+        "qroc-positive-number": "Para validar, introduce un número mayor o igual que 0; de lo contrario, puedes pasar.",
+        "qrocm": "Para validar, rellena todos los campos de respuesta. De lo contrario, puedes pasar."
+      },
+      "statement": {
+        "alternative-instruction": {
+          "actions": {
+            "display": "Mostrar el texto alternativo",
+            "hide": "Ocultar el texto alternativo"
+          }
+        },
+        "file-download": {
+          "actions": {
+            "choose-type": "Elige el tipo de archivo que deseas utilizar",
+            "download": "Descargar"
+          },
+          "description": "Pix te permite elegir el formato del archivo que deseas descargar. Si no sabes qué opción elegir, quédate con la opción por defecto. Este es el formato de archivo admitido por el mayor número de aplicaciones de software.",
+          "file-type": "archivo .{fileExtension}",
+          "help": "¿Necesitas ayuda con '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"abrir, modificar o encontrar este archivo (abrir en una nueva ventana)\">'abrir, modificar o encontrar este archivo'</a>'?"
+        },
+        "sr-only": {
+          "alternative-instruction": "Esta prueba contiene una ilustración con un texto alternativo.",
+          "embed": "Esta prueba incluye un simulador."
+        },
+        "text-to-speech": {
+          "activate": "Activar la vocalización",
+          "deactivate": "Desactivar la vocalización",
+          "play": "Lectura en voz alta",
+          "stop": "Para de leer"
+        },
+        "tooltip": {
+          "aria-label": "Mostrar la indicación en la prueba.",
+          "close": "Lo he entendido",
+          "focused": {
+            "content": "'<p class=\"tooltip-tag-information__title--focused\">'¡Quédate en esta página para responder!'</p>' No utilices internet ni ninguna aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
+            "title": "Modo enfoque"
+          },
+          "other": {
+            "content": "Puedes utilizar internet o aplicaciones para responder a esta pregunta.",
+            "title": "Modo libre"
+          }
+        }
+      },
+      "timed": {
+        "cannot-answer": "El tiempo límite ha pasado. Tu respuesta no será validada."
+      },
+      "title": {
+        "default": "Modo libre - Pregunta {stepNumber} de {totalChallengeNumber}",
+        "focused": "Modo enfoque - Pregunta {stepNumber} de {totalChallengeNumber}",
+        "focused-out": "Fallo - Modo enfoque - Pregunta {stepNumber} de {totalChallengeNumber}",
+        "timed-out": "Tiempo transcurrido - Pregunta {stepNumber} de {totalChallengeNumber}"
+      }
+    },
+    "checkpoint": {
+      "actions": {
+        "next-page": {
+          "continue": "Continuar",
+          "results": "Ver mis resultados"
+        }
+      },
+      "answers": {
+        "already-finished": {
+          "explanation": "Si ya has respondido a estas preguntas en pruebas anteriores, puedes acceder directamente a tus resultados. ¿Quieres mejorar tu puntuación? Haz clic en «Ver mis resultados» para volver a realizar el test.",
+          "info": "¡Ya has contestado!"
+        },
+        "header": "tus respuestas"
+      },
+      "completion-percentage": {
+        "caption": "progreso del test",
+        "label": "'<p class=\"sr-only\">'Has completado el '</p>'{completionPercentage}%'<p class=\"sr-only\">' del test.'</p>'"
+      },
+      "title": {
+        "assessment-progress": "Progreso",
+        "end-of-assessment": "Fin de la evaluación"
+      }
+    },
+    "combined-courses": {
+      "content": {
+        "start-button": "Iniciar el curso",
+        "resume-course": "Reanudar mi curso"
+      },
+      "completed": {
+        "title": "¡Enhorabuena! ¡Ya ha terminado!",
+        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital."
+      },
+      "items": {
+        "formation": {
+          "title": "Me estoy formando",
+          "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados."
+        },
+        "completed": "¡Completado!",
+        "tagText": "¡Ya estás ahí!",
+        "durationUnit": "min",
+        "approximatelySymbol": "≈"
+      }
+    },
+    "comparison-window": {
+      "results": {
+        "a11y": {
+          "good-answer": "La respuesta dada es válida",
+          "skipped-answer": "Pregunta saltada",
+          "the-answer-was": "La respuesta correcta es",
+          "timedout": "Has superado el límite de tiempo",
+          "wrong-answer": "La respuesta dada es incorrecta"
+        },
+        "aband": {
+          "title": "No has respondido",
+          "tooltip": "Sin respuesta"
+        },
+        "abandAutoReply": {
+          "title": "Has saltado la prueba",
+          "tooltip": "Prueba saltada"
+        },
+        "default": {
+          "title": "Respuesta",
+          "tooltip": "Corrección automática en desarrollo ;)"
+        },
+        "feedback": {
+          "correct": "Respuesta correcta",
+          "wrong": "Respuesta incorrecta. '<br>'La respuesta correcta es:"
+        },
+        "focusedOut": {
+          "title": "Has salido de la prueba",
+          "tooltip": "Prueba fallida"
+        },
+        "ko": {
+          "title": "La respuesta es correcta.",
+          "tooltip": "Respuesta incorrecta"
+        },
+        "koAutoReply": {
+          "title": "No has superado la prueba",
+          "tooltip": "Prueba fallida"
+        },
+        "ok": {
+          "title": "La respuesta es correcta.",
+          "tooltip": "Respuesta correcta"
+        },
+        "okAutoReply": {
+          "title": "Has superado la prueba",
+          "tooltip": "Prueba superada"
+        },
+        "solutions": {
+          "end": "o...",
+          "or": "o"
+        },
+        "timedout": {
+          "title": "Has superado el límite de tiempo",
+          "tooltip": "Tiempo superado"
+        },
+        "tips": {
+          "other-proposition": "Otra propuesta",
+          "your-answer": "Tu respuesta"
+        }
+      },
+      "upcoming-tutorials": "Pronto encontrarás aquí tutoriales que te ayudarán a superar con éxito este tipo de pruebas."
+    },
+    "competence-details": {
+      "actions": {
+        "continue": {
+          "extra-information": "Retomar la competencia {competenceName}",
+          "label": "Retomar"
+        },
+        "improve": {
+          "description": {
+            "countdown": "{ daysBeforeImproving, plural, =0 {0 días.} =1 {1 día.} other {# días.} }",
+            "waiting-text": "Probar el siguiente nivel en"
+          },
+          "improvingText": "¡Intenta alcanzar el siguiente nivel!",
+          "label": "Volver a intentarlo"
+        },
+        "reset": {
+          "description": "Reinicio disponible en { daysBeforeReset, plural, =0 {0 días.} =1 {1 día.} other {# días.} }",
+          "label": "Poner a cero",
+          "modal": {
+            "important-message": "Tus { earnedPix } Pix se van a eliminar de la competencia: { scoreCardName }.",
+            "important-message-above-level-one": "Tu nivel { level } y tus { earnedPix } Pix se van a eliminar de la competencia: { scoreCardName }.",
+            "title": "Puesta a cero de la competencias",
+            "warning": {
+              "certification": "si deseas que se certifique tu perfil y tus distintos resultados, esto podría afectar a tu certificación.",
+              "header": "Atención: ",
+              "ongoing-assessment": "si tienes una evaluación en curso, es posible que te vuelvan a hacer ciertas preguntas."
+            }
+          }
+        },
+        "start": {
+          "extra-information": "Empezar la competencia {competenceName}",
+          "label": "Empezar"
+        }
+      },
+      "for-competence": "la competencia {competence}",
+      "next-level-info": "{ remainingPixToNextLevel } pix antes del nivel { level }",
+      "title": "Competencia",
+      "tutorials": {
+        "description": "Aquí tienes una selección de tutoriales que te ayudarán a ganar Pix.",
+        "title": "Cultiva tus competencias"
+      }
+    },
+    "competence-result": {
+      "header": {
+        "congratulations": "¡Felicidades!",
+        "not-bad": "No está mal, pero ¡puedes mejorar!",
+        "not-bad-subtitle": "Un poco más de esfuerzo y habrás alcanzado el primer nivel.",
+        "too-bad": "¡Qué se le va a hacer!",
+        "too-bad-subtitle": "Obviamente no es tu día, pero lo harás mejor la próxima vez.",
+        "you-have-earned": "Tienes",
+        "you-have-reached-level": "Has alcanzado"
+      },
+      "title": "Resultados de tu competencia"
+    },
+    "course": {
+      "errors": {
+        "not-accessible": "Uy, la página solicitada no está disponible."
+      }
+    },
+    "dashboard": {
+      "campaigns": {
+        "resume": {
+          "action": "Continuar",
+          "text": "<h2>No olvides finalizar el envío de tu perfil.</h2>"
+        },
+        "subtitle": "Continúa con la prueba actual o envía tus resultados",
+        "tests-link": "Todos mis tests",
+        "title": "Mis tests"
+      },
+      "empty-dashboard": {
+        "link-to-competences": "Ver mis competencias",
+        "message": "<h2>¡Enhorabuena, has completado las competencias recomendadas!</h2> <p> Para ir más lejos, sigue practicando volviendo a probar competencias. </p>"
+      },
+      "improvable-competences": {
+        "extra-information": "Accede a todas las competencias que puedes volver a intentar",
+        "profile-link": "Todas las competencias",
+        "subtitle": "¿Estás listo para pasar tu competencia al siguiente nivel?",
+        "title": "Volver a intentar una competencia"
+      },
+      "presentation": {
+        "link": {
+          "text": "Más información",
+          "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
+        },
+        "message": "<h2>Hola, descubre tu panel de control.</h2><p>Accede rápida y fácilmente a los tests y pruebas de competencias que ya has empezado.<br/>Comprueba cómo progresa tu puntuación Pix y si tu perfil está listo para la certificación Pix.</p>"
+      },
+      "recommended-competences": {
+        "extra-information": "Acceder a todas las competencias recomendadas",
+        "profile-link": "Todas las competencias",
+        "subtitle": "Explora las competencias recomendadas para ti.",
+        "title": "Competencias recomendadas"
+      },
+      "score": {
+        "profile-link": "Ver mis competencias"
+      },
+      "started-competences": {
+        "subtitle": "Continúa con tus pruebas de competencias, aquí encontrará las más recientes.",
+        "title": "Recuperar una competencia"
+      },
+      "title": "Inicio",
+      "welcome": "Bienvenido { firstName }"
+    },
+    "download-session-results": {
+      "button": {
+        "label": "Descargue los resultados"
+      },
+      "errors": {
+        "invalid-token": "El enlace de descarga de los resultados de la sesión no es válido."
+      },
+      "title": "Descargar los resultados de la sesión"
+    },
+    "error": {
+      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
+      "first-title": "¡Uy, se ha producido un error!"
+    },
+    "evaluation-results": {
+      "quit-results": {
+        "leave-without-signup-modal": {
+          "actions": {
+            "cancel": "Cancelar",
+            "leave": "Sí, dejar el curso"
+          },
+          "content-information": "Si abandona este curso sin inscribirse, no podrá mantener su progreso.",
+          "content-instruction": "¿Quiere continuar?",
+          "title": "¿Salir y volver a Pix?"
+        },
+        "send-result-modal": {
+          "actions": {
+            "cancel-to-share": "Permanecer para enviar",
+            "quit-without-sharing": "Salir sin enviar"
+          },
+          "content-information": "Enviar sus resultados al organizador del curso es esencial para su apoyo. Permanezca en esta página y haga clic en \"Enviar mis resultados\" para enviarlos.",
+          "content-instruction": "¿De verdad quieres irte sin enviarlos?",
+          "title": "Ups, ¡aún no has enviado tus resultados!"
+        }
+      }
+    },
+    "fill-in-campaign-code": {
+      "description": "Este código se compone de 9 dígitos y/o letras. Lo envía tu centro/organización y sirve para iniciar un test o enviar tu perfil.",
+      "errors": {
+        "forbidden": "¡Uy, no conseguimos encontrarte! Comprueba tus datos para continuar o avisa al organizador.",
+        "missing-code": "Por favor, introduce un código.",
+        "not-found": "Tu código es incorrecto, comprueba el formato (por ejemplo, ABCDEF234) o ponte en contacto con el organizador."
+      },
+      "first-title-connected": "{ firstName }, introduce tu código",
+      "first-title-not-connected": "Introduce tu código",
+      "label": "Introducir tu código para empezar.",
+      "mediacentre-start-campaign-modal": {
+        "actions": {
+          "continue": "Continuar",
+          "quit": "Salir"
+        },
+        "message": "Para acceder al test:",
+        "message-footer": "Conéctate a Pix a través de tu Mediacentre",
+        "organised-by": "propuesto por ",
+        "title": "Acceso al test a través de Mediacentre"
+      },
+      "start": "Acceder al test",
+      "title": "Tengo un código",
+      "warning-message": "¿No eres { firstName } { lastName }?",
+      "warning-message-logout": "Desconectarse"
+    },
+    "fill-in-certificate-verification-code": {
+      "description": "La certificación Pix acredita un nivel de competencia digital: introduce a continuación el «código de comprobación» del certificado Pix que desees comprobar.",
+      "errors": {
+        "missing-code": "Por favor, introduce el código de comprobación.",
+        "not-found": "No existe ningún certificado Pix correspondiente.",
+        "unallowed-access": "Introduce el código de comprobación con el formato P-XXXXXXXX en el campo anterior.",
+        "wrong-format": "Comprueba el formato del código (P-XXXXXXXX)."
+      },
+      "first-title": "Comprobar un certificado Pix",
+      "label": "Código de comprobación",
+      "sub-label": "Ejemplo: P-XXXXXXXX",
+      "title": "Comprobar un certificado Pix",
+      "verify": "Comprobar el certificado"
+    },
+    "fill-in-participant-external-id": {
+      "announcement": "El organizador necesita la siguiente información para poder ayudarte:",
+      "buttons": {
+        "cancel": "Cancelar",
+        "continue": "Continuar"
+      },
+      "errors": {
+        "invalid-external-id": "{ externalIdLabel } El suyo no es válido.",
+        "invalid-external-id-email": "La dirección de correo electrónico no es válida.",
+        "max-length-external-id": "Tu { externalIdLabel } no debe superar 255 caracteres.",
+        "missing-external-id": "Por favor, introduce tu { externalIdLabel }."
+      },
+      "first-title": "Antes de empezar",
+      "title": "Introducir mi nombre de usuario"
+    },
+    "focused-certification-challenge-instructions": {
+      "action": "Estoy listo",
+      "description": "Para la o las siguientes preguntas, no podrás salir de la página.",
+      "title": "Modo enfoque"
+    },
+    "join": {
+      "button": "¡Empecemos!",
+      "fields": {
+        "birthdate": {
+          "day-error": "Tu día de nacimiento no es válido.",
+          "day-format": "DD",
+          "day-label": "día de nacimiento",
+          "label": "Fecha de nacimiento",
+          "month-error": "Tu mes de nacimiento no es válido.",
+          "month-format": "MM",
+          "month-label": "mes de nacimiento",
+          "year-error": "Tu año de nacimiento no es válido.",
+          "year-format": "AAAA",
+          "year-label": "año de nacimiento"
+        },
+        "firstname": {
+          "error": "No has indicado tu nombre.",
+          "label": "Nombre"
+        },
+        "lastname": {
+          "error": "No has indicado tus apellidos.",
+          "label": "Apellidos"
+        }
+      },
+      "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
+      "rgpd-legal-notice-link": "aviso legal.",
+      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+      "sco": {
+        "associate": "Asociar",
+        "continue-with-pix": "Continuar con mi cuenta Pix",
+        "error-not-found": "¿Eres un alumno? '<br>' Comprueba tus datos (nombre, apellidos y fecha de nacimiento) o ponte en contacto con un profesor.'<br><br>' ¿Eres profesor? '<br>' El acceso a un test no está disponible de momento.",
+        "first-title": "Únete a la organización { organizationName }",
+        "invalid-reconciliation-error": "Se ha producido un error. '<br>' Ponte en contacto con el servicio de asistencia.",
+        "login-information-message": "La cuenta Pix '<b>'{ connectionMethod }'</b>' se va a asociar con el estudiante: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Si efectivamente eres tú, haz clic en «Asociar», de lo contrario, desconéctate.",
+        "login-information-title": "Información sobre la conexión",
+        "subtitle": "Rellena la información que falta"
+      },
+      "sup": {
+        "error": "Comprueba la información que has introducido o, si ya tienes una cuenta Pix, conéctate con ella.",
+        "fields": {
+          "student-number": {
+            "error": "No has indicado tu número de estudiante.",
+            "label": "Número de estudiante",
+            "modify": "Cambiar el número de estudiante",
+            "not-existing": "No tengo número de estudiante"
+          }
+        },
+        "message": "Introduce la información tal y como aparece en tu tarjeta de estudiante para acceder a la prueba y enviar los resultados. Pix la recordará la próxima vez.",
+        "title": "Declara tu cuenta Pix en {organizationName}."
+      },
+      "title": "Unirse"
+    },
+    "learning-more": {
+      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+      "title": "Para más información"
+    },
+    "levelup-notif": {
+      "obtained-level": "¡Nivel { level } conseguido!"
+    },
+    "llm-preview": {
+      "iframe-title": "ChatPix",
+      "title": "Previsualización ChatPix"
+    },
+    "login-or-register-oidc": {
+      "error": {
+        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
+        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
+        "error-message": "Debes aceptar las condiciones de uso de Pix.",
+        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
+        "invalid-email": "Tu dirección de correo electrónico no es válida.",
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
+      },
+      "login-form": {
+        "button": "Iniciar sesión",
+        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
+        "email": "Dirección de correo electrónico",
+        "password": "Contraseña",
+        "title": "Ya tengo una cuenta Pix"
+      },
+      "register-form": {
+        "button": "Creo una cuenta",
+        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "last-name-label-and-value": "Apellidos: {lastName}",
+        "first-name-label-and-value": "Nombre: {firstName}",
+        "title": "No tengo una cuenta Pix"
+      },
+      "title": "Crea una cuenta Pix"
+    },
+    "login-or-register": {
+      "invitation": "{ organizationName } te invita a unirte a Pix",
+      "login-form": {
+        "button": "Conectarse",
+        "fields": {
+          "login": {
+            "label": "Dirección de correo electrónico o nombre de usuario"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "forgotten-password": {
+          "email": "Una dirección de correo electrónico:",
+          "instruction": "¿Olvidaste tu contraseña? Tienes una cuenta Pix con:",
+          "other-identity": "Un nombre de usuario: ponte en contacto con tu profesor para restablecerlo",
+          "reset-link": "Haz clic aquí para restablecerlo"
+        },
+        "title": "Ya tengo una cuenta Pix",
+        "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
+      },
+      "register-form": {
+        "button": "Inscribirse",
+        "button-form": "Crear cuenta",
+        "fields": {
+          "birthdate": {
+            "day": {
+              "error": "Tu día de nacimiento no es válido.",
+              "label": "Día de nacimiento",
+              "placeholder": "DD"
+            },
+            "label": "Fecha de nacimiento (DD/MM/AAAA)",
+            "month": {
+              "error": "Tu mes de nacimiento no es válido.",
+              "label": "Mes de nacimiento",
+              "placeholder": "MM"
+            },
+            "year": {
+              "error": "Tu año de nacimiento no es válido.",
+              "label": "Año de nacimiento",
+              "placeholder": "AAAA"
+            }
+          },
+          "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'",
+          "email": {
+            "error": "Tu correo electrónico no es válido.",
+            "help": "(ej. nombre@ejemplo.fr)",
+            "label": "Dirección de correo electrónico"
+          },
+          "firstname": {
+            "error": "No has indicado tu nombre.",
+            "label": "Nombre"
+          },
+          "lastname": {
+            "error": "No has indicado tus apellidos.",
+            "label": "Apellidos"
+          },
+          "password": {
+            "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
+            "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
+            "label": "Contraseña",
+            "show-button": "mostrar la contraseña"
+          },
+          "username": {
+            "label": "Mi nombre de usuario"
+          }
+        },
+        "not-me": "No soy yo",
+        "options": {
+          "email": "Mi dirección de correo electrónico",
+          "text": "Me inscribo con:",
+          "username": "Mi nombre de usuario"
+        },
+        "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
+        "rgpd-legal-notice-link": "aviso legal.",
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "title": "Crear cuenta"
+      },
+      "title": "Conectarse a Pix"
+    },
+    "modulix": {
+      "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
+      "buttons": {
+        "activity": {
+          "retry": "Volver a intentarlo",
+          "verify": "Compruebe mi respuesta"
+        },
+        "element": {
+          "alternativeText": "Mostrar el texto alternativo",
+          "transcription": "Ver transcripción"
+        },
+        "embed": {
+          "start": {
+            "ariaLabel": "Empezar simulación",
+            "name": "Empezar"
+          }
+        },
+        "flashcards": {
+          "answers": {
+            "almost": "Casi",
+            "no": "No, en absoluto.",
+            "yes": "¡Sí!"
+          },
+          "nextCard": "Siguiente",
+          "retry": "Volver a intentarlo",
+          "seeAgain": "Repasar la pregunta",
+          "seeAnswer": "Ver la respuesta",
+          "start": "Empezar"
+        },
+        "grain": {
+          "continue": "Continuar",
+          "skip": "Ir a",
+          "skipActivity": "Ir a la actividad",
+          "terminate": "Finalizar"
+        },
+        "interactive-element": {
+          "reset": {
+            "ariaLabel": "Reiniciar simulación",
+            "name": "Restablecer"
+          }
+        },
+        "stepper": {
+          "controls": {
+            "next": {
+              "ariaLabel": "Paso siguiente"
+            },
+            "previous": {
+              "ariaLabel": "Paso anterior"
+            }
+          },
+          "next": {
+            "ariaLabel": "Ir al paso siguiente",
+            "horizontal": {
+              "name": "Siguiente"
+            },
+            "vertical": {
+              "name": "Leer más"
+            }
+          }
+        }
+      },
+      "details": {
+        "duration": "Duración",
+        "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Aproximadamente '</span>'{duration} min",
+        "level": "Nivel",
+        "levels": {
+          "advanced": "Avanzado",
+          "expert": "Experto",
+          "independent": "Independiente",
+          "novice": "Principiante"
+        },
+        "objectives": "Objetivos",
+        "smallScreenModal": {
+          "cancel": "Volver a los detalles",
+          "description": "Algunas de las actividades de este módulo pueden resultar difíciles de realizar en una pantalla pequeña. Para disfrutar de la mejor experiencia, le recomendamos que utilice un ordenador.",
+          "startModule": "Inicio",
+          "title": "Parece que estás usando una pantalla pequeña"
+        },
+        "startModule": "Iniciar el módulo"
+      },
+      "download": {
+        "button": "Descargar",
+        "description": "Elija el formato en función del software que utilice. Si no estás seguro, elige el primer archivo, que es compatible con la mayoría de los programas.",
+        "documentationLinkHref": "https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix",
+        "documentationLinkLabel": "¿Cómo puedo abrir, modificar o recuperar este archivo?",
+        "format": "Formato {format}",
+        "intro": "Elija el formato de archivo que desea utilizar.",
+        "label": "Descargue el archivo en {format}"
+      },
+      "flashcards": {
+        "answerDirection": "¿Tienes la respuesta?",
+        "completed": "Finalizado",
+        "counters": {
+          "almost": "Casi: {totalAlmost}",
+          "no": "En absoluto: {totalNo}",
+          "yes": "¡Sí! {totalYes}"
+        },
+        "direction": "Busca la respuesta y gira la tarjeta",
+        "navigation": {
+          "shortCurrentStep": "{current}/{total}",
+          "longCurrentStep": "{current} Paso a paso {total}"
+        },
+        "position": "{currentCardPosition}Tarjeta /{totalCards}"
+      },
+      "grain": {
+        "tag": {
+          "activity": "Actividad",
+          "challenge": "Desafío",
+          "discovery": "Descubrimiento",
+          "lesson": "Lección",
+          "summary": "Recapitular"
+        },
+        "title": {
+          "lesson": "Lección",
+          "summary": "Recapitular"
+        }
+      },
+      "interactiveElement": {
+        "label": "Elemento interactivo"
+      },
+      "modals": {
+        "alternativeText": {
+          "title": "Texto alternativo"
+        },
+        "transcription": {
+          "title": "Transcripción"
+        }
+      },
+      "preview": {
+        "showJson": "Show JSON",
+        "textarea-label": "Contenido del módulo"
+      },
+      "qab": {
+        "correct-answer": "Respuesta correcta",
+        "incorrect-answer": "Respuesta incorrecta",
+        "retry": "Volver a intentarlo",
+        "score": {
+          "title": "Serie terminada",
+          "yourScore": "Tu puntuación : {score}/{total}"
+        }
+      },
+      "qcm": {
+        "direction": "Seleccione varias respuestas."
+      },
+      "qcu": {
+        "direction": "Seleccione una sola respuesta."
+      },
+      "qcuDeclarative": {
+        "complementaryInstruction": "Seleccione una sola respuesta.",
+        "direction": "There is no right or wrong answer."
+      },
+      "qcuDiscovery": {
+        "direction": "Seleccione la respuesta que le parezca más adecuada."
+      },
+      "qrocm": {
+        "direction": "Rellena {count, plural, =1 {le champ vide} other {les champs vides}}."
+      },
+      "recap": {
+        "backToModuleDetails": "Deje de",
+        "goToHomepage": "Continuar",
+        "subtitle": "Has trabajado en los siguientes objetivos:",
+        "title": "¡Módulo completado!"
+      },
+      "section": {
+        "question-yourself": "Pregúntate a ti mismo",
+        "explore-to-understand": "Explora para comprender",
+        "retain-the-essentials": "Retén lo esencial",
+        "practise": "Practica",
+        "go-further": "Ve más allá"
+      },
+      "sidebar": {
+        "button": "Visualizar los pasos del módulo"
+      },
+      "stepper": {
+        "aria-role-description": "Secuencia de etapas",
+        "step": {
+          "aria-role-description": "etapa",
+          "aria-label": "{currentStep} de {totalSteps}"
+        }
+      },
+      "verification-precondition-failed-alert": {
+        "qcm": "Para validar, selecciona al menos dos respuestas.",
+        "qcu": "Para validar, selecciona una respuesta.",
+        "qrocm": "Para validar, rellena todos los campos de respuesta."
+      }
+    },
+    "not-connected": {
+      "message": "Te has desconectado correctamente.'<br>'Gracias, hasta pronto.",
+      "title": "Desconectado"
+    },
+    "oidc-reconciliation": {
+      "authentication-method-to-add": "Conexión añadida:",
+      "confirm": "Continuar",
+      "current-authentication-methods": "Mis métodos de conexión actuales:",
+      "email": "Dirección de correo electrónico",
+      "external-connection": "Conexión externa",
+      "external-connection-via": "Conexión a través de",
+      "information": "Dado que la evaluación de competencias es personalizada, tu cuenta debe seguir siendo estrictamente personal.",
+      "return": "Volver",
+      "sub-title": "Un nuevo método de conexión está a punto de ser añadido a tu cuenta Pix",
+      "switch-account": "Cambiar cuenta",
+      "title": "¡Atención!",
+      "username": "Nombre de usuario"
+    },
+    "password-reset-demand": {
+      "title": "¿Olvidaste tu contraseña?"
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Continúa tu experiencia Pix"
+      },
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "first-title": "Ha habido un imprevisto",
+      "retry": {
+        "button": "Reenviar mi perfil",
+        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
+      },
+      "title": "Perfil ya enviado"
+    },
+    "profile": {
+      "accessibility": {
+        "title": "Tu perfil Pix",
+        "user-score": "Tu número de Pix",
+        "user-skills": "Tus competencias Pix"
+      },
+      "competence-card": {
+        "congrats": "¡Enhorabuena!",
+        "details": "detalles",
+        "image-info": {
+          "first-level": "El primer nivel está en curso y se ha completado en un {percentageAheadOfNextLevel}%.",
+          "level": "Nivel actual: {currentLevel}. El siguiente nivel se ha completado en un {percentageAheadOfNextLevel}.",
+          "no-level": "Competencia sin empezar"
+        }
+      },
+      "first-title": "Tienes 16 competencias en las que hacer pruebas. '<br>'¡Concéntrate y a por ello!",
+      "resume-campaign-banner": {
+        "accessibility": {
+          "resume": "Continúa el test",
+          "share": "Comparte los resultados del test"
+        },
+        "actions": {
+          "continue": "Continuar",
+          "resume": "Retomar"
+        },
+        "reminder-continue-campaign": "No has finalizado el test",
+        "reminder-continue-campaign-with-title": "No has finalizado el test «{title}»",
+        "reminder-send-campaign": "¡No olvides finalizar el envío!",
+        "reminder-send-campaign-with-title": "Test «{title}» finalizado. ¡No olvides finalizar el envío!"
+      },
+      "title": "Competencias",
+      "total-score-helper": {
+        "explanation": "'<p>'Este es el número máximo de pix que se podrá alcanzar cuando estén disponibles los 8 niveles del referencial Pix.'</p><p>'En la actualidad, '<span class=\"hexagon-score-information__text--strong\">'el máximo es de {maxReachablePixScore} pix'</span>', correspondiente al nivel {maxReachableLevel}.'</p>'",
+        "icon": "Información sobre los pix",
+        "label": "Abrir la información emergente",
+        "title": "¿Por qué 1024 pix?"
+      },
+      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix."
+    },
+    "reset-password": {
+      "error": {
+        "expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, vuelve a intentarlo."
+      },
+      "first-title": "Restablecer contraseña",
+      "title": "Cambiar mi contraseña"
+    },
+    "result-item": {
+      "aband": "Sin respuesta",
+      "actions": {
+        "see-answers-and-tutorials": {
+          "label": "Respuestas y consejos"
+        }
+      },
+      "ko": "Respuesta incorrecta",
+      "ok": "Respuesta correcta",
+      "timedout": "Tiempo superado"
+    },
+    "send-profile": {
+      "disabled-share": "Este test ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
+      "errors": {
+        "archived": "Ya no puedes enviar tu perfil porque el organizador ha archivado la recogida de perfiles."
+      },
+      "first-title": "Envío de tu perfil Pix",
+      "form": {
+        "continue": "Continúa tu experiencia Pix",
+        "recipient": "Destinatario: {recipient}",
+        "send": "Envío mi perfil",
+        "shared": "¡Gracias, tu perfil ha sido enviado correctamente!"
+      },
+      "instructions": "Vas a enviar la puntuación y los niveles de competencia de tu perfil Pix. '<br>' Cualquier cambio en tu perfil después de haber enviado esta información no se transmitirá. '<br>' ¡Compruébalo bien antes de enviarlo!",
+      "title": "Enviar mi perfil"
+    },
+    "shared-certification": {
+      "back-link": "Volver a la introducción del código de comprobación",
+      "title": "Compartir certificado"
+    },
+    "sign-in": {
+      "actions": {
+        "submit": "Me conecto"
+      },
+      "fields": {
+        "legend": "Información necesaria para conectarse.",
+        "login": {
+          "label": "Dirección de correo electrónico o nombre de usuario",
+          "placeholder": "ej. juan.perez@email.es"
+        },
+        "password": {
+          "label": "Contraseña"
+        }
+      },
+      "first-title": "Conéctate",
+      "forgotten-password": "¿Olvidaste tu contraseña?",
+      "title": "Conexión"
+    },
+    "sign-up": {
+      "actions": {
+        "login": "Iniciar sesión",
+        "submit": "Crear cuenta",
+        "sign-up-on-pix": "Crear cuenta en Pix"
+      },
+      "fields": {
+        "email": {
+          "help": "(ej. nombre@ejemplo.fr)"
+        }
+      },
+      "first-title": "Inscríbete",
+      "save-progress-message": "Para hacer un seguimiento de tus progresos y seguir evaluándote, ¡regístrate en Pix!",
+      "title": "Inscripción"
+    },
+    "sitemap": {
+      "accessibility": {
+        "help": "Ayuda con tus preguntas sobre accesibilidad en Pix",
+        "title": "Accesibilidad"
+      },
+      "cgu": {
+        "policy": "Política de protección de datos",
+        "subcontractors": "Lista de subcontratistas"
+      },
+      "resources": "Recursos",
+      "title": "Mapa del sitio"
+    },
+    "skill-review": {
+      "abstract": "Has dominado el '<strong>'{rate, number, ::percent}'</strong><br>'de las competencias evaluadas.",
+      "abstract-title": "Tu resultado para este test",
+      "actions": {
+        "back-to-pix": "Salir y volver a Pix",
+        "continue": "Continúa tu experiencia Pix",
+        "improve": "Lo vuelvo a intentar",
+        "send": "Envío mis resultados"
+      },
+      "already-shared": "¡Gracias, tus resultados se han enviado correctamente!",
+      "badge-card": {
+        "acquired": "Aprobado",
+        "acquired-full": "Insignia obtenida",
+        "certifiable": "Certificación",
+        "not-acquired": "No has aprobado",
+        "not-acquired-full": "Insignia no obtenida",
+        "progress-bar-label": "Porcentaje de éxito de la insignia"
+      },
+      "badges-title": "Tus insignias",
+      "details": {
+        "caption": "Detalle de tus resultados en términos porcentuales según las competencias",
+        "header-result": "Resultados",
+        "header-skill": "Competencias probadas",
+        "percentage": "{rate, number, ::percent}",
+        "progress-bar-label": "Porcentaje de éxito de la competencia",
+        "result": "Resultado global",
+        "title": "Tus resultados por competencia"
+      },
+      "disabled-share": "Este test ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
+      "error": "¡Uy, se ha producido un error!",
+      "hero": {
+        "acquired-badges-title": "Premios obtenidos",
+        "thanks": "¡Gracias, {name}, por participar!",
+        "explanations": {
+          "improve": "Si quieres mejorar tu puntuación, puedes volver a intentar algunas preguntas.",
+          "send-results": "Envíe sus resultados al organizador del curso y siga avanzando con los cursos recomendados.",
+          "trainings": "Para ayudarle a progresar, eche un vistazo a nuestros cursos de formación recomendados y encuentre los que más le convienen."
+        },
+        "mastery-rate": "de éxito en las preguntas",
+        "retry": {
+          "actions": {
+            "reset": "Poner a cero y volver a intentarlo todo",
+            "retry": "Repetir el test"
+          },
+          "description": "Tu organizador te pedira que repites la prueba.",
+          "retryIn": "Aún no puede retomar este curso. Vuelva dentro de {duration}.",
+          "title": "Mejora tus resultados"
+        },
+        "see-trainings": "Ver los cursos",
+        "shared-message": "Tus resultados se enviaron el {date} a las {time}."
+      },
+      "improve": {
+        "description": "Puedes volver a intentar algunas de las preguntas",
+        "title": "¿Quieres mejorar tus resultados?"
+      },
+      "information": "Si ya has completado tests en Pix, las preguntas a las que ya has respondido no se han vuelto a plantear. No obstante, el resultado que aparece aquí tiene en cuenta todas tus respuestas.",
+      "net-promoter-score": {
+        "link": {
+          "href": "https://pix.fr",
+          "label": "Doy mi opinión"
+        },
+        "text": "Dedica unos minutos a decirnos qué te ha parecido esta prueba y ayudarnos a mejorarla.",
+        "title": "¡Tu opinión cuenta!"
+      },
+      "not-finished": "Todavía no puedes enviar tus resultados, aún tenemos algunas preguntas para ti.",
+      "reset": {
+        "button": "Poner a cero y volver a intentarlo todo",
+        "modal": {
+          "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
+          "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
+        },
+        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
+        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+      },
+      "retry": {
+        "button": "Repetir el test",
+        "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
+        "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
+        "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+      },
+      "send-results": "No olvides enviar tus resultados al organizador del test.",
+      "send-status": {
+        "in-progress": "Enviando"
+      },
+      "send-title": "Envía tus resultados",
+      "stage": {
+        "caption": "Detalles de tus resultados en porcentaje y estrellas según las competencias",
+        "masteryPercentage": "{rate, number, ::percent} de éxito",
+        "starsAcquired": "{acquired, plural, =0 {ninguna estrella obtenida} =1 {# estrella obtenida} other {# estrellas obtenidas}} de {total}",
+        "title": "Detalles de las competencias"
+      },
+      "tabs": {
+        "aria-label": "3 pestañas con los resultados",
+        "results-details": {
+          "description": "Descubra tus competencias en detalle, organizadas por áreas específicas, para comprender mejor tus puntos fuertes y tus áreas de mejora. Identifica tus puntos fuertes y las áreas en las que puedes centrar tus esfuerzos para seguir progresando.",
+          "tab-label": "Detalle de los resultados",
+          "title": "Detalle de los resultados"
+        },
+        "rewards": {
+          "description": "En esta sección se destacan los premios recibidos y las expectativas del organizador del curso. Descubra cómo se ha evaluado su rendimiento e identifique las áreas de mejora en el desarrollo de sus competencias.",
+          "tab-label": "Premios",
+          "title": "Recompensas y expectativas del organizador"
+        },
+        "trainings": {
+          "description": "Obtenga recomendaciones de entrenamiento personalizadas para seguir avanzando y alimentar su curiosidad para ayudarle a desarrollar todo su potencial.",
+          "modal": {
+            "content": "Envía tus resultados para que el organizador del curso pueda apoyarte.'<br />'¡Una vez que hayas compartido tus resultados, tendrás acceso a estos cursos de formación!",
+            "share-error": "Se ha producido un error al enviar sus resultados. Por favor, inténtalo de nuevo."
+          },
+          "shared-results-modal": {
+            "return-results-action": "Cerrar y volver a los resultados",
+            "subtitle": "¿Listo para desarrollar tus habilidades? \uD83C\uDF93",
+            "title": "Resultados compartidos"
+          },
+          "tab-label": "Formación",
+          "title": "¿Quiere saber más?"
+        }
+      },
+      "title": "Resultado",
+      "trainings": {
+        "description": "Descubre las formaciones recomendadas para ti, basadas en tus resultados, ¡para ayudarte a progresar!",
+        "title": "¿Quieres aprender más?"
+      }
+    },
+    "terms-of-service": {
+      "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'condiciones de uso de Pix'</a>'",
+      "form": {
+        "button": "Continúo",
+        "error-message": "Debes aceptar las condiciones de uso de Pix."
+      },
+      "message": "Hemos actualizado nuestras condiciones de uso. Por favor, acéptalas para continuar con tu experiencia Pix.",
+      "title": "Condiciones de uso"
+    },
+    "timed-challenge-instructions": {
+      "action": "Empezar",
+      "primary": "Dispondrás de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' para superar la siguiente pregunta.",
+      "secondary": "Podrás seguir respondiendo después, pero la pregunta no se considerará acertada.",
+      "time": {
+        "and": " y ",
+        "minutes": "{minutes, plural, =0 {} =1 {# minuto} other {# minutos}}",
+        "seconds": "{seconds, plural, =0 {} =1 {# segundo} other {# segundos}}"
+      }
+    },
+    "training": {
+      "editor": "Contenido formativo propuesto por",
+      "type": {
+        "autoformation": "Test de autoformación",
+        "e-learning": "Formación a distancia",
+        "hybrid-training": "Formación híbrida",
+        "in-person-training": "Formación presencial",
+        "modulix": "Módulo Pix (Beta)",
+        "webinaire": "Webinario"
+      }
+    },
+    "tutorial-panel": {
+      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+      "title": "Para tener éxito la próxima vez"
+    },
+    "tutorial": {
+      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
+      "dot-action-description": "Acceder al paso {stepNumber} en {stepsCount}",
+      "dots-nav-label": "Pasos del tutorial",
+      "next": "Siguiente",
+      "next-title": "Mostrar siguiente paso",
+      "pages": {
+        "page0": {
+          "explanation": "Si no conoces una respuesta, probablemente esté en Internet.",
+          "title": "Puedes buscar en internet..."
+        },
+        "page1": {
+          "explanation": "Si aparece esta imagen, ¡utiliza solo tus conocimientos! No debes utilizar Internet ni ningún software.",
+          "title": "... excepto para ciertas preguntas"
+        },
+        "page2": {
+          "explanation": "Tómate el tiempo que necesites para completar el test. Si una pregunta está cronometrada, se te indicará.",
+          "title": "¡Sin límite de tiempo!"
+        },
+        "page3": {
+          "explanation": "Accede a tutoriales para aprender más sobre cada pregunta y progresar.",
+          "title": "Tutoriales para aprender"
+        },
+        "page4": {
+          "explanation": "Pix adapta la dificultad de las preguntas en función de tus respuestas.",
+          "title": "Un nivel adecuado de dificultad"
+        }
+      },
+      "pass": "Ignorar",
+      "pass-title": "Sáltate el tutorial y empieza mi viaje",
+      "start": "Comenzar el test",
+      "title": "Tutorial de la campaña"
+    },
+    "update-expired-password": {
+      "button": "Restablecer",
+      "fields": {
+        "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
+        "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
+        "label": "Contraseña"
+      },
+      "first-title": "Restablecer contraseña",
+      "go-to-login": "Me conecto",
+      "subtitle": "Elige una nueva contraseña para continuar",
+      "title": "Cambiar mi contraseña",
+      "validation": "Tu contraseña ha sido actualizada."
+    },
+    "user-account": {
+      "account-update-email-with-validation": {
+        "fields": {
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-email": "Tu dirección de correo electrónico no es válida.",
+            "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando."
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña",
+            "security-information": "La seguridad de tu información personal es esencial. Por ello, tenemos que comprobar que eres el autor de esta solicitud. Introduce tu contraseña para recibir un código de comprobación."
+          }
+        },
+        "save-button": "Recibir un código de comprobación",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
+      "account-update-email": {
+        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
+        "fields": {
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+          },
+          "new-email-confirmation": {
+            "label": "Confirmación de la dirección de correo electrónico"
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "password-information": "Introduce tu contraseña para confirmar",
+        "save-button": "Confirmar",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
+      "connexion-methods": {
+        "authentication-methods": {
+          "gar": "a través de ENT/Mediacentre",
+          "label": "Conexión externa",
+          "via": "a través de {identityProviderOrganizationName}"
+        },
+        "edit-button": "Modificar",
+        "email": "Dirección de correo electrónico",
+        "menu-link-title": "Mis métodos de conexión",
+        "username": "Nombre de usuario"
+      },
+      "delete-account": {
+        "actions": {
+          "delete": "Eliminar mi cuenta"
+        },
+        "menu-link-title": "Eliminar mi cuenta",
+        "modal": {
+          "error-403": "No puedes eliminar tu cuenta. Póngase en contacto con el servicio de asistencia de Pix.",
+          "question": "¿Seguro que quieres eliminar tu cuenta?",
+          "title": "Está a punto de eliminar su cuenta",
+          "warning-1": "Tenga en cuenta que la cuenta no se puede recuperar después de eliminarla.",
+          "warning-2": "En cuanto lo confirme, se cerrará automáticamente su sesión y su solicitud se tramitará inmediatamente."
+        },
+        "more-information": "Para más información,",
+        "more-information-contact-support": "puede ponerse en contacto con el servicio de asistencia.",
+        "title": "Eliminar mi cuenta definitivamente",
+        "warning-email": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán de forma permanente para la cuenta PIX que utilice la dirección de correo electrónico <strong>{email}</strong>.",
+        "warning-other": "Esta acción es irreversible. {pixScore} Todas las habilidades, cursos y píxeles que haya obtenido se eliminarán permanentemente de la cuenta PIX <strong>{firstName} {lastName}</strong>."
+      },
+      "email-confirmed": "Dirección de correo electrónico verificada.",
+      "email-verification": {
+        "code-explanation-of-use": "Para pasar de un campo a otro, utiliza el tabulador o las flechas izquierda y derecha del teclado. Para rellenar un campo, introduce dígitos del 1 al 9 o utiliza las flechas arriba y abajo del teclado.",
+        "code-label": "Campo",
+        "code-legend": "Introducir el código de comprobación enviado por correo electrónico",
+        "confirmation-message": "¡E-mail enviado!",
+        "description": "Introduce el código de comprobación recibido en la dirección de correo electrónico:",
+        "did-not-receive": "No he recibido nada.",
+        "errors": {
+          "email-modification-demand-expired": "Este código ha caducado. Por favor, renueva la solicitud.",
+          "incorrect-code": "El código introducido es incorrecto.",
+          "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+          "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia."
+        },
+        "send-back-the-code": "volver a enviarme el código",
+        "time-code-validation": "El código recibido es válido durante 10 minutos",
+        "title": "Comprobación de tu dirección de correo electrónico",
+        "update-successful": "Tu dirección de correo electrónico ha sido modificada."
+      },
+      "language": {
+        "lang": "Idioma",
+        "menu-link-title": "Elegir idioma",
+        "update-successful": "El idioma ha sido cambiado."
+      },
+      "personal-information": {
+        "first-name": "Nombre",
+        "last-name": "Apellidos",
+        "menu-link-title": "Mis datos personales"
+      },
+      "title": "Mi cuenta"
+    },
+    "user-tests": {
+      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
+      "title": "Mis tests",
+      "anonymised-participations": {
+        "course": "Recorrido",
+        "states": {
+          "completed": "terminado",
+          "started": "comenzado"
+        },
+        "title": "rutas desactivadas"
+      }
+    },
+    "user-trainings": {
+      "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",
+      "title": "Mis formaciones"
+    },
+    "user-tutorials": {
+      "description": "Aprovecha al máximo los tutoriales sugeridos por la comunidad de usuarios de Pix.",
+      "empty-list-info": {
+        "description": {
+          "part1": "A medida que vayas realizando tus pruebas, te recomendaremos tutoriales: haz clic en el icono del marcador",
+          "part2": "para guardar los que desees encontrar aquí."
+        },
+        "image-link": "images/illustrations/user-tutorials/illustration-fr.svg",
+        "title": "Aún no has guardado nada"
+      },
+      "filter": "Filtrar",
+      "label": "tutoriales",
+      "list": {
+        "title": "Mi lista",
+        "tutorial": {
+          "actions": {
+            "evaluate": {
+              "extra-information": "Marcar este tutorial como útil",
+              "label": "Dejar de considerar útil este tutorial"
+            },
+            "remove": {
+              "label": "Eliminar de mi lista de tutoriales"
+            },
+            "save": {
+              "label": "Guardar en mi lista de tutoriales"
+            }
+          },
+          "source": "Por"
+        }
+      },
+      "recommended": "Recomendados",
+      "recommended-empty": {
+        "description": "Para poder recomendarte tutoriales adaptados a tu nivel, es necesario que empieces una prueba de competencias.",
+        "link": "Empiezo",
+        "title": "{firstName}, encuentra aquí tus tutoriales favoritos"
+      },
+      "saved": "Guardados",
+      "saved-empty": {
+        "description": "Debes guardar un tutorial recomendado para que aparezca aquí.",
+        "title": "Todavía no has guardado ningún tutorial"
+      },
+      "sidebar": {
+        "reset": "Restablecer",
+        "reset-aria-label": "Restablecer y anular la selección de todos los filtros",
+        "see-results": "Ver los resultados"
+      },
+      "title": "Mis tutoriales"
+    }
+  }
+}


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre de l’Epix d’ajout de l’espagnol d’Amerique Latine sur Pix, on souhaite donc ajouter la variable espagnol d’Amérique Latine.

## ⛱️ Proposition

- Ajout d’un fichier es-419.json

- Ajout dans la liste des supported locales

## 🌊 Remarques

Ne pas ajouter l’espagnol d’Amerique Latine à la dropdown de sélection de langue. 

## 🏄 Pour tester

- Les tests passent
- Aller sur Pix App en positionnant la locale dans l’URL (avec par exemple les URL https://app-pr13642.review.pix.org/connexion?locale=es-419 ou https://app.dev.pix.org/connexion?locale=es-419), et constater que le cookie `locale` a la valeur `es-419`.
