### PR TITLE
[BUGFIX] Permettre l'authentification par SSO aux utilisateurs sortant d'un parcours Modulix (PIX-19665)

### DIFF
--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -74,19 +74,27 @@ export default class LoginOidcRoute extends Route {
   async _makeOidcAuthenticationRequest(identityProvider) {
     this.session.set('data.nextURL', undefined);
 
-    // Storing the `attemptedTransition` in the localstorage so when the user returns after
-    // the login they can be sent to the initial destination.
+    // Storing the `attemptedTransition` in the localstorage so that when the user returns after
+    // the login he can be sent to the initial destination.
     if (this.session.get('attemptedTransition')) {
-      // There is two types of intent in transition (see: https://github.com/tildeio/router.js/blob/9b3d00eb923e0bbc34c44f08c6de1e05684b907a/ARCHITECTURE.md#transitionintent)
-      // When the route is accessed by url (/campagnes/:code), the url is provided.
-      // When the route is accessed by the submit of the campaign code,
-      // the route name (organizations.access) and contexts ([Campaign]) are provided.
-      let { url } = this.session.get('attemptedTransition.intent');
-      const { name, contexts } = this.session.get('attemptedTransition.intent');
-      if (!url) {
-        url = this.router.urlFor(name, contexts[0]);
+      // cf. https://github.com/tildeio/router.js/blob/master/ARCHITECTURE.md#transitionintent
+      // there are 2 types of TransitionIntents:
+      // - URLTransitionIntent: for example when the route is accessed by url (/campagnes/:code), the url is provided
+      // - NamedTransitionIntent: for example when the route is accessed by the submit of the campaign code
+      //   the route name (organizations.access) and contexts ([Campaign]) are provided.
+      const { url, name, contexts } = this.session.get('attemptedTransition.intent');
+      let nextURL;
+      if (url) {
+        nextURL = url;
+      } else {
+        if (contexts[0]) {
+          nextURL = this.router.urlFor(name, contexts[0]);
+        } else {
+          nextURL = this.router.urlFor(name);
+        }
       }
-      this.session.set('data.nextURL', url);
+
+      this.session.set('data.nextURL', nextURL);
     }
 
     const response = await fetch(

--- a/mon-pix/app/routes/inscription/inscription.js
+++ b/mon-pix/app/routes/inscription/inscription.js
@@ -9,7 +9,7 @@ export default class InscriptionRoute extends Route {
   @service currentUser;
 
   get isAnonymous() {
-    return this.currentUser?.user?.isAnonymous || false;
+    return Boolean(this.currentUser?.user?.isAnonymous);
   }
 
   beforeModel() {


### PR DESCRIPTION
## 🔆 Problème

Les utilisateurs ne peuvent pas s'inscrire via SSO à l'issue d'un parcours Modulix

## ⛱️ Proposition

Modifier la route oidc-login pour couvrir les cas dans lesquels l'url n'a pas de "contexte" c'est à dire ne comporte pas de segments dynamiques (exemple d'url avec contexte : '/organisations/**PIXOIDC01**/acces')

## 🌊 Remarques

ras

## 🏄 Pour tester

**Le test est à faire en local (sso)**

TEST EN SORTIE DE MODULIX
 **Sans vous connecter au préalable**, passez un modulix (par exemple **https://app.dev.pix.fr/modules/demo-combinix-1/details** ou 
**https://app.dev.pix.fr/modules/demo-combinix-2/details**)
A la fin du modulix cliquez sur 'Continuer' pour arriver sur la mire de connexion et faites une connexion via oidc.

NON REGRESSION : TEST EN SORTIE DE CAMPAGNE
- Sur Pix Orga, avec le compte admin-orga@example.net, créez une campagne de collecte de profils d'une organisation PRO 
- Sur Pix Admin, associez cette orga PRO à un SSO
- Toujours **non connecté sur Pix App**, copiez - collez le lien de la campagne, qui commence par https://app.dev.pix.fr (ou org) /campagnes/{...} et passez cette campagne
- A l'issue de cette campagne connectez-vous via le SSO associé