### PR TITLE
[FEATURE] Enregistrer l'équipe en charge lors de la création d'une nouvelle organisation (PIX-19506)

### DIFF
--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -51,9 +51,9 @@ const addOrganizationFeatureInBatch = async function (request, h) {
 };
 
 const create = async function (request) {
-  const superAdminUserId = extractUserIdFromRequest(request);
+  const { userId } = request.auth.credentials;
   const organization = organizationForAdminSerializer.deserialize(request.payload);
-  organization.createdBy = superAdminUserId;
+  organization.createdBy = userId;
 
   const createdOrganization = await usecases.createOrganization({ organization });
   const serializedOrganization = organizationForAdminSerializer.serialize(createdOrganization);

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -53,12 +53,10 @@ const addOrganizationFeatureInBatch = async function (request, h) {
 const create = async function (request) {
   const superAdminUserId = extractUserIdFromRequest(request);
   const organization = organizationForAdminSerializer.deserialize(request.payload);
-
   organization.createdBy = superAdminUserId;
 
   const createdOrganization = await usecases.createOrganization({ organization });
   const serializedOrganization = organizationForAdminSerializer.serialize(createdOrganization);
-
   return serializedOrganization;
 };
 

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -49,6 +49,8 @@ class OrganizationForAdmin {
     code,
     parentOrganizationId,
     parentOrganizationName,
+    administrationTeamId,
+    administrationTeamName,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -77,6 +79,8 @@ class OrganizationForAdmin {
     this.identityProviderForCampaigns = identityProviderForCampaigns;
     this.tags = tags;
     this.tagIds = tagIds;
+    this.administrationTeamId = administrationTeamId;
+    this.administrationTeamName = administrationTeamName;
 
     // @deprecated you should use value stored in features property
     this.isManagingStudents = isManagingStudents;

--- a/api/src/organizational-entities/domain/validators/organization-creation-validator.js
+++ b/api/src/organizational-entities/domain/validators/organization-creation-validator.js
@@ -17,6 +17,8 @@ const organizationValidationJoiSchema = Joi.object({
   documentationUrl: Joi.string().uri().allow(null).messages({
     'string.uri': 'Le lien vers la documentation n’est pas valide.',
   }),
+  // TODO passer l'administrationTeamId en .required() avant la fin de l'Epix
+  administrationTeamId: Joi.string().allow(null),
 });
 
 const validate = function (organizationCreationParams) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -112,8 +112,15 @@ const get = async function ({ organizationId }) {
       identityProviderForCampaigns: 'organizations.identityProviderForCampaigns',
       parentOrganizationId: 'organizations.parentOrganizationId',
       parentOrganizationName: 'parentOrganizations.name',
+      administrationTeamId: 'organizations.administrationTeamId',
+      administrationTeamName: 'administrationTeams.name',
     })
     .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
+    .leftJoin(
+      'administration_teams AS administrationTeams',
+      'administrationTeams.id',
+      'organizations.administrationTeamId',
+    )
     .leftJoin('users AS creators', 'creators.id', 'organizations.createdBy')
     .leftJoin(
       'data-protection-officers AS dataProtectionOfficers',
@@ -200,6 +207,7 @@ const save = async function ({ organization }) {
     'credit',
     'createdBy',
     'documentationUrl',
+    'administrationTeamId',
   ]);
   const [organizationCreated] = await knexConn(ORGANIZATIONS_TABLE_NAME).returning('*').insert(data);
   const savedOrganization = _toDomain(organizationCreated);
@@ -230,6 +238,7 @@ const update = async function ({ organization }) {
     'provinceCode',
     'showSkills',
     'type',
+    'administrationTeamId',
   ]);
 
   await _enableFeatures(knexConn, organization.features, organization.id);
@@ -418,6 +427,8 @@ function _toDomain(rawOrganization) {
     tags: rawOrganization.tags || [],
     parentOrganizationId: rawOrganization.parentOrganizationId,
     parentOrganizationName: rawOrganization.parentOrganizationName,
+    administrationTeamId: rawOrganization.administrationTeamId,
+    administrationTeamName: rawOrganization.administrationTeamName,
   });
 
   return organization;

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -46,6 +46,8 @@ const serialize = function (organizations, meta) {
       'features',
       'parentOrganizationId',
       'parentOrganizationName',
+      'administrationTeamId',
+      'administrationTeamName',
     ],
     organizationMemberships: {
       ref: 'id',
@@ -114,6 +116,7 @@ const deserialize = function (json) {
     dataProtectionOfficerFirstName: attributes['data-protection-officer-first-name'],
     dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
     dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
+    administrationTeamId: attributes['administration-team-id'],
     features: attributes.features,
     tagIds,
   });

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -411,6 +411,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         });
         const archivedAt = new Date('2019-04-28T02:42:00Z');
         const createdAt = new Date('2019-04-28T02:42:00Z');
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization catalina',
@@ -425,6 +426,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           archivedBy: archivist.id,
           archivedAt,
           createdAt,
+          administrationTeamId: administrationTeam.id,
         });
         const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
           firstName: 'Justin',
@@ -473,6 +475,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
               'archived-at': archivedAt,
               'creator-full-name': 'Tom Dereck',
               'identity-provider-for-campaigns': null,
+              'administration-team-id': administrationTeam.id,
+              'administration-team-name': administrationTeam.name,
               features: {
                 [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false, params: null },
                 [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -661,6 +661,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
   describe('#get', function () {
     it('returns an organization for admin by provided id', async function () {
       // given
+      const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
       const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
       const parentOrganization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
@@ -691,6 +692,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         showSkills: false,
         identityProviderForCampaigns: 'genericOidcProviderCode',
         parentOrganizationId: parentOrganization.id,
+        administrationTeamId: administrationTeam.id,
       });
 
       databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
@@ -748,6 +750,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         creatorFirstName: 'Cécile',
         creatorLastName: 'Encieux',
         identityProviderForCampaigns: 'genericOidcProviderCode',
+        administrationTeamId: administrationTeam.id,
+        administrationTeamName: administrationTeam.name,
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false },
           [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'BIDON' } },
@@ -774,6 +778,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       it('should return an organization with import feature with empty params', async function () {
         // given
         const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization of the dark side',
@@ -790,6 +795,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           formNPSUrl: 'https://pix.fr/',
           showSkills: false,
           identityProviderForCampaigns: 'genericOidcProviderCode',
+          administrationTeamId: administrationTeam.id,
         });
 
         databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
@@ -847,6 +853,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           },
           parentOrganizationId: null,
           parentOrganizationName: null,
+          administrationTeamId: administrationTeam.id,
+          administrationTeamName: administrationTeam.name,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
       });
@@ -856,6 +864,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       it('should return if its enable and the additional params', async function () {
         // given
         const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization of the dark side',
@@ -872,6 +881,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           formNPSUrl: 'https://pix.fr/',
           showSkills: false,
           identityProviderForCampaigns: 'genericOidcProviderCode',
+          administrationTeamId: administrationTeam.id,
         });
 
         databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
@@ -952,6 +962,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           },
           parentOrganizationId: null,
           parentOrganizationName: null,
+          administrationTeamId: administrationTeam.id,
+          administrationTeamName: administrationTeam.name,
         });
         expect(foundOrganizationForAdmin).to.deep.equal(expectedOrganizationForAdmin);
       });
@@ -992,6 +1004,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         const superAdminUser = databaseBuilder.factory.buildUser();
         const archivist = databaseBuilder.factory.buildUser();
         const archivedAt = new Date('2022-02-02');
+        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
 
         const insertedOrganization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
@@ -1010,6 +1023,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           showSkills: false,
           archivedBy: archivist.id,
           archivedAt,
+          administrationTeamId: administrationTeam.id,
         });
 
         await databaseBuilder.commit();
@@ -1052,6 +1066,8 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           features: {},
           parentOrganizationId: null,
           parentOrganizationName: null,
+          administrationTeamId: administrationTeam.id,
+          administrationTeamName: administrationTeam.name,
         });
         expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
       });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -9,6 +9,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
   describe('#serialize', function () {
     it('returns a JSON API serialized organization', function () {
       // given
+      const administrationTeam = domainBuilder.buildAdministrationTeam();
       const tags = [
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
@@ -47,6 +48,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         },
         parentOrganizationId: parentOrganization.id,
         parentOrganizationName: parentOrganization.name,
+        administrationTeamId: administrationTeam.id,
+        administrationTeamName: administrationTeam.name,
       });
       const meta = { some: 'meta' };
 
@@ -83,6 +86,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'data-protection-officer-email': organization.dataProtectionOfficer.email,
             'creator-full-name': organization.creatorFullName,
             'identity-provider-for-campaigns': NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+            'administration-team-id': organization.administrationTeamId,
+            'administration-team-name': organization.administrationTeamName,
             features: organization.features,
           },
           relationships: {
@@ -157,6 +162,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        administrationTeamId: '1',
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true },
           [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
@@ -184,6 +190,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'data-protection-officer-first-name': organizationAttributes.dataProtectionOfficerFirstName,
             'data-protection-officer-last-name': organizationAttributes.dataProtectionOfficerLastName,
             'data-protection-officer-email': organizationAttributes.dataProtectionOfficerEmail,
+            'administration-team-id': organizationAttributes.administrationTeamId,
             features: organizationAttributes.features,
           },
         },
@@ -207,6 +214,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerFirstName: organizationAttributes.dataProtectionOfficerFirstName,
         dataProtectionOfficerLastName: organizationAttributes.dataProtectionOfficerLastName,
         dataProtectionOfficerEmail: organizationAttributes.dataProtectionOfficerEmail,
+        administrationTeamId: organizationAttributes.administrationTeamId,
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
             active: organizationAttributes.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.active,
@@ -249,6 +257,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             logoUrl: organizationAttributes.logoUrl,
             'external-id': organizationAttributes.externalId,
             'province-code': organizationAttributes.provinceCode,
+            'organization-id': organizationAttributes.organizationId,
             features: organizationAttributes.features,
           },
           relationships: {

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -29,6 +29,8 @@ function buildOrganizationForAdmin({
   features = {},
   parentOrganizationId = null,
   parentOrganizationName = null,
+  administrationTeamId = null,
+  administrationTeamName = null,
 } = {}) {
   return new OrganizationForAdmin({
     id,
@@ -59,6 +61,8 @@ function buildOrganizationForAdmin({
     features,
     parentOrganizationId,
     parentOrganizationName,
+    administrationTeamId,
+    administrationTeamName,
   });
 }
 


### PR DESCRIPTION
## 🔆 Problème

Il faut pouvoir identifier quelle équipe gère chaque organisation.

## ⛱️ Proposition

Sur Pix Admin (`/organization/new`), lors de la création d’une nouvelle organisation, quand un utilisateur clique sur “Ajouter” après avoir rempli le formulaire et renseigné le champ “Equipe Pix”, cette information doit être enregistré en base de données.

route à modifier : `POST api/admin/organizations`

Pour les tests : 
– modifier le domain builder `api/tests/tooling/domain-builder/factory/build-organization-for-admin.js `
– modifier le `database-builder-organization.js`  (fait lors d'une précédente PR : https://github.com/1024pix/pix/pull/13559/files)
– rajouter des seeds (fait lors d'une précédente PR) (https://github.com/1024pix/pix/pull/13567)

## 🌊 Remarques
La gestion du caractère obligatoire de l'attribut administration team sera faite dans https://1024pix.atlassian.net/browse/PIX-19677

## 🏄 Pour tester

- Aller sur Pix Admin (ouvrir la console dev)
- Créer une organisation
- Vérifier que les routes `POST /admin/organizations et GET admin/organization/{id}` retournent bien un attribut `administrationTeamId` renseigné avec l'id de l'équipe choisie et un attribut `administrationTeamName` renseigné avec le nom de l'équipe choisie.

