### PR TITLE
[FEATURE] Désactiver les propositions lors de la vérification des réponses des QROCM (PIX-19374)

### DIFF
--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -17,6 +17,7 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 export default class ModuleQrocm extends ModuleElement {
   @tracked selectedValues = {};
   @tracked currentCorrection;
+  @tracked isVerifying = false;
   @service passageEvents;
   @service qrocmSolutionVerification;
   @service modulixPreviewMode;
@@ -93,6 +94,7 @@ export default class ModuleQrocm extends ModuleElement {
 
   @action
   async onAnswer(event) {
+    this.isVerifying = true;
     super.onAnswer(event);
 
     if (this.shouldDisplayRequiredMessage === true) {
@@ -115,6 +117,8 @@ export default class ModuleQrocm extends ModuleElement {
       type: 'QROCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
+
+    this.isVerifying = false;
   }
 
   #waitFor(duration) {
@@ -138,6 +142,10 @@ export default class ModuleQrocm extends ModuleElement {
 
   isValidFeedbackForPreview(feedback) {
     return feedback.status === 'valid';
+  }
+
+  get disableInput() {
+    return super.disableInput || this.isVerifying;
   }
 
   <template>

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -11,6 +11,7 @@ import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import ModuleElement from 'mon-pix/components/module/element/module-element';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
+import ENV from 'mon-pix/config/environment';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
 export default class ModuleQrocm extends ModuleElement {
@@ -98,6 +99,8 @@ export default class ModuleQrocm extends ModuleElement {
       return;
     }
 
+    await this.#waitFor(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY);
+
     const answerIsValid = this.answerIsValid;
     const status = answerIsValid ? 'ok' : 'ko';
 
@@ -112,6 +115,10 @@ export default class ModuleQrocm extends ModuleElement {
       type: 'QROCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
+  }
+
+  #waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
   #updateSelectedValues(block, value) {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -125,6 +125,7 @@ module.exports = function (environment) {
       COMBINIX_SURVEY_LINK:
         process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
+      MODULIX_QROCM_VERIFICATION_DELAY: 500,
     },
 
     fontawesome: {
@@ -214,6 +215,8 @@ module.exports = function (environment) {
       enabled: true,
       usingProxy: false,
     };
+
+    ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = 0;
   }
 
   if (environment === 'production') {

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -1,4 +1,4 @@
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { clickByName, visit, within } from '@1024pix/ember-testing-library';
 import { click, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -94,9 +94,10 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     await click(verifyButton);
 
     assert.dom(screen.getByRole('status')).exists();
+    const feedback = await screen.findByRole('status');
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
@@ -125,7 +126,8 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     );
     await click(qrocmVerifyButtonCameBack);
 
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Wrong!\nToo Bad!');
+    await within(feedback).findByText('Wrong!');
+    await within(feedback).findByText('Too Bad!');
   });
 
   test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
@@ -202,7 +204,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
       id: 'bien-ecrire-son-adresse-mail',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
-      isBeta: true,
+      isBeta: false,
       sections: [section],
     });
 
@@ -229,13 +231,13 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     assert.dom(screen.getByRole('status')).exists();
 
     // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    const retryButton = await screen.findByRole('button', { name: 'Réessayer' });
     await click(retryButton);
 
     // then
     const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     await click(qrocmVerifyButtonCameBack);
-    const validationAlert = screen.queryAllByRole('alert')[1];
+    const validationAlert = await screen.findByRole('alert');
 
     assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
   });

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -13,6 +13,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | QROCM', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  const originalDelay = ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY;
   let passageEventService, passageEventRecordStub;
 
   hooks.beforeEach(function () {
@@ -22,6 +23,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
 
   hooks.afterEach(function () {
     passageEventRecordStub.restore();
+    ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = originalDelay;
   });
 
   test('should display a block QROCM', async function (assert) {
@@ -264,9 +266,10 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       .doesNotExist();
   });
 
-  module('should call action and send an event when verify button is clicked', function () {
+  module('should call action, disable inputs, and send an event when verify button is clicked', function () {
     test('when proposal is an input', async function (assert) {
       // given
+      const clock = sinon.useFakeTimers();
       const qrocm = {
         id: '994b6a96-a3c2-47ae-a461-87548ac6e02b',
         instruction: 'Instruction',
@@ -297,6 +300,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       };
       const userResponse = 'user-response';
       const onElementAnswerSpy = sinon.spy();
+      ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = 10;
 
       // when
       const screen = await render(
@@ -304,10 +308,13 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       );
       await fillIn(screen.getByLabelText('Réponse 1'), userResponse);
 
+      const input = screen.getByRole('textbox', { name: 'Réponse 1' });
       const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
       await click(verifyButton);
 
       // then
+      assert.dom(input).hasAttribute('readonly');
+      await clock.tick(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY);
       sinon.assert.calledWith(onElementAnswerSpy, {
         userResponse: [
           {
@@ -331,6 +338,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
         },
       });
       assert.ok(true);
+      clock.restore();
     });
 
     test('when proposal is a select', async function (assert) {

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -4,6 +4,7 @@ import Service from '@ember/service';
 import { click, fillIn, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModuleQrocm from 'mon-pix/components/module/element/qrocm';
+import ENV from 'mon-pix/config/environment';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 


### PR DESCRIPTION
## 🔆 Problème

Sur les QCU, QCM et QROCM, on peut, lors de la vérification des réponses, sélectionner une autre proposition ou recliquer sur le bouton vérifier.

Cela peut provoquer des effets de bords (double appel…)

## ⛱️ Proposition

Il faudrait désactiver ces boutons pendant la soumission → géré niveau ModuleElement. 
Tests d’acceptance à faire pour tester tous les états. Et à recetter avec une connexion lente ou sans connexion.

## 🌊 Remarques

RAS

## 🏄 Pour tester

1. Se rendre sur le module [bac à sable](https://app-pr13705.review.pix.fr/modules/bac-a-sable)
2. Défiler jusqu'au QROCM
3. Remplir les champs et cliquer sur **Vérifier**
4. Constater que les champs sont désactivés immédiatement
