### PR TITLE
[FEATURE] Afficher les participations aux parcours combinés dans PixOrga (pix-19704)

### DIFF
--- a/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
@@ -4,7 +4,17 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourse) {
   return new Serializer('combined-courses', {
-    attributes: ['name', 'code', 'campaignIds'],
+    attributes: ['name', 'code', 'campaignIds', 'combinedCourseParticipations'],
+    combinedCourseParticipations: {
+      ref: 'id',
+      nullIfMissing: true,
+      ignoreRelationshipData: true,
+      relationshipLinks: {
+        related: function (record) {
+          return `/api/combined-courses/${record.id}/participations`;
+        },
+      },
+    },
   }).serialize(combinedCourse);
 };
 

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
@@ -39,6 +39,13 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-details'
           code: 'COMBINIX1',
           'campaign-ids': [1],
         },
+        relationships: {
+          'combined-course-participations': {
+            links: {
+              related: '/api/combined-courses/1/participations',
+            },
+          },
+        },
         type: 'combined-courses',
         id: '1',
       },

--- a/orga/app/components/combined-course/combined-course.gjs
+++ b/orga/app/components/combined-course/combined-course.gjs
@@ -1,3 +1,5 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -5,6 +7,7 @@ import ActivityType from 'pix-orga/components/activity-type';
 import CopyPasteButton from 'pix-orga/components/copy-paste-button';
 import Breadcrumb from 'pix-orga/components/ui/breadcrumb';
 import PageTitle from 'pix-orga/components/ui/page-title';
+import ParticipationStatus from 'pix-orga/components/ui/participation-status';
 
 export default class CombinedCourse extends Component {
   @service intl;
@@ -56,5 +59,41 @@ export default class CombinedCourse extends Component {
         </dl>
       </:tools>
     </PageTitle>
+
+    <PixTable
+      @variant="orga"
+      @caption={{t "pages.combined-course.table.description"}}
+      @data={{@model.combinedCourseParticipations}}
+      class="table"
+    >
+      <:columns as |participation context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.combined-course.table.column.last-name"}}
+          </:header>
+          <:cell>
+            {{participation.lastName}}
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.combined-course.table.column.first-name"}}
+          </:header>
+          <:cell>
+            {{participation.firstName}}
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.combined-course.table.column.status"}}
+          </:header>
+          <:cell>
+            <ParticipationStatus @status={{participation.status}} />
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
   </template>
 }

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -25,4 +25,5 @@ export default class ParticipationStatus extends Component {
 const COLORS = {
   STARTED: 'yellow-light',
   SHARED: 'green-light',
+  COMPLETED: 'green-light',
 };

--- a/orga/app/models/combined-course-participation.js
+++ b/orga/app/models/combined-course-participation.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CombinedCourseParticipation extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') status;
+}

--- a/orga/app/models/combined-course.js
+++ b/orga/app/models/combined-course.js
@@ -1,7 +1,8 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class CombinedCourse extends Model {
   @attr('string') name;
   @attr('string') code;
-  @attr campaignIds;
+  @attr({ defaultValue: () => [] }) campaignIds;
+  @hasMany('combined-course-participation', { async: true, inverse: null }) combinedCourseParticipations;
 }

--- a/orga/app/routes/authenticated/combined-course.js
+++ b/orga/app/routes/authenticated/combined-course.js
@@ -13,8 +13,15 @@ export default class CombinedCourseRoute extends Route {
   }
 
   model(params) {
-    return this.store.findRecord('combined-course', params.combined_course_id).catch(() => {
-      this.router.replaceWith('not-found', params.combined_course_id);
-    });
+    return this.store
+      .findRecord('combined-course', params.combined_course_id)
+      .then(async (data) => {
+        await data.combinedCourseParticipations;
+        return data;
+      })
+      .catch((error) => {
+        console.error(error);
+        this.router.replaceWith('not-found');
+      });
   }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -667,4 +667,18 @@ function routes() {
       campaignIds: [],
     });
   });
+  this.get('/combined-courses/:combinedCourseId/participations', function (schema) {
+    const data = schema.combinedCourseParticipations.all();
+
+    if (data) {
+      return data;
+    }
+    schema.combinedCourseParticipation.create({
+      id: 123,
+      fistName: 'Gérard',
+      lastName: 'Etlestars',
+      status: 'COMPLETED',
+    });
+    return schema.combinedCourseParticipations.all();
+  });
 }

--- a/orga/mirage/serializers/combined-course.js
+++ b/orga/mirage/serializers/combined-course.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  links(combinedCourse) {
+    return {
+      combinedCourseParticipations: {
+        related: `/api/combined-courses/${combinedCourse.id}/participations`,
+      },
+    };
+  },
+});

--- a/orga/tests/acceptance/combined-course-test.js
+++ b/orga/tests/acceptance/combined-course-test.js
@@ -11,28 +11,43 @@ module('Acceptance | Combined course page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
+  let combinedCourse;
 
   hooks.beforeEach(async function () {
     const user = createUserManagingStudents('ADMIN');
     createPrescriberByUser({ user });
 
     await authenticateSession(user.id);
-  });
 
-  test('it should display a combined course', async function (assert) {
-    // given
-    const combinedCourse = server.create('combined-course', {
+    combinedCourse = server.create('combined-course', {
       id: 2,
       code: 'AZERTY',
       name: 'Parcours Magimix',
       campaignIds: [123454],
+    });
+  });
+
+  test('it should display a combined course', async function (assert) {
+    // when
+    const screen = await visit(`/parcours/${combinedCourse.id}`);
+
+    // then
+    assert.ok(await screen.getByRole('heading', { name: new RegExp(combinedCourse.name) }));
+  });
+
+  test('it should display combined course participation', async function (assert) {
+    // given
+    const participation = server.create('combined-course-participation', {
+      id: 3,
+      firstName: 'bob',
+      lastName: 'Azerty',
+      status: 'STARTED',
     });
 
     // when
     const screen = await visit(`/parcours/${combinedCourse.id}`);
 
     // then
-
-    assert.ok(await screen.getByRole('heading', { name: new RegExp(combinedCourse.name) }));
+    assert.ok(screen.getByText(participation.firstName));
   });
 });

--- a/orga/tests/integration/components/combined-course/combined-course-test.gjs
+++ b/orga/tests/integration/components/combined-course/combined-course-test.gjs
@@ -6,9 +6,24 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CombinedCourse', function (hooks) {
+  const combinedCourse = {
+    id: 1,
+    name: 'Parcours MagiPix',
+    code: '1234PixTest',
+    campaignIds: [123],
+    combinedCourseParticipations: [
+      {
+        id: 123,
+        firstName: 'TOTO',
+        lastName: 'Cornichon',
+        status: 'STARTED',
+      },
+    ],
+  };
+
   setupIntlRenderingTest(hooks);
 
-  test('it should display campaign name', async function (assert) {
+  test('it should display course name', async function (assert) {
     // given
     const combinedCourse = {
       id: 1,
@@ -28,7 +43,60 @@ module('Integration | Component | CombinedCourse', function (hooks) {
     assert.ok(screen.getByText('1234PixTest'));
   });
 
-  module('campaign code display', function () {
+  test('it should have a caption to describe the table ', async function (assert) {
+    const screen = await render(<template><CombinedCourse @model={{combinedCourse}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('table', { name: t('pages.combined-course.table.description') }));
+  });
+
+  test('it should display column headers', async function (assert) {
+    // when
+    const screen = await render(<template><CombinedCourse @model={{combinedCourse}} /></template>);
+
+    const table = screen.getByRole('table');
+    // then
+    assert.ok(
+      within(table).getByRole('columnheader', {
+        name: t('pages.combined-course.table.column.first-name'),
+      }),
+    );
+    assert.ok(
+      within(table).getByRole('columnheader', {
+        name: t('pages.combined-course.table.column.last-name'),
+      }),
+    );
+    assert.ok(
+      within(table).getByRole('columnheader', {
+        name: t('pages.combined-course.table.column.status'),
+      }),
+    );
+  });
+
+  test('it should display participation details', async function (assert) {
+    // when
+    const screen = await render(<template><CombinedCourse @model={{combinedCourse}} /></template>);
+
+    const table = screen.getByRole('table');
+    // then
+    assert.ok(
+      within(table).getByRole('cell', {
+        name: combinedCourse.combinedCourseParticipations[0].lastName,
+      }),
+    );
+    assert.ok(
+      within(table).getByRole('cell', {
+        name: combinedCourse.combinedCourseParticipations[0].firstName,
+      }),
+    );
+    assert.ok(
+      within(table).getByRole('cell', {
+        name: t(`components.participation-status.${combinedCourse.combinedCourseParticipations[0].status}`),
+      }),
+    );
+  });
+
+  module('combined course code display', function () {
     test('it should display combined course code', async function (assert) {
       // given
       const combinedCourse = {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -405,6 +405,7 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participation-status": {
+      "COMPLETED": "Completed",
       "SHARED": "Completed",
       "STARTED": "In progress"
     },
@@ -1008,7 +1009,15 @@
       "title": "Certification results"
     },
     "combined-course": {
-      "introduction": "text d'intro"
+      "introduction": "text d'intro",
+      "table": {
+        "column": {
+          "first-name": "First name",
+          "last-name": "Last name",
+          "status": "Status"
+        },
+        "description": "List of the combined course participations"
+      }
     },
     "index": {
       "title": "Home"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -405,6 +405,7 @@
       "title": "{count, plural, =0 {Participants} =1 {Participant ({count})} other {Participants ({count})}}"
     },
     "participation-status": {
+      "COMPLETED": "Terminé",
       "SHARED": "Terminé",
       "STARTED": "En cours"
     },
@@ -1008,7 +1009,15 @@
       "title": "Résultats de certification"
     },
     "combined-course": {
-      "introduction": "Un parcours apprenant est un parcours qui mixe campagnes d'évaluation et modules de formations. La selection des modules de formation sera adapter au niveau du prescrit"
+      "introduction": "Un parcours apprenant est un parcours qui mixe campagnes d'évaluation et modules de formations. La selection des modules de formation sera adapter au niveau du prescrit",
+      "table": {
+        "column": {
+          "first-name": "Prénom",
+          "last-name": "Nom",
+          "status": "Statut"
+        },
+        "description": "Listes des participations au parcours"
+      }
     },
     "index": {
       "title": "Accueil"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -405,6 +405,7 @@
       "title": "{count, plural, =0 {Deelnemer} =1 {Deelnemer ({count})} other {Deelnemers ({count})}}"
     },
     "participation-status": {
+      "COMPLETED": "Voltooid",
       "SHARED": "Voltooid",
       "STARTED": "Bezig"
     },
@@ -1008,7 +1009,15 @@
       "title": "Resultaten certificering"
     },
     "combined-course": {
-      "introduction": "text d'intro"
+      "introduction": "text d'intro",
+      "table": {
+        "column": {
+          "first-name": "Voornaam",
+          "last-name": "Achternaam",
+          "status": "Status"
+        },
+        "description": "List of the combined course participations"
+      }
     },
     "index": {
       "title": "Home"


### PR DESCRIPTION

## 🔆 Problème
Actuellement on n'affiche seulement le titre et le code du parcours combiné
ce qui n'est pas super utile.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On affiche les participations au parcours combinés pour aider le prescripteur à suivre les participations
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques
Il faut revoir les wordings liés à la table des participations 
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

- Passer le parcours combiné COMBINIX2 avec 2 utilisateur
- Depuis la liste des campagnes de l'orga PROCLASSIC, 
- Afficher le parcours combiné combinix2
- Voir les participations
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
