### PR TITLE
[FEATURE] Afficher le champ "Equipe en charge" dans la page de détail d'une organisation (PIX-19509)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -91,6 +91,12 @@ class OrganizationDescription extends Component {
 
       <DescriptionList.Divider />
 
+      <DescriptionList.Item @label="Équipe en charge">
+        {{if @organization.administrationTeamName @organization.administrationTeamName "Non spécifié"}}
+      </DescriptionList.Item>
+
+      <DescriptionList.Divider />
+
       <DescriptionList.Item @label="Nom du DPO">
         {{@organization.dataProtectionOfficerFullName}}
       </DescriptionList.Item>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -28,6 +28,7 @@ export default class Organization extends Model {
   @attr('nullable-string') parentOrganizationName;
   //TODO REMOVE nullable-string BEFORE THE END OF EPIX
   @attr('nullable-string') administrationTeamId;
+  @attr('nullable-string') administrationTeamName;
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;
 

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -47,6 +47,7 @@ module('Integration | Component | organizations/information-section-view', funct
         identityProviderForCampaigns: 'IDP',
         dataProtectionOfficerFullName: 'Justin Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        administrationTeamName: 'team Rocket',
       };
 
       // when
@@ -58,6 +59,7 @@ module('Integration | Component | organizations/information-section-view', funct
       assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('justin.ptipeu@example.net');
       assert.dom(screen.getByText('Créée par').nextElementSibling).hasText('Gilles Parbal (1)');
       assert.dom(screen.getByText('Créée le').nextElementSibling).hasText('02/09/2022');
+      assert.dom(screen.getByText('Équipe en charge').nextElementSibling).hasText('team Rocket');
       assert
         .dom(
           screen.getByLabelText(

--- a/api/tests/organizational-entities/unit/domain/usecases/get-organization-details.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/get-organization-details.usecase.test.js
@@ -26,7 +26,7 @@ describe('Unit | Organizational Entities | Domain | UseCase | get-organization-d
       // given
       const organizationId = 1234;
       const code = 'MINIPIXOU';
-      const foundOrganization = domainBuilder.buildOrganization({
+      const foundOrganization = domainBuilder.buildOrganizationForAdmin({
         id: organizationId,
         email: 'sco.generic.account@example.net',
         type: Organization.types.SCO1D,


### PR DESCRIPTION
## 🔆 Problème

Dans la page de détail d'une organisation, on veut pouvoir visulaiser le nom de l'équipe en charge

## ⛱️ Proposition

 Sur la page de détail d’une organisation, sous “département”, il faut faire un deuxième bloc qui contiendra pour l’instant “Equipe en charge  “ (les deux autres champs sont à venir)

## 🌊 Remarques

Suite de #13689

## 🏄 Pour tester
- Depuis pix-admin
- Créer une nouvelle organisation en renseignant une équipe en charge
- Aller sur la page de détail de cette organisation et constater l'affichage de l'équipe en charge

<img width="654" height="460" alt="image" src="https://github.com/user-attachments/assets/358a4e52-963c-45f9-80cb-b6b9dc39f656" />
