### PR TITLE
[FEATURE] Design combinix (PIX-19597)

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -4,12 +4,15 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
-import { eq, or } from 'ember-truth-helpers';
+import { and, eq } from 'ember-truth-helpers';
 import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 
 const Content = <template>
   <div
-    class="combined-course-item {{if (or @isCompleted @isLocked) 'combined-course-item--ended-locked-state'}}"
+    class="combined-course-item
+      {{if @hasYellowBorder 'combined-course-item--yellow-border'}}
+      {{if @hasWhiteBackground 'combined-course-item--white'}}
+      {{if @isCurrentItem 'combined-course-item--current'}}"
     ...attributes
   >
     <div class="combined-course-item__content">
@@ -37,9 +40,17 @@ const Content = <template>
       </div>
     {{/if}}
     {{#if @isCompleted}}
-      <div class="combined-course-item__indicator--completed">
+      <div
+        class="combined-course-item__indicator--completed
+          {{if @hasYellowBorder 'combined-course-item__indicator--yellow'}}"
+      >
         <span>{{t "pages.combined-courses.items.completed"}}</span>
-        <PixIcon @name="checkCircle" @plainIcon={{true}} class="combined-course-item__icon" @ariaHidden={{true}} />
+        <PixIcon
+          @name="checkCircle"
+          @plainIcon={{true}}
+          class="combined-course-item__icon {{if @hasYellowBorder 'combined-course-item__icon--yellow'}}"
+          @ariaHidden={{true}}
+        />
       </div>
 
     {{/if}}
@@ -55,6 +66,16 @@ const Duration = <template>
     }}{{@item.duration}}
     {{t "pages.combined-courses.items.durationUnit"}}</span>
 </template>;
+
+function hasWhiteBackground(item) {
+  if (!item.isCompleted && !item.isLocked) {
+    return true;
+  } else if (item.type === CombinedCourseItemTypes.MODULE && item.isCompleted) {
+    return true;
+  } else {
+    return false;
+  }
+}
 
 <template>
   {{#if (eq @item.type CombinedCourseItemTypes.FORMATION)}}
@@ -94,6 +115,9 @@ const Duration = <template>
           @isCompleted={{@item.isCompleted}}
           @iconUrl={{@item.iconUrl}}
           @displayDuration={{eq @item.type "MODULE"}}
+          @hasWhiteBackground={{hasWhiteBackground @item}}
+          @hasYellowBorder={{and (eq @item.type "MODULE") @isCombinedCourseCompleted}}
+          @isCurrentItem={{@isNextItemToComplete}}
         >
           <:duration>
             {{#if @item.duration}}
@@ -102,10 +126,10 @@ const Duration = <template>
           </:duration>
           <:blockEnd>
             {{#if @isNextItemToComplete}}
-              <PixTag @color="purple-light" @plainIcon={{true}} class="combined-course-item__current-item-tag">{{t
+              <PixTag @color="purple-light" class="combined-course-item__tag">{{t
                   "pages.combined-courses.items.tagText"
                 }}
-                <PixIcon @name="distance" @ariaHidden={{true}} /></PixTag>
+                <PixIcon @name="distance" @plainIcon={{true}} @ariaHidden={{true}} /></PixTag>
             {{/if}}
           </:blockEnd>
         </Content>

--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -88,6 +88,7 @@ export default class CombinedCourses extends Component {
           @isLocked={{item.isLocked}}
           @isNextItemToComplete={{eq @combinedCourse.nextCombinedCourseItem item}}
           @onClick={{if (eq @combinedCourse.status "NOT_STARTED") this.startQuestParticipation noop}}
+          @isCombinedCourseCompleted={{eq @combinedCourse.status "COMPLETED"}}
         />
       {{/each}}
     </section>

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -18,7 +18,7 @@
     margin-bottom: var(--pix-spacing-6x);
   }
 
-  &-completed {
+  &--completed {
     display: flex;
     gap: var(--pix-spacing-4x);
     align-items: center;
@@ -88,17 +88,20 @@
   justify-content: space-between;
   margin-bottom: var(--pix-spacing-4x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
-  background: var(--pix-neutral-0);
-  border: 6px solid var(--pix-primary-300);
+  background: rgb(var(--pix-primary-100-inline), 0.20);
+  border: 1px solid var(--pix-primary-100);
   border-radius: var(--pix-spacing-4x);
 
   &--formation {
     background: color-mix(in srgb, var(--pix-primary-100) 20%, transparent);
   }
 
-  &--ended-locked-state {
-  background: rgb(var(--pix-primary-100-inline), 0.20);
-  border: 1px solid var(--pix-primary-100);
+  &--yellow-border {
+    border: 6px solid var(--pix-secondary-500);
+  }
+
+  &--white {
+    background: var(--pix-neutral-0);
   }
 
   &__content {
@@ -150,26 +153,38 @@
       .combined-course-item__icon {
         width: var(--pix-spacing-8x);
         height: var(--pix-spacing-8x);
+
+        &--yellow {
+          color: var(--pix-secondary-500);
+        }
       }
+    }
+
+     &--yellow {
+      color: var(--pix-secondary-700);
     }
   }
 
-  &__current-item-tag {
-    display: flex;
-    gap: var(--pix-spacing-1x);
-    align-items: center;
-    padding: 6px var(--pix-spacing-4x);
-    background: var(--pix-tertiary-100);
-    border-radius: 50px;
-  }
+   &--current {
+      border: 6px solid var(--pix-primary-300);
+
+      .combined-course-item__tag {
+        display: flex;
+        gap: var(--pix-spacing-1x);
+        align-items: center;
+        padding: 6px var(--pix-spacing-4x);
+        background: var(--pix-tertiary-100);
+        border-radius: 50px;
+      }
+   }
+
 
   &__duration {
     display: inline-flex;
     gap: var(--pix-spacing-1x);
+    align-items:center;
 
     @extend %pix-body-s;
-
-    align-items:center;
 
     &__icon {
       width: 16px;


### PR DESCRIPTION
## 🔆 Problème
On veut pouvoir signaler visuellement à l'utilisateur qu'un module complété est repassable alors qu'une campagne de complétée ne l'est pas.
On veut aussi changer le visuel quand tout le parcours est terminé (voir maquettes).

## ⛱️ Proposition
On met le fond du bloc de la campagne de diagnostic en violet quand elle est terminée. Les modules terminés restent sur fond blanc.

## 🌊 Remarques
On en a profité pour rectifier un oubli et mettre un icône à plain.

## 🏄 Pour tester
Passer une campagne avec le compte attestation-blank@example.net et le code COMBINIX1.
Passer la campagne de diagnostic et vérifier que le fond du bloc devient violet après le passage.
Vérifier qu'un bloc de module complété reste avec un fond blanc.