### PR TITLE
[TECH] Ajouter une colonne duration à la table complementary-certifications (PIX-19706)

### DIFF
--- a/api/db/migrations/20250917000000_add-duration-column-to-complementary-certifications.js
+++ b/api/db/migrations/20250917000000_add-duration-column-to-complementary-certifications.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'complementary-certifications';
+const COLUMN_NAME = 'duration';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
🍂 Problème
-----------
La table `complementary-certifications` nécessite une colonne `duration` pour stocker la durée des certifications complémentaires.

🌰 Proposition
--------------
Ajout d'une migration qui crée la colonne `duration` de type integer dans la table `complementary-certifications`.

🎃 Remarques
------------
Cette migration a été cherry-pickée du commit 7085c759d2  de la PR #13618 pour être dans une PR dédiée conformément à l'ADR 56 qui impose que les migrations soient dans des PR séparées.

🪵 Pour tester
--------------
