### PR TITLE
[FEATURE] Parler de "référentiel de certification" à la place de "référentiel cadre"(PIX-19555).

### DIFF
--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -430,14 +430,14 @@
       "item": {
         "complementary-certification": "Complementary certification",
         "framework": {
-          "create-button": "Create a new consolidated framework",
+          "create-button": "Create a new certification framework",
           "creation-form": {
-            "submit-button": "Submit the new consolidated framework",
-            "success-notification": "The new framework has been successfully created.",
-            "title": "Creating a new consolidated framework for {complementaryCertificationLabel}"
+            "submit-button": "Submit the new certification framework",
+            "success-notification": "The new certification framework has been successfully created.",
+            "title": "Creating a new certification framework for {complementaryCertificationLabel}"
           },
           "details": {
-            "title": "Current consolidated framework details"
+            "title": "Current certification framework details"
           },
           "history": {
             "table": {
@@ -445,8 +445,8 @@
             },
             "title": "Framework versions history"
           },
-          "no-current-framework": "No consolidated framework is currently used.",
-          "tab": "Consolidated framework"
+          "no-current-framework": "No certification framework is currently used.",
+          "tab": "Certification framework"
         },
         "navigation": {
           "aria-label": "Navigation of the complementary certification section"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -430,15 +430,15 @@
       "item": {
         "complementary-certification": "Certification complémentaire",
         "framework": {
-          "create-button": "Créer un nouveau référentiel cadre",
+          "create-button": "Créer un nouveau référentiel de certification",
           "creation-form": {
-            "submit-button": "Créer le nouveau référentiel cadre",
-            "success-notification": "Le nouveau référentiel cadre a été créé avec succès",
-            "title": "Créer un nouveau référentiel cadre pour {complementaryCertificationLabel}"
+            "submit-button": "Créer le nouveau référentiel de certification",
+            "success-notification": "Le nouveau référentiel de certification a été créé avec succès",
+            "title": "Créer un nouveau référentiel de certification pour {complementaryCertificationLabel}"
           },
           "details": {
-            "empty-current-framework": "Le référentiel cadre actuel est vide.",
-            "title": "Détails du référentiel cadre actuel"
+            "empty-current-framework": "Le référentiel de certification actuel est vide.",
+            "title": "Détails du référentiel de certification actuel"
           },
           "history": {
             "table": {
@@ -446,8 +446,8 @@
             },
             "title": "Historique des versions du référentiel"
           },
-          "no-current-framework": "Aucun référentiel cadre n'est utilisé actuellement.",
-          "tab": "Référentiel cadre"
+          "no-current-framework": "Aucun référentiel de certification n'est utilisé actuellement.",
+          "tab": "Référentiel de certification"
         },
         "navigation": {
           "aria-label": "Navigation de la section certification complémentaire"


### PR DESCRIPTION
## 🔆 Problème

Le terme référentiel cadre est déjà utilisé par ailleurs pour désigner des référentiels comme le Digcomp. Il existe un risque de confusion des partenaires entre le référentiel cadre et notre nouvelle utilisation.

## ⛱️ Proposition

Remplacer la notion de "référentiel cadre" par “référentiel de certification”

## 🏄 Pour tester

Tests verts ✅
