### PR TITLE
[TECH] Rapatrier la logic dans le usecase et non dans le repository d'eligibilité (Pix-19633).

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -183,7 +183,7 @@ export class CombinedCourseDetails extends CombinedCourse {
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         const campaign = itemDetails.find(({ id }) => id === requirement.data.campaignId.data);
 
-        const isCompleted = requirement.isFulfilled(dataForQuest);
+        const isCompleted = dataForQuest ? requirement.isFulfilled(dataForQuest) : false;
 
         const doesCampaignRecommendModules =
           recommendableModuleIds.find((recommandableModule) => {
@@ -195,7 +195,7 @@ export class CombinedCourseDetails extends CombinedCourse {
         }
         this.items.push(this.#createCampaignCombinedCourseItem(campaign, isCompleted, isLocked));
       } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
-        const isCompleted = requirement.isFulfilled(dataForQuest);
+        const isCompleted = dataForQuest ? requirement.isFulfilled(dataForQuest) : false;
         const module = itemDetails.find(({ id }) => id === requirement.data.moduleId.data);
 
         const recommandableModule = recommendableModuleIds.find(

--- a/api/src/quest/domain/usecases/get-combined-course-by-code.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-code.js
@@ -47,21 +47,25 @@ export async function getCombinedCourseByCode({
 
   const moduleIds = combinedCourseDetails.moduleIds;
 
-  const eligibility = await eligibilityRepository.findByUserIdAndOrganizationId({
-    userId,
-    organizationId: combinedCourse.organizationId,
-    moduleIds,
-  });
-
-  const dataForQuest = new DataForQuest({ eligibility });
-
-  const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
-
   let recommendedModuleIdsForUser = [];
-  if (campaignParticipationIds.length > 0) {
-    recommendedModuleIdsForUser = await recommendedModulesRepository.findIdsByCampaignParticipationIds({
-      campaignParticipationIds,
+  let dataForQuest;
+
+  if (participation) {
+    const eligibility = await eligibilityRepository.findByUserIdAndOrganizationId({
+      userId,
+      organizationId: combinedCourse.organizationId,
+      moduleIds,
     });
+
+    dataForQuest = new DataForQuest({ eligibility });
+
+    const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+    if (campaignParticipationIds.length > 0) {
+      recommendedModuleIdsForUser = await recommendedModulesRepository.findIdsByCampaignParticipationIds({
+        campaignParticipationIds,
+      });
+    }
   }
 
   const modules = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds });

--- a/api/src/quest/infrastructure/repositories/eligibility-repository.js
+++ b/api/src/quest/infrastructure/repositories/eligibility-repository.js
@@ -1,4 +1,3 @@
-import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Eligibility } from '../../domain/models/Eligibility.js';
 
 export const find = async ({ userId, organizationLearnerWithParticipationApi }) => {
@@ -14,17 +13,10 @@ export const findByUserIdAndOrganizationId = async ({
   moduleIds = [],
 }) => {
   const passages = await modulesApi.getUserModuleStatuses({ userId, moduleIds });
-  let result = { campaignParticipations: [] };
-  try {
-    result = await organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId({
-      userId,
-      organizationId,
-    });
-  } catch (err) {
-    if (!(err instanceof NotFoundError)) {
-      throw err;
-    }
-  }
+  const result = await organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId({
+    userId,
+    organizationId,
+  });
   return toDomain({ ...result, passages });
 };
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -17,264 +17,372 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
     cryptoService.encrypt.withArgs(combinedCourseUrl).resolves('encryptedUrl');
   });
 
-  it('should return CombinedCourse for provided code', async function () {
-    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
-    const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
-    const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
-    const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
-    databaseBuilder.factory.buildCampaignParticipation({
-      campaignId: campaign.id,
-      userId,
-      organizationLearnerId,
-      status: 'STARTED',
-    });
-    databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
-    databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
-    const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
-    const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
-
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
-      code,
-      organizationId,
-      successRequirements: [
-        {
-          requirement_type: 'campaignParticipations',
-          comparison: 'all',
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: 'equal',
-            },
-            status: {
-              data: 'SHARED',
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: moduleId1,
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: moduleId2,
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-      ],
-    });
-
-    await databaseBuilder.commit();
-
-    const result = await usecases.getCombinedCourseByCode({ code, userId });
-
-    expect(result).to.be.instanceOf(CombinedCourse);
-    expect(result.items).to.be.deep.equal([
-      {
-        id: campaign.id,
-        reference: campaign.code,
-        title: campaign.title,
-        type: ITEM_TYPE.CAMPAIGN,
-        redirection: undefined,
-        isCompleted: false,
-        isLocked: false,
-        duration: undefined,
-        image: undefined,
-      },
-      {
-        id: moduleId1,
-        reference: 'bac-a-sable',
-        title: 'Bac à sable',
-        type: ITEM_TYPE.MODULE,
-        redirection: 'encryptedUrl',
-        isCompleted: false,
-        isLocked: true,
-        duration: 5,
-        image: 'https://assets.pix.org/modules/placeholder-details.svg',
-      },
-      {
-        id: moduleId2,
-        reference: 'bases-clavier-1',
-        title: 'Les bases du clavier sur ordinateur 1/2',
-        type: ITEM_TYPE.MODULE,
-        redirection: 'encryptedUrl',
-        isCompleted: false,
-        isLocked: true,
-        duration: 10,
-        image: 'https://assets.pix.org/modules/placeholder-details.svg',
-      },
-    ]);
-    expect(result.id).to.equal(questId);
-    expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
-    expect(result.items[0]).instanceOf(CombinedCourseItem);
-    expect(result.items[1]).instanceOf(CombinedCourseItem);
-    expect(result.items[2]).instanceOf(CombinedCourseItem);
-  });
-
-  it('should return started combined course for given userId', async function () {
-    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
-    const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
-    const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
-    const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
-    const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-      campaignId: campaign.id,
-      userId,
-      organizationLearnerId,
-      status: 'SHARED',
-    });
-    const training1 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
-    const training2 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
-    databaseBuilder.factory.buildTraining({
-      type: 'modulix',
-      link: '/modules/bien-ecrire-son-adresse-mail',
-    });
-    const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
-    const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
-    const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
-    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfile.id, trainingId: training1.id });
-    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfile.id, trainingId: training2.id });
-    databaseBuilder.factory.buildUserRecommendedTraining({
-      userId,
-      trainingId: training1.id,
-      campaignParticipationId: campaignParticipation.id,
-    });
-    databaseBuilder.factory.buildPassage({ moduleId: moduleId1, userId, terminatedAt: new Date() });
-
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
-      code,
-      organizationId,
-      successRequirements: [
-        {
-          requirement_type: 'campaignParticipations',
-          comparison: 'all',
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: 'equal',
-            },
-            status: {
-              data: 'SHARED',
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: moduleId1,
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: moduleId2,
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: moduleId3,
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-      ],
-    });
-
-    databaseBuilder.factory.buildCombinedCourseParticipation({ questId, organizationLearnerId });
-
-    await databaseBuilder.commit();
-
-    const result = await usecases.getCombinedCourseByCode({ code, userId });
-
-    expect(result.items).to.be.deep.equal([
-      {
-        id: campaign.id,
-        reference: campaign.code,
-        title: campaign.title,
-        type: ITEM_TYPE.CAMPAIGN,
-        redirection: undefined,
-        isCompleted: true,
-        isLocked: false,
-        duration: undefined,
-        image: undefined,
-      },
-      {
-        id: moduleId1,
-        reference: 'bac-a-sable',
-        title: 'Bac à sable',
-        type: ITEM_TYPE.MODULE,
-        redirection: 'encryptedUrl',
-        isCompleted: true,
-        isLocked: false,
-        duration: 5,
-        image: 'https://assets.pix.org/modules/placeholder-details.svg',
-      },
-      {
-        id: moduleId3,
-        reference: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire une adresse mail',
-        type: ITEM_TYPE.MODULE,
-        redirection: 'encryptedUrl',
-        isCompleted: false,
-        isLocked: false,
-        duration: 10,
-        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
-      },
-    ]);
-    expect(result).to.be.instanceOf(CombinedCourse);
-    expect(result.id).to.equal(questId);
-    expect(result.status).to.equal(CombinedCourseStatuses.STARTED);
-    expect(result.items[0]).instanceOf(CombinedCourseItem);
-    expect(result.items[1]).instanceOf(CombinedCourseItem);
-    expect(result.items[2]).instanceOf(CombinedCourseItem);
-  });
-
   it('should throw an error if CombinedCourse does not exist', async function () {
     const code = 'NOTHINGTT';
 
     const error = await catchErr(usecases.getCombinedCourseByCode)({ code });
 
     expect(error).to.be.instanceOf(NotFoundError);
+  });
+  describe('when there is a combined course participation', function () {
+    it('should return CombinedCourse for provided code', async function () {
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+      const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId,
+        organizationLearnerId,
+        status: 'STARTED',
+      });
+      databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
+      databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
+      const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
+
+      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        code,
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId2,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getCombinedCourseByCode({ code, userId });
+
+      expect(result).to.be.instanceOf(CombinedCourse);
+      expect(result.items).to.be.deep.equal([
+        {
+          id: campaign.id,
+          reference: campaign.code,
+          title: campaign.title,
+          type: ITEM_TYPE.CAMPAIGN,
+          redirection: undefined,
+          isCompleted: false,
+          isLocked: false,
+          duration: undefined,
+          image: undefined,
+        },
+        {
+          id: moduleId1,
+          reference: 'bac-a-sable',
+          title: 'Bac à sable',
+          type: ITEM_TYPE.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: false,
+          isLocked: true,
+          duration: 5,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        },
+        {
+          id: moduleId2,
+          reference: 'bases-clavier-1',
+          title: 'Les bases du clavier sur ordinateur 1/2',
+          type: ITEM_TYPE.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: false,
+          isLocked: true,
+          duration: 10,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        },
+      ]);
+      expect(result.id).to.equal(questId);
+      expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
+      expect(result.items[0]).instanceOf(CombinedCourseItem);
+      expect(result.items[1]).instanceOf(CombinedCourseItem);
+      expect(result.items[2]).instanceOf(CombinedCourseItem);
+    });
+
+    it('should return started combined course for given userId', async function () {
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+      const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId,
+        organizationLearnerId,
+        status: 'SHARED',
+      });
+      const training1 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
+      const training2 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
+      databaseBuilder.factory.buildTraining({
+        type: 'modulix',
+        link: '/modules/bien-ecrire-son-adresse-mail',
+      });
+      const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
+      const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training1.id,
+      });
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training2.id,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        trainingId: training1.id,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      databaseBuilder.factory.buildPassage({ moduleId: moduleId1, userId, terminatedAt: new Date() });
+
+      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        code,
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId2,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId3,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+
+      databaseBuilder.factory.buildCombinedCourseParticipation({ questId, organizationLearnerId });
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getCombinedCourseByCode({ code, userId });
+
+      expect(result.items).to.be.deep.equal([
+        {
+          id: campaign.id,
+          reference: campaign.code,
+          title: campaign.title,
+          type: ITEM_TYPE.CAMPAIGN,
+          redirection: undefined,
+          isCompleted: true,
+          isLocked: false,
+          duration: undefined,
+          image: undefined,
+        },
+        {
+          id: moduleId1,
+          reference: 'bac-a-sable',
+          title: 'Bac à sable',
+          type: ITEM_TYPE.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: true,
+          isLocked: false,
+          duration: 5,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        },
+        {
+          id: moduleId3,
+          reference: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire une adresse mail',
+          type: ITEM_TYPE.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: false,
+          isLocked: false,
+          duration: 10,
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+        },
+      ]);
+      expect(result).to.be.instanceOf(CombinedCourse);
+      expect(result.id).to.equal(questId);
+      expect(result.status).to.equal(CombinedCourseStatuses.STARTED);
+      expect(result.items[0]).instanceOf(CombinedCourseItem);
+      expect(result.items[1]).instanceOf(CombinedCourseItem);
+      expect(result.items[2]).instanceOf(CombinedCourseItem);
+    });
+  });
+  describe('when there is no organization learner yet', function () {
+    it('should return correct data for a not started combined course participation', async function () {
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const training1 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
+      const training2 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
+      databaseBuilder.factory.buildTraining({
+        type: 'modulix',
+        link: '/modules/bien-ecrire-son-adresse-mail',
+      });
+      const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
+      const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training1.id,
+      });
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training2.id,
+      });
+
+      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        code,
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId2,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId3,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getCombinedCourseByCode({ code, userId });
+      expect(result).to.be.instanceOf(CombinedCourse);
+      expect(result.id).to.equal(questId);
+      expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
+      expect(result.items[0]).instanceOf(CombinedCourseItem);
+      expect(result.items[1]).instanceOf(CombinedCourseItem);
+      expect(result.items[2]).instanceOf(CombinedCourseItem);
+    });
   });
 });

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -695,89 +695,130 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
     });
 
     describe('#generateItems', function () {
-      it('returns a combined course item for provided campaign', function () {
-        // given
-        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
+      describe('when item is type campaign', function () {
+        it('returns a combined course item for provided campaign', function () {
+          // given
+          const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
 
-        const combinedCourseTemplate = new CombinedCourseTemplate({
-          successRequirements: [
-            {
-              requirement_type: 'campaignParticipations',
-              comparison: 'all',
-              data: {
-                targetProfileId: {
-                  data: campaign.targetProfileId,
-                  comparison: 'equal',
+          const combinedCourseTemplate = new CombinedCourseTemplate({
+            successRequirements: [
+              {
+                requirement_type: 'campaignParticipations',
+                comparison: 'all',
+                data: {
+                  targetProfileId: {
+                    data: campaign.targetProfileId,
+                    comparison: 'equal',
+                  },
                 },
               },
-            },
-          ],
-        });
-        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-        const combinedCourse = new CombinedCourseDetails(
-          new CombinedCourse({ id, organizationId, name, code }),
-          combinedCourseQuestFormat,
-        );
+            ],
+          });
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
 
-        const dataForQuest = new DataForQuest({
-          eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
-        });
-        // when
-        combinedCourse.generateItems({ itemDetails: [campaign], dataForQuest });
+          const dataForQuest = new DataForQuest({
+            eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
+          });
+          // when
+          combinedCourse.generateItems({ itemDetails: [campaign], dataForQuest });
 
-        // then
-        expect(combinedCourse.items).to.deep.equal([
-          new CombinedCourseItem({
-            id: campaign.id,
-            reference: campaign.code,
-            title: campaign.title,
-            type: ITEM_TYPE.CAMPAIGN,
-            isCompleted: true,
-            isLocked: false,
-          }),
-        ]);
-      });
-      it('should not take encryptedCombinedCourseUrl if item type is campaign', function () {
-        // given
-        const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-        const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
-        const combinedCourseTemplate = new CombinedCourseTemplate({
-          successRequirements: [
-            {
-              requirement_type: 'campaignParticipations',
-              comparison: 'all',
-              data: {
-                targetProfileId: {
-                  data: campaign.targetProfileId,
-                  comparison: 'equal',
+          // then
+          expect(combinedCourse.items).to.deep.equal([
+            new CombinedCourseItem({
+              id: campaign.id,
+              reference: campaign.code,
+              title: campaign.title,
+              type: ITEM_TYPE.CAMPAIGN,
+              isCompleted: true,
+              isLocked: false,
+            }),
+          ]);
+        });
+        it('should not take encryptedCombinedCourseUrl if item type is campaign', function () {
+          // given
+          const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
+          const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
+          const combinedCourseTemplate = new CombinedCourseTemplate({
+            successRequirements: [
+              {
+                requirement_type: 'campaignParticipations',
+                comparison: 'all',
+                data: {
+                  targetProfileId: {
+                    data: campaign.targetProfileId,
+                    comparison: 'equal',
+                  },
                 },
               },
-            },
-          ],
-        });
-        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
-        const combinedCourse = new CombinedCourseDetails(
-          new CombinedCourse({ id, organizationId, name, code }),
-          combinedCourseQuestFormat,
-        );
-        const dataForQuest = new DataForQuest({
-          eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
-        });
-        // when
-        combinedCourse.generateItems({ itemDetails: [campaign], encryptedCombinedCourseUrl, dataForQuest });
+            ],
+          });
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
+          const dataForQuest = new DataForQuest({
+            eligibility: new Eligibility({ campaignParticipations: [{ campaignId: campaign.id, status: 'SHARED' }] }),
+          });
+          // when
+          combinedCourse.generateItems({ itemDetails: [campaign], encryptedCombinedCourseUrl, dataForQuest });
 
-        // then
-        expect(combinedCourse.items).to.deep.equal([
-          new CombinedCourseItem({
-            id: campaign.id,
-            reference: campaign.code,
-            title: campaign.title,
-            type: ITEM_TYPE.CAMPAIGN,
-            redirection: undefined,
-            isCompleted: true,
-            isLocked: false,
-          }),
-        ]);
+          // then
+          expect(combinedCourse.items).to.deep.equal([
+            new CombinedCourseItem({
+              id: campaign.id,
+              reference: campaign.code,
+              title: campaign.title,
+              type: ITEM_TYPE.CAMPAIGN,
+              redirection: undefined,
+              isCompleted: true,
+              isLocked: false,
+            }),
+          ]);
+        });
+        it('should return a combined course item even if data for quest is empty', function () {
+          // given
+          const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
+
+          const combinedCourseTemplate = new CombinedCourseTemplate({
+            successRequirements: [
+              {
+                requirement_type: 'campaignParticipations',
+                comparison: 'all',
+                data: {
+                  targetProfileId: {
+                    data: campaign.targetProfileId,
+                    comparison: 'equal',
+                  },
+                },
+              },
+            ],
+          });
+          const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+          const combinedCourse = new CombinedCourseDetails(
+            new CombinedCourse({ id, organizationId, name, code }),
+            combinedCourseQuestFormat,
+          );
+
+          // when
+          combinedCourse.generateItems({ itemDetails: [campaign] });
+
+          // then
+          expect(combinedCourse.items).to.deep.equal([
+            new CombinedCourseItem({
+              id: campaign.id,
+              reference: campaign.code,
+              title: campaign.title,
+              type: ITEM_TYPE.CAMPAIGN,
+              isCompleted: false,
+              isLocked: false,
+            }),
+          ]);
+        });
       });
 
       describe('when items are type module', function () {
@@ -1201,6 +1242,84 @@ describe('Quest | Unit | Domain | Models | CombinedCourse ', function () {
               new CombinedCourseItem({
                 id: 'formation_' + combinedCourse.quest.id + '_' + secondCampaign.targetProfileId,
                 reference: secondCampaign.targetProfileId,
+                type: ITEM_TYPE.FORMATION,
+                isLocked: true,
+              }),
+            ]);
+          });
+          it('should return a combined course item even if data for quest is empty', function () {
+            // given
+            const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
+            const firstModule = new Module({ id: 1, title: 'module' });
+            const secondModule = new Module({ id: 2, title: 'module' });
+            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+
+            const recommendableModuleIds = [
+              { moduleId: firstModule.id, targetProfileIds: [campaign.targetProfileId] },
+              { moduleId: secondModule.id, targetProfileIds: [campaign.targetProfileId] },
+            ];
+            const recommendedModuleIdsForUser = [];
+            const combinedCourseTemplate = new CombinedCourseTemplate({
+              successRequirements: [
+                {
+                  requirement_type: 'campaignParticipations',
+                  comparison: 'all',
+                  data: {
+                    targetProfileId: {
+                      data: campaign.targetProfileId,
+                      comparison: 'equal',
+                    },
+                  },
+                },
+                {
+                  requirement_type: 'passages',
+                  comparison: 'all',
+                  data: {
+                    moduleId: {
+                      data: firstModule.id,
+                      comparison: 'equal',
+                    },
+                  },
+                },
+                {
+                  requirement_type: 'passages',
+                  comparison: 'all',
+                  data: {
+                    moduleId: {
+                      data: secondModule.id,
+                      comparison: 'equal',
+                    },
+                  },
+                },
+              ],
+            });
+            const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+            const combinedCourse = new CombinedCourseDetails(
+              new CombinedCourse({ id: 1, organizationId: 1, name: 'COMBINIX', code: 'COMBINIX1' }),
+              combinedCourseQuestFormat,
+            );
+
+            // when
+            combinedCourse.generateItems({
+              itemDetails: [campaign, firstModule, secondModule],
+              recommendableModuleIds,
+              recommendedModuleIdsForUser,
+              encryptedCombinedCourseUrl,
+            });
+
+            // then
+            expect(combinedCourse.items).to.deep.equal([
+              new CombinedCourseItem({
+                id: campaign.id,
+                reference: campaign.code,
+                title: campaign.title,
+                type: ITEM_TYPE.CAMPAIGN,
+                isCompleted: false,
+                isLocked: false,
+              }),
+              new CombinedCourseItem({
+                id: 'formation_' + combinedCourse.quest.id + '_' + campaign.targetProfileId,
+                reference: campaign.targetProfileId,
                 type: ITEM_TYPE.FORMATION,
                 isLocked: true,
               }),

--- a/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/eligibility-repository_test.js
@@ -2,7 +2,6 @@ import sinon from 'sinon';
 
 import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
-import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Infrastructure | repositories | eligibility', function () {
@@ -83,29 +82,6 @@ describe('Quest | Unit | Infrastructure | repositories | eligibility', function 
       expect(result.organizationLearner.id).to.equal(organizationLearnerId);
       expect(result.campaignParticipations[0].targetProfileId).to.equal(targetProfileId);
       expect(result.passages).to.deep.equal([{ moduleId: 1, isTerminated: true }]);
-    });
-    it('should ignore not found error', async function () {
-      // given
-      const organizationId = 1;
-      const userId = 2;
-      const organizationLearnerWithParticipationApi = {
-        getByUserIdAndOrganizationId: sinon.stub(),
-      };
-      organizationLearnerWithParticipationApi.getByUserIdAndOrganizationId
-        .withArgs({ userId, organizationId })
-        .rejects(new NotFoundError());
-
-      const modulesApi = { getUserModuleStatuses: sinon.stub() };
-      modulesApi.getUserModuleStatuses.withArgs({ userId, moduleIds: [] }).resolves([{ id: 1, status: 'COMPLETED' }]);
-
-      // when
-      const result = await repositories.eligibilityRepository.findByUserIdAndOrganizationId({
-        userId,
-        organizationId,
-        organizationLearnerWithParticipationApi,
-        modulesApi,
-      });
-      expect(result).to.be.an.instanceof(Eligibility);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème

On mettez de la logique dans le repository d'eligibility alors que ce n'est pas à lui de gérer ce cas là.

## ⛱️ Proposition

Remonter la logique plus haut dans le usecase l'appelant. et autoriser le combinedCourseDetail model à ne pas prendre de dataForquest dans le cas ou il n'y a pas encore de learner associé. 

## 🌊 Remarques

RAS

## 🏄 Pour tester

Accèder a COMBINIX2 sur un user pas encore rattaché à l'orgnisation et vérifier que tout fonctionne