### PR TITLE
[FEATURE] Ajouter deux tables pour relier les participations à des parcours combinés aux organization learners (PIX-19676)

### DIFF
--- a/api/db/migrations/20250926083934_add-organization_learner_participations-table.js
+++ b/api/db/migrations/20250926083934_add-organization_learner_participations-table.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'organization_learner_participations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains all kinds of participation for organization-learners.');
+    table.increments('id').primary();
+    table.string('type', 50).notNullable().comment('Type of participation : campaign, combined-course, passage');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').defaultTo(knex.fn.now());
+    table.dateTime('completedAt');
+    table.dateTime('deletedAt');
+    table.integer('deletedBy').references('users.id');
+    table.integer('organizationLearnerId').references('organization-learners.id').notNullable().index();
+    table.string('status').notNullable().comment('Status of the participation : started, completed');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/migrations/20250926090213_add-organization_learner_passage_participations.js
+++ b/api/db/migrations/20250926090213_add-organization_learner_passage_participations.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'organization_learner_passage_participations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment(
+      'this table contains specific data related to passages for organization_learner_participations table',
+    );
+    table.increments('id').primary().notNullable();
+    table.string('moduleId').notNullable();
+    table
+      .integer('organizationLearnerParticipationId')
+      .references('organization_learner_participations.id')
+      .index()
+      .notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème
Dans le cadre des travaux sur l'anonymisation, on a besoin de pouvoir fournir des données à l'organisation sur les participations aux parcours combinés en se basant uniquement sur l'organizationLearnerId et pas sur le userId.

## ⛱️ Proposition
On crée une table générique, organization_learner_participations, qui contient des attributs utiles pour trois types de participations (les participations aux campagnes, aux parcours combinés, et les passages de modules).
On crée une table supplémentaire avec les infos spécifiques aux passages (organization_learner_passages_participations).
