### PR TITLE
[FEATURE] Enlever le fond violet en début de module (PIX-19679)

### DIFF
--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -11,6 +11,7 @@
   --modulix-z-index-above-all: 10;
 
   flex-grow: 1;
+  min-height: 100vh;
   overflow-x: hidden;
   color: var(--pix-neutral-900);
   background: var(--pix-neutral-0);


### PR DESCRIPTION
## 🔆 Problème

Pour une raison obscure, une partie de la page de passage du module est violette :

<img width="1216" height="946" alt="image" src="https://github.com/user-attachments/assets/3b7071f5-6c38-44b8-b1b1-b499b027d4ba" />

C’est une régression.

## ⛱️ Proposition

Mettre un fond blanc.

Également corriger la position de la barre de navigation qui ne restait plus accrochée en haut (régression).

## 🌊 Remarques

RAS

## 🏄 Pour tester

Sur [un passage de module](https://app-pr13675.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage), vérifier que le fond est blanc et qu'il n'y a pas de barre de scroll. Tester également en mobile.