### PR TITLE
[FEATURE] Ajouter les migrations des tables chats et chat-messages (PIX-19689)

### DIFF
--- a/api/db/migrations/20250925130247_add-chats-table-migration.js
+++ b/api/db/migrations/20250925130247_add-chats-table-migration.js
@@ -1,0 +1,41 @@
+const TABLE_NAME = 'chats';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.uuid('id').primary();
+    table.dateTime('startedAt').notNullable().defaultTo(knex.fn.now()).index();
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now()).index();
+    table.string('configId').nullable();
+    table.jsonb('configContent').notNullable();
+    table.integer('assessmentId').nullable();
+    table.string('challengeId').nullable();
+    table.integer('passageId').nullable();
+    table.uuid('moduleId').nullable();
+    table
+      .boolean('hasAttachmentContextBeenAdded')
+      .defaultTo(false)
+      .notNullable()
+      .comment('True if a file has been attached to prompt by user');
+    table.integer('totalInputTokens').nullable().comment('Input tokens consumption updated after each message');
+    table.integer('totalOutputTokens').nullable().comment('Output tokens consumption updated after each message');
+
+    table.comment(
+      'Table to store LLM chats.' +
+        'Related challenge can be found by reading assessmentId and challengeId. Same for related module with passageId and moduleId.',
+    );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20250925131427_add-chat-messages-table-migration.js
+++ b/api/db/migrations/20250925131427_add-chat-messages-table-migration.js
@@ -1,0 +1,35 @@
+const TABLE_NAME = 'chat_messages';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.uuid('chatId').references('id').inTable('chats').index();
+    table.integer('index').notNullable();
+    table.string('emitter').notNullable().comment("Can be 'user' or 'assistant'");
+    table.text('content').notNullable();
+    this.string('attachmentName').nullable();
+    this.text('attachmentContext').nullable();
+    this.boolean('shouldBeForwardedToLLM').defaultTo(false);
+    this.boolean('shouldBeRenderedInPreview').defaultTo(false);
+    this.boolean('shouldBeCountedAsPrompt').defaultTo(false);
+    this.boolean('hasAttachmentBeenSubmittedAlongWithAPrompt').defaultTo(false);
+    this.boolean('haveVictoryConditionsBeenFulfilled').defaultTo(false);
+    table.boolean('wasModerated').nullable().comment('if null, the message has not been processed by moderation');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.comment('Table to store LLM chats messages.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

On veut stocker les conversations du LLM dans Postgres.

## ⛱️ Proposition

Ajouter les migrations permettant de faire cela : 
- La table `chats` pour stocker la configuration et les metadata dessus.
- La table `chat-messages` pour les différents messages. 

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Tester les migrations et vérifier que ça fonctionne.
