### PR TITLE
[FEATURE] Empêcher le layout shift sur les images vectorielles de Modulix (PIX-19650)

### DIFF
--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -85,6 +85,19 @@
     border: none;
   }
 
+  /* See https://youtube.com/watch?v=345V2MU3E_w */
+  img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+    font-style: italic;
+    vertical-align: middle;
+    background-color: var(--pix-neutral-0);
+    background-repeat: no-repeat;
+    background-size: contain;
+    shape-margin: 1rem;
+  }
+
   .modulix-two-columns {
     columns: 2;
   }

--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -9,6 +9,8 @@ import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
 export default class ModulixImageElement extends Component {
   @tracked modalIsOpen = false;
 
+  static MAX_WIDTH = 700;
+
   get hasAlternativeText() {
     return this.args.image.alternativeText.length > 0;
   }
@@ -28,10 +30,38 @@ export default class ModulixImageElement extends Component {
     return this.args.image.legend?.length > 0 || this.args.image.licence?.length > 0;
   }
 
+  get width() {
+    if (this.args.image.infos && this.hasDimensions) {
+      if (this.args.image.infos.type === 'vector') {
+        return ModulixImageElement.MAX_WIDTH;
+      }
+    }
+    return null;
+  }
+
+  get height() {
+    if (this.args.image.infos && this.hasDimensions) {
+      if (this.args.image.infos.type === 'vector') {
+        return Math.round((ModulixImageElement.MAX_WIDTH * this.args.image.infos.height) / this.args.image.infos.width);
+      }
+    }
+    return null;
+  }
+
+  get hasDimensions() {
+    return this.args.image.infos.width > 0 && this.args.image.infos.height > 0;
+  }
+
   <template>
     <div class="element-image">
       <figure class="element-image__container">
-        <img class="element-image-container__image" alt={{@image.alt}} src={{@image.url}} />
+        <img
+          class="element-image-container__image"
+          alt={{@image.alt}}
+          src={{@image.url}}
+          width={{this.width}}
+          height={{this.height}}
+        />
         {{#if this.hasCaption}}
           <figcaption class="element-image-container__caption">{{@image.legend}}<span
               class="element-image-container__licence"

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -28,10 +28,74 @@ module('Integration | Component | Module | Image', function (hooks) {
     // then
     assert.ok(screen);
     assert.strictEqual(findAll('.element-image').length, 1);
-    assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+    const imgElement = screen.getByRole('img', { name: 'alt text' });
+    assert.dom(imgElement).hasAttribute('src', url);
     assert.ok(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
     assert.dom(screen.getByText(imageElement.legend)).exists();
     assert.dom(screen.getByText(imageElement.licence)).exists();
+    assert.false(imgElement.hasAttribute('width'));
+    assert.false(imgElement.hasAttribute('height'));
+  });
+
+  module('when width and height are available', function () {
+    module('when image type is vector', function () {
+      test('should extend width to 700px and height respecting aspect-ratio', async function (assert) {
+        // given
+        const url =
+          'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+
+        const imageElement = {
+          url,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+          legend: 'je suis une légende',
+          licence: 'Je suis une licence',
+          infos: { width: 1920, height: 1280, type: 'vector' },
+        };
+
+        //  when
+        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+
+        // then
+        assert.ok(screen);
+        assert.strictEqual(findAll('.element-image').length, 1);
+        const imgElement = screen.getByRole('img', { name: 'alt text' });
+        assert.dom(imgElement).hasAttribute('src', url);
+        assert.dom(imgElement).hasAttribute('width', '700');
+        const expectedHeight = Math.round(
+          (ModulixImageElement.MAX_WIDTH * imageElement.infos.height) / imageElement.infos.width,
+        );
+        assert.dom(imgElement).hasAttribute('height', `${expectedHeight}`);
+      });
+    });
+
+    module('when image type is raster', function () {
+      test('should not set width and height', async function (assert) {
+        // given
+        const url =
+          'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.png';
+
+        const imageElement = {
+          url,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+          legend: 'je suis une légende',
+          licence: 'Je suis une licence',
+          infos: { width: 1920, height: 1280, type: 'raster' },
+        };
+
+        //  when
+        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+
+        // then
+        assert.ok(screen);
+        assert.strictEqual(findAll('.element-image').length, 1);
+        const imgElement = screen.getByRole('img', { name: 'alt text' });
+        assert.dom(imgElement).hasAttribute('src', url);
+        assert.false(imgElement.hasAttribute('width'));
+        assert.false(imgElement.hasAttribute('height'));
+      });
+    });
   });
 
   test('should be able to use the modal for alternative instruction', async function (assert) {


### PR DESCRIPTION
## 🔆 Problème

Lors du processus d'affichage d'une image dans un navigateur, il essaye d'abord de déterminer l'espace nécessaire afin de réserver cet espace dans la page. En cas de mauvaise connexion, par exemple sur mobile dans le train, cet espace ne sera pas occupé tant que le navigateur n'a pas les informations des dimensions. Lors du chargement de l'image, l'espace devient réservé et le reste du contenu est décalé plus bas et donc une mauvaise UX. C'est ce qu'on appelle du [Layout shift](https://web.dev/articles/cls).

Exemple dans Modulix :
<img width="300" height="250" alt="avant le chargement" title="avant le chargement" src="https://github.com/user-attachments/assets/f43ff7e2-1d23-48fa-93c5-f28b0ccbc581" />

<img width="300" height="350" alt="après le chargement" title="après le chargement" src="https://github.com/user-attachments/assets/c6a072a0-db3a-4737-bf96-0f0b0c8f5f5e" />

## ⛱️ Proposition

Si l’image est vectorielle et qu'elle possède les champs `width` et `height`, on peut faire un produit en croix pour préciser le contenu nécessaire avant affichage.

Techniquement il s'agit de remplir la balise `img` avec les attributs `width` (`MAX_WIDTH` = 700) et `height` (`MAX_WIDTH * imageHeight / imageWidth`) : 

> Including height and width enables the aspect ratio of the image to be calculated by the browser prior to the image being loaded. This aspect ratio is used to reserve the space needed to display the image, reducing or even preventing a layout shift when the image is downloaded and painted to the screen. Reducing layout shift is a major component of good user experience and web performance.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#height

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. [Commencer un passage dans le module pour apprendre à bien écrire une adresse mail](https://app-pr13673.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage).
2. Simuler une mauvaise connectivité réseau (dans l'onglet Network des devtools).
3. Passer/Continuer les grains jusqu'à la leçon.
4. Constater que l'image en SVG réserve un espace avant qu'elle ne soit affichée.
5. Constater que les autres images (en PNG) créent du layout shift.
