### PR TITLE
[BUGFIX] Éviter les problèmes de timezone dans la page de restriction d'accès de PixCertif (PIX-19747).

### DIFF
--- a/certif/app/controllers/authenticated/restricted-access.js
+++ b/certif/app/controllers/authenticated/restricted-access.js
@@ -1,17 +1,26 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import dayjs from 'dayjs';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(LocalizedFormat);
+dayjs.extend(utc);
 
 export default class RestrictedAccessController extends Controller {
   @service intl;
 
   get certificationOpeningDate() {
     if (this.model.isAccessBlockedCollege) {
-      return this.model.pixCertifScoBlockedAccessDateCollege;
+      return this.intl.t('pages.sco.restricted-access.title-access', {
+        date: dayjs.utc(this.model.pixCertifScoBlockedAccessDateCollege).format('L'),
+      });
     }
 
     if (this.model.isAccessBlockedLycee || this.model.isAccessBlockedAEFE || this.model.isAccessBlockedAgri) {
-      return this.model.pixCertifScoBlockedAccessDateLycee;
+      return this.intl.t('pages.sco.restricted-access.title-access', {
+        date: dayjs.utc(this.model.pixCertifScoBlockedAccessDateLycee).format('L'),
+      });
     }
 
     return null;
@@ -19,7 +28,7 @@ export default class RestrictedAccessController extends Controller {
 
   get accessBlockedLabel() {
     return this.intl.t('restricted-access', {
-      date: dayjs(this.model.pixCertifBlockedAccessUntilDate).format('DD/MM/YYYY'),
+      date: dayjs.utc(this.model.pixCertifBlockedAccessUntilDate).format('L'),
     });
   }
 }

--- a/certif/app/templates/authenticated/restricted-access.hbs
+++ b/certif/app/templates/authenticated/restricted-access.hbs
@@ -4,8 +4,7 @@
     {{#if this.model.isAccessBlockedUntilDate}}
       {{this.accessBlockedLabel}}
     {{else}}
-      {{t "pages.sco.restricted-access.title"}}
-      {{dayjs-format this.certificationOpeningDate "DD/MM/YYYY"}}
+      {{this.certificationOpeningDate}}
     {{/if}}
   </h1>
 </div>

--- a/certif/tests/acceptance/restricted-access-test.js
+++ b/certif/tests/acceptance/restricted-access-test.js
@@ -76,7 +76,13 @@ module('Acceptance | Restricted access', function (hooks) {
         const screen = await visitScreen('/espace-ferme');
 
         // then
-        assert.dom(screen.getByText('Ouverture de votre espace Pix Certif le 12/11/2022')).exists();
+        assert
+          .dom(
+            screen.getByText(
+              'Ouverture de votre espace Pix Certif le 12/11/2022 (00h00, heure France métropolitaine).',
+            ),
+          )
+          .exists();
       });
     });
   });

--- a/certif/tests/integration/components/login-session-supervisor/form-test.gjs
+++ b/certif/tests/integration/components/login-session-supervisor/form-test.gjs
@@ -118,7 +118,7 @@ module('Integration | Component | Login session supervisor | Form', function (ho
         assert
           .dom(
             within(screen.getByRole('alert')).getByText(
-              'Site en maintenance, réouverture de votre espace Pix Certif le 10/10/2020.',
+              'Site en maintenance, réouverture de votre espace Pix Certif le 10/10/2020 (00h00, heure France métropolitaine).',
             ),
           )
           .exists();

--- a/certif/tests/unit/controllers/restricted-access-test.js
+++ b/certif/tests/unit/controllers/restricted-access-test.js
@@ -9,6 +9,14 @@ module('Unit | Controller | authenticated/restricted-access', function (hooks) {
       test('should return a the pixCertifScoBlockedAccessDateCollege', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
+        const intlService = this.owner.lookup('service:intl');
+        intlService.t = (key, options) => {
+          if (key === 'pages.sco.restricted-access.title-access') {
+            return `Date: ${options.date}`;
+          }
+          return key;
+        };
+
         const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
           isAccessBlockedCollege: true,
           pixCertifScoBlockedAccessDateCollege: '2020-12-12',
@@ -17,13 +25,21 @@ module('Unit | Controller | authenticated/restricted-access', function (hooks) {
         controller.model = currentAllowedCertificationCenterAccess;
 
         // when then
-        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+        assert.strictEqual(controller.certificationOpeningDate, 'Date: 12/12/2020');
       });
     });
     module('when isAccessBlockedLycee is true', function () {
       test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
+        const intlService = this.owner.lookup('service:intl');
+        intlService.t = (key, options) => {
+          if (key === 'pages.sco.restricted-access.title-access') {
+            return `Date: ${options.date}`;
+          }
+          return key;
+        };
+
         const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
           isAccessBlockedLycee: true,
           pixCertifScoBlockedAccessDateLycee: '2020-12-12',
@@ -32,13 +48,21 @@ module('Unit | Controller | authenticated/restricted-access', function (hooks) {
         controller.model = currentAllowedCertificationCenterAccess;
 
         // when then
-        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+        assert.strictEqual(controller.certificationOpeningDate, 'Date: 12/12/2020');
       });
     });
     module('when isAccessBlockedAgri is true', function () {
       test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
+        const intlService = this.owner.lookup('service:intl');
+        intlService.t = (key, options) => {
+          if (key === 'pages.sco.restricted-access.title-access') {
+            return `Date: ${options.date}`;
+          }
+          return key;
+        };
+
         const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
           isAccessBlockedAgri: true,
           pixCertifScoBlockedAccessDateLycee: '2020-12-12',
@@ -47,13 +71,21 @@ module('Unit | Controller | authenticated/restricted-access', function (hooks) {
         controller.model = currentAllowedCertificationCenterAccess;
 
         // when then
-        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+        assert.strictEqual(controller.certificationOpeningDate, 'Date: 12/12/2020');
       });
     });
     module('when isAccessBlockedAEFE is true', function () {
       test('should return a the pixCertifScoBlockedAccessDateLycee', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
+        const intlService = this.owner.lookup('service:intl');
+        intlService.t = (key, options) => {
+          if (key === 'pages.sco.restricted-access.title-access') {
+            return `Date: ${options.date}`;
+          }
+          return key;
+        };
+
         const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
           isAccessBlockedAEFE: true,
           pixCertifScoBlockedAccessDateLycee: '2020-12-12',
@@ -62,7 +94,7 @@ module('Unit | Controller | authenticated/restricted-access', function (hooks) {
         controller.model = currentAllowedCertificationCenterAccess;
 
         // when then
-        assert.strictEqual(controller.certificationOpeningDate, '2020-12-12');
+        assert.strictEqual(controller.certificationOpeningDate, 'Date: 12/12/2020');
       });
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -322,7 +322,7 @@
         "title": "Enrol candidates"
       },
       "restricted-access": {
-        "title": "Opening of your PixCertif space on"
+        "title-access": "Opening of your PixCertif space on {date} (00:00, Metropolitan France time)."
       }
     },
     "session-finalization": {
@@ -1080,5 +1080,5 @@
       "title": "Terms and conditions of use of the Pix Certif platform"
     }
   },
-  "restricted-access": "Site under maintenance, your Pix Certif space will reopen on {date}."
+  "restricted-access": "Site under maintenance, your Pix Certif space will reopen on {date} (00:00, Metropolitan France time)."
 }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -322,7 +322,7 @@
         "title": "Inscrire des candidats"
       },
       "restricted-access": {
-        "title": "Ouverture de votre espace Pix Certif le"
+        "title-access": "Ouverture de votre espace Pix Certif le {date} (00h00, heure France métropolitaine)."
       }
     },
     "session-finalization": {
@@ -1080,5 +1080,5 @@
       "title": "Conditions générales d'utilisation de la plateforme Pix Certif"
     }
   },
-  "restricted-access": "Site en maintenance, réouverture de votre espace Pix Certif le {date}."
+  "restricted-access": "Site en maintenance, réouverture de votre espace Pix Certif le {date} (00h00, heure France métropolitaine)."
 }


### PR DESCRIPTION
## 🔆 Problème

Pendant les périodes de fermeture de l'accès à l'administration sur PixCertif, une page annonçant la date de réouverture affiche une date.

Or, en fonction de la timezone, on ne voit pas la même date.

## ⛱️ Proposition

Afficher une date unique, avec une heure précisant "en France métropolitaine"

## 🏄 Pour tester

- Ajouter la variable d'env `PIX_CERTIF_BLOCKED_ACCESS_UNTIL_DATE` dans le futur (format `YYYY-MM-DD`).
- Constater sur PixCertif le texte actualisé
