### PR TITLE
[BUGFIX] Coquille dans la modale de validation d'activation de fonctionnalité sur admin (PIX-19660)

### DIFF
--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -104,7 +104,7 @@
       "add-organization-features-in-batch": {
         "description": "Note: Chercher à activer à nouveau des fonctionnalités déjà existantes sur une organisation renverrait une erreur.",
         "notifications": {
-          "success": "Les fonctionnalités ont bien été activés."
+          "success": "Les fonctionnalités ont bien été activées."
         },
         "title": "Activation de fonctionnalités",
         "upload-button": "Importer un fichier CSV"


### PR DESCRIPTION
## 🔆 Problème

Petite faute d'orthographe qui trainait
<img width="703" height="347" alt="image" src="https://github.com/user-attachments/assets/3e57a45a-6f29-4181-9448-90ee594cd078" />



## ⛱️ Proposition



## 🌊 Remarques


## 🏄 Pour tester
Remplacer le message de validation par “Les fonctionnalités ont bien été activées.”


