### PR TITLE
[FEATURE] Afficher le champ "Équipe en charge" dans le formulaire d'édition d'une organisation (PIX-19598)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -255,6 +255,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @value={{this.form.identityProviderForCampaigns}}
             @onChange={{this.onChangeIdentityProvider}}
             @hideDefaultOption={{true}}
+            class="admin-form__select"
           >
             <:label>SSO</:label>
           </PixSelect>

--- a/admin/app/models/organization-form.js
+++ b/admin/app/models/organization-form.js
@@ -107,6 +107,7 @@ export default class OrganizationForm extends Model.extend(Validations) {
   @attr('number') credit;
   @attr('string') documentationUrl;
   @attr() identityProviderForCampaigns;
+  @attr('string') administrationTeamId;
 
   #getErrorAttribute(name) {
     const nameAttribute = this.validations.attrs.get(name);

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -27,7 +27,7 @@ export default class Organization extends Model {
   @attr() parentOrganizationId;
   @attr('nullable-string') parentOrganizationName;
   //TODO REMOVE nullable-string BEFORE THE END OF EPIX
-  @attr('nullable-string') administrationTeamId;
+  @attr() administrationTeamId;
   @attr('nullable-string') administrationTeamName;
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -141,3 +141,7 @@
   gap: var(--pix-spacing-4x);
   margin-top: var(--pix-spacing-6x);
 }
+
+.admin-form__select {
+  width: 100%;
+}

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -17,6 +17,13 @@ module('Integration | Component | organizations/information-section', function (
       hasAccessToOrganizationActionsScope = true;
     }
     this.owner.register('service:access-control', AccessControlStub);
+
+    const store = this.owner.lookup('service:store');
+    store.findAll = () =>
+      Promise.resolve([
+        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
+        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+      ]);
   });
 
   module('when displaying organization', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -555,9 +555,17 @@
       },
       "creation": {
         "administration-team": {
-          "selector" : {
+          "selector": {
             "label": "Choose an administration team",
             "placeholder": "Administration team"
+          }
+        }
+      },
+      "editing": {
+        "administration-team": {
+          "selector": {
+            "label": "Administration team",
+            "placeholder": "Choose an administration team"
           }
         }
       },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -556,9 +556,17 @@
       },
       "creation": {
         "administration-team": {
-          "selector" : {
+          "selector": {
             "label": "Sélectionner une équipe en charge",
             "placeholder": "Équipe en charge"
+          }
+        }
+      },
+      "editing": {
+        "administration-team": {
+          "selector": {
+            "label": "Équipe en charge",
+            "placeholder": "Sélectionner une équipe en charge"
           }
         }
       },


### PR DESCRIPTION
## 🔆 Problème

Sur Pix Admin, quand un utilisateur modifie une organisation (sur la page de détail d’une organisation), il doit voir et pouvoir sélectionner un champ “Équipe en charge”

## ⛱️ Proposition

Rajouter un champ de formulaire et un menu déroulant contenant l'ensemble des équipes.

## 🌊 Remarques
1- La route back n'étant pas encore mise à jour, l'édition d'une orga ne sera pas effective

2- Il est pour le moment possible qu'une organisation n'aie pas d'équipe en charge. On affiche dans ce cas, en état initial, le placeholder du menu déroulant. Dans un premier temps il est possible de soumettre le formulaire sans avoir choisi d'équipe.

3- Erreur sur l'identifiant de la branche. Ticket associé : PIX-19598



## 🏄 Pour tester

Sur Pix Admin:
- créer des orgas avec et sans équipe en charge
- sur la page de détail, cliquer sur modifier et vérifier que le menu "Équipe en charge" est pré-sélectionné avec l'équipe choisie lors de la création ou le placeholder du champ si pas d'équipe
- changer l'option
- cliquer sur enregistrer et vérifier que le payload de l'appel PATCH à la route contient bien l'id de l'équipe sélectionnée ou `null` si pas d'équipe sélectionnée

