### PR TITLE
[FEATURE] Ajouter un route pour afficher le détail d'un parcours combiné (PIX-19672)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -3,6 +3,7 @@ import { createReadStream } from 'node:fs';
 import { getDataBuffer } from '../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
 import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 
 const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
@@ -12,6 +13,13 @@ const getByCode = async function (request, _, dependencies = { combinedCourseSer
 
   const combinedCourse = await usecases.getCombinedCourseByCode({ userId, code });
   return dependencies.combinedCourseSerializer.serialize(combinedCourse);
+};
+
+const getById = async (request, _, dependencies = { combinedCourseDetailsSerializer }) => {
+  const questId = request.params.questId;
+  const combinedCourseDetails = await usecases.getCombinedCourseByQuestId({ questId });
+
+  return dependencies.combinedCourseDetailsSerializer.serialize(combinedCourseDetails);
 };
 
 const start = async function (request, h) {
@@ -48,6 +56,7 @@ const createCombinedCourses = async function (request, h) {
 
 const combinedCourseController = {
   getByCode,
+  getById,
   start,
   reassessStatus,
   createCombinedCourses,

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -7,6 +7,7 @@ const ERRORS = {
 import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { MAX_FILE_SIZE_UPLOAD } from '../../shared/domain/constants.js';
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { combinedCourseController } from './combined-course-controller.js';
 
 const register = async function (server) {
@@ -32,6 +33,28 @@ const register = async function (server) {
         },
         notes: ['- Récupération du parcours combiné dont le code est spécifié dans les filtres de la requête'],
         tags: ['api', 'quest'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/combined-courses/{questId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserCanManageCombinedCourse,
+          },
+        ],
+        handler: combinedCourseController.getById,
+        validate: {
+          params: Joi.object({
+            questId: identifiersType.questId,
+          }),
+        },
+        notes: [
+          "- Récupération du parcours combiné dont l'id de la quête est passé en paramètre," +
+            " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
+        ],
+        tags: ['api', 'combined-course', 'orga'],
       },
     },
     {

--- a/api/src/quest/application/usecases/check-user-can-manage-combined-course.js
+++ b/api/src/quest/application/usecases/check-user-can-manage-combined-course.js
@@ -1,0 +1,18 @@
+import * as membershipRepository from '../../../shared/infrastructure/repositories/membership-repository.js';
+import * as combinedCourseRepository from '../../infrastructure/repositories/combined-course-repository.js';
+
+const execute = async function ({
+  userId,
+  questId,
+  dependencies = { membershipRepository, combinedCourseRepository },
+}) {
+  const { organizationId } = await dependencies.combinedCourseRepository.getById({ id: questId });
+  const memberships = await dependencies.membershipRepository.findByUserIdAndOrganizationId({
+    userId,
+    organizationId,
+  });
+
+  return memberships.length > 0;
+};
+
+export { execute };

--- a/api/src/quest/domain/usecases/get-combined-course-by-quest-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-by-quest-id.js
@@ -1,0 +1,10 @@
+import { CombinedCourseDetails } from '../models/CombinedCourse.js';
+
+const getCombinedCourseByQuestId = async ({ questId, combinedCourseRepository, questRepository }) => {
+  const quest = await questRepository.findById({ questId });
+  const combinedCourse = await combinedCourseRepository.getById({ id: questId });
+
+  return new CombinedCourseDetails(combinedCourse, quest);
+};
+
+export default getCombinedCourseByQuestId;

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -26,6 +26,7 @@ import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
+import getCombinedCourseByQuestId from './get-combined-course-by-quest-id.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
 import { getVerifiedCode } from './get-verified-code.js';
 import { rewardUser } from './reward-user.js';
@@ -37,6 +38,7 @@ const usecasesWithoutInjectedDependencies = {
   createOrUpdateQuestsInBatch,
   findCombinedCourseByCampaignId,
   getCombinedCourseByCode,
+  getCombinedCourseByQuestId,
   getQuestResultsForCampaignParticipation,
   getVerifiedCode,
   rewardUser,

--- a/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (combinedCourse) {
+  return new Serializer('combined-courses', {
+    attributes: ['name', 'code', 'campaignIds'],
+  }).serialize(combinedCourse);
+};
+
+export { serialize };

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -215,4 +215,34 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
       expect(response.statusCode).to.equal(204);
     });
   });
+
+  describe('GET /api/combined-courses/{questId}', function () {
+    context('when user has membership in the combined course organization', function () {
+      it('should return the combined course details', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+          name: 'Mon parcours combiné',
+          code: 'PARCOURS123',
+          organizationId,
+          successRequirements: [],
+        });
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/combined-courses/${questId}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
 });

--- a/api/tests/quest/integration/application/usecases/check-user-can-manage-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-user-can-manage-combined-course_test.js
@@ -1,0 +1,72 @@
+import * as checkUserCanManageCombinedCourse from '../../../../../src/quest/application/usecases/check-user-can-manage-combined-course.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Application | Usecases | checkUserCanManageCombinedCourse', function () {
+  context('when user has membership in combined course organization', function () {
+    it('should return true', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const canManage = await checkUserCanManageCombinedCourse.execute({ userId, questId });
+
+      // then
+      expect(canManage).to.be.true;
+    });
+  });
+
+  context('when user does not have membership in combined course organization', function () {
+    it('should return false', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const canManage = await checkUserCanManageCombinedCourse.execute({ userId, questId });
+
+      // then
+      expect(canManage).to.be.false;
+    });
+  });
+
+  context('when quest is not a combined course', function () {
+    it('should throw NotFoundError', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const questId = databaseBuilder.factory.buildQuest({
+        code: null,
+        name: 'Not a combined course',
+        organizationId: null,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when / then
+      const error = await catchErr(checkUserCanManageCombinedCourse.execute)({ userId, questId });
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when user has disabled membership in combined course organization', function () {
+    it('should return false', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const canManage = await checkUserCanManageCombinedCourse.execute({ userId, questId });
+
+      // then
+      expect(canManage).to.be.false;
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-quest-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-quest-id_test.js
@@ -1,0 +1,87 @@
+import { CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import getCombinedCourseByQuestId from '../../../../../src/quest/domain/usecases/get-combined-course-by-quest-id.js';
+import * as combinedCourseRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-repository.js';
+import * as questRepository from '../../../../../src/quest/infrastructure/repositories/quest-repository.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Domain | Usecases | getCombinedCourseByQuestId', function () {
+  it('should return a CombinedCourseDetails instance with quest and combined course data', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const questId = databaseBuilder.factory.buildQuest({
+      name: 'Test Combined Course',
+      description: 'A test combined course description',
+      illustration: 'https://example.com/image.png',
+      code: 'TEST_COURSE_123',
+      organizationId,
+      eligibilityRequirements: [],
+      successRequirements: [
+        {
+          data: { status: { data: 'SHARED', comparison: 'equal' }, campaignId: { data: 100, comparison: 'equal' } },
+          comparison: 'all',
+          requirement_type: 'campaignParticipations',
+        },
+        {
+          data: { status: { data: 'SHARED', comparison: 'equal' }, campaignId: { data: 200, comparison: 'equal' } },
+          comparison: 'all',
+          requirement_type: 'campaignParticipations',
+        },
+        {
+          data: { status: { data: 'SHARED', comparison: 'equal' }, campaignId: { data: 300, comparison: 'equal' } },
+          comparison: 'all',
+          requirement_type: 'campaignParticipations',
+        },
+      ],
+      rewardType: 'attestations',
+      rewardId: null,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await getCombinedCourseByQuestId({
+      questId,
+      questRepository,
+      combinedCourseRepository,
+    });
+
+    // then
+    expect(result).to.be.instanceOf(CombinedCourseDetails);
+    expect(result.id).to.equal(questId);
+    expect(result.name).to.equal('Test Combined Course');
+    expect(result.description).to.equal('A test combined course description');
+    expect(result.illustration).to.equal('https://example.com/image.png');
+    expect(result.code).to.equal('TEST_COURSE_123');
+    expect(result.organizationId).to.equal(organizationId);
+    expect(result.campaignIds).to.deep.equal([100, 200, 300]);
+  });
+
+  it('should throw if quest is not combined course', async function () {
+    // given
+    const questId = databaseBuilder.factory.buildQuest({
+      name: 'Test Combined Course',
+      description: 'A test combined course description',
+      illustration: 'https://example.com/image.png',
+      code: null,
+      organizationId: null,
+      eligibilityRequirements: [],
+      successRequirements: [],
+      rewardType: null,
+      rewardId: null,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(getCombinedCourseByQuestId)({
+      questId,
+      questRepository,
+      combinedCourseRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
+});

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -1,0 +1,29 @@
+import { combinedCourseController } from '../../../../src/quest/application/combined-course-controller.js';
+import { usecases } from '../../../../src/quest/domain/usecases/index.js';
+import { expect, sinon } from '../../../test-helper.js';
+
+describe('Unit | Quest | Application | Controller | CombinedCourse', function () {
+  describe('#getById', function () {
+    it('should call getCombinedCourseByQuestId usecase with questId', async function () {
+      // given
+      const questId = 'questId123';
+      const combinedCourse = Symbol('combinedCourse');
+      const serializedCombinedCourse = Symbol('serializedCombinedCourse');
+      const request = {
+        params: { questId },
+      };
+
+      sinon.stub(usecases, 'getCombinedCourseByQuestId').resolves(combinedCourse);
+      const combinedCourseDetailsSerializer = { serialize: sinon.stub() };
+      combinedCourseDetailsSerializer.serialize.withArgs(combinedCourse).returns(serializedCombinedCourse);
+
+      // when
+      const result = await combinedCourseController.getById(request, null, { combinedCourseDetailsSerializer });
+
+      // then
+      expect(usecases.getCombinedCourseByQuestId).to.have.been.calledOnceWithExactly({ questId });
+      expect(combinedCourseDetailsSerializer.serialize).to.have.been.calledOnceWithExactly(combinedCourse);
+      expect(result).to.equal(serializedCombinedCourse);
+    });
+  });
+});

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -21,6 +21,23 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     });
   });
 
+  describe('GET /api/combined-courses/{questId}', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserCanManageCombinedCourse').returns(() => true);
+      sinon.stub(combinedCourseController, 'getById').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('GET', '/api/combined-courses/123');
+
+      // then
+      expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
+    });
+  });
+
   describe('PUT /api/combined-course/{code}/start', function () {
     it('should call prehandler', async function () {
       // given

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
@@ -1,0 +1,47 @@
+import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
+import * as combinedCourseDetailsSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-details-serializer.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | combined-course-details', function () {
+  it('#serialize', function () {
+    // given
+    const combinedCourseDetails = domainBuilder.buildCombinedCourseDetails({
+      name: 'Mon parcours',
+      code: 'COMBINIX1',
+      quest: new Quest({
+        id: 1,
+        rewardId: null,
+        rewardType: null,
+        eligibilityRequirements: [],
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: 1,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    // when
+    const serializedCombinedCourseDetails = combinedCourseDetailsSerializer.serialize(combinedCourseDetails);
+
+    // then
+    expect(serializedCombinedCourseDetails).to.deep.equal({
+      data: {
+        attributes: {
+          name: 'Mon parcours',
+          code: 'COMBINIX1',
+          'campaign-ids': [1],
+        },
+        type: 'combined-courses',
+        id: '1',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Résumé

Cette PR implémente la fonctionnalité backend pour récupérer un parcours combiné.

## 🔆 Problème

Les organisations ont besoin de pouvoir consulter et gérer les parcours combinés.

## ⛱️ Proposition

Ajout d'un support backend complet pour la gestion des parcours combinés :

1. **Couche d'autorisation** : Implémentation des vérifications prehandler pour assurer un contrôle d'accès approprié aux opérations sur les parcours combinés
2. **Point d'API** : Création d'une nouvelle route `/api/combined-courses/{questId}`
3. **Logique métier** : Ajout du cas d'usage pour récupérer les parcours combinés par ID de quête
4. **Couche de données** : Implémentation du sérialiseur pour formater les données de parcours combinés pour la consommation frontend

## 🏄 Pour tester

```bash
COMBINED_COURSE_ID=107724
REVIEW_URL="https://api-pr13671.review.pix.fr/api"
ACCESS_TOKEN=$( \
  curl -X POST "$REVIEW_URL/token" \
    --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' \
  | jq -r .access_token \
)
curl "$REVIEW_URL/combined-courses/$COMBINED_COURSE_ID" -X GET\
 -H 'content-type: application/vnd.api+json'\
 -H "Authorization: Bearer $ACCESS_TOKEN"
```
