### PR TITLE
[BUGFIX] Rendre les dates de naissance de l'ES insensibles à la timezone (PIX-19499).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -28,7 +28,7 @@
     </div>
 
     <div class="session-supervising-candidate-in-list__middle-information">
-      <p>{{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}</p>
+      <p>{{this.formattedBirthdate}}</p>
       {{#if this.shouldDisplayEnrolledComplementaryCertification}}
         <p class="session-supervising-candidate-in-list-details__enrolment">
           <PixIcon

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -3,6 +3,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(LocalizedFormat);
+dayjs.extend(utc);
 
 const Modals = {
   Confirmation: 'Confirmation',
@@ -27,6 +32,12 @@ export default class CandidateInList extends Component {
 
   get candidateFullName() {
     return `${this.args.candidate.firstName} ${this.args.candidate.lastName}`;
+  }
+
+  get formattedBirthdate() {
+    if (!this.args.candidate.birthdate) return '';
+
+    return dayjs.utc(this.args.candidate.birthdate).format('L');
   }
 
   get isConfirmButtonToBeDisplayed() {

--- a/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/unit/components/session-supervising/candidate-in-list-test.js
@@ -151,4 +151,54 @@ module('Unit | Component | session-supervising/candidate-in-list', function (hoo
       });
     });
   });
+
+  module('formattedBirthdate', function () {
+    test('it should format birthdate from YYYY-MM-DD to DD/MM/YYYY', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-in-list');
+      component.args.candidate = { birthdate: '1984-05-28' };
+
+      // when
+      const result = component.formattedBirthdate;
+
+      // then
+      assert.strictEqual(result, '28/05/1984');
+    });
+
+    test('it should return empty string when birthdate is null', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-in-list');
+      component.args.candidate = { birthdate: null };
+
+      // when
+      const result = component.formattedBirthdate;
+
+      // then
+      assert.strictEqual(result, '');
+    });
+
+    test('it should return empty string when birthdate is undefined', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-in-list');
+      component.args.candidate = { birthdate: undefined };
+
+      // when
+      const result = component.formattedBirthdate;
+
+      // then
+      assert.strictEqual(result, '');
+    });
+
+    test('it should return empty string when birthdate is empty string', function (assert) {
+      // given
+      const component = createGlimmerComponent('component:session-supervising/candidate-in-list');
+      component.args.candidate = { birthdate: '' };
+
+      // when
+      const result = component.formattedBirthdate;
+
+      // then
+      assert.strictEqual(result, '');
+    });
+  });
 });


### PR DESCRIPTION
## 🔆 Problème

#### Contexte problématique

- un utilisateur Pix Certif créé une session pour le matin du jour J
- il y inscrit un candidat né le 01/01/2000
- un surveillant ouvre l’Espace surveillant dans une time-zone à UTC-10 (par exemple) = 12 heures de décalage horaire avec Paris

#### Résultat obtenu

Le surveillant voit la date de naissance dans l’Espace surveillant s’afficher au 31/12/1999 au lieu du 01/01/2000 comme indiqué lors de l’inscription

## ⛱️ Proposition

Éviter de passer par un objet `Date` pour les dates de naissance et ne traiter que des `String` pour ne pas être impacté par le changement de timezone.

## 🏄 Pour tester

#### Étape 1 : reproduire le problème

- Sur PixCertif en RA, aller sur l'espace surveillant de la session `7402`
- L'utilisateur `Lagagne Maxou` a `31/12/1999` comme date de naissance

#### Étape 2 : vérifier la solution apportée

- Installer l'extension **“Change Timezone for Google Chrome™“**
- via l'extension, passer sur la timezone `Pacific/Pago_Pago (-660)` (tout en bas de la liste)
- Recharger la page de l'espace surveillant
- L'utilisateur `Lagagne Maxou` a maintenant bien `01/01/2000` comme date de naissance (la date attendue)
