### PR TITLE
[FEATURE] Remplir la table `organization_learner_participations` lors du passage de module (PIX-19738).

### DIFF
--- a/api/db/database-builder/factory/build-organization-learner-participation.js
+++ b/api/db/database-builder/factory/build-organization-learner-participation.js
@@ -1,0 +1,45 @@
+import _ from 'lodash';
+
+import { databaseBuffer } from '../database-buffer.js';
+import { buildOrganizationLearner } from './prescription/organization-learners/build-organization-learner.js';
+
+const buildOrganizationLearnerParticipation = function ({
+  id = databaseBuffer.getNextId(),
+  type = 'passage',
+  createdAt = new Date(),
+  updatedAt = new Date(),
+  completedAt = null,
+  deletedAt = null,
+  deletedBy = null,
+  organizationLearnerId,
+  status,
+  moduleId,
+} = {}) {
+  organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
+
+  const values = {
+    id,
+    type,
+    createdAt,
+    updatedAt,
+    completedAt,
+    deletedAt,
+    deletedBy,
+    organizationLearnerId,
+    status,
+  };
+
+  const organizationLearnerParticipation = databaseBuffer.pushInsertable({
+    tableName: 'organization_learner_participations',
+    values,
+  });
+
+  databaseBuffer.pushInsertable({
+    tableName: 'organization_learner_passage_participations',
+    values: { id, moduleId, organizationLearnerParticipationId: organizationLearnerParticipation.id },
+  });
+
+  return organizationLearnerParticipation;
+};
+
+export { buildOrganizationLearnerParticipation };

--- a/api/src/prescription/organization-learner/application/api/models/OrganizationLearner.js
+++ b/api/src/prescription/organization-learner/application/api/models/OrganizationLearner.js
@@ -1,9 +1,10 @@
 export class OrganizationLearner {
-  constructor({ id, firstName, lastName, features, organizationId, ...attributes }) {
+  constructor({ id, firstName, lastName, userId, features, organizationId, ...attributes }) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.features = features;
+    this.userId = userId;
     this.organizationId = organizationId;
     this.division = attributes['Libellé classe'];
   }

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -40,7 +40,8 @@ function _buildIsCertifiable(queryBuilder, organizationLearnerId) {
 }
 
 async function get({ organizationLearnerId }) {
-  const row = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const row = await knexConn
     .with('subquery', (qb) => _buildIsCertifiable(qb, organizationLearnerId))
     .select(
       'view-active-organization-learners.id',
@@ -58,6 +59,7 @@ async function get({ organizationLearnerId }) {
       knex.raw('array_remove(ARRAY_AGG(features.key), NULL) as features'),
       'users.email',
       'users.username',
+      'users.id AS userId',
     )
     .from('view-active-organization-learners')
     .where('view-active-organization-learners.id', organizationLearnerId)

--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -1,0 +1,57 @@
+import { StatusesEnumValues } from '../../../devcomp/domain/models/module/UserModuleStatus.js';
+
+export const OrganizationLearnerParticipationTypes = {
+  PASSAGE: 'PASSAGE',
+};
+
+export const OrganizationLearnerParticipationStatuses = {
+  NOT_STARTED: 'NOT_STARTED',
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED',
+};
+
+export class OrganizationLearnerParticipation {
+  constructor({ id, organizationLearnerId, createdAt, updatedAt, completedAt, deletedAt, deletedBy, status, type }) {
+    this.id = id;
+    this.organizationLearnerId = organizationLearnerId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.completedAt = completedAt;
+    this.deletedAt = deletedAt;
+    this.deletedBy = deletedBy;
+    this.status = status;
+    this.type = type;
+  }
+
+  static buildFromPassage({
+    id,
+    organizationLearnerId,
+    createdAt,
+    updatedAt,
+    terminatedAt,
+    deletedAt,
+    deletedBy,
+    status,
+  }) {
+    let participationStatus;
+
+    if (status === StatusesEnumValues.IN_PROGRESS)
+      participationStatus = OrganizationLearnerParticipationStatuses.STARTED;
+    else if (status === StatusesEnumValues.COMPLETED)
+      participationStatus = OrganizationLearnerParticipationStatuses.COMPLETED;
+    else if (status == StatusesEnumValues.NOT_STARTED)
+      participationStatus = OrganizationLearnerParticipationStatuses.NOT_STARTED;
+
+    return new OrganizationLearnerParticipation({
+      id,
+      organizationLearnerId,
+      createdAt,
+      updatedAt,
+      completedAt: terminatedAt,
+      deletedAt,
+      deletedBy,
+      status: participationStatus,
+      type: OrganizationLearnerParticipationTypes.PASSAGE,
+    });
+  }
+}

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   campaignRepository: repositories.campaignRepository,
   userRepository: repositories.userRepository,
   targetProfileRepository: repositories.targetProfileRepository,
+  organizationLearnerPassageParticipationRepository: repositories.organizationLearnerPassageParticipationRepository,
   codeGenerator,
   logger,
 };

--- a/api/src/quest/domain/usecases/update-combined-course.js
+++ b/api/src/quest/domain/usecases/update-combined-course.js
@@ -1,79 +1,96 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { CombinedCourseDetails } from '../models/CombinedCourse.js';
 import { DataForQuest } from '../models/DataForQuest.js';
 
-export async function updateCombinedCourse({
-  userId,
-  code,
-  combinedCourseRepository,
-  combinedCourseParticipationRepository,
-  questRepository,
-  eligibilityRepository,
-  campaignRepository,
-  recommendedModulesRepository,
-}) {
-  const combinedCourse = await combinedCourseRepository.getByCode({ code });
-  const quest = await questRepository.getByCode({ code });
-
-  let combinedCourseParticipation;
-  try {
-    combinedCourseParticipation = await combinedCourseParticipationRepository.getByUserId({
-      questId: quest.id,
-      userId,
-    });
-  } catch (err) {
-    if (!(err instanceof NotFoundError)) {
-      throw err;
-    }
-  }
-
-  if (!combinedCourseParticipation || combinedCourseParticipation.isCompleted()) {
-    return;
-  }
-
-  const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest, combinedCourseParticipation);
-
-  const eligibility = await eligibilityRepository.findByUserIdAndOrganizationId({
+export const updateCombinedCourse = withTransaction(
+  async ({
     userId,
-    organizationId: combinedCourse.organizationId,
-    moduleIds: combinedCourseDetails.moduleIds,
-  });
+    code,
+    combinedCourseRepository,
+    combinedCourseParticipationRepository,
+    questRepository,
+    eligibilityRepository,
+    campaignRepository,
+    recommendedModulesRepository,
+    organizationLearnerPassageParticipationRepository,
+  }) => {
+    const combinedCourse = await combinedCourseRepository.getByCode({ code });
+    const quest = await questRepository.getByCode({ code });
 
-  const dataForQuest = new DataForQuest({ eligibility });
+    let combinedCourseParticipation;
+    try {
+      combinedCourseParticipation = await combinedCourseParticipationRepository.getByUserId({
+        questId: quest.id,
+        userId,
+      });
+    } catch (err) {
+      if (!(err instanceof NotFoundError)) {
+        throw err;
+      }
+    }
 
-  const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+    if (!combinedCourseParticipation || combinedCourseParticipation.isCompleted()) {
+      return;
+    }
 
-  const campaignIds = combinedCourseDetails.campaignIds;
-  const targetProfileIds = [];
-  for (const campaignId of campaignIds) {
-    const campaign = await campaignRepository.get({ id: campaignId });
-    targetProfileIds.push(campaign.targetProfileId);
-  }
+    const combinedCourseDetails = new CombinedCourseDetails(combinedCourse, quest, combinedCourseParticipation);
 
-  let recommendableModuleIds = [];
-  if (targetProfileIds.length > 0) {
-    recommendableModuleIds = await recommendedModulesRepository.findIdsByTargetProfileIds({
-      targetProfileIds,
+    const eligibility = await eligibilityRepository.findByUserIdAndOrganizationId({
+      userId,
+      organizationId: combinedCourse.organizationId,
+      moduleIds: combinedCourseDetails.moduleIds,
     });
-  }
 
-  let recommendedModuleIdsForUser = [];
-  if (campaignParticipationIds.length > 0) {
-    recommendedModuleIdsForUser = await recommendedModulesRepository.findIdsByCampaignParticipationIds({
-      campaignParticipationIds,
+    const dataForQuest = new DataForQuest({ eligibility });
+
+    const campaignParticipationIds = quest.findCampaignParticipationIdsContributingToQuest(dataForQuest);
+
+    const campaignIds = combinedCourseDetails.campaignIds;
+    const targetProfileIds = [];
+    for (const campaignId of campaignIds) {
+      const campaign = await campaignRepository.get({ id: campaignId });
+      targetProfileIds.push(campaign.targetProfileId);
+    }
+
+    let recommendableModules = [];
+    if (targetProfileIds.length > 0) {
+      recommendableModules = await recommendedModulesRepository.findIdsByTargetProfileIds({
+        targetProfileIds,
+      });
+    }
+    const recommendableModuleIds = recommendableModules.map((module) => module.moduleId);
+
+    let recommendedModulesForUser = [];
+    if (campaignParticipationIds.length > 0) {
+      recommendedModulesForUser = await recommendedModulesRepository.findIdsByCampaignParticipationIds({
+        campaignParticipationIds,
+      });
+    }
+
+    const mandatoryModuleIds = combinedCourseDetails.moduleIds.filter(
+      (moduleId) => !recommendableModuleIds.includes(moduleId),
+    );
+
+    const recommendedModuleIds = recommendedModulesForUser.map(({ moduleId }) => moduleId);
+    const moduleToSynchronizeIds = [...recommendedModuleIds, ...mandatoryModuleIds];
+
+    await organizationLearnerPassageParticipationRepository.synchronize({
+      organizationLearnerId: combinedCourseParticipation.organizationLearnerId,
+      moduleIds: moduleToSynchronizeIds,
     });
-  }
 
-  const isCombinedCourseCompleted = combinedCourseDetails.isCompleted(
-    dataForQuest,
-    recommendableModuleIds,
-    recommendedModuleIdsForUser,
-  );
+    const isCombinedCourseCompleted = combinedCourseDetails.isCompleted(
+      dataForQuest,
+      recommendableModules,
+      recommendedModulesForUser,
+    );
 
-  if (isCombinedCourseCompleted) {
-    combinedCourseParticipation.complete();
-    return combinedCourseParticipationRepository.update({ combinedCourseParticipation });
-  }
+    if (isCombinedCourseCompleted) {
+      combinedCourseParticipation.complete();
+      return combinedCourseParticipationRepository.update({ combinedCourseParticipation });
+    }
 
-  return combinedCourseParticipation;
-}
+    return combinedCourseParticipation;
+  },
+);

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -4,6 +4,7 @@ import * as knowledgeElementsApi from '../../../evaluation/application/api/knowl
 import * as userApi from '../../../identity-access-management/application/api/users-api.js';
 import * as skillsApi from '../../../learning-content/application/api/skills-api.js';
 import * as campaignsApi from '../../../prescription/campaign/application/api/campaigns-api.js';
+import * as organizationLearnerApi from '../../../prescription/organization-learner/application/api/organization-learners-api.js';
 import * as organizationLearnerWithParticipationApi from '../../../prescription/organization-learner/application/api/organization-learners-with-participations-api.js';
 import * as targetProfilesApi from '../../../prescription/target-profile/application/api/target-profile-api.js';
 import * as profileRewardApi from '../../../profile/application/api/profile-reward-api.js';
@@ -17,6 +18,7 @@ import * as combinedCourseParticipationRepository from './combined-course-partic
 import * as combinedCourseRepository from './combined-course-repository.js';
 import * as eligibilityRepository from './eligibility-repository.js';
 import * as moduleRepository from './module-repository.js';
+import * as organizationLearnerPassageParticipationRepository from './organization-learner-passage-participation-repository.js';
 import * as questRepository from './quest-repository.js';
 import * as recommendedModulesRepository from './recommended-module-repository.js';
 import * as rewardRepository from './reward-repository.js';
@@ -29,6 +31,7 @@ const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewar
 const repositoriesWithoutInjectedDependencies = {
   accessCodeRepository,
   eligibilityRepository,
+  organizationLearnerPassageParticipationRepository,
   moduleRepository,
   successRepository,
   rewardRepository,
@@ -46,6 +49,7 @@ const dependencies = {
   organizationLearnerWithParticipationApi,
   knowledgeElementsApi,
   campaignsApi,
+  organizationLearnerApi,
   skillsApi,
   profileRewardApi,
   modulesApi,

--- a/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
@@ -1,0 +1,53 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { OrganizationLearnerParticipation } from '../../domain/models/OrganizationLearnerParticipation.js';
+
+export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi, organizationLearnerApi }) => {
+  if (moduleIds.length === 0) {
+    return;
+  }
+
+  const knexConn = DomainTransaction.getConnection();
+
+  const learner = await organizationLearnerApi.get(organizationLearnerId);
+  const modulePassages = await modulesApi.getUserModuleStatuses({ userId: learner.userId, moduleIds });
+
+  const learnerParticipationsByModule = await knexConn('organization_learner_participations')
+    .join(
+      'organization_learner_passage_participations',
+      'organization_learner_participations.id',
+      'organization_learner_passage_participations.organizationLearnerParticipationId',
+    )
+    .where({ organizationLearnerId: organizationLearnerId })
+    .whereNull('deletedAt')
+    .whereIn('moduleId', moduleIds);
+
+  for (const modulePassage of modulePassages) {
+    const learnerParticipationModule = learnerParticipationsByModule.find(
+      (learnerParticipation) => learnerParticipation.moduleId === modulePassage.id,
+    );
+
+    const organizationLearnerPassageParticipation = OrganizationLearnerParticipation.buildFromPassage({
+      id: learnerParticipationModule?.id,
+      organizationLearnerId,
+      createdAt: modulePassage.createdAt,
+      status: modulePassage.status,
+      updatedAt: modulePassage.updatedAt,
+      terminatedAt: modulePassage.terminatedAt,
+    });
+
+    if (organizationLearnerPassageParticipation.id) {
+      await knexConn('organization_learner_participations')
+        .update(organizationLearnerPassageParticipation)
+        .where('id', organizationLearnerPassageParticipation.id);
+    } else {
+      const [{ id: organizationLearnerParticipationId }] = await knexConn('organization_learner_participations')
+        .insert(organizationLearnerPassageParticipation)
+        .returning('id');
+
+      await knexConn('organization_learner_passage_participations').insert({
+        moduleId: modulePassage.id,
+        organizationLearnerParticipationId,
+      });
+    }
+  }
+};

--- a/api/tests/prescription/organization-learner/integration/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/api/organization-learners-api_test.js
@@ -1,3 +1,4 @@
+import { OrganizationLearner } from '../../../../../../src/prescription/organization-learner/application/api/models/OrganizationLearner.js';
 import * as organizationLearnersApi from '../../../../../../src/prescription/organization-learner/application/api/organization-learners-api.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
@@ -62,6 +63,7 @@ describe('Integration | API | Organization Learner', function () {
 
       // then
       expect(learner.id).to.equal(organizationLearnerId);
+      expect(learner).instanceOf(OrganizationLearner);
     });
   });
 });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -45,6 +45,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
 
         const organizationLearner = await organizationLearnerRepository.get({ organizationLearnerId: 1233 });
         expect(organizationLearner.id).to.equal(1233);
+        expect(organizationLearner.userId).to.equal(userId);
         expect(organizationLearner.firstName).to.equal('Dark');
         expect(organizationLearner.lastName).to.equal('Sasuke');
         expect(organizationLearner.division).to.equal('Alone');

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearner_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearner_test.js
@@ -9,6 +9,7 @@ describe('Unit | Application| API | Models | OrganizationLearner', function () {
       lastName: 'Delaforêt',
       'Libellé classe': '4ème',
       organizationId: 358,
+      userId: 777,
     });
 
     // then
@@ -16,5 +17,6 @@ describe('Unit | Application| API | Models | OrganizationLearner', function () {
     expect(organizationLearner.lastName).to.equal('Delaforêt');
     expect(organizationLearner.division).to.equal('4ème');
     expect(organizationLearner.organizationId).to.equal(358);
+    expect(organizationLearner.userId).to.equal(777);
   });
 });

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
@@ -151,7 +151,7 @@ describe('Unit | API | Organization Learner', function () {
 
       // then
       expect(learner).to.be.instanceOf(OrganizationLearner);
-      expect(learner.division).to.equal(organizationLearner['Libellé classe']);
+      expect(learner.id).to.equal(1242);
     });
   });
 });

--- a/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
@@ -18,7 +18,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     clock.restore();
   });
   it('should update combined course if it is completed', async function () {
-    nock('https://assets.pix.org').head('/modules/bac-a-sable/ordi-spatial.svg').reply(200, {});
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
     const code = 'SOMETHING';
     const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
     const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
@@ -81,6 +81,107 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     expect(result.updatedAt).to.deep.equal(now);
   });
 
+  it('should update organization learner participations when passage is on a recommended module', async function () {
+    nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+    const code = 'SOMETHING';
+    const moduleId = '6282925d-4775-4bca-b513-4c3009ec5886';
+    const module2Id = '9beb922f-4d8e-495d-9c85-0e7265ca78d6';
+    const module3Id = 'd4c4a2b2-0046-471d-ad9c-15f9cfc8f1f6';
+
+    const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+    const trainingId = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' }).id;
+    const training2Id = databaseBuilder.factory.buildTraining({
+      type: 'modulix',
+      link: '/modules/au-dela-des-mots-de-passe',
+    }).id;
+    const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfile.id, trainingId });
+    databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId: targetProfile.id, trainingId: training2Id });
+
+    const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      campaignId: campaign.id,
+      userId,
+      organizationLearnerId,
+      status: 'SHARED',
+    }).id;
+    databaseBuilder.factory.buildUserRecommendedTraining({
+      userId,
+      trainingId: trainingId,
+      campaignParticipationId,
+    });
+    databaseBuilder.factory.buildPassage({ userId, moduleId, terminatedAt: new Date() });
+    databaseBuilder.factory.buildPassage({ userId, module2Id, terminatedAt: null });
+
+    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+      code,
+      organizationId,
+      successRequirements: [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            campaignId: {
+              data: campaign.id,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: moduleId,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: module2Id,
+              comparison: 'equal',
+            },
+          },
+        },
+        {
+          requirement_type: 'passages',
+          comparison: 'all',
+          data: {
+            moduleId: {
+              data: module3Id,
+              comparison: 'equal',
+            },
+          },
+        },
+      ],
+    });
+    databaseBuilder.factory.buildCombinedCourseParticipation({
+      organizationLearnerId,
+      questId,
+      createdAt: new Date('2022-01-01'),
+      updatedAt: new Date('2022-01-01'),
+      status: CombinedCourseParticipationStatuses.STARTED,
+    });
+    await databaseBuilder.commit();
+
+    await usecases.updateCombinedCourse({ userId, code });
+
+    // then
+    const result = await knex('organization_learner_participations')
+      .join(
+        'organization_learner_passage_participations',
+        'organization_learner_participations.id',
+        'organization_learner_passage_participations.organizationLearnerParticipationId',
+      )
+      .where({ organizationLearnerId });
+
+    expect(result).to.be.lengthOf(2);
+    expect(result[0].moduleId).equal(moduleId);
+  });
   it('should not update combined course if it not completed', async function () {
     const code = 'SOMETHING';
     const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
@@ -1,0 +1,154 @@
+import dayjs from 'dayjs';
+import sinon from 'sinon';
+
+import { StatusesEnumValues } from '../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Infrastructure | repositories | organization learner passage participations', function () {
+  describe('#synchronize', function () {
+    let organizationLearner;
+    let modulesApi;
+    let clock;
+    const now = new Date('2022-11-28T12:00:00Z');
+
+    beforeEach(async function () {
+      organizationLearner = databaseBuilder.factory.buildOrganizationLearner();
+
+      await databaseBuilder.commit();
+
+      modulesApi = {
+        getUserModuleStatuses: sinon.stub(),
+      };
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('should create passage when participations does not exist', async function () {
+      //given
+      const moduleApiResponse = [
+        {
+          id: 1234,
+          status: 'COMPLETED',
+          createdAt: dayjs().subtract('30', 'days').toDate(),
+          updatedAt: now,
+          terminatedAt: null,
+        },
+      ];
+      modulesApi.getUserModuleStatuses
+        .withArgs({ userId: organizationLearner.userId, moduleIds: [1234] })
+        .resolves(moduleApiResponse);
+
+      // when
+      await repositories.organizationLearnerPassageParticipationRepository.synchronize({
+        organizationLearnerId: organizationLearner.id,
+        moduleIds: [1234],
+        modulesApi,
+      });
+
+      // then
+      const result = await knex('organization_learner_participations')
+        .join(
+          'organization_learner_passage_participations',
+          'organization_learner_participations.id',
+          'organization_learner_passage_participations.organizationLearnerParticipationId',
+        )
+        .where({ organizationLearnerId: organizationLearner.id });
+
+      expect(result).lengthOf(1);
+      expect(result[0].updatedAt).deep.equal(now);
+      expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());
+      expect(result[0].completedAt).equal(null);
+    });
+
+    it('should update passage when participation already exists', async function () {
+      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        status: 'STARTED',
+        moduleId: 1234,
+        createdAt: dayjs().subtract('40', 'days').toDate(),
+        updatedAt: dayjs().subtract('35', 'days').toDate(),
+        completedAt: null,
+      });
+
+      await databaseBuilder.commit();
+
+      const moduleApiResponse = [
+        {
+          id: 1234,
+          status: 'COMPLETED',
+          createdAt: dayjs().subtract('30', 'days').toDate(),
+          updatedAt: now,
+          terminatedAt: now,
+        },
+      ];
+      modulesApi.getUserModuleStatuses
+        .withArgs({ userId: organizationLearner.userId, moduleIds: [1234] })
+        .resolves(moduleApiResponse);
+
+      // when
+      await repositories.organizationLearnerPassageParticipationRepository.synchronize({
+        organizationLearnerId: organizationLearner.id,
+        moduleIds: [1234],
+        modulesApi,
+      });
+
+      // then
+      const result = await knex('organization_learner_participations')
+        .join(
+          'organization_learner_passage_participations',
+          'organization_learner_participations.id',
+          'organization_learner_passage_participations.organizationLearnerParticipationId',
+        )
+        .where({ organizationLearnerId: organizationLearner.id });
+
+      expect(result).lengthOf(1);
+      expect(result[0].updatedAt).deep.equal(now);
+      expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());
+      expect(result[0].completedAt).deep.equal(now);
+    });
+
+    it('should insert more than one line when needed', async function () {
+      //given
+      const moduleApiResponse = [
+        {
+          id: 1234,
+          status: StatusesEnumValues.COMPLETED,
+          createdAt: dayjs().subtract('30', 'days').toDate(),
+          updatedAt: now,
+          terminatedAt: null,
+        },
+        {
+          id: 4567,
+          status: StatusesEnumValues.IN_PROGRESS,
+          createdAt: dayjs().subtract('50', 'days').toDate(),
+          updatedAt: dayjs().subtract('10', 'days').toDate(),
+          terminatedAt: null,
+        },
+      ];
+      modulesApi.getUserModuleStatuses
+        .withArgs({ userId: organizationLearner.userId, moduleIds: [1234, 4567] })
+        .resolves(moduleApiResponse);
+
+      // when
+      await repositories.organizationLearnerPassageParticipationRepository.synchronize({
+        organizationLearnerId: organizationLearner.id,
+        moduleIds: [1234, 4567],
+        modulesApi,
+      });
+
+      // then
+      const result = await knex('organization_learner_participations')
+        .join(
+          'organization_learner_passage_participations',
+          'organization_learner_participations.id',
+          'organization_learner_passage_participations.organizationLearnerParticipationId',
+        )
+        .where({ organizationLearnerId: organizationLearner.id });
+
+      expect(result).lengthOf(2);
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -1,0 +1,67 @@
+import { StatusesEnumValues } from '../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import {
+  OrganizationLearnerParticipation,
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', function () {
+  describe('buildFromPassage', function () {
+    it('should instantiate an OrganizationLearnerParticipation with passage data', function () {
+      // given && when
+      const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromPassage({
+        id: 12,
+        organizationLearnerId: 15,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-01-01'),
+        terminatedAt: new Date('2025-02-01'),
+        deletedAt: new Date('2025-03-01'),
+        deletedBy: 13,
+        status: StatusesEnumValues.IN_PROGRESS,
+      });
+
+      // then
+      expect(organizationLearnerParticipation.id).to.equal(12);
+      expect(organizationLearnerParticipation.organizationLearnerId).to.equal(15);
+      expect(organizationLearnerParticipation.createdAt).deep.to.equal(new Date('2024-01-01'));
+      expect(organizationLearnerParticipation.updatedAt).deep.to.equal(new Date('2025-01-01'));
+      expect(organizationLearnerParticipation.completedAt).deep.to.equal(new Date('2025-02-01'));
+      expect(organizationLearnerParticipation.deletedAt).deep.to.equal(new Date('2025-03-01'));
+      expect(organizationLearnerParticipation.deletedBy).to.equal(13);
+      expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.PASSAGE);
+    });
+
+    describe('status', function () {
+      it('should map IN_PROGRESS to STARTED status on OrganizationLearnerParticipation', function () {
+        // given && when
+        const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromPassage({
+          status: StatusesEnumValues.IN_PROGRESS,
+        });
+
+        // then
+        expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
+      });
+
+      it('should map modules status COMPLETED to OrganizationLearnerParticipation COMPLETED status on OrganizationLearnerParticipation', function () {
+        // given && when
+        const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromPassage({
+          status: StatusesEnumValues.COMPLETED,
+        });
+
+        // then
+        expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
+      });
+
+      it('should map modules status NOT_STARTED to OrganizationLearnerParticipation NOT_STARTED status on OrganizationLearnerParticipation', function () {
+        // given && when
+        const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromPassage({
+          status: StatusesEnumValues.NOT_STARTED,
+        });
+
+        // then
+        expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.NOT_STARTED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Actuellement nous ne pouvons restituer les données lié aux organizations lorsqu'un utilisateur s'anonymise

## ⛱️ Proposition

Enregister des données dans organization_learner_participations afin de noter les dernières infos de passage d'un learner. ces données permetttront de garder un historique après une demande de suppression / anonymisation d'un utilisateur

## 🌊 Remarques

RAS

## 🏄 Pour tester

Faire un parcours combiné => vérifier que la table organization learner participation se rempli correctement
