### PR TITLE
[TECH] Inverser la manière dont on récupère les module recommandé (Pix-19284).

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -139,9 +139,10 @@ export class CombinedCourseDetails extends CombinedCourse {
   }
 
   #createFormationCombinedCourseItemIfNeeded(recommandableModule, targetProfileIdsThatNeedAFormationItem) {
-    const targetProfileId = recommandableModule.targetProfileIds.find((t) =>
-      targetProfileIdsThatNeedAFormationItem.includes(t),
+    const targetProfileId = targetProfileIdsThatNeedAFormationItem.find((targetProfileIdOfCampaign) =>
+      recommandableModule.targetProfileIds.includes(targetProfileIdOfCampaign),
     );
+
     const shouldBeInFormationItem = Boolean(targetProfileId);
     const hasFormationItem = this.items.find((item) => {
       if (item.type !== ITEM_TYPE.FORMATION) return false;


### PR DESCRIPTION
## 🔆 Problème

Le code en lui même n'est pas logique dans la manière dont on retrouve les module à insérer dans le bloc formation.

## ⛱️ Proposition

Passer par les profil cible puis aller chercher le module

## 🌊 Remarques

Rajout d'un test qui montre la possibilité d'avoir deux bloc formation

## 🏄 Pour tester

CI au vert