### PR TITLE
[TECH] Mettre à jour les service url-base et locale dans les fronts (PIX-19641)

### DIFF
--- a/admin/app/services/locale.js
+++ b/admin/app/services/locale.js
@@ -16,11 +16,11 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
-const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const PIX_LANGUAGES = [
   { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },

--- a/admin/app/services/url-base.js
+++ b/admin/app/services/url-base.js
@@ -55,6 +55,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   nl: 'https://pix.org/nl-be',
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
+  'es-419': 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -67,6 +68,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'algemene-gebruiksvoorwaarden',
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
+    'es-419': 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -76,6 +78,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'wettelijke-vermeldingen',
     en: 'legal-notice',
     es: 'legal-notice',
+    'es-419': 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -85,6 +88,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
+    'es-419': 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -94,6 +98,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid',
     en: 'accessibility',
     es: 'accessibility',
+    'es-419': 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -103,6 +108,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-orga',
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
+    'es-419': 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -112,6 +118,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-certif',
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
+    'es-419': 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -121,6 +128,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'support',
     en: 'support',
     es: 'support',
+    'es-419': 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -130,6 +138,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'mijn-certificeringsresultaten-begrijpen',
     en: 'understand-certification-results',
     es: 'understand-certification-results',
+    'es-419': 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
 };

--- a/admin/tests/unit/services/locale-test.js
+++ b/admin/tests/unit/services/locale-test.js
@@ -65,7 +65,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 
@@ -310,7 +310,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixChallengeLocales = localeService.pixChallengeLocales;
 
       // then
-      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de']);
+      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de']);
     });
   });
 

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -16,11 +16,11 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
-const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const PIX_LANGUAGES = [
   { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },

--- a/certif/app/services/url-base.js
+++ b/certif/app/services/url-base.js
@@ -55,6 +55,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   nl: 'https://pix.org/nl-be',
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
+  'es-419': 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -67,6 +68,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'algemene-gebruiksvoorwaarden',
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
+    'es-419': 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -76,6 +78,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'wettelijke-vermeldingen',
     en: 'legal-notice',
     es: 'legal-notice',
+    'es-419': 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -85,6 +88,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
+    'es-419': 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -94,6 +98,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid',
     en: 'accessibility',
     es: 'accessibility',
+    'es-419': 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -103,6 +108,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-orga',
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
+    'es-419': 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -112,6 +118,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-certif',
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
+    'es-419': 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -121,6 +128,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'support',
     en: 'support',
     es: 'support',
+    'es-419': 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -130,6 +138,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'mijn-certificeringsresultaten-begrijpen',
     en: 'understand-certification-results',
     es: 'understand-certification-results',
+    'es-419': 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
 };

--- a/certif/tests/unit/services/locale-test.js
+++ b/certif/tests/unit/services/locale-test.js
@@ -65,7 +65,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 
@@ -310,7 +310,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixChallengeLocales = localeService.pixChallengeLocales;
 
       // then
-      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de']);
+      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de']);
     });
   });
 

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -16,11 +16,11 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 const DEFAULT_LANGUAGE = new Intl.Locale(DEFAULT_LOCALE).language;
 
-const PIX_LOCALES = ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
+const PIX_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 // Currently the challenge locales are not in canonical locales, thus the "fr-fr" value.
 // This cannot be changed without migrating the challenges content.
-const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const PIX_CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const PIX_LANGUAGES = [
   { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },

--- a/orga/app/services/url-base.js
+++ b/orga/app/services/url-base.js
@@ -55,6 +55,7 @@ export const PIX_WEBSITE_ROOT_URLS = {
   nl: 'https://pix.org/nl-be',
   en: 'https://pix.org/en',
   es: 'https://pix.org/en',
+  'es-419': 'https://pix.org/en',
   fr: 'https://pix.org/fr',
 };
 
@@ -67,6 +68,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'algemene-gebruiksvoorwaarden',
     en: 'terms-and-conditions',
     es: 'terms-and-conditions',
+    'es-419': 'terms-and-conditions',
     fr: 'conditions-generales-d-utilisation',
   },
   LEGAL_NOTICE: {
@@ -76,6 +78,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'wettelijke-vermeldingen',
     en: 'legal-notice',
     es: 'legal-notice',
+    'es-419': 'legal-notice',
     fr: 'mentions-legales',
   },
   DATA_PROTECTION_POLICY: {
@@ -85,6 +88,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'beleid-inzake-de-bescherming-van-persoonsgegevens',
     en: 'personal-data-protection-policy',
     es: 'personal-data-protection-policy',
+    'es-419': 'personal-data-protection-policy',
     fr: 'politique-protection-donnees-personnelles-app',
   },
   ACCESSIBILITY: {
@@ -94,6 +98,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid',
     en: 'accessibility',
     es: 'accessibility',
+    'es-419': 'accessibility',
     fr: 'accessibilite',
   },
   ACCESSIBILITY_ORGA: {
@@ -103,6 +108,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-orga',
     en: 'accessibility-pix-orga',
     es: 'accessibility-pix-orga',
+    'es-419': 'accessibility-pix-orga',
     fr: 'accessibilite-pix-orga',
   },
   ACCESSIBILITY_CERTIF: {
@@ -112,6 +118,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'toegankelijkheid-pix-certif',
     en: 'accessibility-pix-certif',
     es: 'accessibility-pix-certif',
+    'es-419': 'accessibility-pix-certif',
     fr: 'accessibilite-pix-certif',
   },
   SUPPORT: {
@@ -121,6 +128,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'support',
     en: 'support',
     es: 'support',
+    'es-419': 'support',
     fr: 'support',
   },
   CERTIFICATION_RESULTS_EXPLANATION: {
@@ -130,6 +138,7 @@ export const PIX_WEBSITE_PATHS = {
     nl: 'mijn-certificeringsresultaten-begrijpen',
     en: 'understand-certification-results',
     es: 'understand-certification-results',
+    'es-419': 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
 };

--- a/orga/tests/unit/services/locale-test.js
+++ b/orga/tests/unit/services/locale-test.js
@@ -65,7 +65,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixLocales = localeService.pixLocales;
 
       // then
-      assert.deepEqual(pixLocales, ['en', 'es', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
+      assert.deepEqual(pixLocales, ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE']);
     });
   });
 
@@ -310,7 +310,7 @@ module('Unit | Services | locale', function (hooks) {
       const pixChallengeLocales = localeService.pixChallengeLocales;
 
       // then
-      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de']);
+      assert.deepEqual(pixChallengeLocales, ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de']);
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

Dans le cadre de l’Epix d’ajout de l’espagnol d’Amerique Latine sur Pix, on souhaite donc ajouter la variable espagnol d’Amérique Latine.

## ⛱️ Proposition

Mettre à jour les services locale et url-base des différents applications

## 🌊 Remarques

suite de #13642

## 🏄 Pour tester

- Tests au vert
- Pas de tests fonctionnels ici, `es-419` n'est pas à ajouter aux `SUPPORTED_LOCALES`
- Depuis pix-admin, modifier avec succès un utilisateur en changeant sa locale par `es-419`

<img width="507" height="262" alt="image" src="https://github.com/user-attachments/assets/005458f9-2013-4b1a-a560-64afc005560c" />

