### PR TITLE
[FEATURE] Ajouter une route pour récupérer les participations à un parcours combiné (PIX-19703)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -4,6 +4,7 @@ import { getDataBuffer } from '../../prescription/learner-management/infrastruct
 import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
+import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 
 const getByCode = async function (request, _, dependencies = { combinedCourseSerializer }) {
@@ -20,6 +21,12 @@ const getById = async (request, _, dependencies = { combinedCourseDetailsSeriali
   const combinedCourseDetails = await usecases.getCombinedCourseByQuestId({ questId });
 
   return dependencies.combinedCourseDetailsSerializer.serialize(combinedCourseDetails);
+};
+
+const findParticipations = async (request, _, dependencies = { combinedCourseParticipationSerializer }) => {
+  const questId = request.params.questId;
+  const combinedCourseParticipations = await usecases.findCombinedCourseParticipations({ questId });
+  return dependencies.combinedCourseParticipationSerializer.serialize(combinedCourseParticipations);
 };
 
 const start = async function (request, h) {
@@ -57,6 +64,7 @@ const createCombinedCourses = async function (request, h) {
 const combinedCourseController = {
   getByCode,
   getById,
+  findParticipations,
   start,
   reassessStatus,
   createCombinedCourses,

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -58,6 +58,28 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/combined-courses/{questId}/participations',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserCanManageCombinedCourse,
+          },
+        ],
+        handler: combinedCourseController.findParticipations,
+        validate: {
+          params: Joi.object({
+            questId: identifiersType.questId,
+          }),
+        },
+        notes: [
+          "- Récupération des participations d'un parcours combiné dont l'id de la quête est passé en paramètre,\n" +
+            " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
+        ],
+        tags: ['api', 'combined-course', 'orga'],
+      },
+    },
+    {
       method: 'PUT',
       path: '/api/combined-courses/{code}/start',
       config: {

--- a/api/src/quest/domain/models/CombinedCourseParticipation.js
+++ b/api/src/quest/domain/models/CombinedCourseParticipation.js
@@ -1,13 +1,15 @@
 import { CombinedCourseParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
 
 export class CombinedCourseParticipation {
-  constructor({ id, questId, organizationLearnerId, status, updatedAt, createdAt }) {
+  constructor({ id, firstName, lastName, questId, organizationLearnerId, status, updatedAt, createdAt }) {
     this.id = id;
     this.questId = questId;
     this.organizationLearnerId = organizationLearnerId;
     this.status = status;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.firstName = firstName;
+    this.lastName = lastName;
   }
 
   complete() {

--- a/api/src/quest/domain/usecases/find-combined-course-participations.js
+++ b/api/src/quest/domain/usecases/find-combined-course-participations.js
@@ -1,0 +1,3 @@
+export const findCombinedCourseParticipations = async ({ questId, combinedCourseParticipationRepository }) => {
+  return combinedCourseParticipationRepository.findByQuestId({ questId });
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -25,6 +25,7 @@ import { checkUserQuest } from './check-user-quest-success.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
+import { findCombinedCourseParticipations } from './find-combined-course-participations.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import getCombinedCourseByQuestId from './get-combined-course-by-quest-id.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
@@ -39,6 +40,7 @@ const usecasesWithoutInjectedDependencies = {
   findCombinedCourseByCampaignId,
   getCombinedCourseByCode,
   getCombinedCourseByQuestId,
+  findCombinedCourseParticipations,
   getQuestResultsForCampaignParticipation,
   getVerifiedCode,
   rewardUser,

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -53,3 +53,33 @@ export const update = async function ({ combinedCourseParticipation }) {
 
   return new CombinedCourseParticipation(updatedRow);
 };
+
+export const findByQuestId = async function ({ questId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const questParticipations = await knexConnection('combined_course_participations')
+    .select(
+      'combined_course_participations.id',
+      'firstName',
+      'lastName',
+      'combined_course_participations.status',
+      'questId',
+      'organizationLearnerId',
+      'combined_course_participations.status',
+      'combined_course_participations.createdAt',
+      'combined_course_participations.updatedAt',
+    )
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.id',
+      '=',
+      'combined_course_participations.organizationLearnerId',
+    )
+    .where({
+      questId,
+    })
+    .orderBy([
+      { column: 'lastName', order: 'asc' },
+      { column: 'firstName', order: 'asc' },
+    ]);
+  return questParticipations.map((participation) => new CombinedCourseParticipation(participation));
+};

--- a/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-participation-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (combinedCourseParticipations) {
+  return new Serializer('combined-course-participations', {
+    attributes: ['firstName', 'lastName', 'status', 'createdAt', 'updatedAt'],
+  }).serialize(combinedCourseParticipations);
+};
+
+export { serialize };

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -245,4 +245,40 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
       });
     });
   });
+
+  describe('GET /api/combined-courses/{questId}/participations', function () {
+    context('when user has membership in the combined course organization', function () {
+      it('should return the combined course participations', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+          name: 'Mon parcours combiné',
+          code: 'PARCOURS123',
+          organizationId,
+          successRequirements: [],
+        });
+        const learner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+        databaseBuilder.factory.buildCombinedCourseParticipation({
+          organizationLearnerId: learner.id,
+          questId,
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/combined-courses/${questId}/participations`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data[0].type).to.equal('combined-course-participations');
+      });
+    });
+  });
 });

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-participations_test.js
@@ -1,0 +1,44 @@
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipations', function () {
+  it('should return  CombinedCourseParticipations', async function () {
+    // given
+    const learner = databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Paul', lastName: 'Azerty' });
+    const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
+      organizationLearnerId: learner.id,
+      questId,
+      status: CombinedCourseParticipationStatuses.COMPLETED,
+    });
+    const anotherquestId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    databaseBuilder.factory.buildCombinedCourseParticipation({
+      organizationLearnerId: learner.id,
+      questId: anotherquestId,
+      status: CombinedCourseParticipationStatuses.COMPLETED,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const results = await usecases.findCombinedCourseParticipations({ questId });
+
+    // then
+    expect(results).lengthOf(1);
+    expect(results[0]).instanceOf(CombinedCourseParticipation);
+    expect(results).deep.equal([
+      {
+        id: participation1.id,
+        firstName: learner.firstName,
+        lastName: learner.lastName,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+        createdAt: participation1.createdAt,
+        updatedAt: participation1.updatedAt,
+        organizationLearnerId: learner.id,
+        questId,
+      },
+    ]);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -142,4 +142,64 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(updatedParticipation.updatedAt).to.deep.equal(now);
     });
   });
+  describe('#findByQuestId', function () {
+    it('should return participations for a given questId', async function () {
+      // given
+      const learner = databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Paul', lastName: 'Azerty' });
+      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId: learner.id,
+        questId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+      });
+      const anotherlearner = databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'Jeanne',
+        lastName: 'Qwertee',
+      });
+      const participation2 = databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId: anotherlearner.id,
+        questId,
+        status: CombinedCourseParticipationStatuses.STARTED,
+      });
+      const anotherquestId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId: anotherlearner.id,
+        questId: anotherquestId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const results = await combinedCourseParticipationRepository.findByQuestId({ questId });
+
+      // then
+      expect(results).lengthOf(2);
+      expect(results[0]).instanceOf(CombinedCourseParticipation);
+      expect(results[1]).instanceOf(CombinedCourseParticipation);
+
+      expect(results).deep.equal([
+        {
+          id: participation1.id,
+          firstName: learner.firstName,
+          lastName: learner.lastName,
+          status: CombinedCourseParticipationStatuses.COMPLETED,
+          createdAt: participation1.createdAt,
+          updatedAt: participation1.updatedAt,
+          organizationLearnerId: learner.id,
+          questId,
+        },
+        {
+          id: participation2.id,
+          firstName: anotherlearner.firstName,
+          lastName: anotherlearner.lastName,
+          status: CombinedCourseParticipationStatuses.STARTED,
+          createdAt: participation2.createdAt,
+          updatedAt: participation2.updatedAt,
+          organizationLearnerId: anotherlearner.id,
+          questId,
+        },
+      ]);
+    });
+  });
 });

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -26,4 +26,33 @@ describe('Unit | Quest | Application | Controller | CombinedCourse', function ()
       expect(result).to.equal(serializedCombinedCourse);
     });
   });
+  describe('#getParticipations', function () {
+    it('should call getCombinedCourseParticipation usecase with questId', async function () {
+      // given
+      const questId = 'questId123';
+      const combinedCourseParticipations = Symbol('combinedCourseParticipations');
+      const serializedCombinedCourseParticipations = Symbol('serializedCombinedCourseParticipations');
+      const request = {
+        params: { questId },
+      };
+
+      sinon.stub(usecases, 'findCombinedCourseParticipations').resolves(combinedCourseParticipations);
+      const combinedCourseParticipationSerializer = { serialize: sinon.stub() };
+      combinedCourseParticipationSerializer.serialize
+        .withArgs(combinedCourseParticipations)
+        .returns(serializedCombinedCourseParticipations);
+
+      // when
+      const result = await combinedCourseController.findParticipations(request, null, {
+        combinedCourseParticipationSerializer: combinedCourseParticipationSerializer,
+      });
+
+      // then
+      expect(usecases.findCombinedCourseParticipations).to.have.been.calledOnceWithExactly({ questId });
+      expect(combinedCourseParticipationSerializer.serialize).to.have.been.calledOnceWithExactly(
+        combinedCourseParticipations,
+      );
+      expect(result).to.equal(serializedCombinedCourseParticipations);
+    });
+  });
 });

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -38,6 +38,23 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     });
   });
 
+  describe('GET /api/combined-courses/{questId}/participations', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserCanManageCombinedCourse').returns(() => true);
+      sinon.stub(combinedCourseController, 'getById').callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('GET', '/api/combined-courses/123/participations');
+
+      // then
+      expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
+    });
+  });
+
   describe('PUT /api/combined-course/{code}/start', function () {
     it('should call prehandler', async function () {
       // given

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-serializer_test.js
@@ -1,0 +1,34 @@
+import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
+import { serialize } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('CombinedCourseParticipationSerializer', function () {
+  it('should serialize a CombinedCourseParticipation', function () {
+    const combinedCourseParticipation = new CombinedCourseParticipation({
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      questId: 123,
+      organizationLearnerId: 456,
+      status: 'COMPLETED',
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: new Date('2023-01-02T00:00:00Z'),
+    });
+
+    const serialized = serialize(combinedCourseParticipation);
+
+    expect(serialized).to.deep.equal({
+      data: {
+        type: 'combined-course-participations',
+        id: '1',
+        attributes: {
+          'first-name': 'John',
+          'last-name': 'Doe',
+          status: 'COMPLETED',
+          'created-at': new Date('2023-01-01T00:00:00Z'),
+          'updated-at': new Date('2023-01-02T00:00:00Z'),
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

La page des parcours combinés n'est très utile pour un prescripteur sans les participations

## ⛱️ Proposition
On ajoute un route dans l'api pour récupérer les participations d'un parcours combinés

## 🌊 Remarques

On a fait le choix de faire évoluer le modèle de CombinedCourseParticipation en ajoutant les champs qui nous manquait

## 🏄 Pour tester
``` sh
REVIEW_URL="https://api-pr13697.review.pix.fr/api"
ACCESS_TOKEN=$(curl -X POST "$REVIEW_URL/token" \
    --data-raw 'grant_type=password&username=admin-orga%40example.net&password=pix123' | jq -r .access_token )
COMBINED_COURSE_ID=107600
curl "$REVIEW_URL/combined-courses/$COMBINED_COURSE_ID/participations"\ 
 -X GET \ 
 -H 'content-type: application/vnd.api+json' \
 -H "Authorization: Bearer $ACCESS_TOKEN"
```
