### PR TITLE
[FEATURE] : S'assurer que le bouton "passer" devient "continuer" après l'apparition des feedbacks pour les QCM (PIX-19425)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -62,6 +62,7 @@ export default class ModulixElement extends Component {
         @onAnswer={{@onElementAnswer}}
         @onRetry={{@onElementRetry}}
         @correction={{this.getLastCorrectionForElement @element}}
+        @updateSkipButton={{@updateSkipButton}}
       />
     {{else if (eq @element.type "qrocm")}}
       <QrocmElement

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -77,14 +77,15 @@ export default class ModuleQcm extends ModuleElement {
 
   @action
   async onAnswer(event) {
+    this.args.updateSkipButton(true);
     this.isAnswering = true;
     event.preventDefault();
-
     await this.waitFor(VERIFY_RESPONSE_DELAY);
 
     super.onAnswer(event);
     if (this.shouldDisplayRequiredMessage === true) {
       this.isAnswering = false;
+      this.args.updateSkipButton(false);
       return;
     }
     this.validAnswer();
@@ -101,7 +102,9 @@ export default class ModuleQcm extends ModuleElement {
       type: 'QCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
+
     this.isAnswering = false;
+    this.args.updateSkipButton(false);
   }
 
   waitFor(duration) {

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -80,6 +80,8 @@ export default class ModuleQcm extends ModuleElement {
     this.isAnswering = true;
     event.preventDefault();
 
+    await this.waitFor(VERIFY_RESPONSE_DELAY);
+
     super.onAnswer(event);
     if (this.shouldDisplayRequiredMessage === true) {
       this.isAnswering = false;
@@ -99,7 +101,6 @@ export default class ModuleQcm extends ModuleElement {
       type: 'QCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
-    await this.waitFor(VERIFY_RESPONSE_DELAY);
     this.isAnswering = false;
   }
 

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -15,6 +15,7 @@ export default class ModuleGrain extends Component {
   @service modulixAutoScroll;
   @service intl;
   @tracked answeredElements = new TrackedSet();
+  @tracked isSkipButtonDisabled = false;
 
   grain = this.args.grain;
 
@@ -64,6 +65,11 @@ export default class ModuleGrain extends Component {
     } else {
       return 'lesson';
     }
+  }
+
+  @action
+  updateSkipButton(value) {
+    this.isSkipButtonDisabled = value;
   }
 
   @action
@@ -284,6 +290,7 @@ export default class ModuleGrain extends Component {
                   @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
+                  @updateSkipButton={{this.updateSkipButton}}
                 />
               </div>
             {{else if (eq component.type "stepper")}}
@@ -301,6 +308,7 @@ export default class ModuleGrain extends Component {
                   @onFileDownload={{@onFileDownload}}
                   @onExpandToggle={{@onExpandToggle}}
                   @direction={{this.stepperDirection}}
+                  @updateSkipButton={{this.updateSkipButton}}
                 />
               </div>
             {{/if}}
@@ -310,7 +318,12 @@ export default class ModuleGrain extends Component {
 
       {{#if this.shouldDisplaySkipButton}}
         <footer class="grain-card__footer">
-          <PixButton @variant="tertiary" @triggerAction={{@onGrainSkip}} @iconAfter="arrowBottom">
+          <PixButton
+            @variant="tertiary"
+            @triggerAction={{@onGrainSkip}}
+            @iconAfter="arrowBottom"
+            @isDisabled={{this.isSkipButtonDisabled}}
+          >
             {{this.skipButtonLabel}}
           </PixButton>
         </footer>

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -14,6 +14,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
 
   let passageEventService, passageEventRecordStub;
   let clock;
+  const updateSkipButton = sinon.stub();
 
   hooks.beforeEach(function () {
     clock = sinon.useFakeTimers();
@@ -83,7 +84,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const onAnswerSpy = sinon.spy();
 
     // when
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
     const proposal1Element = screen.getByLabelText(qcmElement.proposals[0].content);
     const proposal2Element = screen.getByLabelText(qcmElement.proposals[1].content);
     const proposal3Element = screen.getByLabelText(qcmElement.proposals[2].content);
@@ -128,7 +133,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
       type: 'qcm',
     };
     const onAnswerSpy = sinon.spy();
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
 
     // when
     await click(screen.getByLabelText('checkbox1'));
@@ -164,7 +173,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
       type: 'qcm',
     };
     const onAnswerSpy = sinon.spy();
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
 
     // when
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
@@ -203,7 +216,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const onAnswerSpy = sinon.spy();
 
     // when
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
     await click(screen.getByLabelText('checkbox1'));
     await click(screen.getByLabelText('checkbox2'));
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
@@ -245,7 +262,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const onAnswerSpy = sinon.spy();
 
     // when
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
     await click(screen.getByLabelText('checkbox1'));
     await click(screen.getByLabelText('checkbox3'));
     await click(screen.queryByRole('button', { name: 'Vérifier ma réponse' }));
@@ -287,7 +308,11 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const onAnswerSpy = sinon.spy();
 
     // when
-    const screen = await render(<template><ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} /></template>);
+    const screen = await render(
+      <template>
+        <ModulixQcm @element={{qcmElement}} @onAnswer={{onAnswerSpy}} @updateSkipButton={{updateSkipButton}} />
+      </template>,
+    );
 
     // then
     const checkbox1 = screen.getByRole('checkbox', { name: 'checkbox1', disabled: true });
@@ -325,7 +350,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       };
 
       // when
-      const screen = await render(<template><ModulixQcm @element={{qcm}} /></template>);
+      const screen = await render(
+        <template><ModulixQcm @element={{qcm}} @updateSkipButton={{updateSkipButton}} /></template>,
+      );
 
       // then
       assert.dom(screen.getByText('Correct!')).exists();


### PR DESCRIPTION
## 🔆 Problème

Le bouton “passer l’activité” devient “continuer” dès qu’on valide son activité. On souhaite d’abord visualiser le feedback, avant que ce bouton ne change.

## ⛱️ Proposition

Idéalement, il faudrait également disable le “passer” le temps de la vérification.

 Cinématique : 

=>Le personnage principal clique sur une solution 

=> Le personnage principal clique sur “Vérifier ma réponse” 

=> Désactiver le bouton “Passer l’activité” 

=> On affiche le feedback 

=> On remplace le bouton “passer l’activité” par “continuer” qui est activé

## 🌊 Remarques

Voir si on mutualise isAnswering et disableSkipButton au niveau du QCM

## 🏄 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr13738.review.pix.fr/modules/bac-a-sable/passage)
- Afficher le QCM
- Saisir deux réponses au choix
- Appuyer sur "Vérifier la réponse"
- Constater que le bouton "Passer l'activité" devient `disabled`
- Quand le feedback apparaît, le bouton "Continuer" remplace "Passer l'activité"