### PR TITLE
[FEATURE] Transmettre un event d'erreur durant le stream d'une réponse LLM si celle-ci contient une erreur (PIX-19697)

### DIFF
--- a/api/db/migrations/20250926065009_add-boolean-column-has-error-occurred-in-chat-messages-table.js
+++ b/api/db/migrations/20250926065009_add-boolean-column-has-error-occurred-in-chat-messages-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'chat_messages';
+const COLUMN_NAME = 'hasErrorOccurred';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .boolean(COLUMN_NAME)
+      .nullable()
+      .defaultTo(null)
+      .comment(
+        'when message is of emitter "assistant", will indicates if an error occurred during the streaming phase',
+      );
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -86,15 +86,16 @@ export class Chat {
   }
 
   /**
-   * @param {string=} message
+   * @param {string} message
+   * @param {boolean} shouldBeForwardedToLLM
    */
-  addLLMMessage(message) {
+  addLLMMessage(message, shouldBeForwardedToLLM) {
     if (!message) return;
     this.messages.push(
       new Message({
         content: message,
         isFromUser: false,
-        shouldBeForwardedToLLM: true,
+        shouldBeForwardedToLLM,
         shouldBeRenderedInPreview: true,
         shouldBeCountedAsAPrompt: false,
       }),

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -88,8 +88,9 @@ export class Chat {
   /**
    * @param {string} message
    * @param {boolean} shouldBeForwardedToLLM
+   * @param {boolean} hasErrorOccurred
    */
-  addLLMMessage(message, shouldBeForwardedToLLM) {
+  addLLMMessage(message, shouldBeForwardedToLLM, hasErrorOccurred) {
     if (!message) return;
     this.messages.push(
       new Message({
@@ -98,6 +99,7 @@ export class Chat {
         shouldBeForwardedToLLM,
         shouldBeRenderedInPreview: true,
         shouldBeCountedAsAPrompt: false,
+        hasErrorOccurred,
       }),
     );
   }
@@ -211,6 +213,7 @@ export class Message {
     hasAttachmentBeenSubmittedAlongWithAPrompt,
     haveVictoryConditionsBeenFulfilled,
     wasModerated,
+    hasErrorOccurred,
   }) {
     this.content = content;
     this.isFromUser = isFromUser;
@@ -222,6 +225,7 @@ export class Message {
     this.hasAttachmentBeenSubmittedAlongWithAPrompt = hasAttachmentBeenSubmittedAlongWithAPrompt;
     this.haveVictoryConditionsBeenFulfilled = haveVictoryConditionsBeenFulfilled;
     this.wasModerated = wasModerated;
+    this.hasErrorOccurred = hasErrorOccurred;
   }
 
   get isAttachment() {
@@ -255,6 +259,7 @@ export class Message {
       hasAttachmentBeenSubmittedAlongWithAPrompt: this.hasAttachmentBeenSubmittedAlongWithAPrompt,
       haveVictoryConditionsBeenFulfilled: this.haveVictoryConditionsBeenFulfilled,
       wasModerated: this.wasModerated,
+      hasErrorOccurred: this.hasErrorOccurred,
     };
   }
 

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -95,7 +95,7 @@ function finalize(chat, message, hasJustBeenSentToLLM, chatRepository) {
       streamCapture.haveVictoryConditionsBeenFulfilled,
       streamCapture.wasModerated,
     );
-    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''));
+    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''), true);
     chat.updateTokenConsumption(streamCapture.inputTokens, streamCapture.outputTokens);
     await chatRepository.save(chat);
   };

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -86,8 +86,9 @@ export async function promptChat({
  */
 function finalize(chat, message, hasJustBeenSentToLLM, chatRepository) {
   return async (streamCapture) => {
-    const shouldBeCountedAsAPrompt = hasJustBeenSentToLLM;
-    const shouldBeForwardedToLLM = hasJustBeenSentToLLM && !streamCapture.wasModerated;
+    const hasErrorOccurredDuringStream = !!streamCapture.errorOccurredDuringStream;
+    const shouldBeCountedAsAPrompt = hasJustBeenSentToLLM && !hasErrorOccurredDuringStream;
+    const shouldBeForwardedToLLM = hasJustBeenSentToLLM && !streamCapture.wasModerated && !hasErrorOccurredDuringStream;
     chat.addUserMessage(
       message,
       shouldBeCountedAsAPrompt,
@@ -95,7 +96,7 @@ function finalize(chat, message, hasJustBeenSentToLLM, chatRepository) {
       streamCapture.haveVictoryConditionsBeenFulfilled,
       streamCapture.wasModerated,
     );
-    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''), true);
+    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''), !hasErrorOccurredDuringStream);
     chat.updateTokenConsumption(streamCapture.inputTokens, streamCapture.outputTokens);
     await chatRepository.save(chat);
   };

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -96,7 +96,11 @@ function finalize(chat, message, hasJustBeenSentToLLM, chatRepository) {
       streamCapture.haveVictoryConditionsBeenFulfilled,
       streamCapture.wasModerated,
     );
-    chat.addLLMMessage(streamCapture.LLMMessageParts.join(''), !hasErrorOccurredDuringStream);
+    chat.addLLMMessage(
+      streamCapture.LLMMessageParts.join(''),
+      !hasErrorOccurredDuringStream,
+      hasErrorOccurredDuringStream,
+    );
     chat.updateTokenConsumption(streamCapture.inputTokens, streamCapture.outputTokens);
     await chatRepository.save(chat);
   };

--- a/api/src/llm/infrastructure/serializers/json/chat-serializer.js
+++ b/api/src/llm/infrastructure/serializers/json/chat-serializer.js
@@ -37,12 +37,20 @@ export function serialize(chat) {
     totalOutputTokens: chat.totalOutputTokens,
     hasVictoryConditions: chat.hasVictoryConditions,
     messages: messagesForPreview.map(
-      ({ content, attachmentName, isFromUser, haveVictoryConditionsBeenFulfilled, wasModerated }) => ({
+      ({
         content,
         attachmentName,
         isFromUser,
         haveVictoryConditionsBeenFulfilled,
         wasModerated,
+        hasErrorOccurred,
+      }) => ({
+        content,
+        attachmentName,
+        isFromUser,
+        haveVictoryConditionsBeenFulfilled,
+        wasModerated,
+        hasErrorOccurred,
         isAttachmentValid: Boolean(attachmentName && chat.isAttachmentValid(attachmentName)),
       }),
     ),

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -20,6 +20,7 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  * @property {number} inputTokens
  * @property {number} outputTokens
  * @property {boolean} wasModerated
+ * @property {string=} errorOccurredDuringStream
  */
 
 /**

--- a/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
@@ -8,7 +8,7 @@ export function getTransform(streamCapture) {
   return new Transform({
     objectMode: true,
     transform(chunk, _encoding, callback) {
-      const { message, isValid, usage, wasModerated, ping } = chunk;
+      const { error, message, isValid, usage, wasModerated, ping } = chunk;
       let data = '';
 
       if (ping) {
@@ -28,6 +28,11 @@ export function getTransform(streamCapture) {
       if (message) {
         streamCapture.LLMMessageParts.push(...message.split(''));
         data += getFormattedMessage(message);
+      }
+
+      if (error) {
+        streamCapture.errorOccurredDuringStream = error;
+        data += getErrorEvent();
       }
 
       if (usage) {
@@ -56,4 +61,8 @@ function getMessageModeratedEvent() {
 
 function getPingEvent() {
   return 'event: ping\ndata: \n\n';
+}
+
+function getErrorEvent() {
+  return 'event: error\ndata: \n\n';
 }

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -273,7 +273,7 @@ describe('Acceptance | Route | llm-preview', function () {
           totalOutputTokens: 5_000,
           messages: [
             { content: 'coucou user1', isFromUser: true, shouldBeRenderedInPreview: true },
-            { content: 'coucou LLM1', isFromUser: false, shouldBeRenderedInPreview: true },
+            { content: 'coucou LLM1', isFromUser: false, shouldBeRenderedInPreview: true, hasErrorOccurred: true },
             {
               attachmentName: 'expected_file.txt',
               isFromUser: true,
@@ -326,6 +326,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
           {
             content: 'coucou LLM1',
@@ -334,6 +335,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: true,
           },
           {
             content: 'un message',
@@ -342,6 +344,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isAttachmentValid: true,
             haveVictoryConditionsBeenFulfilled: true,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
           {
             content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
@@ -350,6 +353,7 @@ describe('Acceptance | Route | llm-preview', function () {
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
         ],
       });

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -343,6 +343,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 shouldBeRenderedInPreview: true,
                 shouldBeForwardedToLLM: true,
                 shouldBeCountedAsAPrompt: false,
+                hasErrorOccurred: false,
               },
             ],
           });
@@ -471,6 +472,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   shouldBeRenderedInPreview: true,
                   shouldBeForwardedToLLM: true,
                   shouldBeCountedAsAPrompt: false,
+                  hasErrorOccurred: false,
                 },
               ],
             });
@@ -707,6 +709,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                       shouldBeForwardedToLLM: true,
                       shouldBeRenderedInPreview: true,
                       shouldBeCountedAsAPrompt: false,
+                      hasErrorOccurred: false,
                     },
                   ],
                 });
@@ -993,6 +996,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                       shouldBeRenderedInPreview: true,
                       shouldBeForwardedToLLM: true,
                       shouldBeCountedAsAPrompt: false,
+                      hasErrorOccurred: false,
                     },
                   ],
                 });
@@ -1143,6 +1147,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                       shouldBeRenderedInPreview: true,
                       shouldBeForwardedToLLM: true,
                       shouldBeCountedAsAPrompt: false,
+                      hasErrorOccurred: false,
                     },
                   ],
                 });
@@ -1778,6 +1783,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
               shouldBeRenderedInPreview: true,
               shouldBeForwardedToLLM: true,
               shouldBeCountedAsAPrompt: false,
+              hasErrorOccurred: false,
             },
           ],
         });
@@ -1893,6 +1899,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
               shouldBeRenderedInPreview: true,
               shouldBeForwardedToLLM: true,
               shouldBeCountedAsAPrompt: false,
+              hasErrorOccurred: false,
             },
           ],
         });
@@ -2096,6 +2103,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 shouldBeRenderedInPreview: true,
                 shouldBeForwardedToLLM: true,
                 shouldBeCountedAsAPrompt: false,
+                hasErrorOccurred: false,
               },
             ],
           });
@@ -2207,6 +2215,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 shouldBeRenderedInPreview: true,
                 shouldBeForwardedToLLM: true,
                 shouldBeCountedAsAPrompt: false,
+                hasErrorOccurred: false,
               },
             ],
           });
@@ -2334,6 +2343,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             shouldBeRenderedInPreview: true,
             shouldBeForwardedToLLM: false,
             shouldBeCountedAsAPrompt: false,
+            hasErrorOccurred: true,
           },
         ],
       });

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -2232,7 +2232,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       });
     });
 
-    it.skip('should return a stream which will contain the partial llm response and the error', async function () {
+    it('should return a stream which will contain the partial llm response and the error', async function () {
       // given
       const chat = new Chat({
         id: 'chatId',
@@ -2289,7 +2289,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       }
       const llmResponse = parts.join('');
       expect(llmResponse).to.deep.equal(
-        "data: coucou c'est super\n\ndata: \ndata: le couscous c plutot bon\n\nevent:  error\ndata: \n\n",
+        "data: coucou c'est super\n\ndata: \ndata: le couscous c plutot bon\n\nevent: error\ndata: \n\n",
       );
       expect(await chatTemporaryStorage.get('chatId')).to.deep.equal({
         id: 'chatId',

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -2215,6 +2215,131 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       });
     });
   });
+
+  context('when an error occurs in stream', function () {
+    let configuration;
+    const configurationId = 'uneConfigQuiExist';
+
+    beforeEach(function () {
+      configuration = new Configuration({
+        llm: {
+          historySize: 123,
+        },
+        challenge: {
+          inputMaxPrompts: 100,
+          inputMaxChars: 255,
+        },
+      });
+    });
+
+    it.skip('should return a stream which will contain the partial llm response and the error', async function () {
+      // given
+      const chat = new Chat({
+        id: 'chatId',
+        userId: 123,
+        configurationId,
+        configuration,
+        hasAttachmentContextBeenAdded: false,
+        messages: [buildBasicUserMessage('coucou user1'), buildBasicAssistantMessage('coucou LLM1')],
+      });
+      await chatTemporaryStorage.save({
+        key: chat.id,
+        value: chat.toDTO(),
+        expirationDelaySeconds: ms('24h'),
+      });
+      const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
+        .post('/chat', {
+          configuration: {
+            llm: {
+              historySize: 123,
+            },
+            challenge: {
+              inputMaxPrompts: 100,
+              inputMaxChars: 255,
+            },
+          },
+          history: [
+            { content: 'coucou user1', role: 'user' },
+            { content: 'coucou LLM1', role: 'assistant' },
+          ],
+          prompt: 'un message',
+        })
+        .reply(
+          201,
+          Readable.from([
+            '60:{"ceci":"nest pas important","message":"coucou c\'est super"}',
+            '40:{"message":"\\nle couscous c plutot bon"}35:{"error":"une erreur est survenue"}',
+          ]),
+        );
+
+      // when
+      const stream = await promptChat({
+        chatId: 'chatId',
+        userId: 123,
+        message: 'un message',
+        attachmentName: null,
+        ...dependencies,
+      });
+
+      // then
+      const parts = [];
+      const decoder = new TextDecoder();
+      for await (const chunk of stream) {
+        parts.push(decoder.decode(chunk));
+      }
+      const llmResponse = parts.join('');
+      expect(llmResponse).to.deep.equal(
+        "data: coucou c'est super\n\ndata: \ndata: le couscous c plutot bon\n\nevent:  error\ndata: \n\n",
+      );
+      expect(await chatTemporaryStorage.get('chatId')).to.deep.equal({
+        id: 'chatId',
+        userId: 123,
+        configurationId: 'uneConfigQuiExist',
+        configuration: {
+          llm: {
+            historySize: 123,
+          },
+          challenge: {
+            inputMaxPrompts: 100,
+            inputMaxChars: 255,
+          },
+        },
+        hasAttachmentContextBeenAdded: false,
+        messages: [
+          {
+            content: 'coucou user1',
+            isFromUser: true,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeCountedAsAPrompt: true,
+          },
+          {
+            content: 'coucou LLM1',
+            isFromUser: false,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: true,
+            shouldBeCountedAsAPrompt: false,
+          },
+          {
+            content: 'un message',
+            isFromUser: true,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: false,
+            shouldBeCountedAsAPrompt: false,
+            wasModerated: false,
+          },
+          {
+            content: "coucou c'est super\nle couscous c plutot bon",
+            isFromUser: false,
+            shouldBeRenderedInPreview: true,
+            shouldBeForwardedToLLM: false,
+            shouldBeCountedAsAPrompt: false,
+          },
+        ],
+      });
+      expect(llmPostPromptScope.isDone()).to.be.true;
+    });
+  });
 });
 
 function buildBasicUserMessage(content) {

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -95,6 +95,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
         {
           content: 'un message pas vide',
@@ -107,6 +108,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: false,
           wasModerated: false,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -138,6 +140,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -167,6 +170,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: false,
           wasModerated: false,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -196,6 +200,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: false,
           wasModerated: false,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -225,6 +230,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: true,
           wasModerated: false,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -254,6 +260,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: false,
           wasModerated: true,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -285,6 +292,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
         {
           content: 'un message pas vide',
@@ -297,6 +305,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -328,6 +337,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
       ]);
     });
@@ -358,6 +368,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
         },
         {
           content: 'message2',
@@ -370,6 +381,51 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,
           wasModerated: undefined,
+          hasErrorOccurred: undefined,
+        },
+      ]);
+    });
+
+    it('should set "hasErrorOccurred" to the value passed in parameter', function () {
+      // given
+      const chat = new Chat({
+        id: 'some-chat-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
+        hasAttachmentContextBeenAdded: false,
+        messages: [],
+      });
+
+      // when
+      chat.addLLMMessage('message1', true, true);
+      chat.addLLMMessage('message2', true, false);
+
+      // then
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'message1',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: false,
+          shouldBeForwardedToLLM: true,
+          shouldBeRenderedInPreview: true,
+          shouldBeCountedAsAPrompt: false,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
+          hasErrorOccurred: true,
+        },
+        {
+          content: 'message2',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: false,
+          shouldBeForwardedToLLM: true,
+          shouldBeRenderedInPreview: true,
+          shouldBeCountedAsAPrompt: false,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
+          hasErrorOccurred: false,
         },
       ]);
     });
@@ -415,6 +471,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -427,6 +484,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -439,6 +497,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -451,6 +510,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -492,6 +552,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -504,6 +565,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -516,6 +578,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -528,6 +591,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -572,6 +636,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -584,6 +649,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -596,6 +662,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -637,6 +704,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -649,6 +717,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -661,6 +730,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -707,6 +777,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -719,6 +790,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -731,6 +803,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -772,6 +845,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -784,6 +858,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -796,6 +871,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -840,6 +916,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -852,6 +929,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -864,6 +942,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: true,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -905,6 +984,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: 'some answer',
@@ -917,6 +997,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
               {
                 content: undefined,
@@ -929,6 +1010,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
                 hasAttachmentBeenSubmittedAlongWithAPrompt: false,
                 haveVictoryConditionsBeenFulfilled: undefined,
                 wasModerated: undefined,
+                hasErrorOccurred: undefined,
               },
             ]);
           });
@@ -1296,6 +1378,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'message llm 1',
@@ -1308,6 +1391,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
           ],
         });
@@ -1370,6 +1454,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'message llm 1',
@@ -1382,6 +1467,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
               hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
           ],
         });
@@ -1417,6 +1503,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             shouldBeCountedAsAPrompt: false,
             shouldBeRenderedInPreview: true,
             shouldBeForwardedToLLM: true,
+            hasErrorOccurred: true,
           }),
           new Message({
             attachmentName: 'file.txt',
@@ -1464,6 +1551,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: true,
+            hasErrorOccurred: undefined,
           },
           {
             content: 'message llm 1',
@@ -1476,6 +1564,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: true,
           },
           {
             content: undefined,
@@ -1488,6 +1577,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             hasAttachmentBeenSubmittedAlongWithAPrompt: false,
             haveVictoryConditionsBeenFulfilled: true,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
           {
             content: undefined,
@@ -1500,6 +1590,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
             hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
         ],
       });

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -270,7 +270,7 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addLLMMessage('un message pas vide');
+      chat.addLLMMessage('un message pas vide', true);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -311,9 +311,9 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
       });
 
       // when
-      chat.addLLMMessage('');
-      chat.addLLMMessage(null);
-      chat.addLLMMessage();
+      chat.addLLMMessage('', true);
+      chat.addLLMMessage(null, true);
+      chat.addLLMMessage(undefined, true);
 
       // then
       expect(chat.toDTO()).to.have.deep.property('messages', [
@@ -324,6 +324,48 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           isFromUser: false,
           shouldBeForwardedToLLM: false,
           shouldBeRenderedInPreview: false,
+          shouldBeCountedAsAPrompt: false,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
+        },
+      ]);
+    });
+
+    it('should set "shouldBeForwardedToLLM" to the value passed in parameter', function () {
+      // given
+      const chat = new Chat({
+        id: 'some-chat-id',
+        configuration: new Configuration({ id: 'some-config-id' }),
+        hasAttachmentContextBeenAdded: false,
+        messages: [],
+      });
+
+      // when
+      chat.addLLMMessage('message1', true);
+      chat.addLLMMessage('message2', false);
+
+      // then
+      expect(chat.toDTO()).to.have.deep.property('messages', [
+        {
+          content: 'message1',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: false,
+          shouldBeForwardedToLLM: true,
+          shouldBeRenderedInPreview: true,
+          shouldBeCountedAsAPrompt: false,
+          hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
+          haveVictoryConditionsBeenFulfilled: undefined,
+          wasModerated: undefined,
+        },
+        {
+          content: 'message2',
+          attachmentName: undefined,
+          attachmentContext: undefined,
+          isFromUser: false,
+          shouldBeForwardedToLLM: false,
+          shouldBeRenderedInPreview: true,
           shouldBeCountedAsAPrompt: false,
           hasAttachmentBeenSubmittedAlongWithAPrompt: undefined,
           haveVictoryConditionsBeenFulfilled: undefined,

--- a/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
+++ b/api/tests/llm/unit/infrastructure/serializers/chat-serializer_test.js
@@ -32,6 +32,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             content: 'Bonjour comment puis-je vous aider ?',
             isFromUser: false,
             shouldBeRenderedInPreview: true,
+            hasErrorOccurred: true,
           }),
         ],
       });
@@ -57,6 +58,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: undefined,
           },
           {
             content: 'Bonjour comment puis-je vous aider ?',
@@ -65,6 +67,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
             isAttachmentValid: false,
             haveVictoryConditionsBeenFulfilled: undefined,
             wasModerated: undefined,
+            hasErrorOccurred: true,
           },
         ],
       });
@@ -127,6 +130,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
               wasModerated: true,
+              hasErrorOccurred: undefined,
             },
           ],
         });
@@ -213,6 +217,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -221,6 +226,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Que contient ce fichier ?',
@@ -229,6 +235,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: true,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
@@ -237,6 +244,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
@@ -245,6 +253,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
               wasModerated: true,
+              hasErrorOccurred: undefined,
             },
           ],
         });
@@ -331,6 +340,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Bonjour comment puis-je vous aider ?',
@@ -339,6 +349,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: undefined,
@@ -347,6 +358,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: true,
               haveVictoryConditionsBeenFulfilled: true,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Que contient ce fichier ?',
@@ -355,6 +367,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'Le fichier contient la photo d’un ours',
@@ -363,6 +376,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: undefined,
@@ -371,6 +385,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: undefined,
               wasModerated: undefined,
+              hasErrorOccurred: undefined,
             },
             {
               content: 'tu veux bien lire ce fichier avec un chat dedans ?',
@@ -379,6 +394,7 @@ describe('LLM | Unit | Infrastructure | Serializers | Chat', function () {
               isAttachmentValid: false,
               haveVictoryConditionsBeenFulfilled: true,
               wasModerated: true,
+              hasErrorOccurred: undefined,
             },
           ],
         });


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'une erreur, côté ChatPix, se produit pendant la phase de streaming des chunks de réponse, ChatPix va streamer cette erreur, puis fermer le stream. Au même titre que les autres informations, cette erreur est streamée dans un length-prefixed JSON du style :
 `33:{"error":"la raison de l erreur'}`
A ce jour, côté API Pix, cette information n'est pas traitée. Donc côté utilisateur, on a simplement un début de message de réponse qui apparaît, puis tout s'arrête.

## ⛱️ Proposition

- Convertir en event-stream l'information d'erreur reçue depuis ChatPix
- Marquer le message LLM partielle comme étant en erreur (pour l'historique + pour la preview)
- Marquer le message utilisateur ET le message LLM à exclure de l'historique de conversation envoyée à ChatPix
- Marquer le message utilisateur comme ne devant pas être décompté du nombre de prompts autorisé par l'utilisateur

## 🌊 Remarques
Comme on ajoute une nouvelle info dans "messages" il faut ajouter cette colonne dans la table chat_messages

## 🏄 Pour tester
🤡 
