### PR TITLE
[BUGFIX] Corriger le fond des svg de succès/erreur sur les QAB et les bords de l'image de la flashcard (PIX-19742).

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
+++ b/mon-pix/app/components/module/element/flashcards/_flashcards-card.scss
@@ -24,6 +24,13 @@
       @extend %pix-title-s;
     }
   }
+
+  &__image {
+    img {
+      border-top-left-radius: var(--modulix-radius-l);
+      border-top-right-radius: var(--modulix-radius-l);
+    }
+  }
 }
 
 .element-flashcards-card {

--- a/mon-pix/app/components/module/element/qab/_proposal-button.scss
+++ b/mon-pix/app/components/module/element/qab/_proposal-button.scss
@@ -74,14 +74,6 @@
     color: var(--pix-neutral-800);
     font-weight: var(--pix-font-bold);
   }
-
-  &__icon {
-    position: absolute;
-    top: -6px;
-    right: -5px;
-    width: 40px;
-    height: 40px;
-  }
 }
 
 @include breakpoints.device-is('mobile') {
@@ -90,4 +82,13 @@
     gap: var(--pix-spacing-6x);
     align-items: center;
   }
+}
+
+img.qab-proposal-button__icon {
+  position: absolute;
+  top: -6px;
+  right: -5px;
+  width: 40px;
+  height: 40px;
+  background-color: transparent;
 }


### PR DESCRIPTION
## 🔆 Problème

Sur Pix App, nous avons pu constater qu'un fond blanc s'affiche derrière les svg d'erreur/succès sur les QAB. 
L'image d'intro (flashcard) présente également un soucis avec le bord de la carte.

<img width="413" height="181" alt="Capture d’écran 2025-09-29 à 11 36 47" src="https://github.com/user-attachments/assets/0913c092-5512-4d00-b551-ca964fef7753" />



## ⛱️ Proposition

Corriger tout cela.

## 🏄 Pour tester

- Se rendre sur https://app-pr13720.review.pix.fr/modules/bac-a-sable
- Constater en choissant des réponses sur le qab que les svg ont un fond transparent
- Sur la flashcard, constater que l'image d'intro à un bord (haut droit et haut gauche) arrondi
