### PR TITLE
[TECH] Ajout des traductions anglaises pour les URLs des fiches d'incident (PIX-19664)

### DIFF
--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -35,15 +35,11 @@ export default class Url extends UrlBaseService {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    if (this.locale.currentLanguage === 'fr') {
-      return 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download';
-    }
-
-    return 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download';
+    return this.intl.t('common.urls.session-issue-report-sheet');
   }
 
   get urlToDownloadSessionV3IssueReportSheet() {
-    return 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download';
+    return this.intl.t('common.urls.session-v3-issue-report-sheet');
   }
 
   get fraudFormUrl() {

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -157,4 +157,54 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download');
     });
   });
+
+  module('#urlToDownloadSessionIssueReportSheet', function () {
+    test('should return the session issue report sheet url in French', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const urlToDownloadSessionIssueReportSheet = service.urlToDownloadSessionIssueReportSheet;
+
+      // then
+      assert.strictEqual(urlToDownloadSessionIssueReportSheet, 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download');
+    });
+
+    test('should return the session issue report sheet url in English', async function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      await setCurrentLocale('en');
+
+      // when
+      const urlToDownloadSessionIssueReportSheet = service.urlToDownloadSessionIssueReportSheet;
+
+      // then
+      assert.strictEqual(urlToDownloadSessionIssueReportSheet, 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download');
+    });
+  });
+
+  module('#urlToDownloadSessionV3IssueReportSheet', function () {
+    test('should return the session V3 issue report sheet url in French', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+
+      // when
+      const urlToDownloadSessionV3IssueReportSheet = service.urlToDownloadSessionV3IssueReportSheet;
+
+      // then
+      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download');
+    });
+
+    test('should return the session V3 issue report sheet url in English', async function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      await setCurrentLocale('en');
+
+      // when
+      const urlToDownloadSessionV3IssueReportSheet = service.urlToDownloadSessionV3IssueReportSheet;
+
+      // then
+      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download');
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -188,7 +188,9 @@
       "invigilator": "Invigilator"
     },
     "urls": {
-      "fraud": "https://cloud.pix.fr/s/9A598pR5ksp6jss/download"
+      "fraud": "https://cloud.pix.fr/s/9A598pR5ksp6jss/download",
+      "session-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download",
+      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download"
     }
   },
   "components": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -188,7 +188,9 @@
       "invigilator": "Surveillant"
     },
     "urls": {
-      "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download"
+      "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download",
+      "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",
+      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download"
     }
   },
   "components": {


### PR DESCRIPTION
## 🍂 Problème
Le lien de téléchargement de la fiche d'incident V3 n'avait pas de version anglaise

## 🌰 Proposition
Migration des URLs vers les fichiers de traduction pour faciliter la gestion multilingue + ajout des tests unitaires

## 🪵 Pour tester
1. Aller dans une session de certification
2. Vérifier que le lien "Fiche d'incident" fonctionne en français
3. Changer la langue en anglais
4. Vérifier que le lien "Incident report" fonctionne et télécharge le fichier en anglais
5. Tester avec une session V2 ?