### PR TITLE
[TECH] Activer l'auto retry sur les tests de l'api d'integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,6 +450,8 @@ jobs:
             MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: mocha-junit-reporter
           when: always
+          max_auto_reruns: 3
+          auto_rerun_delay: 10s
       - store_test_results:
           path: /home/circleci/test-results
       - store_artifacts:


### PR DESCRIPTION
## 🔆 Problème
On a que 90% de success rate sur l'api integration, mais c'est souvent du à des flakys. C'est fastidieux de relancer les tests juste pour un flaky. 

<img width="2882" height="1486" alt="Screenshot 2025-09-25 at 11 01 57" src="https://github.com/user-attachments/assets/8d8b553a-3ed0-4522-9a83-071b8eaf5ec2" />

## ⛱️ Proposition
Ajouter de l'automatique retry comme proposé par [CircleCI](https://circleci.com/docs/guides/orchestrate/automatic-reruns/)

## 🌊 Remarques

J'ai mis 3 ça me semble pas mal

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
