### PR TITLE
[FEATURE] À la connexion, protéger les OIDC Providers contre les multiples appels (PIX-18388)

### DIFF
--- a/mon-pix/app/components/authentication/other-authentication-providers.scss
+++ b/mon-pix/app/components/authentication/other-authentication-providers.scss
@@ -19,6 +19,7 @@
     content: "";
   }
 
+  &__button,
   &__button-link {
     white-space: normal;
     border: 1px solid;

--- a/mon-pix/app/components/authentication/sso-selection-form.gjs
+++ b/mon-pix/app/components/authentication/sso-selection-form.gjs
@@ -1,5 +1,4 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -49,6 +48,13 @@ export default class SsoSelectionForm extends Component {
     return this.router.urlFor('account-recovery');
   }
 
+  @action
+  goToOidcProviderLoginPage() {
+    this.oidcIdentityProviders.isOidcProviderAuthenticationInProgress = true;
+    const selectedOidcProviderSlug = this.oidcIdentityProviders[this.selectedProviderId].slug;
+    this.router.transitionTo('authentication.login-oidc', selectedOidcProviderSlug);
+  }
+
   <template>
     <section class="sso-selection-form">
       <h2 class="pix-title-s">
@@ -71,17 +77,18 @@ export default class SsoSelectionForm extends Component {
             }}
           </PixNotificationAlert>
         {{/if}}
-        <PixButtonLink
+
+        <PixButton
+          @triggerAction={{this.goToOidcProviderLoginPage}}
+          @isLoading={{this.oidcIdentityProviders.isOidcProviderAuthenticationInProgress}}
           aria-describedby="signin-message"
-          @route="authentication.login-oidc"
-          @model={{this.selectedProviderId}}
         >
           {{#if @isForSignup}}
             {{t "pages.authentication.sso-selection.signup.button"}}
           {{else}}
             {{t "pages.authentication.sso-selection.signin.button"}}
           {{/if}}
-        </PixButtonLink>
+        </PixButton>
 
         <p id="signin-message" class="sso-selection-form__signin-message" aria-live="polite">
           {{t "pages.authentication.sso-selection.signin.message" providerName=this.selectedProviderName}}

--- a/mon-pix/app/routes/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/routes/authentication/login-or-register-oidc.js
@@ -1,3 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class LoginOrRegisterOidcRoute extends Route {}

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -1,4 +1,5 @@
 import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 // TODO: Manage this through the API
 const FR_FEATURED_IDENTITY_PROVIDER_CODE = 'POLE_EMPLOI';
@@ -10,6 +11,8 @@ const USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES = [FER_IDENTITY_PROVIDER
 export default class OidcIdentityProviders extends Service {
   @service store;
   @service currentDomain;
+
+  @tracked isOidcProviderAuthenticationInProgress = false;
 
   get list() {
     return this.store.peekAll('oidc-identity-provider');

--- a/mon-pix/tests/integration/components/authentication/other-authentication-providers-test.gjs
+++ b/mon-pix/tests/integration/components/authentication/other-authentication-providers-test.gjs
@@ -116,39 +116,42 @@ module('Integration | Component | Authentication | other-authentication-provider
       this.owner.register('service:oidcIdentityProviders', OneFeaturedNoOthersOidcIdentityProvidersServiceStub);
     });
 
-    module('when it’s for login');
-    test('it displays a login featured identity provider link', async function (assert) {
-      // when
-      const screen = await render(<template><OtherAuthenticationProviders /></template>);
+    module('when it’s for login', function () {
+      test('it displays a login featured identity provider link', async function (assert) {
+        // when
+        const screen = await render(<template><OtherAuthenticationProviders /></template>);
 
-      // then
-      const link = await screen.findByRole('link', {
-        name: t(
-          'components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link',
-          {
-            featuredIdentityProvider: 'Some Identity Provider',
-          },
-        ),
+        // then
+        const link = await screen.findByRole('link', {
+          name: t(
+            'components.authentication.other-authentication-providers.login.login-with-featured-identity-provider-link',
+            {
+              featuredIdentityProvider: 'Some Identity Provider',
+            },
+          ),
+        });
+        assert.dom(link).exists();
+        assert.strictEqual(link.getAttribute('href'), '/connexion/some-identity-provider');
       });
-      assert.dom(link).exists();
-      assert.strictEqual(link.getAttribute('href'), '/connexion/some-identity-provider');
     });
-    module('when it’s for signup');
-    test('it displays a signup featured identity provider link', async function (assert) {
-      // when
-      const screen = await render(<template><OtherAuthenticationProviders @isForSignup="true" /></template>);
 
-      // then
-      const link = await screen.findByRole('link', {
-        name: t(
-          'components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link',
-          {
-            featuredIdentityProvider: 'Some Identity Provider',
-          },
-        ),
+    module('when it’s for signup', function () {
+      test('it displays a signup featured identity provider link', async function (assert) {
+        // when
+        const screen = await render(<template><OtherAuthenticationProviders @isForSignup="true" /></template>);
+
+        // then
+        const link = await screen.findByRole('link', {
+          name: t(
+            'components.authentication.other-authentication-providers.signup.signup-with-featured-identity-provider-link',
+            {
+              featuredIdentityProvider: 'Some Identity Provider',
+            },
+          ),
+        });
+        assert.dom(link).exists();
+        assert.strictEqual(link.getAttribute('href'), '/connexion/some-identity-provider');
       });
-      assert.dom(link).exists();
-      assert.strictEqual(link.getAttribute('href'), '/connexion/some-identity-provider');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

L’absence de `isLoading` sur les boutons _« Se connecter avec {SSO} »_ laisse la possibilité aux utilisateurs de cliquer de nombreuses fois sur ces boutons. Ceci se produit d’autant plus lorsque le fournisseur d’identité OIDC (OIDC Provider) met du temps à répondre, c’est à dire lorsqu’il est potentiellement surchargé.

## ⛱️ Proposition

### Sur la page de connexion

- Protéger le bouton _« Se connecter avec {SSO} »_ contre les clics multiples en le rendant non-actionable plusieurs fois grâce à l’activation de la propriété `isLoading`
- Désactiver le bouton _« Choisir une autre organisation »_ lorsque le bouton _« Se connecter avec {SSO} »_ est activé

<img width="1008" height="729" alt="Screenshot_2025-09-23_at_18-40-26_Connexion_Pix" src="https://github.com/user-attachments/assets/b989fe6d-5630-4208-8c02-551fe8dbe27c" />

### Sur la page du choix d’un autre fournisseur d’identié

Protéger le boutons _« Se connecter avec {SSO} »_ contre les clics multiples en le rendant non-actionable plusieurs fois grâce à l’activation de la propriété `isLoading`

<img width="1008" height="729" alt="Screenshot_2025-09-23_at_18-41-00_Connexion_Pix" src="https://github.com/user-attachments/assets/5ab8fb78-5a6c-4361-8dec-c7c8207f24b6" />


## 🌊 Remarques

Utilisation de l’événement [`pageshow`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageshow_event) pour arrêter le `isLoading` sur les boutons.

:gift: BONUS : Ajout d’un nouveau helper `stubOidcIdentityProvidersService` dans `mon-pix/tests/helpers/service-stubs.js`.

## 🏄 Pour tester

:bulb: Pour simuler un OIDC Provider lent à la réponse on pourra agir dans la console web de son navigateur au niveau du réglage du réseau ou modifier le fichier `mon-pix/app/routes/authentication/login-oidc.js` comme expliqué ci-dessous.

<img width="1057" height="1187" alt="network-change_bandwith" src="https://github.com/user-attachments/assets/6fc71015-1558-4772-8a6f-34fa285c94ac" />

On pourra par exemple commenter une ligne comme suit :
```javascript
// Location.assign(authorizationUrl);
```
ou bien ajouter une temporisation comme suit :
```javascript
const delayInMs = 3000;
await new Promise((resolve) => setTimeout(() => resolve(), delayInMs));
Location.assign(authorizationUrl);
```

En local, sur le domaine `.pix.fr` et `.pix.org` : 
- chercher à cliquer à de multiples reprises sur les différents bouton de connexion SSO OIDC et constater et constater que seul le premier clic est pris en compte.
- dans les parcours d’authentification SSO OIDC, faire des retours arrière et des retours avant dans la navigation et constater que la navigation et l’interface utilisateur restent toujours logiques

