### PR TITLE
[BUGFIX] Retourner une erreur lorsque la campagne est supprimée lors de l'appel à POST /answers (PIX-19750).

### DIFF
--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-campaign.js
@@ -25,6 +25,9 @@ const saveAndCorrectAnswerForCampaign = withTransaction(async function ({
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
+  if (!assessment.campaignParticipationId) {
+    throw new ForbiddenAccess('Campaign does not accept any answer.');
+  }
   if (assessment.answers.some((existingAnswer) => existingAnswer.challengeId === answer.challengeId)) {
     throw new ChallengeAlreadyAnsweredError();
   }

--- a/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -5,13 +5,93 @@ import * as knowledgeElementSnapshotApi from '../../../../../src/prescription/ca
 import { CampaignTypes } from '../../../../../src/prescription/shared/domain/constants.js';
 import { KnowledgeElementCollection } from '../../../../../src/prescription/shared/domain/models/KnowledgeElementCollection.js';
 import { PIX_COUNT_BY_LEVEL } from '../../../../../src/shared/domain/constants.js';
+import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { KnowledgeElement } from '../../../../../src/shared/domain/models/KnowledgeElement.js';
-import { databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Evaluation | Integration | Usecase | Save and correct answer for campaign', function () {
   const skillIds = ['monAcquisA_Id', 'monAcquisB_Id', 'monAcquisC_Id'];
+
+  context('for deleted campaign', function () {
+    it('should throw a ForbiddenAccess', async function () {
+      // given
+      const locale = 'fr';
+      const userId = databaseBuilder.factory.buildUser().id;
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: null,
+        type: Assessment.types.CAMPAIGN,
+      });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        userId,
+        status: CompetenceEvaluation.statuses.STARTED,
+      });
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'monAreaId',
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'maCompetenceId',
+        areaId: 'monAreaId',
+        name_i18n: {
+          fr: 'nom de la compétence',
+        },
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'monEpreuveId',
+        skillId: skillIds[2],
+        competenceId: 'maCompetenceId',
+        locales: [locale],
+        status: 'validé',
+        solution: 'correct',
+        proposals: '${a}',
+        type: 'QROC',
+      });
+      skillIds.map((id, index) =>
+        databaseBuilder.factory.learningContent.buildSkill({
+          id,
+          competenceId: 'maCompetenceId',
+          pixValue: PIX_COUNT_BY_LEVEL,
+          status: 'actif',
+          tubeId: 'monTubeId',
+          level: index + 1,
+        }),
+      );
+      const someAnswerId = databaseBuilder.factory.buildAnswer().id;
+      const someOtherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+      databaseBuilder.factory.buildKnowledgeElement({
+        skillId: skillIds[0],
+        earnedPix: PIX_COUNT_BY_LEVEL,
+        userId,
+        assessmentId: someOtherAssessmentId,
+        answerId: someAnswerId,
+        status: KnowledgeElement.StatusType.VALIDATED,
+        source: KnowledgeElement.SourceType.DIRECT,
+        competenceId: 'maCompetenceId',
+        createdAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      const answer = new Answer({
+        value: 'correct',
+        challengeId: 'monEpreuveId',
+        assessmentId: assessment.id,
+      });
+      const error = await catchErr(evaluationUsecases.saveAndCorrectAnswerForCampaign)({
+        answer,
+        userId,
+        assessment,
+        locale,
+        forceOKAnswer: false,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenAccess);
+    });
+  });
 
   context('for campaign of type assessment with method smart_random', function () {
     it('should correct answer and save both answer and knowledge-elements', async function () {

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-campaign_test.js
@@ -180,8 +180,9 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       challengeRepository.get.resolves(challenge);
       assessment = domainBuilder.buildAssessment({
         userId,
+        campaignParticipationId: 12,
         lastQuestionDate: new Date('2021-03-11T11:00:00Z'),
-        type: Assessment.types.COMPETENCE_EVALUATION,
+        type: Assessment.types.CAMPAIGN,
         answers: [],
       });
 


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'une campagne est supprimé avec la nouvelle anonymisation et qu'un utilisateur répond à cette campagne en même temps il survient une erreur PG car nous supprimons le campaignParticipationId

## ⛱️ Proposition

Throw une ForbiddenAccess lorsque la campaignParticipationId n'existe plus

## 🏄 Pour tester

Participer a une campagn PROASSMUL 
Activer l'anonymisation
Supprimer la campagne
Tenter de répondre à la question suivante
Voir la FobiddenAccess