### PR TITLE
[FEATURE] Adapter l'heure de fin théorique des certification aux Pix plus (PIX-19086)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -1,100 +1,101 @@
 <li class="session-supervising-candidate-in-list">
   <div class="session-supervising-candidate-in-list__candidate-data">
-
-    <div class="session-supervising-candidate-in-list__top-information">
-      <div class="session-supervising-candidate-in-list__full-name">
-        {{@candidate.lastName}}
-        {{@candidate.firstName}}
-      </div>
-      <div>
-        {{#if @candidate.hasStarted}}
-          {{#if @candidate.currentLiveAlert}}
-            <PixTag @color="error">
-              {{this.currentLiveAlertLabel}}
-            </PixTag>
-            <PixTag @color="yellow">
-              {{t "common.forms.certification-labels.candidate-status.on-hold"}}
-            </PixTag>
-          {{else}}
-            <PixTag @color="green">
-              {{t "common.forms.certification-labels.candidate-status.ongoing"}}
-            </PixTag>
-          {{/if}}
+    <div class="session-supervising-candidate-in-list__status">
+      {{#if @candidate.hasStarted}}
+        {{#if @candidate.currentLiveAlert}}
+          <PixTag @color="error">
+            {{this.currentLiveAlertLabel}}
+          </PixTag>
+          <PixTag @color="yellow">
+            {{t "common.forms.certification-labels.candidate-status.on-hold"}}
+          </PixTag>
+        {{else}}
+          <PixTag @color="green">
+            {{t "common.forms.certification-labels.candidate-status.ongoing"}}
+          </PixTag>
         {{/if}}
-        {{#if @candidate.hasCompleted}}
-          <PixTag @color="blue">{{t "common.forms.certification-labels.candidate-status.finished"}}</PixTag>
-        {{/if}}
-      </div>
-    </div>
-
-    <div class="session-supervising-candidate-in-list__middle-information">
-      <p>{{this.formattedBirthdate}}</p>
-      {{#if this.shouldDisplayEnrolledComplementaryCertification}}
-        <p class="session-supervising-candidate-in-list-details__enrolment">
-          <PixIcon
-            @name="awards"
-            @ariaHidden={{true}}
-            class="session-supervising-candidate-in-list-details-enrolment__icon"
-          />
-          {{t
-            "pages.session-supervising.candidate-in-list.complementary-certification-enrolment"
-            complementaryCertification=this.enrolledCertificationLabel
-          }}
-        </p>
       {{/if}}
-      {{#if this.shouldDisplayNonEligibilityWarning}}
-        <PixNotificationAlert @type="warning" @withIcon={{true}}>
-          {{t "pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning"}}
-        </PixNotificationAlert>
+      {{#if @candidate.hasCompleted}}
+        <PixTag @color="blue">{{t "common.forms.certification-labels.candidate-status.finished"}}</PixTag>
       {{/if}}
     </div>
+    <div class="session-supervising-candidate-in-list__infos">
+      <div class="session-supervising-candidate-in-list__top-information">
+        <div class="session-supervising-candidate-in-list__full-name">
+          {{@candidate.lastName}}
+          {{@candidate.firstName}}
+        </div>
+      </div>
 
-    {{#if @candidate.hasStarted}}
-      <div class="session-supervising-candidate-in-list__bottom-information">
-        <div class="session-supervising-candidate-in-list-details-time">
-          <div class="session-supervising-candidate-in-list-details-time__text">
+      <div class="session-supervising-candidate-in-list__middle-information">
+        <p>{{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}</p>
+        {{#if this.shouldDisplayEnrolledComplementaryCertification}}
+          <p class="session-supervising-candidate-in-list-details__enrolment">
             <PixIcon
-              @name="time"
-              @plainIcon={{true}}
-              class="session-supervising-candidate-in-list-details-time__clock"
+              @name="awards"
+              @ariaHidden={{true}}
+              class="session-supervising-candidate-in-list-details-enrolment__icon"
             />
-            <span>
-              {{t "pages.session-supervising.candidate-in-list.start-date-time"}}
-              <time>{{this.candidateStartTime}}</time>
-            </span>
-            <span class="session-supervising-candidate-in-list-details-time__text__end-date-time">
-              {{t "pages.session-supervising.candidate-in-list.end-date-time"}}
-              <time>{{this.candidateTheoricalEndDateTime}}</time>
-            </span>
+            {{t
+              "pages.session-supervising.candidate-in-list.complementary-certification-enrolment"
+              complementaryCertification=this.enrolledCertificationLabel
+            }}
+          </p>
+        {{/if}}
+        {{#if this.shouldDisplayNonEligibilityWarning}}
+          <PixNotificationAlert @type="warning" @withIcon={{true}}>
+            {{t "pages.session-supervising.candidate-in-list.double-certification-non-eligibility-warning"}}
+          </PixNotificationAlert>
+        {{/if}}
+      </div>
+
+      {{#if @candidate.hasStarted}}
+        <div class="session-supervising-candidate-in-list__bottom-information">
+          <div class="session-supervising-candidate-in-list-details-time">
+            <div class="session-supervising-candidate-in-list-details-time__text">
+              <PixIcon
+                @name="time"
+                @ariaHidden={{true}}
+                class="session-supervising-candidate-in-list-details-time__clock"
+              />
+              <span>
+                {{t "pages.session-supervising.candidate-in-list.start-date-time"}}
+                <time>{{this.candidateStartTime}}</time>
+              </span>
+              <span class="session-supervising-candidate-in-list-details-time__text__end-date-time">
+                {{t "pages.session-supervising.candidate-in-list.end-date-time"}}
+                <time>{{this.candidateTheoricalEndDateTime}}</time>
+              </span>
+            </div>
+            {{#if @candidate.extraTimePercentage}}
+              <PixTag @color="grey">
+                {{t
+                  "pages.session-supervising.candidate-in-list.extratime"
+                  extraTimePercentage=(format-percentage @candidate.extraTimePercentage)
+                }}
+              </PixTag>
+            {{/if}}
           </div>
-          {{#if @candidate.extraTimePercentage}}
-            <PixTag @color="grey">
-              {{t
-                "pages.session-supervising.candidate-in-list.extratime"
-                extraTimePercentage=(format-percentage @candidate.extraTimePercentage)
-              }}
-            </PixTag>
+
+          {{#if @candidate.hasOngoingChallengeLiveAlert}}
+            <PixButton @triggerAction={{this.askUserToHandleLiveAlert}} @variant="error">
+              {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
+            </PixButton>
           {{/if}}
         </div>
-
-        {{#if @candidate.hasOngoingChallengeLiveAlert}}
-          <PixButton @triggerAction={{this.askUserToHandleLiveAlert}} @variant="error">
-            {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
-          </PixButton>
-        {{/if}}
-      </div>
-    {{/if}}
-    {{#if this.isConfirmButtonToBeDisplayed}}
-      <PixButton
-        aria-label={{this.authorizationButtonAriaLabel}}
-        @triggerAction={{fn this.toggleCandidate @candidate}}
-        @variant={{this.authorizationButtonBackgroundColor}}
-        @isBorderVisible={{@candidate.authorizedToStart}}
-        class="session-supervising-candidate-in-list__confirm-button"
-      >
-        {{this.authorizationButtonLabel}}
-      </PixButton>
-    {{/if}}
+      {{/if}}
+      {{#if this.isConfirmButtonToBeDisplayed}}
+        <PixButton
+          aria-label={{this.authorizationButtonAriaLabel}}
+          @triggerAction={{fn this.toggleCandidate @candidate}}
+          @variant={{this.authorizationButtonBackgroundColor}}
+          @isBorderVisible={{@candidate.authorizedToStart}}
+          class="session-supervising-candidate-in-list__confirm-button"
+        >
+          {{this.authorizationButtonLabel}}
+        </PixButton>
+      {{/if}}
+    </div>
   </div>
 
   {{#if this.optionsMenuShouldBeDisplayed}}

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -16,6 +16,12 @@ const Modals = {
   HandledLiveAlertSuccess: 'HandledLiveAlertSuccess',
 };
 
+const PIX_PLUS_DURATIONS = {
+  DROIT: 45,
+  PRO_SANTE: 45,
+  EDU: 90,
+};
+
 export default class CandidateInList extends Component {
   @service pixToast;
   @service intl;
@@ -322,8 +328,30 @@ export default class CandidateInList extends Component {
   }
 
   get candidateTheoricalEndDateTime() {
+    const pixPlusDuration = this._getPixPlusDurationInMinutes();
+
+    if (pixPlusDuration !== null) {
+      const endTime = dayjs(this.args.candidate.startDateTime).add(pixPlusDuration, 'minute').format('HH:mm');
+      return endTime;
+    }
+
     const theoricalEndDateTime = dayjs(this.args.candidate.theoricalEndDateTime).format('HH:mm');
     return theoricalEndDateTime;
+  }
+
+  _getPixPlusDurationInMinutes() {
+    const label = this.enrolledCertificationLabel?.toLowerCase() || '';
+
+    switch (true) {
+      case label.includes('droit'):
+        return PIX_PLUS_DURATIONS.DROIT;
+      case label.includes('pro') && label.includes('santé'):
+        return PIX_PLUS_DURATIONS.PRO_SANTE;
+      case label.includes('edu'):
+        return PIX_PLUS_DURATIONS.EDU;
+      default:
+        return null;
+    }
   }
 
   get currentLiveAlertLabel() {

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -12,9 +12,24 @@
   &__candidate-data {
     width: calc(100% - var(--pix-spacing-8x));
     padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-2x);
+
+    @include breakpoints.device-is('tablet') {
+      display: flex;
+      flex-direction: row-reverse;
+      gap: var(--pix-spacing-4x);
+    }
+  }
+
+  &__infos {
+    flex-grow: 1;
+  }
+
+  &__status {
+    flex-shrink: 0;
+
+    @include breakpoints.device-is('mobile') {
+      margin-bottom: var(--pix-spacing-2x);
+    }
   }
 
   &__full-name {
@@ -97,9 +112,9 @@
 .session-supervising-candidate-in-list-details-time {
   display: flex;
   align-items: center;
-  margin-top: var(--pix-spacing-2x);
   gap: var(--pix-spacing-2x);
   width: fit-content;
+  margin-top: var(--pix-spacing-1x);
 
   @include breakpoints.device-is('mobile') {
     flex-direction: column;
@@ -111,8 +126,8 @@
   }
 
   &__text {
-    padding: 6px var(--pix-spacing-2x);
-    background-color: var(--pix-neutral-500);
+    padding: 4px var(--pix-spacing-2x);
+    background-color: rgba(255,255,255,0.1);
     border-radius: 8px;
     color: var(--pix-neutral-0);
     flex-grow: 1;
@@ -120,19 +135,27 @@
     align-items: center;
     gap: var(--pix-spacing-1x);
 
-    &__end-date-time::before {
-      content: '|';
-      display: inline-block;
-      color: transparent;
-      width: 1px;
-      background-color: var(--pix-neutral-0);
-      border-radius: 25px;
+    &__end-date-time {
+      display: flex;
+      align-items: center;
+
+      &::before {
+        content: '';
+        display: block;
+        width: 1px;
+        height: 1em;
+        margin-inline: var(--pix-spacing-1x) var(--pix-spacing-2x);
+        background-color: var(--pix-neutral-0);
+      }
+    }
+
+    time {
+      font-weight: 500;
     }
   }
 
   &__clock {
     width: 1rem;
-    height: 1rem;
     fill: var(--pix-neutral-0);
   }
 }

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -14,21 +14,13 @@
       max-width: 800px;
     }
 
-    &__description {
-      display: flex;
-      justify-content: flex-start;
+    &__title {
+      @extend %pix-title-s;
       color: var(--pix-neutral-0);
-      font-size: 0.875rem;
-      font-weight: normal;
-      min-height: 14px;
-      letter-spacing: 0;
-      margin: 0 0 24px;
     }
 
-    &__title {
-      @extend %pix-title-xs;
-      font-weight: 600;
-      margin: 0 0 8px;
+    &__description {
+      @extend %pix-body-s;
       color: var(--pix-neutral-0);
     }
 
@@ -64,6 +56,7 @@
       display: flex;
       flex-direction: row;
       height: 44px;
+      margin: var(--pix-spacing-4x) 0;
       padding: 0 var(--pix-spacing-4x);
       width: 100%;
     }
@@ -76,7 +69,7 @@
       font-weight: normal;
       height: 14px;
       letter-spacing: 0;
-      margin: 16px 0 24px;
+      margin: var(--pix-spacing-4x) 0 var(--pix-spacing-6x);
     }
 
     .search-icon {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -1,5 +1,6 @@
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import dayjs from 'dayjs';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
@@ -559,6 +560,195 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         await screen.findByRole('dialog');
         assert.dom(screen.getByRole('heading', { name: 'Confirmer que Alain Cendy a bien l’extension ?' })).exists();
+      });
+    });
+  });
+
+  module('when calculating theoretical end time for different certification types', function () {
+    module('when candidate has Pix+ Droit certification', function () {
+      test('it calculates end time using 45 minutes duration', async function (assert) {
+        // given
+        const startTime = new Date('2022-10-19T14:30:00Z');
+        const expectedEndTime = dayjs(startTime).add(45, 'minute').format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Marie',
+          lastName: 'Dupont',
+          startDateTime: startTime,
+          theoricalEndDateTime: new Date('2022-10-19T16:15:00Z'),
+          enrolledComplementaryCertificationLabel: 'Pix+ Droit',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedEndTime)).exists();
+      });
+    });
+
+    module('when candidate has Pix+ Pro Santé certification', function () {
+      test('it calculates end time using 45 minutes duration', async function (assert) {
+        // given
+        const startTime = new Date('2022-10-19T10:00:00Z');
+        const expectedEndTime = dayjs(startTime).add(45, 'minute').format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Jean',
+          lastName: 'Martin',
+          startDateTime: startTime,
+          theoricalEndDateTime: new Date('2022-10-19T11:45:00Z'),
+          enrolledComplementaryCertificationLabel: 'Pix+ Pro Santé',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedEndTime)).exists();
+      });
+    });
+
+    module('when candidate has Pix+ Edu certification', function () {
+      test('it calculates end time using 90 minutes duration for 1er degré', async function (assert) {
+        // given
+        const startTime = new Date('2022-10-19T09:00:00Z');
+        const expectedEndTime = dayjs(startTime).add(90, 'minute').format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Pierre',
+          lastName: 'Durand',
+          startDateTime: startTime,
+          theoricalEndDateTime: new Date('2022-10-19T10:45:00Z'),
+          enrolledComplementaryCertificationLabel: 'Pix+ Edu 1er Degré',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedEndTime)).exists();
+      });
+
+      test('it calculates end time using 90 minutes duration for 2nd degré', async function (assert) {
+        // given
+        const startTime = new Date('2022-10-19T14:15:00Z');
+        const expectedEndTime = dayjs(startTime).add(90, 'minute').format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Sophie',
+          lastName: 'Bernard',
+          startDateTime: startTime,
+          theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
+          enrolledComplementaryCertificationLabel: 'Pix+ Edu 2nd Degré',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedEndTime)).exists();
+      });
+
+      test('it calculates end time using 90 minutes duration for CPE', async function (assert) {
+        // given
+        const startTime = new Date('2022-10-19T16:30:00Z');
+        const expectedEndTime = dayjs(startTime).add(90, 'minute').format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Antoine',
+          lastName: 'Moreau',
+          startDateTime: startTime,
+          theoricalEndDateTime: new Date('2022-10-19T18:15:00Z'),
+          enrolledComplementaryCertificationLabel: 'Pix+ Edu CPE',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedEndTime)).exists();
+      });
+    });
+
+    module('when candidate has standard Pix certification', function () {
+      test('it uses backend calculated theoretical end time', async function (assert) {
+        // given
+        const backendEndTime = new Date('2022-10-19T16:15:00Z');
+        const expectedDisplayTime = dayjs(backendEndTime).format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Claire',
+          lastName: 'Dubois',
+          startDateTime: new Date('2022-10-19T14:30:00Z'),
+          theoricalEndDateTime: backendEndTime,
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedDisplayTime)).exists();
+      });
+    });
+
+    module('when candidate has CléA certification', function () {
+      test('it uses backend calculated theoretical end time', async function (assert) {
+        // given
+        const backendEndTime = new Date('2022-10-19T14:45:00Z');
+        const expectedDisplayTime = dayjs(backendEndTime).format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Lucas',
+          lastName: 'Petit',
+          startDateTime: new Date('2022-10-19T13:00:00Z'),
+          theoricalEndDateTime: backendEndTime,
+          enrolledComplementaryCertificationLabel: 'CléA',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedDisplayTime)).exists();
+      });
+    });
+
+    module('when candidate has unknown complementary certification', function () {
+      test('it uses backend calculated theoretical end time as fallback', async function (assert) {
+        // given
+        const backendEndTime = new Date('2022-10-19T12:45:00Z');
+        const expectedDisplayTime = dayjs(backendEndTime).format('HH:mm');
+
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: '456',
+          firstName: 'Emma',
+          lastName: 'Leroy',
+          startDateTime: new Date('2022-10-19T11:00:00Z'),
+          theoricalEndDateTime: backendEndTime,
+          enrolledComplementaryCertificationLabel: 'Certification Inconnue',
+          assessmentStatus: 'started',
+        });
+
+        // when
+        const screen = await renderScreen(hbs`<SessionSupervising::CandidateInList @candidate={{this.candidate}} />`);
+
+        // then
+        assert.dom(screen.getByText(expectedDisplayTime)).exists();
       });
     });
   });


### PR DESCRIPTION
## :fallen_leaf: Problème
Dans l’espace surveillant, quand un candidat rentre en session (a visualisé sa première question), on affiche l’heure de début de certification au surveillant et on calcule l’heure théorique de fin de test pour le candidat.

Pour ce faire, on ajoute 1h45 (durée de la Certification Pix) à l’heure de début.

Cette horaire est donné à titre indicatif et n’interrompt pas la certification du candidat lorsque le délai est écoulé car cela est laissé à la main du surveillant, mieux à même d’ajuster pour apprécier l’heure de fin réelle du candidat (exemple : coupure internet, alarme incendie etc…).

Les nouvelles certifications Pix+ vont être testées pour des durées différentes donc il faut que cet affichage dépende du type de certif passé..

## :chestnut: Proposition
Adapter l’affichage de l’heure théorique de fin en fonction de la durée de la certification Pix+ passée : 

- Pix+ Droit = 45mins
- Pix+ Pro Santé = 45mins 
- Pix+ Edu 1erD = 1h30 
- Pix+ Edu 2ndD = 1h30 
- Pix+ Edu CPE = 1h30

On a choisi de mettre ces durée en dur dans le front dans un premier temps

## :jack_o_lantern: Remarques
Cette PR remplace https://github.com/1024pix/pix/pull/13618/files

## :wood: Pour tester
- Créer une session avec des candidats inscrits dans différents Pix + et en cœur/CLEA
- Entrer en certif avec les différents candidats et vérifier côté surveillant que l'horaire de fin estimé est correct pour chaque
Example :
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3a547a69-e6d3-4368-8c74-7794542b1ccc" />