### PR TITLE
[FEATURE] Placer les attributs width/height des images matricielles si elles sont disponibles (PIX-19681)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -639,9 +639,9 @@
               "element": {
                 "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
                 "type": "image",
-                "url": "https://assets.pix.org/modules/bac-a-sable/ordi-spatial.svg",
-                "alt": "Dessin détaillé dans l'alternative textuelle",
-                "alternativeText": "Dessin d'un ordinateur dans un univers spatial.",
+                "url": "https://assets.pix.org/draft/flamingo.jpg",
+                "alt": "Image de flamant rose",
+                "alternativeText": "Image de flamant rose.",
                 "legend": "Faite avant le séminaire de juin 2023",
                 "licence": "©Pix Corporation & Fun, 2025, Challenge Accepted Inc. "
               }

--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -32,18 +32,14 @@ export default class ModulixImageElement extends Component {
 
   get width() {
     if (this.args.image.infos && this.hasDimensions) {
-      if (this.args.image.infos.type === 'vector') {
-        return ModulixImageElement.MAX_WIDTH;
-      }
+      return ModulixImageElement.MAX_WIDTH;
     }
     return null;
   }
 
   get height() {
     if (this.args.image.infos && this.hasDimensions) {
-      if (this.args.image.infos.type === 'vector') {
-        return Math.round((ModulixImageElement.MAX_WIDTH * this.args.image.infos.height) / this.args.image.infos.width);
-      }
+      return Math.round((ModulixImageElement.MAX_WIDTH * this.args.image.infos.height) / this.args.image.infos.width);
     }
     return null;
   }

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -38,63 +38,33 @@ module('Integration | Component | Module | Image', function (hooks) {
   });
 
   module('when width and height are available', function () {
-    module('when image type is vector', function () {
-      test('should extend width to 700px and height respecting aspect-ratio', async function (assert) {
-        // given
-        const url =
-          'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+    test('should extend width to 700px and height respecting aspect-ratio', async function (assert) {
+      // given
+      const url =
+        'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
 
-        const imageElement = {
-          url,
-          alt: 'alt text',
-          alternativeText: 'alternative instruction',
-          legend: 'je suis une légende',
-          licence: 'Je suis une licence',
-          infos: { width: 1920, height: 1280, type: 'vector' },
-        };
+      const imageElement = {
+        url,
+        alt: 'alt text',
+        alternativeText: 'alternative instruction',
+        legend: 'je suis une légende',
+        licence: 'Je suis une licence',
+        infos: { width: 1920, height: 1280, type: 'vector' },
+      };
 
-        //  when
-        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
+      //  when
+      const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
 
-        // then
-        assert.ok(screen);
-        assert.strictEqual(findAll('.element-image').length, 1);
-        const imgElement = screen.getByRole('img', { name: 'alt text' });
-        assert.dom(imgElement).hasAttribute('src', url);
-        assert.dom(imgElement).hasAttribute('width', '700');
-        const expectedHeight = Math.round(
-          (ModulixImageElement.MAX_WIDTH * imageElement.infos.height) / imageElement.infos.width,
-        );
-        assert.dom(imgElement).hasAttribute('height', `${expectedHeight}`);
-      });
-    });
-
-    module('when image type is raster', function () {
-      test('should not set width and height', async function (assert) {
-        // given
-        const url =
-          'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.png';
-
-        const imageElement = {
-          url,
-          alt: 'alt text',
-          alternativeText: 'alternative instruction',
-          legend: 'je suis une légende',
-          licence: 'Je suis une licence',
-          infos: { width: 1920, height: 1280, type: 'raster' },
-        };
-
-        //  when
-        const screen = await render(<template><ModulixImageElement @image={{imageElement}} /></template>);
-
-        // then
-        assert.ok(screen);
-        assert.strictEqual(findAll('.element-image').length, 1);
-        const imgElement = screen.getByRole('img', { name: 'alt text' });
-        assert.dom(imgElement).hasAttribute('src', url);
-        assert.false(imgElement.hasAttribute('width'));
-        assert.false(imgElement.hasAttribute('height'));
-      });
+      // then
+      assert.ok(screen);
+      assert.strictEqual(findAll('.element-image').length, 1);
+      const imgElement = screen.getByRole('img', { name: 'alt text' });
+      assert.dom(imgElement).hasAttribute('src', url);
+      assert.dom(imgElement).hasAttribute('width', '700');
+      const expectedHeight = Math.round(
+        (ModulixImageElement.MAX_WIDTH * imageElement.infos.height) / imageElement.infos.width,
+      );
+      assert.dom(imgElement).hasAttribute('height', `${expectedHeight}`);
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

On ne gère que les images vectorielles pour l'instant.

## ⛱️ Proposition

Gérer les images matricielles.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Aller sur le module [bac-a-sable ](https://app-pr13706.review.pix.fr/modules/bac-a-sable)et le commencer
- Une fois le passage démarré, mettre en hors ligne le navigateur
- Parcourir le module jusqu'au grain contenant une image de flamant rose
- Vérifier que l'image n'apparaît pas, mais qu'un espace lui est alloué
