### PR TITLE
[FEATURE] Renvoyer les width/height des images dans les flashcards (PIX-19682)

### DIFF
--- a/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
+++ b/api/src/devcomp/domain/models/element/flashcards/Flashcards.js
@@ -1,5 +1,4 @@
 import { Element } from '../Element.js';
-import { Card } from './Card.js';
 
 class Flashcards extends Element {
   constructor({ id, title, instruction, introImage, cards }) {
@@ -8,7 +7,7 @@ class Flashcards extends Element {
     this.title = title;
     this.instruction = instruction;
     this.setIntroImage(introImage);
-    this.cards = cards.map(({ id, recto, verso }) => new Card({ id, recto, verso }));
+    this.cards = cards;
     this.isAnswerable = true;
   }
 

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -331,19 +331,35 @@ export class ModuleFactory {
     });
   }
 
-  static #buildFlashcards(element) {
+  static async #buildFlashcards(element) {
     return new Flashcards({
       id: element.id,
       title: element.title,
       instruction: element.instruction,
-      introImage: element.introImage,
-      cards: element.cards.map(
-        (card) =>
-          new Card({
+      introImage: {
+        url: element.introImage.url,
+        information: element.introImage?.url ? await getAssetInfos(element.introImage.url) : {},
+      },
+      cards: await Promise.all(
+        element.cards.map(async (card) => {
+          return new Card({
             id: card.id,
-            recto: card.recto,
-            verso: card.verso,
-          }),
+            recto: {
+              text: card.recto.text,
+              image: {
+                url: card.recto.image?.url,
+                information: card.recto.image?.url ? await getAssetInfos(card.recto.image.url) : {},
+              },
+            },
+            verso: {
+              text: card.verso.text,
+              image: {
+                url: card.verso.image?.url,
+                information: card.verso.image?.url ? await getAssetInfos(card.verso.image.url) : {},
+              },
+            },
+          });
+        }),
       ),
     });
   }

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1098,6 +1098,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
       it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', async function () {
         // given
+        nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
@@ -1129,20 +1130,20 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         title: "Introduction à l'adresse e-mail",
                         instruction: '<p>...</p>',
                         introImage: {
-                          url: 'https://example.org/image.jpeg',
+                          url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                         },
                         cards: [
                           {
                             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
                             recto: {
                               image: {
-                                url: 'https://example.org/image.jpeg',
+                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                               },
                               text: "A quoi sert l'arobase dans mon adresse email ?",
                             },
                             verso: {
                               image: {
-                                url: 'https://example.org/image.jpeg',
+                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                               },
                               text: "Parce que c'est joli",
                             },
@@ -1290,7 +1291,9 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
     describe('With ComponentStepper', function () {
       it('should instantiate a Module with a ComponentStepper which contains an Image Element', async function () {
         // given
-        nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
+        nock('https://assets.pix.org')
+          .head('/modulix/didacticiel/ordi-spatial.svg')
+          .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
@@ -1961,6 +1964,9 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
       it('should instantiate a Module with a ComponentElement which contains a Flashcard Element', async function () {
         // given
+        nock('https://assets.pix.org')
+          .head('/modulix/didacticiel/ordi-spatial.svg')
+          .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
@@ -1995,20 +2001,20 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                               title: "Introduction à l'adresse e-mail",
                               instruction: '<p>...</p>',
                               introImage: {
-                                url: 'https://example.org/image.jpeg',
+                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                               },
                               cards: [
                                 {
                                   id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
                                   recto: {
                                     image: {
-                                      url: 'https://example.org/image.jpeg',
+                                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                                     },
                                     text: "A quoi sert l'arobase dans mon adresse email ?",
                                   },
                                   verso: {
                                     image: {
-                                      url: 'https://example.org/image.jpeg',
+                                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
                                     },
                                     text: "Parce que c'est joli",
                                   },

--- a/api/tests/devcomp/shared/validateFlashcards.js
+++ b/api/tests/devcomp/shared/validateFlashcards.js
@@ -8,6 +8,7 @@ function validateFlashcards(flashcards, expectedFlashcards) {
   expect(flashcards.title).to.equal(expectedFlashcards.title);
   expect(flashcards.instruction).to.equal(expectedFlashcards.instruction);
   expect(flashcards.introImage.url).to.equal(expectedFlashcards.introImage.url);
+  expect(flashcards.introImage.information).to.not.be.undefined;
   expect(flashcards.isAnswerable).to.equal(true);
   validateCard(flashcards.cards[0], expectedFlashcards.cards[0]);
 }
@@ -16,8 +17,10 @@ function validateCard(card, expectedCard) {
   expect(card).to.be.instanceOf(Card);
   expect(card.id).deep.equal(expectedCard.id);
   expect(card.recto.image.url).deep.equal(expectedCard.recto.image.url);
+  expect(card.recto.image.information).to.not.be.undefined;
   expect(card.recto.text).deep.equal(expectedCard.recto.text);
   expect(card.verso.image.url).deep.equal(expectedCard.verso.image.url);
+  expect(card.verso.image.information).to.not.be.undefined;
   expect(card.verso.text).deep.equal(expectedCard.verso.text);
 }
 

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Card_test.js
@@ -11,12 +11,14 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Card', funct
         recto: {
           image: {
             url: 'https://example.org/image.jpeg',
+            information: { width: 300, height: 300, type: 'vector' },
           },
           text: "A quoi sert l'arobase dans mon adresse email ?",
         },
         verso: {
           image: {
             url: 'https://example.org/image.jpeg',
+            information: {},
           },
           text: "Parce que c'est joli",
         },

--- a/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/flashcards/Flashcards_test.js
@@ -3,7 +3,7 @@ import { Flashcards } from '../../../../../../../src/devcomp/domain/models/eleme
 import { expect } from '../../../../../../test-helper.js';
 import { validateFlashcards } from '../../../../../shared/validateFlashcards.js';
 
-describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards', function () {
+describe('Unit | Devcomp | Domain | Models | Element | Flashcards', function () {
   describe('#constructor', function () {
     it('should create a Flashcards element and keep attributes', function () {
       // given
@@ -13,14 +13,16 @@ describe('Unit | Devcomp | Domain | Models | Element | Flashcards | Flashcards',
         instruction: 'instruction',
         introImage: {
           url: 'https://...',
+          information: { width: 300, height: 300, type: 'vector' },
         },
         cards: [
           new Card({
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-            recto: { image: { url: 'https://...' } },
+            recto: { image: { url: 'https://...', information: { width: 300, height: 300, type: 'vector' } } },
             verso: {
               image: {
                 url: 'https://...',
+                information: {},
               },
             },
           }),

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -235,6 +235,11 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           },
         ],
       });
+
+      // when
+      const json = moduleSerializer.serialize(moduleFromDomain);
+
+      // then
       const expectedJson = {
         data: {
           attributes: {
@@ -275,11 +280,6 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           },
         ],
       };
-
-      // when
-      const json = moduleSerializer.serialize(moduleFromDomain);
-
-      // then
       expect(json).to.deep.equal(expectedJson);
     });
   });
@@ -435,10 +435,24 @@ function getComponents() {
         cards: [
           new Card({
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-            recto: { image: { url: 'https://...' } },
+            recto: {
+              image: {
+                url: 'https://...',
+                information: {
+                  height: 333,
+                  width: 333,
+                  type: 'vector',
+                },
+              },
+            },
             verso: {
               image: {
                 url: 'https://...',
+                information: {
+                  height: 333,
+                  width: 333,
+                  type: 'vector',
+                },
               },
             },
           }),
@@ -667,10 +681,24 @@ function getAttributesComponents() {
         cards: [
           {
             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-            recto: { image: { url: 'https://...' } },
+            recto: {
+              image: {
+                url: 'https://...',
+                information: {
+                  height: 333,
+                  width: 333,
+                  type: 'vector',
+                },
+              },
+            },
             verso: {
               image: {
                 url: 'https://...',
+                information: {
+                  height: 333,
+                  width: 333,
+                  type: 'vector',
+                },
               },
             },
           },


### PR DESCRIPTION
## 🔆 Problème

Si peu de connexion, les images apparaissent dans le module après le texte, créant un "saut" dans la page lorsque l'image est chargée.

## ⛱️ Proposition

Afin d'avoir une bonne expérience utilisateur (voir [article CLS](https://web.dev/articles/cls?hl=fr)), on veut récupérer depuis pix-assets-manager les dimensions des images de nos composants Modulix. Cela a été fait pour l'élément Image, mais il manque la fonctionnalité pour: 
- flashcards

## 🌊 Remarques

D'autres PRs seront fait pour QAB et détails de module

## 🏄 Pour tester

- ouvrir sa console navigateur > Réseaux (pour voir les appels)
- se rendre sur https://app-pr13736.review.pix.org/modules/bac-a-sable/details
- voir la réponse API de /api/modules/bac-a-sable
- rechercher flashcards
- constater qu'on retourne les infos

<img width="426" height="178" alt="Capture d’écran 2025-10-02 à 14 58 42" src="https://github.com/user-attachments/assets/6c06f0e4-40ff-4da3-976e-ab8186432334" />

