### PR TITLE
[FEATURE] Afficher tout le contenu d'un stepper horizontal en preview sur Pix App (PIX-19372).

### DIFF
--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -1,4 +1,5 @@
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -160,6 +161,11 @@ export default class ModulixStepper extends Component {
   }
 
   <template>
+    {{#if this.modulixPreviewMode.isEnabled}}
+      <PixTag @color="dark">
+        {{t "pages.modulix.preview.stepper" direction=@direction}}
+      </PixTag>
+    {{/if}}
     <div
       class="stepper stepper--{{this.direction}}"
       aria-live="{{if (eq @direction 'vertical') 'polite'}}"

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -138,7 +138,7 @@ export default class ModulixStepper extends Component {
   }
 
   get isHorizontalDirection() {
-    return this.args.direction === 'horizontal';
+    return this.args.direction === ModuleGrain.STEPPER_DIRECTION.HORIZONTAL && !this.modulixPreviewMode.isEnabled;
   }
 
   get isPreviousButtonControlDisabled() {
@@ -153,9 +153,15 @@ export default class ModulixStepper extends Component {
     return this.args.id || `pix-tabs-${guidFor(this)}`;
   }
 
+  get direction() {
+    return this.isHorizontalDirection
+      ? ModuleGrain.STEPPER_DIRECTION.HORIZONTAL
+      : ModuleGrain.STEPPER_DIRECTION.VERTICAL;
+  }
+
   <template>
     <div
-      class="stepper stepper--{{@direction}}"
+      class="stepper stepper--{{this.direction}}"
       aria-live="{{if (eq @direction 'vertical') 'polite'}}"
       aria-roledescription="{{t 'pages.modulix.stepper.aria-role-description'}}"
       {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -18,6 +18,11 @@ export default class ModuleGrain extends Component {
 
   grain = this.args.grain;
 
+  static STEPPER_DIRECTION = {
+    HORIZONTAL: 'horizontal',
+    VERTICAL: 'vertical',
+  };
+
   static AVAILABLE_ELEMENT_TYPES = [
     'custom',
     'custom-draft',
@@ -44,9 +49,9 @@ export default class ModuleGrain extends Component {
 
   get stepperDirection() {
     if (['challenge', 'activity', 'discovery'].includes(this.grainType)) {
-      return 'horizontal';
+      return ModuleGrain.STEPPER_DIRECTION.HORIZONTAL;
     }
-    return 'vertical';
+    return ModuleGrain.STEPPER_DIRECTION.VERTICAL;
   }
 
   get hasStepper() {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -593,6 +593,42 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
 
       module('when preview mode is enabled', function () {
+        test('should display preview information', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          class PreviewModeServiceStub extends Service {
+            isEnabled = true;
+          }
+
+          this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+          // when
+          const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="vertical" /></template>);
+
+          // then
+          assert.dom(screen.getByText('Preview : stepper vertical')).exists();
+        });
+
         test('should display all the steps', async function (assert) {
           // given
           const steps = [
@@ -1628,6 +1664,43 @@ module('Integration | Component | Module | Stepper', function (hooks) {
     });
 
     module('when in preview mode', function () {
+      test('should display preview information', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        class PreviewModeServiceStub extends Service {
+          isEnabled = true;
+        }
+        this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+        // when
+        const screen = await render(
+          <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText('Preview : stepper horizontal')).exists();
+      });
+
       test('should display all steps (becomes vertical stepper)', async function (assert) {
         // given
         const steps = [

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -708,7 +708,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         const screen = await render(
           <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
         );
-        // await this.pauseTest();
 
         // then
         assert.dom(find('#stepper-container-id-1')).exists();
@@ -1626,9 +1625,92 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             .doesNotExist();
         });
       });
+    });
 
-      module('when preview mode is enabled', function () {
-        test('should display all the steps', async function (assert) {
+    module('when in preview mode', function () {
+      test('should display all steps (becomes vertical stepper)', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        class PreviewModeServiceStub extends Service {
+          isEnabled = true;
+        }
+        this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+        // when
+        const screen = await render(
+          <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText('Text 1')).exists();
+        assert.dom(screen.getByText('Text 2')).exists();
+        assert.dom(find('.stepper--vertical')).exists();
+      });
+
+      test('should not display controls buttons', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+
+        class PreviewModeServiceStub extends Service {
+          isEnabled = true;
+        }
+        this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
+        // when
+        const screen = await render(
+          <template><ModulixStepper @id="stepper-container-id-1" @steps={{steps}} @direction="horizontal" /></template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+          .doesNotExist();
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+          .doesNotExist();
+      });
+
+      module('when has unsupported elements', function () {
+        test('should display all the steps but filter out unsupported element', async function (assert) {
           const steps = [
             {
               elements: [
@@ -1648,6 +1730,14 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 },
               ],
             },
+            {
+              elements: [
+                {
+                  id: 'd7870bf4-e018-482a-829c-6a124066b352',
+                  type: 'nope',
+                },
+              ],
+            },
           ];
 
           class PreviewModeServiceStub extends Service {
@@ -1655,60 +1745,13 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           }
 
           this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+
           // when
           const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
           // then
           assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
           assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
-        });
-
-        module('when has unsupported elements', function () {
-          test('should display all the steps but filter out unsupported element', async function (assert) {
-            const steps = [
-              {
-                elements: [
-                  {
-                    id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                    type: 'text',
-                    content: '<p>Text 1</p>',
-                  },
-                ],
-              },
-              {
-                elements: [
-                  {
-                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                    type: 'text',
-                    content: '<p>Text 2</p>',
-                  },
-                ],
-              },
-              {
-                elements: [
-                  {
-                    id: 'd7870bf4-e018-482a-829c-6a124066b352',
-                    type: 'nope',
-                  },
-                ],
-              },
-            ];
-
-            class PreviewModeServiceStub extends Service {
-              isEnabled = true;
-            }
-
-            this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
-
-            // when
-            const screen = await render(
-              <template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>,
-            );
-
-            // then
-            assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
-            assert.strictEqual(screen.getAllByRole('group', { name: '2 sur 2' }).length, 1);
-          });
         });
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1783,6 +1783,7 @@
       },
       "preview": {
         "showJson": "Show JSON",
+        "stepper": "Preview : stepper {direction}",
         "textarea-label": "Module content"
       },
       "qab": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1769,7 +1769,8 @@
       },
       "preview": {
         "showJson": "Show JSON",
-        "textarea-label": "Contenido del módulo"
+        "textarea-label": "Contenido del módulo",
+        "stepper" : "Preview : stepper {direction}"
       },
       "qab": {
         "correct-answer": "Respuesta correcta",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1783,6 +1783,7 @@
       },
       "preview": {
         "showJson": "Afficher le JSON",
+        "stepper": "Preview : stepper {direction}",
         "textarea-label": "Contenu du Module"
       },
       "qab": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1773,7 +1773,8 @@
       },
       "preview": {
         "showJson": "Show JSON",
-        "textarea-label": "Inhoud module"
+        "textarea-label": "Inhoud module",
+        "stepper" : "Preview : stepper {direction}"
       },
       "qab": {
         "correct-answer": "Correct antwoord",


### PR DESCRIPTION
## 🔆 Problème

Actuellement sur un module en preview, le stepper horizontal garde son format, ce qui ne facilite pas la lecture du contenu pour le métier.

## ⛱️ Proposition

Modifier le format du stepper horizontal pour afficher tout le contenu du stepper.

**Je suis partie sur le choix de passer un stepper horizontal en vertical en cas de preview.** 

## 🌊 Remarques

J'ai créé une const `STEPPER_DIRECTION` coté grain pour éviter les string sur les couches enfants (risque de coquille)

## 🏄 Pour tester

- Aller sur https://app-pr13651.review.pix.fr/modules/bac-a-sable
- Non régression du stepper horizontal (avec les boutons de contrôles etc)
<img width="1306" height="524" alt="Capture d’écran 2025-09-23 à 11 14 36" src="https://github.com/user-attachments/assets/d92aed1d-1f3b-4e75-991b-01e34ffb04f8" />

- Aller sur https://app-pr13651.review.pix.fr/modules/preview/bac-a-sable
- Le stepper horizontal est présenté comme un stepper vertical.
- Un tag mentionne s'il s'agit d'un stepper horizontal ou vertical.

<img width="637" height="345" alt="Capture d’écran 2025-09-23 à 17 39 21" src="https://github.com/user-attachments/assets/f8ab066d-cd58-432a-8c94-4d5c2802c71b" />
<img width="633" height="524" alt="Capture d’écran 2025-09-23 à 17 39 31" src="https://github.com/user-attachments/assets/f3429fa8-2b31-4678-98a8-2603339a068c" />
