### PR TITLE
[FEATURE] Permettre de visualiser les feedbacks lors de la preview (PIX-12252)

### DIFF
--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -30,6 +30,7 @@
   }
 
   &__feedback {
+    margin-top: var(--pix-spacing-1x);
     margin-bottom: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -16,6 +16,7 @@ export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcm extends ModuleElement {
   @service passageEvents;
+  @service modulixPreviewMode;
 
   @tracked isAnswering = false;
   @tracked currentCorrection;
@@ -106,6 +107,18 @@ export default class ModuleQcm extends ModuleElement {
     return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
+  get previewFeedbacks() {
+    const feedbacks = [];
+    for (const [key, value] of Object.entries(this.element.feedbacks)) {
+      feedbacks.push({ status: key, ...value });
+    }
+    return feedbacks;
+  }
+
+  isValidFeedbackForPreview(feedback) {
+    return feedback.status === 'valid';
+  }
+
   <template>
     <form class="element-qcm" aria-describedby="instruction-{{this.element.id}}">
       <fieldset>
@@ -160,6 +173,16 @@ export default class ModuleQcm extends ModuleElement {
           <ModulixFeedback @answerIsValid={{this.answerIsValid}} @feedback={{this.correction.feedback}} />
         {{/if}}
       </div>
+
+      {{#if this.modulixPreviewMode.isEnabled}}
+        <div role="status" tabindex="-1">
+          {{#each this.previewFeedbacks as |feedback|}}
+            <div class="element-qcm__feedback">
+              <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
+            </div>
+          {{/each}}
+        </div>
+      {{/if}}
 
       {{#if this.shouldDisplayRetryButton}}
         <PixButton

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -18,6 +18,7 @@ export default class ModuleQcu extends ModuleElement {
   @tracked selectedAnswerId = null;
   @tracked currentCorrection;
   @service passageEvents;
+  @service modulixPreviewMode;
   @tracked displayFeedbackState = false;
 
   @action
@@ -72,6 +73,11 @@ export default class ModuleQcu extends ModuleElement {
 
   get disableInput() {
     return !this.isOnRetryMode && (this.displayFeedbackState || !!this.currentCorrection);
+  }
+
+  @action
+  isValidFeedbackForPreview(proposalId) {
+    return this.element.solution === proposalId;
   }
 
   @action
@@ -141,6 +147,15 @@ export default class ModuleQcu extends ModuleElement {
                 {{htmlUnsafe proposal.content}}
               </:label>
             </PixRadioButton>
+
+            {{#if this.modulixPreviewMode.isEnabled}}
+              <div class="element-qcu__feedback" role="status" tabindex="-1">
+                <ModulixFeedback
+                  @answerIsValid={{this.isValidFeedbackForPreview proposal.id}}
+                  @feedback={{proposal.feedback}}
+                />
+              </div>
+            {{/if}}
           {{/each}}
         </div>
       </fieldset>

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -18,6 +18,7 @@ export default class ModuleQrocm extends ModuleElement {
   @tracked currentCorrection;
   @service passageEvents;
   @service qrocmSolutionVerification;
+  @service modulixPreviewMode;
 
   constructor() {
     super(...arguments);
@@ -120,6 +121,18 @@ export default class ModuleQrocm extends ModuleElement {
     };
   }
 
+  get previewFeedbacks() {
+    const feedbacks = [];
+    for (const [key, value] of Object.entries(this.element.feedbacks)) {
+      feedbacks.push({ status: key, ...value });
+    }
+    return feedbacks;
+  }
+
+  isValidFeedbackForPreview(feedback) {
+    return feedback.status === 'valid';
+  }
+
   <template>
     <form
       class="element-qrocm"
@@ -220,6 +233,16 @@ export default class ModuleQrocm extends ModuleElement {
           <ModulixFeedback @answerIsValid={{this.answerIsValid}} @feedback={{this.correction.feedback}} />
         {{/if}}
       </div>
+
+      {{#if this.modulixPreviewMode.isEnabled}}
+        <div role="status" tabindex="-1">
+          {{#each this.previewFeedbacks as |feedback|}}
+            <div class="element-qrocm__feedback">
+              <ModulixFeedback @answerIsValid={{this.isValidFeedbackForPreview feedback}} @feedback={{feedback}} />
+            </div>
+          {{/each}}
+        </div>
+      {{/if}}
 
       {{#if this.shouldDisplayRetryButton}}
         <PixButton

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
@@ -292,5 +293,45 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const checkbox1 = screen.getByRole('checkbox', { name: 'checkbox1', disabled: true });
     checkbox1.focus();
     assert.deepEqual(document.activeElement, checkbox1);
+  });
+
+  module('when preview mode is enabled', function () {
+    test('should display all feedbacks', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qcm = {
+        id: 'a2638f8e-05ee-42e0-9820-13a9977cf5dc',
+        instruction: 'Instruction',
+        proposals: [
+          { id: '1', content: 'checkbox1' },
+          { id: '2', content: 'checkbox2' },
+          { id: '3', content: 'checkbox3' },
+        ],
+        feedbacks: {
+          valid: {
+            state: 'Correct!',
+            diagnosis: '<p>Good job!</p>',
+          },
+          invalid: {
+            state: 'Wrong!',
+            diagnosis: '<p>Too Bad!</p>',
+          },
+        },
+        solutions: ['1', '2'],
+        type: 'qcm',
+      };
+
+      // when
+      const screen = await render(<template><ModulixQcm @element={{qcm}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('Correct!')).exists();
+      assert.dom(screen.getByText('Good job!')).exists();
+      assert.dom(screen.getByText('Wrong!')).exists();
+      assert.dom(screen.getByText('Too Bad!')).exists();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
@@ -222,6 +223,26 @@ module('Integration | Component | Module | QCU', function (hooks) {
 
     // then
     assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+  });
+
+  module('when preview mode is enabled', function () {
+    test('should display all feedbacks, without answering', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qcuElement = _getQcuElement();
+
+      // when
+      const screen = await render(<template><ModulixQcu @element={{qcuElement}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('Correct!')).exists();
+      assert.dom(screen.getByText('Good job!')).exists();
+      assert.dom(screen.getByText('Wrong!')).exists();
+      assert.dom(screen.getByText('Try again!')).exists();
+    });
   });
 });
 

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -1,4 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, fillIn, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
@@ -483,6 +484,26 @@ module('Integration | Component | Module | QROCM', function (hooks) {
 
     // then
     assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+  });
+
+  module('when preview mode is enabled', function () {
+    test('should display all feedbacks', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qrocm = prepareQrocm();
+
+      // when
+      const screen = await render(<template><ModuleQrocm @element={{qrocm}} /></template>);
+
+      // then
+      assert.dom(screen.getByText('Correct!')).exists();
+      assert.dom(screen.getByText('Good job!')).exists();
+      assert.dom(screen.getByText('Wrong!')).exists();
+      assert.dom(screen.getByText('Too Bad!')).exists();
+    });
   });
 });
 


### PR DESCRIPTION
## 🔆 Problème

Dans la preview, on ne peut pas afficher tous les feedbacks des Qcu, Qrocm et Qcm.

## ⛱️ Proposition

En mode Preview, permettre l'affichage de tous les feedbacks, avec les bonnes couleurs.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Ouvrir [en preview le bac-a-sable](https://app-pr13702.review.pix.org/modules/preview/bac-a-sable)
- Afficher un QCU et constater l'affichage des feedbacks pour chaque proposition
- Afficher un QCM et constater l'affichage des feedbacks 
- Afficher un QROCM et constater l'affichage des feedbacks 