### PR TITLE
[BUGFIX] Retourner un tableau vide au lieu de null lors de la récupération de campagnes (PIX-19743)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/delete-campaigns.js
@@ -31,7 +31,7 @@ const deleteCampaigns = async ({
     }
   }
 
-  const campaignsToDelete = await campaignAdministrationRepository.getByIds(campaignIds);
+  const campaignsToDelete = await campaignAdministrationRepository.findByIds(campaignIds);
   const campaignParticipationsToDelete = await campaignParticipationRepository.getByCampaignIds(campaignIds);
 
   const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -30,11 +30,9 @@ const CAMPAIGN_ATTRIBUTES = [
   'customResultPageButtonUrl',
 ];
 
-const getByIds = async (ids) => {
+const findByIds = async (ids) => {
   const knexConn = DomainTransaction.getConnection();
   const campaigns = await knexConn('campaigns').whereIn('id', ids);
-
-  if (campaigns.length === 0) return null;
 
   return campaigns.map((campaign) => new Campaign(campaign));
 };
@@ -202,4 +200,4 @@ export const deleteExternalIdLabelFromCampaigns = (campaignIds) => {
     .whereIn('campaign-features.campaignId', campaignIds);
 };
 
-export { archiveCampaigns, get, getByCode, getByIds, isFromSameOrganization, remove, save, swapCampaignCodes, update };
+export { archiveCampaigns, findByIds, get, getByCode, isFromSameOrganization, remove, save, swapCampaignCodes, update };

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -9,13 +9,13 @@ import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants
 import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Campaign Administration', function () {
-  describe('#getByIds', function () {
-    it('should return null if campaigns does not exists', async function () {
+  describe('#findByIds', function () {
+    it('should return an empty array if campaigns does not exists', async function () {
       // given & when
-      const campaigns = await campaignAdministrationRepository.getByIds([1, 2]);
+      const campaigns = await campaignAdministrationRepository.findByIds([1, 2]);
 
       // then
-      expect(campaigns).to.be.null;
+      expect(campaigns).to.be.empty;
     });
 
     it('should return campaigns for given ids', async function () {
@@ -27,7 +27,7 @@ describe('Integration | Repository | Campaign Administration', function () {
       await databaseBuilder.commit();
 
       // when
-      const campaigns = await campaignAdministrationRepository.getByIds([firstCampaign.id, secondCampaign.id]);
+      const campaigns = await campaignAdministrationRepository.findByIds([firstCampaign.id, secondCampaign.id]);
 
       // then
       expect(campaigns).to.deep.equal([firstCampaign, secondCampaign]);


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'aucune campagne n'est trouvée par la méthode `getByIds` du repository `campaign-administration-repository`, la fonction retourne `null` au lieu d'un tableau vide. Cela peut provoquer des erreurs dans les traitements en aval qui s'attendent à recevoir un tableau.

## ⛱️ Proposition

- Renommer `getByIds` 
- Suppression de la condition qui retournait `null` quand aucune campagne n'est trouvée
- La méthode retourne maintenant systématiquement un tableau (vide si aucune campagne trouvée)
- Mise à jour des tests pour refléter ce nouveau comportement

## 🏄 Pour tester

- Vérifier que les tests passent
- Passer le flag isAnonymizationWithDeletionEnabled a true
- Tester l'archivage d'une organisation sans campagne