### PR TITLE
[FEATURE] Mettre à jour l'appel à l'API prompt (PIX-19663)

### DIFF
--- a/api/src/llm/infrastructure/repositories/prompt-repository.js
+++ b/api/src/llm/infrastructure/repositories/prompt-repository.js
@@ -34,7 +34,13 @@ export async function prompt({ message, chat }) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        authorization: `Bearer ${jwt.sign('foo', config.llm.authSecret)}`,
+        authorization: `Bearer ${jwt.sign(
+          {
+            client_id: 'pix-api',
+            scope: 'api',
+          },
+          config.llm.authSecret,
+        )}`,
       },
       body: payload,
     });


### PR DESCRIPTION
## 🔆 Problème

Le token signé pour communiquer avec l'API de prompt du LLM n'est pas au format souhaité pour la nouvelle version.

## ⛱️ Proposition

Changer le token de `foo` à un couple `scope`, `client_id`.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Brancher la nouvelle API du LLM et vérifier que les épreuves ou modules utilisant le LLM sont fonctionnelles.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
