### PR TITLE
[TECH] Ajouter un éditeur de parcours combiné

### DIFF
--- a/admin/app/components/combined-courses/form.gjs
+++ b/admin/app/components/combined-courses/form.gjs
@@ -1,0 +1,165 @@
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { eq, gt } from 'ember-truth-helpers';
+import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
+
+export default class CombineCourseForm extends Component {
+  @service pixToast;
+
+  @tracked combinedCourseItems = [];
+  @tracked itemId = null;
+  @tracked itemType = 'campaign';
+
+  @action
+  addItem(event) {
+    event.preventDefault();
+    if (this.itemType === 'campaign') {
+      this.addCampaign();
+    } else {
+      this.addModule();
+    }
+  }
+
+  addCampaign() {
+    this.combinedCourseItems = [
+      ...this.combinedCourseItems,
+      {
+        requirement_type: 'campaignParticipations',
+        comparison: 'all',
+        data: {
+          targetProfileId: {
+            data: this.itemId,
+            comparison: 'equal',
+          },
+        },
+      },
+    ];
+    this.itemId = null;
+  }
+
+  addModule() {
+    this.combinedCourseItems = [
+      ...this.combinedCourseItems,
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: this.itemId,
+            comparison: 'equal',
+          },
+        },
+      },
+    ];
+    this.itemId = null;
+  }
+
+  @action
+  async copyToClipboard() {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(this.combinedCourseItems, null, 2));
+      this.pixToast.sendSuccessNotification({
+        message: 'Le JSON du parcours a été copié dans votre presse papier.',
+      });
+    } catch (e) {
+      console.error(e);
+      this.pixToast.sendErrorNotification({ message: "Le parcours n'a pas été copié dans votre presse papier." });
+    }
+  }
+
+  getItemType(item) {
+    return item.requirement_type === 'campaignParticipations' ? 'campaign' : 'module';
+  }
+
+  getItemValue(item) {
+    return item.requirement_type === 'campaignParticipations'
+      ? item.data.targetProfileId.data
+      : item.data.moduleId.data;
+  }
+
+  getItemColor(item) {
+    return item.requirement_type === 'campaignParticipations' ? 'purple' : 'blue';
+  }
+
+  setId = (e) => {
+    this.itemId = e.target.value;
+  };
+
+  setItemType = (e) => {
+    this.itemType = e.target.value;
+  };
+
+  <template>
+    <PixBlock @variant="admin" class="combined-course-page">
+      <h1 class="combined-course-page__title">Combined course creator</h1>
+
+      <form class="combined-course-page__form" {{on "submit" this.addItem}}>
+        <PixFieldset>
+          <:title>Choisissez le type d'élément à ajouter :</:title>
+          <:content>
+            <PixRadioButton
+              name="itemType"
+              @value="campaign"
+              checked={{if (eq this.itemType "campaign") "checked"}}
+              {{on "change" this.setItemType}}
+            >
+              <:label>Campagne</:label>
+            </PixRadioButton>
+            <PixRadioButton
+              name="itemType"
+              checked={{if (eq this.itemType "module") "checked"}}
+              @value="module"
+              {{on "change" this.setItemType}}
+            >
+              <:label>Module</:label>
+            </PixRadioButton>
+          </:content>
+        </PixFieldset>
+
+        <PixInput
+          @id="itemId"
+          @value={{this.itemId}}
+          @requiredLabel="Champ obligatoire"
+          {{on "change" this.setId}}
+          class="combined-course-page__input"
+        >
+          <:label>
+            Identifiant
+          </:label>
+        </PixInput>
+
+        <PixButton @type="submit" class="combined-course-page__button">Ajouter un item</PixButton>
+      </form>
+
+      <hr class="combined-course-page__separator" />
+
+      <h2 class="combined-course-page__title">Contenu du parcours tout court</h2>
+
+      {{#if (gt this.combinedCourseItems.length 0)}}
+        <ul class="combined-course-page__list">
+          {{#each this.combinedCourseItems as |item|}}
+            <li class="combined-course-page__list-item"><PixTag @color={{this.getItemColor item}}>
+                {{this.getItemType item}}
+                -
+                {{this.getItemValue item}}
+              </PixTag>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <p>Votre parcours n'a aucun élément ajouté.</p>
+      {{/if}}
+
+      <PixButton class="combined-course-page__button" @triggerAction={{this.copyToClipboard}} @variant="success">Copier
+        le JaSON</PixButton>
+    </PixBlock>
+  </template>
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -35,6 +35,7 @@ Router.map(function () {
   this.route('authenticated', { path: '' }, function () {
     // all routes that require the session to be authenticated
     this.route('quest-creator');
+    this.route('combined-course-creator');
     this.route('quest-new-or-edit-snippet');
     this.route('organizations', function () {
       this.route('new');

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -26,6 +26,7 @@
 
 /* components */
 @use 'components/quests/form' as *;
+@use 'components/combined-course/form' as *;
 @use 'components/administration' as *;
 @use 'components/administration/certification/certification-scoring-configuration' as *;
 @use 'components/administration/certification/competence-scoring-configuration' as *;

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -1,0 +1,36 @@
+@use 'pix-design-tokens/typography';
+
+.combined-course-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-6x);
+
+  &__title {
+    @extend %pix-title-m;
+  }
+
+  &__form {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-6x);
+  }
+
+  &__input {
+    max-width: 30rem;
+  }
+
+  &__button {
+    width: fit-content;
+  }
+
+  &__separator {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+  }
+}

--- a/admin/app/templates/authenticated/combined-course-creator.hbs
+++ b/admin/app/templates/authenticated/combined-course-creator.hbs
@@ -1,0 +1,1 @@
+<CombinedCourses::Form />


### PR DESCRIPTION
## 🔆 Problème

Actuellement, pour créer un parcours combiné, il faut uploader un fichier csv avec une parti contenant du json que l'on doit éditer à la main. Cela est fastidieux et source d'erreur.
## ⛱️ Proposition

On propose de mettre à disposition un petit éditeur qui permet d'ajouter des campagnes et des modules de manière simple
et qui exporte un json une fois l'édition du parcours terminée.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Se rendre sur la page https://admin-pr13655.review.pix.fr/combined-course-creator
