### PR TITLE
[TECH] Supprimer le feature toggle useCookieLocaleInApi (PIX-19338)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -67,13 +67,6 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-acces'],
   },
-  useCookieLocaleInApi: {
-    type: 'boolean',
-    description: 'Enable usage of cookie locale in the API to get the user or challenge locales.',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['team-acces'],
-  },
   isSurveyEnabledForCombinedCourses: {
     type: 'boolean',
     description: 'Enables survey button at the end of the combined courses',

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,7 +18,6 @@
         "@getbrevo/brevo": "^3.0.0",
         "@graphql-yoga/redis-event-target": "^3.0.1",
         "@graphql-yoga/subscription": "^5.0.1",
-        "@hapi/accept": "^6.0.0",
         "@hapi/boom": "^10.0.1",
         "@hapi/hapi": "^21.0.0",
         "@hapi/inert": "^7.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,6 @@
     "@getbrevo/brevo": "^3.0.0",
     "@graphql-yoga/redis-event-target": "^3.0.1",
     "@graphql-yoga/subscription": "^5.0.1",
-    "@hapi/accept": "^6.0.0",
     "@hapi/boom": "^10.0.1",
     "@hapi/hapi": "^21.0.0",
     "@hapi/inert": "^7.0.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -531,6 +531,9 @@ LOG_FOR_HUMANS=true
 # Trace email sending in the mailer
 # DEBUG="pix:mailer:email"
 
+# Trace challenge locales
+# DEBUG="pix:challenge:locales"
+
 # ========
 # SECURITY
 # ========

--- a/api/src/certification/enrolment/application/attendance-sheet-controller.js
+++ b/api/src/certification/enrolment/application/attendance-sheet-controller.js
@@ -5,7 +5,7 @@ const getAttendanceSheet = async function (request, h) {
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
 
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const { attendanceSheet, fileName } = await usecases.getAttendanceSheet({ sessionId, userId, i18n });
   return h

--- a/api/src/certification/enrolment/application/enrolment-controller.js
+++ b/api/src/certification/enrolment/application/enrolment-controller.js
@@ -14,7 +14,7 @@ const enrolStudentsToSession = async function (request, h, dependencies = { enro
 };
 
 const getCandidatesImportSheet = async function (request, h, dependencies = { fillCandidatesImportSheet }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
@@ -40,7 +40,7 @@ const getCandidatesImportSheet = async function (request, h, dependencies = { fi
 };
 
 const importCertificationCandidatesFromCandidatesImportSheet = async function (request) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const odsBuffer = request.payload;

--- a/api/src/certification/enrolment/application/session-mass-import-controller.js
+++ b/api/src/certification/enrolment/application/session-mass-import-controller.js
@@ -17,7 +17,7 @@ const createSessions = async function (request, h) {
 };
 
 const validateSessions = async function (request, h, dependencies = { csvHelpers, csvSerializer }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const certificationCenterId = request.params.certificationCenterId;
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -12,7 +12,7 @@ import * as v3CertificationAttestationPdf from '../infrastructure/utils/pdf/gene
 import * as v2CertificationAttestationPdf from '../infrastructure/utils/pdf/generate-v2-pdf-certificate.js';
 
 const getCertificateByVerificationCode = async function (request, h, dependencies = { certificateSerializer }) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const i18n = await getI18nFromRequest(request);
 
   let certificate;
@@ -39,7 +39,7 @@ const getCertificate = async function (
   h,
   dependencies = { certificateSerializer, privateCertificateSerializer },
 ) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const i18n = await getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;

--- a/api/src/certification/results/application/certificate-controller.js
+++ b/api/src/certification/results/application/certificate-controller.js
@@ -13,7 +13,7 @@ import * as v2CertificationAttestationPdf from '../infrastructure/utils/pdf/gene
 
 const getCertificateByVerificationCode = async function (request, h, dependencies = { certificateSerializer }) {
   const locale = getChallengeLocale(request);
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   let certificate;
   const verificationCode = request.payload.verificationCode;
@@ -40,7 +40,7 @@ const getCertificate = async function (
   dependencies = { certificateSerializer, privateCertificateSerializer },
 ) {
   const locale = getChallengeLocale(request);
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;
 
@@ -63,7 +63,7 @@ const getCertificate = async function (
 };
 
 const findUserCertificates = async function (request) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const userId = request.auth.credentials.userId;
 
@@ -78,7 +78,7 @@ const getPDFCertificate = async function (
 ) {
   const certificationCourseId = request.params.certificationCourseId;
   const { isFrenchDomainExtension } = request.query;
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const certificate = await usecases.getCertificate({ certificationCourseId, locale: i18n.getLocale() });
 
@@ -117,7 +117,7 @@ const getSessionCertificates = async function (
   h,
   dependencies = { v2CertificationAttestationPdf, v3CertificationAttestationPdf },
 ) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const isFrenchDomainExtension = request.query.isFrenchDomainExtension;
@@ -159,7 +159,7 @@ const downloadDivisionCertificates = async function (
   h,
   dependencies = { v2CertificationAttestationPdf, v3CertificationAttestationPdf },
 ) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const { division, isFrenchDomainExtension } = request.query;

--- a/api/src/certification/results/application/certification-results-controller.js
+++ b/api/src/certification/results/application/certification-results-controller.js
@@ -33,7 +33,7 @@ const getSessionResultsByRecipientEmail = async function (
   h,
   dependencies = { getSessionCertificationResultsCsv },
 ) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const token = request.params.token;
 
@@ -55,7 +55,7 @@ const getSessionResultsByRecipientEmail = async function (
 };
 
 const postSessionResultsToDownload = async function (request, h, dependencies = { getSessionCertificationResultsCsv }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const { sessionId } = CertificationResultsLinkToken.decode(request.payload.token);
   const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
@@ -83,8 +83,8 @@ const getCertifiedProfile = async function (
   return dependencies.certifiedProfileSerializer.serialize(certifiedProfile);
 };
 
-const generateSessionResultsDownloadLink = async function (request, h, dependencies = { sessionResultsLinkService }) {
-  const i18n = await getI18nFromRequest(request);
+const generateSessionResultsDownloadLink = function (request, h, dependencies = { sessionResultsLinkService }) {
+  const i18n = getI18nFromRequest(request);
 
   const sessionId = request.params.sessionId;
   const sessionResultsLink = dependencies.sessionResultsLinkService.generateResultsLink({ sessionId, i18n });

--- a/api/src/certification/results/application/organization-controller.js
+++ b/api/src/certification/results/application/organization-controller.js
@@ -7,7 +7,7 @@ const downloadCertificationResults = async function (
   h,
   dependencies = { getDivisionCertificationResultsCsv },
 ) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const { division } = request.query;

--- a/api/src/certification/session-management/application/invigilator-kit-controller.js
+++ b/api/src/certification/session-management/application/invigilator-kit-controller.js
@@ -6,7 +6,7 @@ const getInvigilatorKitPdf = async function (request, h, dependencies = { invigi
   const sessionId = request.params.sessionId;
   const { userId } = request.auth.credentials;
 
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const sessionForInvigilatorKit = await usecases.getInvigilatorKitSessionInfo({ sessionId, userId });
 

--- a/api/src/certification/session-management/application/jury-certification-controller.js
+++ b/api/src/certification/session-management/application/jury-certification-controller.js
@@ -3,7 +3,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as juryCertificationSerializer from '../infrastructure/serializers/jury-certification-serializer.js';
 
 const getJuryCertification = async function (request, h, dependencies = { juryCertificationSerializer }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const certificationCourseId = request.params.certificationCourseId;
   const juryCertification = await usecases.getJuryCertification({ certificationCourseId });

--- a/api/src/certification/session-management/application/session-controller.js
+++ b/api/src/certification/session-management/application/session-controller.js
@@ -49,7 +49,7 @@ const getJuryCertificationSummaries = async function (
 ) {
   const { sessionId } = request.params;
   const { page } = request.query;
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const { juryCertificationSummaries, pagination } =
     await dependencies.juryCertificationSummaryRepository.findBySessionIdPaginated({

--- a/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
+++ b/api/src/devcomp/application/campaign-participations/campaign-participation-controller.js
@@ -5,7 +5,7 @@ import * as trainingSerializer from '../../infrastructure/serializers/jsonapi/tr
 const findTrainings = async function (request, h, dependencies = { trainingSerializer }) {
   const { userId } = request.auth.credentials;
   const { id: campaignParticipationId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const trainings = await devcompUsecases.findCampaignParticipationTrainings({
     userId,

--- a/api/src/devcomp/application/user-trainings/user-trainings-controller.js
+++ b/api/src/devcomp/application/user-trainings/user-trainings-controller.js
@@ -10,7 +10,7 @@ const findPaginatedUserRecommendedTrainings = async function (
     devcompUsecases,
   },
 ) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const { page } = request.query;
   const { userRecommendedTrainings, meta } = await dependencies.devcompUsecases.findPaginatedUserRecommendedTrainings({
     userId: request.auth.credentials.userId,

--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -12,7 +12,7 @@ import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/
 const save = async function (request, h, dependencies = { answerSerializer, assessmentRepository }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);
   const userId = extractUserIdFromRequest(request);
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const assessment = await dependencies.assessmentRepository.getWithAnswers(answer.assessmentId);
   let correctedAnswer;
   if (assessment.isCompetenceEvaluation()) {
@@ -83,7 +83,7 @@ const find = async function (request) {
 
 const getCorrection = async function (request, _h, dependencies = { correctionSerializer }) {
   const userId = extractUserIdFromRequest(request);
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const answerId = request.params.id;
 
   const correction = await evaluationUsecases.getCorrectionForAnswer({

--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -8,7 +8,7 @@ import { evaluationUsecases } from '../../domain/usecases/index.js';
 
 const completeAssessment = async function (request) {
   const assessmentId = request.params.id;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   await DomainTransaction.execute(async () => {
     const assessment = await evaluationUsecases.completeAssessment({ assessmentId, locale });

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -8,8 +8,8 @@ import { Scorecard } from '../../domain/models/Scorecard.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as scorecardSerializer from '../../infrastructure/serializers/jsonapi/scorecard-serializer.js';
 
-const getScorecard = async function (request, h, dependencies = { scorecardSerializer }) {
-  const locale = await getChallengeLocale(request);
+const getScorecard = function (request, h, dependencies = { scorecardSerializer }) {
+  const locale = getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -23,7 +23,7 @@ const getScorecard = async function (request, h, dependencies = { scorecardSeria
 };
 
 const findTutorials = async function (request, h, dependencies = { tutorialSerializer }) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
@@ -39,10 +39,10 @@ const findTutorials = async function (request, h, dependencies = { tutorialSeria
   return dependencies.tutorialSerializer.serialize(tutorials);
 };
 
-const resetScorecard = async function (request, h, dependencies = { scorecardSerializer }) {
+const resetScorecard = function (request, h, dependencies = { scorecardSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
   const competenceId = request.params.competenceId;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   return evaluationUsecases
     .resetScorecard({ userId: authenticatedUserId, competenceId, locale })

--- a/api/src/evaluation/application/scorecards/scorecard-controller.js
+++ b/api/src/evaluation/application/scorecards/scorecard-controller.js
@@ -27,7 +27,7 @@ const findTutorials = async function (request, h, dependencies = { tutorialSeria
   const authenticatedUserId = request.auth.credentials.userId;
   const scorecardId = request.params.id;
 
-  const { userId, competenceId } = await Scorecard.parseId(scorecardId);
+  const { userId, competenceId } = Scorecard.parseId(scorecardId);
   if (parseInt(authenticatedUserId) !== parseInt(userId)) {
     throw new UserNotAuthorizedToAccessEntityError();
   }

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -1,4 +1,8 @@
+import Debug from 'debug';
+
 import { AssessmentEndedError } from '../../../shared/domain/errors.js';
+
+const debugChallengeLocales = Debug('pix:challenge:locales');
 
 const getNextChallengeForCampaignAssessment = async function ({
   assessment,
@@ -24,6 +28,18 @@ const getNextChallengeForCampaignAssessment = async function ({
       campaignParticipationRepository,
       improvementService,
     });
+
+  debugChallengeLocales(
+    'wanted locale "%s", proposed challenges with locales: %O',
+    locale,
+    (challenges || []).map((challenge) => {
+      return {
+        challengeId: challenge.id,
+        challengeLocales: challenge.locales,
+      };
+    }),
+  );
+
   const algoResult = smartRandomService.getPossibleSkillsForNextChallenge({
     knowledgeElements,
     challenges,

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -135,7 +135,7 @@ const getUserAuthenticationMethods = async function (request, h, dependencies = 
  */
 const createUser = async function (request, h, dependencies = { userSerializer, localeService }) {
   const locale = getUserLocale(request);
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const redirectionUrl = request.payload.meta ? request.payload.meta['redirection-url'] : null;
   const user = dependencies.userSerializer.deserialize(request.payload);

--- a/api/src/learning-content/application/frameworks-controller.js
+++ b/api/src/learning-content/application/frameworks-controller.js
@@ -15,7 +15,7 @@ const getFrameworkAreas = async function (request, h, dependencies = { framework
 };
 
 const getPixFrameworkAreasWithoutThematics = async function (request, h, dependencies = { frameworkAreasSerializer }) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const areas = await usecases.getFrameworkAreas({ frameworkName: 'Pix', locale });
   return dependencies.frameworkAreasSerializer.serialize(areas, { withoutThematics: true });
 };

--- a/api/src/maddo/application/organizations-controller.js
+++ b/api/src/maddo/application/organizations-controller.js
@@ -8,7 +8,7 @@ export async function getOrganizations(request, h, dependencies = { findOrganiza
 
 export async function getOrganizationCampaigns(request, h, dependencies = { findCampaigns: usecases.findCampaigns }) {
   const { page } = request.query;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const requestedOrganizationId = request.params.organizationId;
   const result = await dependencies.findCampaigns({
     organizationId: requestedOrganizationId,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -40,7 +40,7 @@ const findPaginatedParticipationsForCampaignManagement = async function (request
 const getAnalysis = async function (request, h, dependencies = { campaignAnalysisSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignParticipationId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAnalysis = await usecases.computeCampaignParticipationAnalysis({
     userId,
@@ -53,7 +53,7 @@ const getAnalysis = async function (request, h, dependencies = { campaignAnalysi
 const getCampaignProfile = async function (request, h, dependencies = { campaignProfileSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const campaignProfile = await usecases.getCampaignProfile({ userId, campaignId, campaignParticipationId, locale });
   return dependencies.campaignProfileSerializer.serialize(campaignProfile);
@@ -104,7 +104,7 @@ const getCampaignAssessmentParticipationResult = async function (
 ) {
   const { userId } = request.auth.credentials;
   const { campaignId, campaignParticipationId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAssessmentParticipationResult = await usecases.getCampaignAssessmentParticipationResult({
     userId,
@@ -179,7 +179,7 @@ const getUserCampaignAssessmentResult = async function (
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const campaignAssessmentResult = await usecases.getUserCampaignAssessmentResult({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -68,7 +68,7 @@ const getSharedCampaignParticipationProfile = async function (
 ) {
   const authenticatedUserId = request.auth.credentials.userId;
   const campaignId = request.params.campaignId;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const sharedProfileForCampaign = await usecases.getSharedCampaignParticipationProfile({
     userId: authenticatedUserId,

--- a/api/src/prescription/campaign/application/campaign-controller.js
+++ b/api/src/prescription/campaign/application/campaign-controller.js
@@ -24,7 +24,7 @@ const getGroups = async function (request) {
 const getPresentationSteps = async function (request, _, dependencies = { presentationStepsSerializer }) {
   const { userId } = request.auth.credentials;
   const campaignCode = request.params.campaignCode;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const presentationSteps = await usecases.getPresentationSteps({ userId, campaignCode, locale });
   return dependencies.presentationStepsSerializer.serialize(presentationSteps);
@@ -36,7 +36,7 @@ const getLevelPerTubesAndCompetences = async function (
   dependencies = { campaignResultLevelsPerTubesAndCompetencesSerializer },
 ) {
   const { campaignId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const campaignAnalysis = await usecases.getResultLevelsPerTubesAndCompetences({
     campaignId,
     locale,

--- a/api/src/prescription/campaign/application/campaign-results-controller.js
+++ b/api/src/prescription/campaign/application/campaign-results-controller.js
@@ -44,7 +44,7 @@ const findProfilesCollectionParticipations = async function (request) {
 const getCollectiveResult = async function (request, h, dependencies = { campaignCollectiveResultSerializer }) {
   const { userId } = request.auth.credentials;
   const { campaignId } = request.params;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId, locale });
   return dependencies.campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -10,7 +10,7 @@ import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers
 const INVALID_FILE_EXTENSION_ERROR = 'INVALID_FILE_EXTENSION';
 
 const importOrganizationLearnersFromSIECLE = async function (request, h, dependencies = { logger }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const authenticatedUserId = request.auth.credentials.userId;
   const organizationId = request.params.id;

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -7,7 +7,7 @@ import { usecases } from '../domain/usecases/index.js';
 import { SupOrganizationLearnerParser } from '../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 
 const importSupOrganizationLearners = async function (request, h, dependencies = { logger, unlink: fs.unlink }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const userId = request.auth.credentials.userId;
@@ -37,7 +37,7 @@ const importSupOrganizationLearners = async function (request, h, dependencies =
 };
 
 const replaceSupOrganizationLearners = async function (request, h, dependencies = { logger, unlink: fs.unlink }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const userId = request.auth.credentials.userId;
   const organizationId = request.params.organizationId;
@@ -69,7 +69,7 @@ const replaceSupOrganizationLearners = async function (request, h, dependencies 
 };
 
 const getOrganizationLearnersCsvTemplate = async function (request, h, dependencies = { tokenService }) {
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const organizationId = request.params.organizationId;
   const token = request.query.accessToken;

--- a/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
+++ b/api/src/prescription/organization-learner/application/sco-organization-learner-controller.js
@@ -43,7 +43,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
 
 const createAndReconcileUserToOrganizationLearner = async function (request, h) {
   const locale = getUserLocale(request);
-  const i18n = await getI18nFromRequest(request);
+  const i18n = getI18nFromRequest(request);
 
   const payload = request.payload.data.attributes;
   const userAttributes = {

--- a/api/src/prescription/target-profile/application/target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/target-profile-controller.js
@@ -14,7 +14,7 @@ const getFrameworksForTargetProfileSubmission = async function (
   _,
   dependencies = { frameworkwithoutskillserializer },
 ) {
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const learningContent = await usecases.getLearningContentForTargetProfileSubmission({ locale });
   return dependencies.frameworkwithoutskillserializer.serialize(learningContent.frameworks);
 };

--- a/api/src/profile/application/profile-controller.js
+++ b/api/src/profile/application/profile-controller.js
@@ -2,18 +2,18 @@ import { getChallengeLocale } from '../../shared/infrastructure/utils/request-re
 import { usecases } from '../domain/usecases/index.js';
 import * as profileSerializer from '../infrastructure/serializers/jsonapi/profile-serializer.js';
 
-const getProfile = async function (request, h, dependencies = { profileSerializer }) {
+const getProfile = function (request, h, dependencies = { profileSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   return usecases
     .getUserProfile({ userId: authenticatedUserId, locale })
     .then(dependencies.profileSerializer.serialize);
 };
 
-const getProfileForAdmin = async function (request, h, dependencies = { profileSerializer }) {
+const getProfileForAdmin = function (request, h, dependencies = { profileSerializer }) {
   const userId = request.params.id;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
 
   return usecases.getUserProfile({ userId, locale }).then(dependencies.profileSerializer.serialize);
 };

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -22,7 +22,7 @@ const save = async function (request, h, dependencies = { assessmentRepository }
 
 const getAssessmentWithNextChallenge = async function (request) {
   const assessmentId = request.params.id;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const userId = extractUserIdFromRequest(request);
 
   const assessment = await DomainTransaction.execute(async () => {
@@ -59,7 +59,7 @@ const findCompetenceEvaluations = async function (request) {
 
 const autoValidateNextChallenge = async function (request, h) {
   const assessmentId = request.params.id;
-  const locale = await getChallengeLocale(request);
+  const locale = getChallengeLocale(request);
   const assessment = await sharedUsecases.getAssessment({ assessmentId, locale });
   const userId = assessment.userId;
   const fakeAnswer = new Answer({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -522,9 +522,9 @@ function _mapToHttpError(error) {
   return new HttpErrors.BaseHttpError(error.message);
 }
 
-async function handle(request, h, error) {
+function handle(request, h, error) {
   if (error instanceof SharedDomainErrors.EntityValidationError) {
-    const locale = await getChallengeLocale(request);
+    const locale = getChallengeLocale(request);
     const language = getBaseLocale(locale);
 
     const jsonApiError =

--- a/api/src/shared/application/healthcheck/healthcheck-controller.js
+++ b/api/src/shared/application/healthcheck/healthcheck-controller.js
@@ -8,8 +8,8 @@ import { getBaseLocale } from '../../domain/services/locale-service.js';
 import { redisMonitor } from '../../infrastructure/utils/redis-monitor.js';
 import { getChallengeLocale } from '../../infrastructure/utils/request-response-utils.js';
 
-const get = async function (request) {
-  const locale = await getChallengeLocale(request);
+const get = function (request) {
+  const locale = getChallengeLocale(request);
 
   return {
     name: packageJSON.name,

--- a/api/src/shared/infrastructure/i18n/i18n.js
+++ b/api/src/shared/infrastructure/i18n/i18n.js
@@ -69,8 +69,8 @@ export function getI18n(locale) {
  * @param {*} request HAPI request
  * @returns the i18n instance according the locale extracted from the request
  */
-export async function getI18nFromRequest(request) {
-  const locale = request.query?.lang || (await getChallengeLocale(request));
+export function getI18nFromRequest(request) {
+  const locale = request.query?.lang || getChallengeLocale(request);
   return getI18n(locale);
 }
 

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -1,17 +1,9 @@
-import accept from '@hapi/accept';
-
 import {
-  getChallengeLocales,
-  getDefaultChallengeLocale,
   getDefaultLocale,
   getNearestChallengeLocale,
   getNearestSupportedLocale,
 } from '../../../shared/domain/services/locale-service.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
-import { featureToggles } from '../feature-toggles/index.js';
-
-const acceptedLanguages = getChallengeLocales();
-const defaultChallengeLocale = getDefaultChallengeLocale();
 
 function extractTLDFromRequest(request) {
   const forwardedHost = request.headers['x-forwarded-host'];
@@ -67,22 +59,8 @@ function getUserLocale(request = {}) {
  * @returns {Promise<string>} - locale of a challenge (ie. fr-fr, fr, nl...)
  */
 async function getChallengeLocale(request) {
-  const useCookieLocaleInApi = await featureToggles.get('useCookieLocaleInApi');
-
-  if (!useCookieLocaleInApi) return _getLegacyChallengeLocale(request);
-
   const locale = request.query?.locale || request.query?.lang || request.state?.locale;
-
   return getNearestChallengeLocale(locale);
-}
-
-function _getLegacyChallengeLocale(request) {
-  const languageHeader = request.headers && request.headers['accept-language'];
-  if (!languageHeader) {
-    return defaultChallengeLocale;
-  }
-
-  return accept.language(languageHeader, acceptedLanguages) || defaultChallengeLocale;
 }
 
 function extractTimestampFromRequest(request) {

--- a/api/src/shared/infrastructure/utils/request-response-utils.js
+++ b/api/src/shared/infrastructure/utils/request-response-utils.js
@@ -56,9 +56,9 @@ function getUserLocale(request = {}) {
  * When no locale found, return the default challenge locale.
  *
  * @param {*} request - http request
- * @returns {Promise<string>} - locale of a challenge (ie. fr-fr, fr, nl...)
+ * @returns {string} - locale of a challenge (ie. fr-fr, fr, nl...)
  */
-async function getChallengeLocale(request) {
+function getChallengeLocale(request) {
   const locale = request.query?.locale || request.query?.lang || request.state?.locale;
   return getNearestChallengeLocale(locale);
 }

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -56,7 +56,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
       method: 'POST',
       url: `/api/users/${userId}/competences/${competenceId}/reset`,
       payload: {},
-      headers: { 'accept-language': 'fr-fr' },
+      headers: {},
     };
 
     const learningContent = [

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -6,6 +6,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   knex,
   learningContentBuilder,
 } from '../../../../../test-helper.js';
@@ -431,12 +432,14 @@ function _createRequestOptions(
       },
     },
   };
-  const options = {
+  const options = generateInjectOptions({
     method: 'POST',
     url: '/api/certification-courses',
-    headers: generateAuthenticatedUserRequestHeaders({ userId, acceptLanguage: locale }),
     payload,
-  };
+    locale,
+    audience: 'https://app.pix.fr',
+    authorizationData: { userId },
+  });
 
   return {
     options,

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/index_test.js
@@ -3,6 +3,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   knex,
   learningContentBuilder,
   mockLearningContent,
@@ -238,19 +239,23 @@ describe('Acceptance | Route | Certification Courses', function () {
         await databaseBuilder.commit();
 
         // when
-        await server.inject({
-          headers: generateAuthenticatedUserRequestHeaders({ userId: 1, acceptLanguage: 'FR' }),
-          method: 'POST',
-          payload: {
-            data: {
-              attributes: {
-                'access-code': 'FMKP39',
-                'session-id': 2,
+        await server.inject(
+          generateInjectOptions({
+            method: 'POST',
+            url: `/api/certification-courses`,
+            payload: {
+              data: {
+                attributes: {
+                  'access-code': 'FMKP39',
+                  'session-id': 2,
+                },
               },
             },
-          },
-          url: `/api/certification-courses`,
-        });
+            locale: 'fr',
+            audience: 'https://app.pix.fr',
+            authorizationData: { userId: 1 },
+          }),
+        );
 
         // then
         const certificationCourse = await knex('certification-courses').select().where({ userId: 1 });

--- a/api/tests/certification/results/unit/application/certificate-controller_test.js
+++ b/api/tests/certification/results/unit/application/certificate-controller_test.js
@@ -13,7 +13,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
       it('should return serialized V3 certificate data', async function () {
         // given
         const locale = 'fr-fr';
-        const request = { payload: { verificationCode: 'P-123456BB' }, headers: { 'accept-language': locale } };
+        const request = { payload: { verificationCode: 'P-123456BB' } };
 
         const certificateSerializerStub = { serialize: sinon.stub() };
 
@@ -49,7 +49,7 @@ describe('Certification | Results | Unit | Application | certificate-controller'
       it('should return a serialized shareable certificate given by verification code', async function () {
         // given
         const locale = 'fr-fr';
-        const request = { payload: { verificationCode: 'P-123456BB' }, headers: { 'accept-language': locale } };
+        const request = { payload: { verificationCode: 'P-123456BB' } };
         const certificateSerializerStub = { serialize: sinon.stub() };
         sinon.stub(usecases, 'getShareableCertificate');
         sinon.stub(usecases, 'getCertificationCourseByVerificationCode');
@@ -88,7 +88,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const request = {
           auth: { credentials: { userId } },
           params: { certificationCourseId },
-          headers: { 'accept-language': locale },
         };
         const certificationCourse = domainBuilder.buildCertificationCourse({
           id: certificationCourseId,
@@ -128,7 +127,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
         const request = {
           auth: { credentials: { userId } },
           params: { certificationCourseId },
-          headers: { 'accept-language': locale },
         };
 
         const certificationCourse = domainBuilder.buildCertificationCourse({
@@ -286,7 +284,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           auth: { credentials: { userId } },
           params: { certificationCourseId: 9 },
           query: { isFrenchDomainExtension: true, lang: 'fr' },
-          headers: { 'accept-language': 'fr' },
         };
 
         const certificationCourse = domainBuilder.buildCertificationCourse({
@@ -343,7 +340,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           auth: { credentials: { userId } },
           params: { sessionId: session.id },
           query: { isFrenchDomainExtension: true },
-          headers: { 'accept-language': 'fr' },
         };
 
         sinon
@@ -406,7 +402,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           auth: { credentials: { userId } },
           params: { sessionId: session.id },
           query: { isFrenchDomainExtension: true },
-          headers: { 'accept-language': 'fr' },
         };
 
         sinon
@@ -469,7 +464,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           auth: { credentials: { userId } },
           params: { organizationId },
           query: { division, isFrenchDomainExtension: true, lang: 'fr' },
-          headers: { 'accept-language': 'fr' },
         };
 
         sinon
@@ -519,7 +513,6 @@ describe('Certification | Results | Unit | Application | certificate-controller'
           auth: { credentials: { userId } },
           params: { organizationId },
           query: { division, isFrenchDomainExtension: true, lang },
-          headers: { 'accept-language': 'fr' },
         };
 
         sinon

--- a/api/tests/certification/session-management/unit/application/invigilator-kit-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/invigilator-kit-controller_test.js
@@ -15,12 +15,13 @@ describe('Certification | Session Management | Unit | Application | Controller |
         const sessionMainInfo = domainBuilder.certification.sessionManagement.buildSession({ id: 1 });
         const invigilatorKitBuffer = 'binary string';
         const userId = 1;
-        const i18n = getI18n(lang);
+        const locale = lang;
+        const i18n = getI18n(locale);
         const request = {
           i18n,
           auth: { credentials: { userId } },
           params: { sessionId: sessionMainInfo.id },
-          headers: { 'accept-language': lang },
+          state: { locale },
         };
 
         const invigilatorKitPdf = {

--- a/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
+++ b/api/tests/devcomp/unit/application/user-trainings/user-trainings-controller_test.js
@@ -10,8 +10,8 @@ describe('Unit | Controller | user-trainings-controller', function () {
       const locale = 'fr';
       const request = {
         auth: { credentials: { userId: 1 } },
+        state: { locale },
         query: { page },
-        headers: { 'accept-language': locale },
       };
       const expectedResult = Symbol('serialized-trainings');
       const userRecommendedTrainings = Symbol('userRecommendedTrainings');

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -184,7 +184,11 @@ describe('Acceptance | Controller | answer-controller-save', function () {
             competenceId: competenceId,
           });
           await databaseBuilder.commit();
-          postAnswersOptions.headers['accept-language'] = testCase.locale;
+
+          postAnswersOptions.headers = generateAuthenticatedUserRequestHeaders({
+            userId,
+            locale: testCase.locale,
+          });
 
           // when
           const response = await server.inject(postAnswersOptions);

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -68,7 +68,8 @@ describe('Unit | Controller | answer-controller', function () {
 
     beforeEach(function () {
       request = {
-        headers: generateAuthenticatedUserRequestHeaders({ userId, acceptLanguage: locale }),
+        state: { locale },
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
         payload: {
           data: {
             attributes: {
@@ -295,7 +296,8 @@ describe('Unit | Controller | answer-controller', function () {
           // given
           await featureToggles.set('isQuestEnabled', true);
           await featureToggles.set('isAsyncQuestRewardingCalculationEnabled', false);
-          request.headers = { 'accept-language': locale }; // userId is not provided
+          // Setting headers so that userId is not provided
+          request.headers = {};
 
           // when
           await answerController.save(request, hFake, {
@@ -330,7 +332,8 @@ describe('Unit | Controller | answer-controller', function () {
       const response = await answerController.getCorrection(
         {
           params: { id: answerId },
-          headers: generateAuthenticatedUserRequestHeaders({ userId, acceptLanguage: locale }),
+          state: { locale },
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
         },
         hFake,
         { correctionSerializer: correctionSerializerStub },

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -38,7 +38,7 @@ describe('Unit | Controller | scorecard-controller', function () {
         params: {
           id: scorecardId,
         },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when
@@ -74,7 +74,7 @@ describe('Unit | Controller | scorecard-controller', function () {
         params: {
           id: scorecardId,
         },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when

--- a/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/evaluation/unit/application/scorecards/scorecard-controller_test.js
@@ -60,7 +60,7 @@ describe('Unit | Controller | scorecard-controller', function () {
         .stub(devCompUsecases, 'findTutorials')
         .withArgs({ userId: authenticatedUserId, competenceId, locale })
         .resolves(tutorials);
-      sinon.stub(Scorecard, 'parseId').withArgs(scorecardId).resolves(scorecard);
+      sinon.stub(Scorecard, 'parseId').withArgs(scorecardId).returns(scorecard);
       const tutorialSerializer = {
         serialize: sinon.stub(),
       };

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -362,7 +362,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
         method: 'POST',
         url: '/api/oidc/users',
         headers: {
-          'accept-language': 'fr',
           cookie: 'locale=fr-FR',
           'x-forwarded-proto': 'https',
           'x-forwarded-host': 'app.pix.fr',

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -1,7 +1,7 @@
 import querystring from 'node:querystring';
 
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import { createServer, databaseBuilder, expect, knex } from '../../../test-helper.js';
+import { createServer, databaseBuilder, expect, generateInjectOptions, knex } from '../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;
 import { UserAccessToken } from '../../../../src/identity-access-management/domain/models/UserAccessToken.js';
@@ -35,10 +35,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
     it('returns a 200 with an access token and a refresh token when authentication is ok', async function () {
       // given
-      const options = _getPostFormOptions({
+      const options = generateInjectOptions({
         url: '/api/token',
-        dataToPost: { grant_type: 'password', username: userEmailAddress, password: userPassword },
-        applicationName: 'orga',
+        method: 'POST',
+        payload: { grant_type: 'password', username: userEmailAddress, password: userPassword },
+        urlEncodePayload: true,
+        audience: 'https://orga.pix.fr',
       });
 
       // when
@@ -66,10 +68,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
 
       await databaseBuilder.commit();
 
-      const options = _getPostFormOptions({
+      const options = generateInjectOptions({
         url: '/api/token',
-        dataToPost: { grant_type: 'password', username: 'beth.rave1212', password: userPassword },
-        applicationName: 'orga',
+        method: 'POST',
+        payload: { grant_type: 'password', username: 'beth.rave1212', password: userPassword },
+        urlEncodePayload: true,
+        audience: 'https://orga.pix.fr',
       });
 
       // when
@@ -84,24 +88,28 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     context('when user needs to refresh his access token', function () {
       it('returns a 200 with a new access token', async function () {
         // given
-        const optionsForAccessToken = _getPostFormOptions({
+        const optionsForAccessToken = generateInjectOptions({
           url: '/api/token',
-          dataToPost: {
+          method: 'POST',
+          payload: {
             grant_type: 'password',
             username: userEmailAddress,
             password: userPassword,
           },
-          applicationName: 'orga',
+          urlEncodePayload: true,
+          audience: 'https://orga.pix.fr',
         });
         const { result: accessTokenResult } = await server.inject(optionsForAccessToken);
 
-        const options = _getPostFormOptions({
+        const options = generateInjectOptions({
           url: '/api/token',
-          dataToPost: {
+          method: 'POST',
+          payload: {
             grant_type: 'refresh_token',
             refresh_token: accessTokenResult.refresh_token,
           },
-          applicationName: 'orga',
+          urlEncodePayload: true,
+          audience: 'https://orga.pix.fr',
         });
 
         // when
@@ -135,10 +143,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: { grant_type: 'password', username: user.email, password: userPassword },
-            applicationName: 'admin',
+            method: 'POST',
+            payload: { grant_type: 'password', username: user.email, password: userPassword },
+            urlEncodePayload: true,
+            audience: 'https://admin.pix.fr',
           });
 
           // when
@@ -160,10 +170,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
         await databaseBuilder.commit();
 
-        const options = _getPostFormOptions({
+        const options = generateInjectOptions({
           url: '/api/token',
-          dataToPost: { grant_type: 'password', username: userEmailAddress, password: userPassword },
-          applicationName: 'certif',
+          method: 'POST',
+          payload: { grant_type: 'password', username: userEmailAddress, password: userPassword },
+          urlEncodePayload: true,
+          audience: 'https://certif.pix.fr',
         });
 
         // when
@@ -194,10 +206,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           databaseBuilder.factory.buildUserLogin({ userId, failureCount: 9 });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: 'wrongPassword' },
-            applicationName: 'app',
+            method: 'POST',
+            payload: { grant_type: 'password', username: 'email@without.mb', password: 'wrongPassword' },
+            urlEncodePayload: true,
+            audience: 'https://app.pix.fr',
           });
 
           // when
@@ -226,10 +240,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
-            applicationName: 'app',
+            method: 'POST',
+            payload: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
+            urlEncodePayload: true,
+            audience: 'https://app.pix.fr',
           });
 
           // when
@@ -255,10 +271,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
-            applicationName: 'app',
+            method: 'POST',
+            payload: { grant_type: 'password', username: 'email@without.mb', password: userPassword },
+            urlEncodePayload: true,
+            audience: 'https://app.pix.fr',
           });
 
           // when
@@ -286,10 +304,12 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: { grant_type: 'password', username: userWithoutLocale.email, password: userPassword },
-            applicationName: 'app',
+            method: 'POST',
+            payload: { grant_type: 'password', username: userWithoutLocale.email, password: userPassword },
+            urlEncodePayload: true,
+            audience: 'https://app.pix.fr',
             locale,
           });
 
@@ -319,14 +339,16 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
           });
           await databaseBuilder.commit();
 
-          const options = _getPostFormOptions({
+          const options = generateInjectOptions({
             url: '/api/token',
-            dataToPost: {
+            method: 'POST',
+            payload: {
               grant_type: 'password',
               username: userWithLocale.email,
               password: userPassword,
             },
-            applicationName: 'app',
+            urlEncodePayload: true,
+            audience: 'https://app.pix.fr',
             locale,
           });
 
@@ -355,13 +377,15 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         databaseBuilder.factory.buildCampaign({ code: campaignCode, targetProfile });
         await databaseBuilder.commit();
 
-        options = _getPostFormOptions({
+        options = generateInjectOptions({
           url: '/api/token/anonymous',
-          dataToPost: {
+          method: 'POST',
+          payload: {
             campaign_code: campaignCode,
             lang,
           },
-          applicationName: 'app',
+          urlEncodePayload: true,
+          audience: 'https://app.pix.fr',
         });
       });
 
@@ -387,13 +411,15 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         databaseBuilder.factory.buildCampaign({ code: simplifiedAccessCampaignCode, targetProfileId });
         await databaseBuilder.commit();
 
-        options = _getPostFormOptions({
+        options = generateInjectOptions({
           url: '/api/token/anonymous',
-          dataToPost: {
+          method: 'POST',
+          payload: {
             campaign_code: simplifiedAccessCampaignCode,
             lang,
           },
-          applicationName: 'app',
+          urlEncodePayload: true,
+          audience: 'https://app.pix.fr',
         });
       });
 
@@ -609,17 +635,3 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
     });
   });
 });
-
-function _getPostFormOptions({ url, dataToPost, applicationName, locale }) {
-  return {
-    method: 'POST',
-    url,
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      'x-forwarded-proto': 'https',
-      'x-forwarded-host': `${applicationName}.pix.fr`,
-      ...(locale && { cookie: `locale=${locale}` }),
-    },
-    payload: querystring.stringify(dataToPost),
-  };
-}

--- a/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.route.test.js
@@ -14,6 +14,7 @@ import {
   domainBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   knex,
   sinon,
 } from '../../../../test-helper.js';
@@ -113,12 +114,9 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
           password: 'Password123',
         };
 
-        const options = {
-          method: 'POST',
+        const options = generateInjectOptions({
           url: '/api/users',
-          headers: {
-            cookie: `locale=${locale}`,
-          },
+          method: 'POST',
           payload: {
             data: {
               type: 'users',
@@ -126,7 +124,8 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
               relationships: {},
             },
           },
-        };
+          locale,
+        });
 
         // when
         const response = await server.inject(options);

--- a/api/tests/identity-access-management/integration/application/password/password.route.test.js
+++ b/api/tests/identity-access-management/integration/application/password/password.route.test.js
@@ -15,9 +15,7 @@ describe('Integration | Identity Access Management | Application | Route | passw
   describe('POST /api/password-reset-demands', function () {
     const method = 'POST';
     const url = '/api/password-reset-demands';
-    const headers = {
-      'accept-language': 'fr',
-    };
+    const headers = {};
     const payload = {
       data: {
         type: 'password-reset-demands',

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -125,7 +125,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       const request = {
         deserializedPayload: { identityProvider: 'OIDC', authenticationKey: 'abcde' },
         headers: {
-          'accept-language': 'fr',
           'x-forwarded-proto': 'https',
           'x-forwarded-host': 'app.pix.fr',
         },
@@ -255,7 +254,6 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         // given
         const request = {
           headers: {
-            'accept-language': 'fr',
             'x-forwarded-proto': 'https',
             'x-forwarded-host': 'app.pix.fr',
           },

--- a/api/tests/identity-access-management/unit/application/user/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user/user.controller.test.js
@@ -299,7 +299,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
     const lastName = 'Doe';
     const password = 'P@ssW0rd';
     const anonymousUserToken = 'anonymous-token';
-    const language = 'fr';
     const locale = 'fr-FR';
     const userId = 1;
 
@@ -340,7 +339,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
               },
             },
           },
-          headers: { 'accept-language': language },
         },
         hFake,
         dependencies,

--- a/api/tests/learning-content/unit/application/frameworks-controller_test.js
+++ b/api/tests/learning-content/unit/application/frameworks-controller_test.js
@@ -59,10 +59,9 @@ describe('Unit | Controller | frameworks-controller', function () {
   describe('#getPixFrameworkAreasWithoutThematics', function () {
     it('should fetch and return framework, serialized as JSONAPI', async function () {
       // given
+      const locale = 'en';
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        state: { locale },
       };
 
       // when

--- a/api/tests/maddo/application/acceptance/organizations-routes_test.js
+++ b/api/tests/maddo/application/acceptance/organizations-routes_test.js
@@ -282,6 +282,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
     context('language negociation', function () {
       it('should return translated tube title and description', async function () {
         // given
+        const locale = 'en';
         const targetProfile = databaseBuilder.factory.buildTargetProfile();
         const campaignInJurisdiction = databaseBuilder.factory.buildCampaign({
           organizationId: orgaInJurisdiction.id,
@@ -320,7 +321,7 @@ describe('Acceptance | Maddo | Route | Organizations', function () {
           url: `/api/organizations/${orgaInJurisdiction.id}/campaigns?page[number]=1&page[size]=1`,
           headers: {
             authorization: generateValidRequestAuthorizationHeaderForApplication(clientId, 'pix-client', 'campaigns'),
-            'accept-language': 'en',
+            cookie: `locale=${locale}`,
           },
         };
 

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -161,7 +161,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { campaignId, campaignParticipationId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
       const h = Symbol('h');
 
@@ -206,7 +206,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { campaignId, campaignParticipationId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
       const h = Symbol('h');
 
@@ -246,7 +246,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { campaignParticipationId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
       const h = Symbol('h');
 
@@ -350,7 +350,7 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { campaignId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
       const dependencies = {
         participantResultSerializer: { serialize: sinon.stub() },

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -238,7 +238,7 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
       request = {
         params: { campaignId },
         auth: { credentials: { userId } },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
     });
 

--- a/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-controller_test.js
@@ -28,7 +28,7 @@ describe('Unit | Application | Controller | Campaign', function () {
       const request = {
         auth: { credentials: { userId } },
         params: { campaignCode },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when
@@ -64,7 +64,7 @@ describe('Unit | Application | Controller | Campaign', function () {
 
       const request = {
         params: { campaignId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -15,7 +15,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
       const locale = FRENCH_SPOKEN;
       const request = {
         query: { filter: { code } },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
       dependencies = {
         campaignToJoinSerializer: { serialize: sinon.stub() },

--- a/api/tests/prescription/campaign/unit/application/campaign-results-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-results-controller_test.js
@@ -30,7 +30,7 @@ describe('Unit | Application | Controller | Campaign Results', function () {
       const request = {
         auth: { credentials: { userId } },
         params: { campaignId },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when
@@ -66,7 +66,6 @@ describe('Unit | Application | Controller | Campaign Results', function () {
   describe('#findAssessmentParticipationResults', function () {
     const campaignId = 1;
     const userId = 1;
-    const locale = FRENCH_SPOKEN;
     let campaignAssessmentResultMinimalSerializer;
     let pageSymbol, filterSymbol, resultSymbol, serializerResponseSymbol;
 
@@ -98,7 +97,6 @@ describe('Unit | Application | Controller | Campaign Results', function () {
           page: pageSymbol,
           filter: filterSymbol,
         },
-        headers: { 'accept-language': locale },
       };
 
       // when

--- a/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/target-profile-controller_test.js
@@ -52,8 +52,9 @@ describe('Unit | Application | Target Profile | target-profile-controller', func
 
     it('should fetch and return frameworks, serialized as JSONAPI', async function () {
       // given
+      const locale = 'en';
       const request = {
-        headers: { 'accept-language': 'en' },
+        state: { locale },
       };
 
       // when

--- a/api/tests/profile/unit/application/attestation-controller_test.js
+++ b/api/tests/profile/unit/application/attestation-controller_test.js
@@ -18,7 +18,6 @@ describe('Profile | Unit | Controller | attestation-controller', function () {
           userId,
           attestationKey,
         },
-        headers: { 'accept-language': locale },
       };
       sinon.stub(hFake, 'response');
       hFake.response.callThrough();

--- a/api/tests/profile/unit/application/profile-controller_test.js
+++ b/api/tests/profile/unit/application/profile-controller_test.js
@@ -27,7 +27,7 @@ describe('Profile | Unit | Controller | profile-controller', function () {
         params: {
           id: userId,
         },
-        headers: { 'accept-language': locale },
+        state: { locale },
       };
 
       // when

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -46,9 +46,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
     it('should translate EntityValidationError', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        state: { locale: 'en' },
       };
       const error = new EntityValidationError({
         invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
@@ -89,9 +87,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
     it('should translate EntityValidationError to french', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'fr-fr',
-        },
+        state: { locale: 'fr-fr' },
       };
       const error = new EntityValidationError({
         invalidAttributes: [{ attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' }],
@@ -119,9 +115,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
     it('should fallback to the message if the translation is not found', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        state: { locale: 'en' },
       };
       const error = new EntityValidationError({
         invalidAttributes: [{ attribute: 'name', message: 'message' }],
@@ -149,9 +143,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
     it('should fallback to the message if the translation is not found with special chars', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        state: { locale: 'en' },
       };
       const error = new EntityValidationError({
         invalidAttributes: [{ attribute: 'name', message: 'special-:{%}/_chars' }],
@@ -179,9 +171,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
     it('should translate EntityValidationError even if invalidAttributes is undefined', async function () {
       // given
       const request = {
-        headers: {
-          'accept-language': 'en',
-        },
+        state: { locale: 'en' },
       };
       const error = new EntityValidationError({
         invalidAttributes: undefined,

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -53,7 +53,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
 
       // when
-      const response = await handle(request, hFake, error);
+      const response = handle(request, hFake, error);
 
       // then
       expect(response.statusCode).to.equal(422);
@@ -78,7 +78,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message);
@@ -94,7 +94,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
 
       // when
-      const response = await handle(request, hFake, error);
+      const response = handle(request, hFake, error);
 
       // then
       expect(response.statusCode).to.equal(422);
@@ -122,7 +122,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
 
       // when
-      const response = await handle(request, hFake, error);
+      const response = handle(request, hFake, error);
 
       // then
       expect(response.statusCode).to.equal(422);
@@ -150,7 +150,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
 
       // when
-      const response = await handle(request, hFake, error);
+      const response = handle(request, hFake, error);
 
       // then
       expect(response.statusCode).to.equal(422);
@@ -178,7 +178,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       });
 
       // when
-      const response = await handle(request, hFake, error);
+      const response = handle(request, hFake, error);
 
       // then
       expect(response.statusCode).to.equal(422);
@@ -198,7 +198,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.NotFoundError).to.have.been.calledWithExactly(error.message);
@@ -211,7 +211,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
@@ -224,7 +224,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(
@@ -239,7 +239,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
@@ -252,7 +252,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
@@ -266,7 +266,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
@@ -284,7 +284,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message);
@@ -297,7 +297,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message, error.code);
@@ -310,7 +310,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly('Aucun certificat pour la classe 1.');
@@ -323,7 +323,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BaseHttpError).to.have.been.calledOnce;
@@ -336,7 +336,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
@@ -350,7 +350,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(
@@ -369,7 +369,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message, error.code, error.meta);
@@ -408,7 +408,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
@@ -421,7 +421,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(error.message);
@@ -434,7 +434,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
         const params = { request: {}, h: hFake, error };
 
         // when
-        await handle(params.request, params.h, params.error);
+        handle(params.request, params.h, params.error);
 
         // then
         expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
@@ -455,7 +455,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message, error.code, error.meta);
@@ -468,7 +468,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
@@ -481,7 +481,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
@@ -494,7 +494,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(error.message);
@@ -507,7 +507,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
@@ -520,7 +520,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.UnauthorizedError).to.have.been.calledWithExactly(error.message);
@@ -533,7 +533,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.PreconditionFailedError).to.have.been.called;
@@ -546,7 +546,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
@@ -559,7 +559,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
@@ -572,7 +572,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
@@ -587,7 +587,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code, error.meta);
@@ -600,7 +600,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
@@ -613,7 +613,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
@@ -626,7 +626,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
@@ -639,7 +639,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
@@ -652,7 +652,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
@@ -665,7 +665,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
@@ -681,7 +681,7 @@ describe('Shared | Unit | Application | ErrorManager', function () {
       const params = { request: {}, h: hFake, error };
 
       // when
-      await handle(params.request, params.h, params.error);
+      handle(params.request, params.h, params.error);
 
       // then
       expect(HttpErrors.NotFoundError).to.have.been.calledWithExactly(error.message, error.code);

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -1,5 +1,4 @@
 import { getDefaultLocale } from '../../../../../src/shared/domain/services/locale-service.js';
-import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import {
   escapeFileName,
   extractTimestampFromRequest,
@@ -172,84 +171,37 @@ describe('Unit | Utils | Request Utils', function () {
   });
 
   describe('#getChallengeLocale', function () {
-    context('When feature toggle useCookieLocaleInApi is disabled, it uses the accept-language header', function () {
-      beforeEach(async function () {
-        await featureToggles.set('useCookieLocaleInApi', false);
-      });
+    it('returns fr-fr locale when there is no header (to ensure retro-compat)', async function () {
+      // given
+      const request = {};
 
-      it('should return fr-fr locale when there is no header (to ensure retro-compat)', async function () {
+      // when
+      const locale = await getChallengeLocale(request);
+
+      // then
+      expect(locale).to.equal('fr-fr');
+    });
+
+    [
+      { userLocale: 'fr-FR', challengeLocale: 'fr-fr' },
+      { userLocale: 'fr', challengeLocale: 'fr' },
+      { userLocale: 'en', challengeLocale: 'en' },
+      { userLocale: 'en-US', challengeLocale: 'en' },
+      { userLocale: 'fr-BE', challengeLocale: 'fr' },
+      { userLocale: 'nl-BE', challengeLocale: 'nl' },
+      { userLocale: 'tlh', challengeLocale: 'fr-fr' }, // tlh: Klingon locale not found, so returns default locale
+    ].forEach(function ({ userLocale, challengeLocale }) {
+      it(`returns ${challengeLocale} when user locale is ${userLocale}`, async function () {
         // given
-        const request = {};
+        const request = { state: { locale: userLocale } };
 
         // when
         const locale = await getChallengeLocale(request);
 
         // then
-        expect(locale).to.equal('fr-fr');
-      });
-
-      [
-        { header: 'fr-FR', expectedLocale: 'fr-fr' },
-        { header: 'fr', expectedLocale: 'fr' },
-        { header: 'en', expectedLocale: 'en' },
-        { header: 'tlh', expectedLocale: 'fr-fr' }, // tlh: Klingon locale not found, so returns default locale
-        { header: 'fr-BE', expectedLocale: 'fr-fr' }, // fr-BE not found, so returns default locale
-      ].forEach(function (data) {
-        it(`should return ${data.expectedLocale} locale when header is ${data.header}`, async function () {
-          // given
-          const request = {
-            headers: { 'accept-language': data.header },
-          };
-
-          // when
-          const locale = await getChallengeLocale(request);
-
-          // then
-          expect(locale).to.equal(data.expectedLocale);
-        });
+        expect(locale).to.equal(challengeLocale);
       });
     });
-
-    context(
-      'When feature toggle useCookieLocaleInApi is enabled, it uses the user locale from the cookie',
-      function () {
-        beforeEach(async function () {
-          await featureToggles.set('useCookieLocaleInApi', true);
-        });
-
-        it('should return fr-fr locale when there is no header (to ensure retro-compat)', async function () {
-          // given
-          const request = {};
-
-          // when
-          const locale = await getChallengeLocale(request);
-
-          // then
-          expect(locale).to.equal('fr-fr');
-        });
-
-        [
-          { userLocale: 'fr-FR', challengeLocale: 'fr-fr' },
-          { userLocale: 'fr', challengeLocale: 'fr' },
-          { userLocale: 'en', challengeLocale: 'en' },
-          { userLocale: 'en-US', challengeLocale: 'en' },
-          { userLocale: 'fr-BE', challengeLocale: 'fr' },
-          { userLocale: 'nl-BE', challengeLocale: 'nl' },
-          { userLocale: 'tlh', challengeLocale: 'fr-fr' }, // tlh: Klingon locale not found, so returns default locale
-        ].forEach(function ({ userLocale, challengeLocale }) {
-          it(`should return ${challengeLocale} when user locale is ${userLocale}`, async function () {
-            // given
-            const request = { state: { locale: userLocale } };
-
-            // when
-            const locale = await getChallengeLocale(request);
-
-            // then
-            expect(locale).to.equal(challengeLocale);
-          });
-        });
-      },
-    );
   });
 
   describe('#extractTimestampFromRequest', function () {

--- a/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/request-response-utils_test.js
@@ -171,12 +171,12 @@ describe('Unit | Utils | Request Utils', function () {
   });
 
   describe('#getChallengeLocale', function () {
-    it('returns fr-fr locale when there is no header (to ensure retro-compat)', async function () {
+    it('returns fr-fr locale when there is no header (to ensure retro-compat)', function () {
       // given
       const request = {};
 
       // when
-      const locale = await getChallengeLocale(request);
+      const locale = getChallengeLocale(request);
 
       // then
       expect(locale).to.equal('fr-fr');
@@ -196,7 +196,7 @@ describe('Unit | Utils | Request Utils', function () {
         const request = { state: { locale: userLocale } };
 
         // when
-        const locale = await getChallengeLocale(request);
+        const locale = getChallengeLocale(request);
 
         // then
         expect(locale).to.equal(challengeLocale);

--- a/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/certification-center-invitation/certification-center-invitation.route.test.js
@@ -4,6 +4,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   knex,
 } from '../../../../test-helper.js';
 
@@ -56,10 +57,9 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
 
         await databaseBuilder.commit();
 
-        request = {
-          headers: generateAuthenticatedUserRequestHeaders({ userId, locale }),
-          method: 'POST',
+        const options = generateInjectOptions({
           url: `/api/certification-centers/${certificationCenterId}/invitations`,
+          method: 'POST',
           payload: {
             data: {
               attributes: {
@@ -67,10 +67,13 @@ describe('Acceptance | Team | Application | Route | Certification Center Invitat
               },
             },
           },
-        };
+          locale,
+          audience: 'https://certif.pix.fr',
+          authorizationData: { userId },
+        });
 
         // when
-        const response = await server.inject(request);
+        const response = await server.inject(options);
 
         // then
         const certificationCenterInvitations = await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME)

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -7,6 +7,7 @@ import {
   databaseBuilder,
   expect,
   generateAuthenticatedUserRequestHeaders,
+  generateInjectOptions,
   insertOrganizationUserWithRoleAdmin,
   knex,
   sinon,
@@ -426,10 +427,9 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
       user2 = databaseBuilder.factory.buildUser();
       const locale = 'fr-FR';
 
-      options = {
-        method: 'POST',
+      options = generateInjectOptions({
         url: `/api/organizations/${organization.id}/invitations`,
-        headers: generateAuthenticatedUserRequestHeaders({ userId: adminUserId, locale }),
+        method: 'POST',
         payload: {
           data: {
             type: 'organization-invitations',
@@ -438,7 +438,10 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
             },
           },
         },
-      };
+        locale,
+        audience: 'https://orga.pix.fr',
+        authorizationData: { userId: adminUserId },
+      });
 
       await databaseBuilder.commit();
     });
@@ -630,10 +633,9 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
       });
       await databaseBuilder.commit();
 
-      const options = {
-        method: 'POST',
+      const options = generateInjectOptions({
         url: '/api/organization-invitations/sco',
-        headers: { cookie: `locale=${locale}` },
+        method: 'POST',
         payload: {
           data: {
             attributes: {
@@ -643,7 +645,8 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
             },
           },
         },
-      };
+        locale,
+      });
 
       // when
       const response = await server.inject(options);

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -169,21 +169,18 @@ function generateInjectOptions({ url, method, payload, locale, audience, authori
  * @param {number} params.userId
  * @param {string} params.source
  * @param {string} params.audience - an origin URL, for example: https://app.pix.org
- * @param {string} params.locale
  * @returns {Object} headers
  */
 function generateAuthenticatedUserRequestHeaders({
   userId = 1234,
   source = 'pix',
   audience = 'https://app.pix.org',
-  locale = 'fr-FR',
 } = {}) {
   const accessToken = UserAccessToken.generateUserToken({ userId, source, audience }).accessToken;
 
   return {
     ...generateForwardedHeaders(audience),
     authorization: `Bearer ${accessToken}`,
-    cookie: `locale=${locale}`,
   };
 }
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -123,7 +123,6 @@ function toStream(data, encoding = 'utf8') {
  * @param {number} params.userId
  * @param {string} params.source
  * @param {string} params.audience
- * @param {string} params.acceptLanguage
  * @param {string} params.locale
  * @returns {Object} Header
  */
@@ -131,7 +130,6 @@ function generateAuthenticatedUserRequestHeaders({
   userId = 1234,
   source = 'pix',
   audience = 'https://app.pix.org',
-  acceptLanguage,
   locale = 'fr-FR',
 } = {}) {
   const url = new URL(audience);
@@ -144,7 +142,6 @@ function generateAuthenticatedUserRequestHeaders({
     'x-forwarded-proto': protoHeader,
     'x-forwarded-host': hostHeader,
     cookie: `locale=${locale}`,
-    ...(acceptLanguage && { 'accept-language': acceptLanguage }),
   };
 }
 

--- a/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaign-participations/campaign-participation-controller_test.js
@@ -31,7 +31,6 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const request = {
         auth: { credentials: { userId } },
         params: { id: campaignParticipationId },
-        headers: { 'accept-language': locale },
       };
       const h = Symbol('h');
 

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -30,7 +30,6 @@ describe('Unit | Controller | certification-course-controller', function () {
             },
           },
         },
-        headers: { 'accept-language': 'fr' },
       };
       sinon.stub(usecases, 'retrieveLastOrCreateCertificationCourse');
       certificationCourseSerializer.serialize.returns('ok');


### PR DESCRIPTION
## 🔆 Problème

Le feature toggle (FT) `useCookieLocaleInApi` fait que c’est le cookie `locale` qui est utilisé dans la fonction `getChallengeLocale` au lieu du header HTTP `accept-language`. Or comme ce FT est activé en production depuis plus de 2 semaines, on peut maintenant le supprimer et simplifier tout le code en conséquence.

## ⛱️ Proposition

1. Supprimer la gestion du feature toggle (FT) `useCookieLocaleInApi`,
2. Adapter tous les tests en conséquence (transmettre le cookie `locale` à la place du header `accept-language`),
3. Réaliser la simplification du code qui peut s’en suivre,
4. Fournir des tests helpers pratiques pour les tests d’acceptance permettant d’utiliser le cookie `locale` sans se tromper,
5. Ajouter du debug pour les locales des challenges permettant de controller fonctionnellement le bon fonctionnement lors de tests manuels.

Au besoin on pourra se reporter à l’introduction du FT `useCookieLocaleInApi` qui a été réalisée avec #13247

## 🌊 Remarques

### Uniquement des helpers pour les tests d’acceptance et pas pour les tests unitaires

Initialement on pensait fournir des tests helpers pour les tests d’acceptance et pour les tests unitaires. Mais cette PR est arrivée à une taille importante en touchant à de nombreux fichiers, et il a été jugé qu’il était plus sage de se limiter à la mise en place des tests helpers pour les tests d’acceptance où des helpers apportent plus de valeur ajoutée.

### Tests unitaires

Pour les tests unitaires, le passage du cookie `locale` a été réalisé en passant la propriété `state` dans l’objet `request` comme suit :

```js
const request = {
  state: { locale },
  params: { campaignId },
  headers: generateAuthenticatedUserRequestHeaders({ userId }),
};

const response = await controller.someFunction(request, hFake);
```

### Tests d’acceptance

Pour les tests d’acceptance, on a créé une nouvelle fonction helper `generateInjectOptions` qui assure le passage du cookie `locale` en passant un header [`Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cookie). Ce helper ne peut pas être utilisé pour les tests unitaires qui manipulent, eux, l’objet `request` pour lequel le header `cookie` n’a pas d’effet.

### Modification de la fonction `generateAuthenticatedUserRequestHeaders`

La fonction helper `generateAuthenticatedUserRequestHeaders` est légitimement utilisée dans tous les types de tests, à la fois par les tests unitaires et par les tests d’acceptance. Mais elle propose un argument `locale` qui n’a d’effet que dans le cadre des tests d’acceptance. De fait, le header `cookie` n’a pas d’effet dans le cas de l’utilisation de l’objet `request` par les tests unitaires. Alors pour rendre la fonction helper `generateAuthenticatedUserRequestHeaders` évidente à utiliser et sans erreur dans toutes les situations où elle est utilisée, on a supprimé son argument `locale`. Ainsi les tests d’acceptance nécessitant le passe du cookie `locale` ont été mis à jour pour utiliser la fonction helper `generateInjectOptions` présentée plus haut.

La suppression de cet argument `locale`a été réalisée avec le commit suivant :
`test(api): remove the misleading locale argument for "cookie" header only supported for server.inject → if you need to pass a cookie "locale", use a generate***InjectOptions function`.


## 🏄 Pour tester

**:warning: À tester en navigation privée**

Configurer la variable suivante dans son `.env` :
```shell
DEBUG="pix:challenge:locales"
```

### Sur domaine `.fr`

Sur Pix App sur le domaine `.fr`, démarrer un parcours autonome (par exemple https://app.dev.pix.fr/campagnes/AUTOCOUR1) et constater que tous les challenges proposés contiennent tous la locale `fr-fr` dans le champ `challengeLocales` du debug :
```
  pix:challenge:locales wanted locale "fr-fr", proposed challenges with locales: [
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1AwoInRBB6Cy5q',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1P1p3WVNof3rtF',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  […]
  pix:challenge:locales   { challengeId: 'rec5PU7e7CE5t8dsK', challengeLocales: [ 'fr-fr' ] },
  pix:challenge:locales   { challengeId: 'recyOyPl5J6Act5xO', challengeLocales: [ 'fr-fr' ] },
  […]
  pix:challenge:locales   { challengeId: 'recya9kdwjZAQCsGa', challengeLocales: [ 'fr-fr' ] }
  pix:challenge:locales ]
```

:bulb: Remarquer qu’il y a des challenges uniquement disponibles pour `fr-fr` (c’est à dire avec `challengeLocales: [ 'fr-fr' ]`).

### Sur domaine `.org` avec locale `fr`

Sur Pix App sur le domaine `.org`, en ayant sélectionné `Français` dans le _LocaleSwitcher_, démarrer un parcours autonome (par exemple https://app.dev.pix.org/campagnes/AUTOCOUR1) et constater que tous les challenges proposés contiennent tous la locale `fr` dans le champ `challengeLocales` du debug :
```
  pix:challenge:locales wanted locale "fr", proposed challenges with locales: [
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1AwoInRBB6Cy5q',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1P1p3WVNof3rtF',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1PdqwwF8qhgf0E',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1q2F6jryuiwxGx',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challengeLnPW3RMhzwzxm',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   },
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'recIqPR6WYdLidpTU',
  pix:challenge:locales     challengeLocales: [ 'fr', 'fr-fr' ]
  pix:challenge:locales   }
  pix:challenge:locales ]
```

:bulb: Remarquer qu’il n’y a **aucun** challenge uniquement disponible pour `fr-fr` (c’est à dire avec `challengeLocales: [ 'fr-fr' ]`).

### Sur domaine `.org` avec locale `en`

Sur Pix App sur le domaine `.org`, en ayant sélectionné `English` dans le _LocaleSwitcher_, démarrer un parcours autonome (par exemple https://app.dev.pix.org/campagnes/AUTOCOUR1) et constater que tous les challenges proposés contiennent tous la locale `en` dans le champ `challengeLocales` du debug : 
```
  pix:challenge:locales wanted locale "en", proposed challenges with locales: [
  pix:challenge:locales   {
  pix:challenge:locales     challengeId: 'challenge1NDG8CtMrQYHoU',
  pix:challenge:locales     challengeLocales: [ 'en' ]
  pix:challenge:locales   },
  […]
  pix:challenge:locales   { challengeId: 'recyjMlCNRF8cd2DT', challengeLocales: [ 'en' ] }
  pix:challenge:locales ]
```

