### PR TITLE
[BUGFIX] Afficher le lien "Mes parcours" lorsque l'on a une participation a un parcours combiné (PIX-19593).

### DIFF
--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -173,6 +173,7 @@ const buildDeletedAndAnonymised = function ({
   userId,
   createdAt,
   sharedAt,
+  organizationLearnerId,
   assessmentCreatedAt,
   assessmentUpdatedAt,
   deletedAt = new Date('1998-07-01'),
@@ -181,10 +182,10 @@ const buildDeletedAndAnonymised = function ({
 } = {}) {
   const campaign = buildCampaign();
   campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
-  const learner = buildOrganizationLearner({ userId, campaignId: campaign.id });
+  const learnerId = organizationLearnerId || buildOrganizationLearner({ userId, campaignId: campaign.id }).id;
 
   const campaignParticipation = buildCampaignParticipation({
-    organizationLearnerId: learner.id,
+    organizationLearnerId: learnerId,
     campaignId: campaign.id,
     createdAt: createdAt,
     sharedAt: sharedAt || createdAt,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -220,7 +220,7 @@ const getCampaignParticipationsCountByUserId = async function ({ userId }) {
 
 const hasAssessmentParticipations = async function (userId) {
   const knexConn = DomainTransaction.getConnection();
-  const { count } = await knexConn('assessments')
+  const { count: assessmentCount } = await knexConn('assessments')
     .count('assessments.id')
     .leftJoin('campaign-participations', 'campaignParticipationId', 'campaign-participations.id')
     .leftJoin('campaigns', 'campaigns.id', 'campaignId')
@@ -248,7 +248,17 @@ const hasAssessmentParticipations = async function (userId) {
     })
     .first();
 
-  return count > 0;
+  const { count: combinedCourseCount } = await knexConn('view-active-organization-learners')
+    .count('combined_course_participations.id')
+    .join(
+      'combined_course_participations',
+      'combined_course_participations.organizationLearnerId',
+      'view-active-organization-learners.id',
+    )
+    .where({ userId })
+    .first();
+
+  return assessmentCount > 0 || combinedCourseCount > 0;
 };
 
 const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async function (userId) {


### PR DESCRIPTION
## 🔆 Problème

Le lien Mes parcours n'était pas présent car nous excluons automatiquement les participations d'une campagne a un parcours combiné. 

Depuis peu nous remontons une carte du parcours combiné pour pouvoir continuer son parcours.

## ⛱️ Proposition

Modifier la gestion du boolean afin d'afficher le bouton "mes parcours" sur PixApp

## 🌊 Remarques

Modifier des tests pour y ajouter un organisation learner lié à chaque participations. c'est quand même vachement plus représentatif.

## 🏄 Pour tester

Aller sur COMBINIX1 commencé votre participation. Vérifier la présence du bouton sur la navigation de PixApp