### PR TITLE
[FEATURE] Sécuriser le prompting en évitant les prompts concurrents sur la même conversation (PIX-19772)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,7 @@ import { JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config, schema as configSchema } from './src/shared/config.js';
 import { learningContentCache } from './src/shared/infrastructure/caches/learning-content-cache.js';
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
+import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -46,6 +47,8 @@ async function _exitOnSignal(signal) {
   await learningContentCache.quit();
   logger.info('Closing connections to storages...');
   await quitAllStorages();
+  logger.info('Closing connections to redis mutex...');
+  await quitMutex();
   logger.info('Closing connections to redis monitor...');
   await redisMonitor.quit();
   logger.info('Exiting process...');

--- a/api/index.maddo.js
+++ b/api/index.maddo.js
@@ -5,6 +5,7 @@ import { createMaddoServer } from './server.maddo.js';
 import { JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config, schema as configSchema } from './src/shared/config.js';
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
+import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -32,6 +33,8 @@ async function _exitOnSignal(signal) {
   await databaseConnections.disconnect();
   logger.info('Closing connections to cache...');
   await quitAllStorages();
+  logger.info('Closing connections to redis mutex...');
+  await quitMutex();
   logger.info('Closing connections to redis monitor...');
   await redisMonitor.quit();
   logger.info('Exiting process...');

--- a/api/sample.env
+++ b/api/sample.env
@@ -429,6 +429,13 @@ LCMS_API_RELEASE_ID=
 # default: '12h'
 # sample: LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS=
 
+# LLM chats lock duration for concurrency control
+#
+# presence: optional
+# type: number
+# default: 200
+# sample: LLM_LOCK_CHAT_EXPIRATION_DELAY_SECONDS=
+
 # LLM API URL to get a configuration by id
 #
 # If not present, embed with LLM will not work

--- a/api/src/llm/domain/errors.js
+++ b/api/src/llm/domain/errors.js
@@ -53,3 +53,9 @@ export class NoAttachmentNorMessageProvidedError extends DomainError {
     super('At least a message or an attachment, if applicable, must be provided');
   }
 }
+
+export class PromptAlreadyOngoingError extends DomainError {
+  constructor(chatId) {
+    super(`A prompt is already ongoing for chat with id ${chatId}`);
+  }
+}

--- a/api/src/llm/domain/usecases/index.js
+++ b/api/src/llm/domain/usecases/index.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import { redisMutex } from '../../../shared/infrastructure/mutex/RedisMutex.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as repositories from '../../infrastructure/repositories/index.js';
 import * as toEventStream from '../../infrastructure/streaming/to-event-stream.js';
@@ -8,6 +9,7 @@ const dependencies = {
   ...repositories,
   toEventStream,
   randomUUID,
+  redisMutex,
 };
 
 import { promptChat } from './prompt-chat.js';

--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -77,14 +77,14 @@ export async function promptChat({
           chat,
         });
       }
-
-      return toEventStream.fromLLMResponse({
-        llmResponse: readableStream,
-        onStreamDone: finalize(chat, message, shouldSendMessageToLLM, chatRepository, redisMutex),
-        attachmentMessageType,
-        shouldSendDebugData: chat.isPreview,
-      });
     }
+
+    return toEventStream.fromLLMResponse({
+      llmResponse: readableStream,
+      onStreamDone: finalize(chat, message, shouldSendMessageToLLM, chatRepository, redisMutex),
+      attachmentMessageType,
+      shouldSendDebugData: chat.isPreview,
+    });
   } catch (error) {
     await redisMutex.release(chatId);
     throw error;

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -26,6 +26,7 @@ export const ATTACHMENT_MESSAGE_TYPES = {
 /**
  * @callback OnStreamDoneCallback
  * @param {StreamCapture} streamCapture
+ * @param {boolean} hasStreamSucceeded
  */
 
 /**
@@ -68,9 +69,8 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
         if (!writableStream.closed && !writableStream.errored) {
           writableStream.end('Error while streaming response from LLM');
         }
-      } else {
-        await onStreamDone(streamCapture);
       }
+      await onStreamDone(streamCapture, !err);
     },
   );
   return writableStream;

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -519,6 +519,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message, error.code);
   }
 
+  if (error instanceof LLMDomainErrors.PromptAlreadyOngoingError) {
+    return new HttpErrors.ConflictError(error.message, error.code);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/src/shared/application/scripts/script-runner.js
+++ b/api/src/shared/application/scripts/script-runner.js
@@ -7,6 +7,7 @@ import yargs from 'yargs/yargs';
 import { databaseConnections } from '../../../../db/database-connections.js';
 import { learningContentCache } from '../../infrastructure/caches/learning-content-cache.js';
 import { quitAllStorages } from '../../infrastructure/key-value-storages/index.js';
+import { quitMutex } from '../../infrastructure/mutex/RedisMutex.js';
 import { child } from '../../infrastructure/utils/logger.js';
 
 function isRunningFromCli(scriptFileUrl) {
@@ -83,6 +84,7 @@ export class ScriptRunner {
       await databaseConnections.disconnect();
       await learningContentCache.quit();
       await quitAllStorages();
+      await quitMutex();
     }
   }
 }

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -403,6 +403,9 @@ const configuration = (function () {
       isOppsyDisabled: toBoolean(process.env.FT_OPPSY_DISABLED),
     },
     module: { secret: process.env.REDIRECTION_URL_SECRET },
+    mutex: {
+      redisUrl: process.env.REDIS_URL,
+    },
     partner: {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
@@ -613,6 +616,8 @@ const configuration = (function () {
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 100;
     config.caching.redisCacheLockedWaitBeforeRetry = 1;
+
+    config.mutex.redisUrl = process.env.TEST_REDIS_URL;
 
     config.redis = {
       url: process.env.TEST_REDIS_URL,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -342,6 +342,7 @@ const configuration = (function () {
       temporaryStorage: {
         expirationDelaySeconds: ms(process.env.LLM_CHAT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS ?? '12h'),
       },
+      lockChatExpirationDelayMilliseconds: (process.env.LLM_LOCK_CHAT_EXPIRATION_DELAY_SECONDS ?? 200) * 1000,
       getConfigurationUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_GET_CONFIGURATIONS_URL ?? ''),
       postPromptUrl: _removeTrailingSlashFromUrl(process.env.LLM_API_POST_PROMPT_URL ?? ''),
       authSecret: process.env.LLM_API_JWT_SECRET,

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -1,0 +1,30 @@
+import { config } from '../../config.js';
+import { RedisClient } from '../utils/RedisClient.js';
+
+class RedisMutex {
+  constructor({ redisUrl }) {
+    this._client = new RedisClient(redisUrl, { name: 'mutex', prefix: 'mutex:' });
+  }
+
+  /**
+   *
+   * @param { string } resourceId
+   * @returns { Promise<boolean> } true : successful lock
+   */
+  async lock(resourceId) {
+    return (
+      (await this._client.set(resourceId, '1', 'PX', config.llm.lockChatExpirationDelayMilliseconds, 'NX')) === 'OK'
+    );
+  }
+
+  /**
+   *
+   * @param { string } resourceId
+   * @returns { Promise<boolean> } true : successful release
+   */
+  async release(resourceId) {
+    return (await this._client.del(resourceId)) === 1;
+  }
+}
+
+export const redisMutex = new RedisMutex({ redisUrl: config.redis.url });

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -45,5 +45,8 @@ export function quitMutex() {
 }
 
 export function clearMutex() {
-  return redisMutex.clearAll();
+  const status = redisMutex._client.status;
+  if (!['close', 'end'].includes(status)) {
+    return redisMutex.clearAll();
+  }
 }

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -25,6 +25,25 @@ class RedisMutex {
   async release(resourceId) {
     return (await this._client.del(resourceId)) === 1;
   }
+
+  async quit() {
+    await this._client.quit();
+  }
+
+  async clearAll() {
+    const keys = (await this._client.keys('*')).map((key) => key.split('mutex:')[1]);
+    for (const key of keys) {
+      await this._client.del(key);
+    }
+  }
 }
 
-export const redisMutex = new RedisMutex({ redisUrl: config.redis.url });
+export const redisMutex = new RedisMutex({ redisUrl: config.mutex.redisUrl });
+
+export function quitMutex() {
+  return redisMutex.quit();
+}
+
+export function clearMutex() {
+  return redisMutex.clearAll();
+}

--- a/api/src/shared/infrastructure/utils/RedisClient.js
+++ b/api/src/shared/infrastructure/utils/RedisClient.js
@@ -30,6 +30,10 @@ class RedisClient {
     this.flushall = this._client.flushall.bind(this._client);
   }
 
+  get status() {
+    return this._client.status;
+  }
+
   _wrapWithPrefix(fn) {
     const prefix = this._prefix;
     return function (key, ...args) {

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -7,6 +7,7 @@ import {
   MaxPromptsReachedError,
   NoAttachmentNeededError,
   NoAttachmentNorMessageProvidedError,
+  PromptAlreadyOngoingError,
   TooLargeMessageInputError,
 } from '../../../../../src/llm/domain/errors.js';
 import { Chat, Message } from '../../../../../src/llm/domain/models/Chat.js';
@@ -18,6 +19,7 @@ import {
   promptRepository,
 } from '../../../../../src/llm/infrastructure/repositories/index.js';
 import * as toEventStream from '../../../../../src/llm/infrastructure/streaming/to-event-stream.js';
+import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
 import {
   catchErr,
   databaseBuilder,
@@ -37,6 +39,7 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       chatRedisRepository,
       chatRepository,
       toEventStream,
+      redisMutex,
     };
   });
 
@@ -48,6 +51,19 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       // then
       expect(err).to.be.instanceOf(ChatNotFoundError);
       expect(err.message).to.equal('The chat of id "null id provided" does not exist');
+    });
+  });
+
+  context('when prompt is already ongoing for given chat', function () {
+    it('should throw a PromptAlreadyOngoingError', async function () {
+      // when
+      const chatId = randomUUID();
+      await dependencies.redisMutex.lock(chatId);
+      const err = await catchErr(promptChat)({ chatId, message: 'un message', userId: 12345, ...dependencies });
+
+      // then
+      expect(err).to.be.instanceOf(PromptAlreadyOngoingError);
+      expect(err.message).to.equal(`A prompt is already ongoing for chat with id ${chatId}`);
     });
   });
 
@@ -349,6 +365,171 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             {
               index: 3,
               content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
+              emitter: 'assistant',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: false,
+              hasErrorOccurred: false,
+              wasModerated: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+          ]);
+          expect(llmPostPromptScope.isDone()).to.be.true;
+        });
+        it('should release chat resource', async function () {
+          // given
+          const chat = new Chat({
+            id: chatId,
+            userId: 123,
+            configurationId,
+            configuration,
+            hasAttachmentContextBeenAdded: false,
+            messages: [buildBasicUserMessage('coucou user1', 0), buildBasicAssistantMessage('coucou LLM1', 1)],
+          });
+          await createChat(chat.toDTO());
+          const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
+            .post('/chat', {
+              configuration: {
+                llm: {
+                  historySize: 123,
+                },
+                challenge: {
+                  inputMaxPrompts: 100,
+                  inputMaxChars: 255,
+                },
+              },
+              history: [
+                { content: 'coucou user1', role: 'user' },
+                { content: 'coucou LLM1', role: 'assistant' },
+              ],
+              prompt: 'un message',
+            })
+            .reply(
+              201,
+              Readable.from([
+                '60:{"ceci":"nest pas important","message":"coucou c\'est super"}',
+                '40:{"message":"\\nle couscous c plutot bon"}47:{"message":" mais la paella c pas mal aussi\\n"}',
+                '29:{"jecrois":{"que":"jaifini"}}',
+              ]),
+            )
+            .post('/chat')
+            .reply(201, Readable.from(['69:{"ceci":"nest pas important","message":"coucou c\'est vraiment super"}']));
+
+          // when
+          await promptChat({
+            chatId,
+            userId: 123,
+            message: 'un message',
+            attachmentName: null,
+            ...dependencies,
+          });
+
+          // then
+          await waitForStreamFinalizationToBeDone();
+          await promptChat({
+            chatId,
+            userId: 123,
+            message: 'un autre message',
+            attachmentName: null,
+            ...dependencies,
+          });
+          await waitForStreamFinalizationToBeDone();
+
+          const { chatDB, messagesDB } = await getChatAndMessagesFromDB(chatId);
+          expect(chatDB).to.deep.equal({
+            id: chatId,
+            userId: 123,
+            configId: 'uneConfigQuiExist',
+            configContent: {
+              llm: {
+                historySize: 123,
+              },
+              challenge: {
+                inputMaxPrompts: 100,
+                inputMaxChars: 255,
+              },
+            },
+            hasAttachmentContextBeenAdded: false,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+          });
+          expect(messagesDB).to.deep.equal([
+            {
+              index: 0,
+              content: 'coucou user1',
+              emitter: 'user',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: true,
+              wasModerated: null,
+              hasErrorOccurred: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+            {
+              index: 1,
+              content: 'coucou LLM1',
+              emitter: 'assistant',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: false,
+              wasModerated: null,
+              hasErrorOccurred: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+            {
+              index: 2,
+              content: 'un message',
+              emitter: 'user',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: true,
+              wasModerated: false,
+              hasErrorOccurred: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+            {
+              index: 3,
+              content: "coucou c'est super\nle couscous c plutot bon mais la paella c pas mal aussi\n",
+              emitter: 'assistant',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: false,
+              hasErrorOccurred: false,
+              wasModerated: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+            {
+              index: 4,
+              content: 'un autre message',
+              emitter: 'user',
+              shouldBeRenderedInPreview: true,
+              shouldBeForwardedToLLM: true,
+              shouldBeCountedAsAPrompt: true,
+              wasModerated: false,
+              hasErrorOccurred: null,
+              attachmentName: null,
+              attachmentContext: null,
+              hasAttachmentBeenSubmittedAlongWithAPrompt: false,
+              haveVictoryConditionsBeenFulfilled: false,
+            },
+            {
+              index: 5,
+              content: "coucou c'est vraiment super",
               emitter: 'assistant',
               shouldBeRenderedInPreview: true,
               shouldBeForwardedToLLM: true,

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -1516,7 +1516,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 attachmentName: 'wrong_file.txt',
                 ...dependencies,
               });
-
               // then
               const parts = [];
               const decoder = new TextDecoder();

--- a/api/tests/shared/integration/application/error-manager_test.js
+++ b/api/tests/shared/integration/application/error-manager_test.js
@@ -74,6 +74,14 @@ describe('Integration | API | Controller Error', function () {
       expect(response.statusCode).to.equal(CONFLICT_ERROR);
       expect(responseCode(response)).to.equal('SESSION_ALREADY_FINALIZED');
     });
+
+    it('responds Conflict when a PromptAlreadyOngoingError error occurs', async function () {
+      routeHandler.throws(new LLMDomainErrors.PromptAlreadyOngoingError('chatId'));
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(CONFLICT_ERROR);
+      expect(responseDetail(response)).to.equal('A prompt is already ongoing for chat with id chatId');
+    });
   });
 
   context('400 Bad Request', function () {

--- a/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
+++ b/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
@@ -1,0 +1,59 @@
+import { config, config as settings } from '../../../../../src/shared/config.js';
+import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
+import { RedisClient } from '../../../../../src/shared/infrastructure/utils/RedisClient.js';
+import { expect, sinon, wait } from '../../../../test-helper.js';
+
+const REDIS_URL = settings.redis.url;
+describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function () {
+  afterEach(async function () {
+    const redisClient = new RedisClient(REDIS_URL, { name: 'mutex', prefix: 'mutex:' });
+    const keys = (await redisClient.keys('*')).map((key) => key.split('mutex:')[1]);
+    for (const key of keys) {
+      await redisClient.del(key);
+    }
+  });
+
+  describe('#lock', function () {
+    it('should successfully lock resource for the first time, but fail the second time because resource is already locked', async function () {
+      // when
+      const isLockSuccess_firstCall = await redisMutex.lock('someResourceId');
+      const isLockSuccess_secondCall = await redisMutex.lock('someResourceId');
+
+      // then
+      expect(isLockSuccess_firstCall).to.be.true;
+      expect(isLockSuccess_secondCall).to.be.false;
+    });
+
+    it('should release automatically after expiration delay', async function () {
+      sinon.stub(config.llm, 'lockChatExpirationDelayMilliseconds').value(250);
+      await redisMutex.lock('someResourceId');
+
+      // when
+      const isLockSuccess_beforeDelay1 = await redisMutex.lock('someResourceId');
+      await wait(100);
+      const isLockSuccess_beforeDelay2 = await redisMutex.lock('someResourceId');
+      await wait(151);
+      const isLockSuccess_afterDelay = await redisMutex.lock('someResourceId');
+
+      // then
+      expect(isLockSuccess_beforeDelay1).to.be.false;
+      expect(isLockSuccess_beforeDelay2).to.be.false;
+      expect(isLockSuccess_afterDelay).to.be.true;
+    });
+  });
+
+  describe('#release', function () {
+    it('should successfully release the resource for the first time, but fail the second time because resource is already released', async function () {
+      // given
+      await redisMutex.lock('someResourceId');
+
+      // when
+      const isReleaseSuccess_firstCall = await redisMutex.release('someResourceId');
+      const isReleaseSuccess_secondCall = await redisMutex.release('someResourceId');
+
+      // then
+      expect(isReleaseSuccess_firstCall).to.be.true;
+      expect(isReleaseSuccess_secondCall).to.be.false;
+    });
+  });
+});

--- a/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
+++ b/api/tests/shared/integration/infrastructure/mutex/RedisMutex_test.js
@@ -1,18 +1,8 @@
-import { config, config as settings } from '../../../../../src/shared/config.js';
+import { config } from '../../../../../src/shared/config.js';
 import { redisMutex } from '../../../../../src/shared/infrastructure/mutex/RedisMutex.js';
-import { RedisClient } from '../../../../../src/shared/infrastructure/utils/RedisClient.js';
 import { expect, sinon, wait } from '../../../../test-helper.js';
 
-const REDIS_URL = settings.redis.url;
 describe('Shared | Integration | Infrastructure | Mutex | RedisMutex', function () {
-  afterEach(async function () {
-    const redisClient = new RedisClient(REDIS_URL, { name: 'mutex', prefix: 'mutex:' });
-    const keys = (await redisClient.keys('*')).map((key) => key.split('mutex:')[1]);
-    for (const key of keys) {
-      await redisClient.del(key);
-    }
-  });
-
   describe('#lock', function () {
     it('should successfully lock resource for the first time, but fail the second time because resource is already locked', async function () {
       // when

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -33,6 +33,7 @@ import * as missionRepository from '../src/school/infrastructure/repositories/mi
 import { ORGANIZATION_FEATURE } from '../src/shared/domain/constants.js';
 import { Membership } from '../src/shared/domain/models/Membership.js';
 import { featureToggles } from '../src/shared/infrastructure/feature-toggles/index.js';
+import { clearMutex, quitMutex } from '../src/shared/infrastructure/mutex/RedisMutex.js';
 import * as areaRepository from '../src/shared/infrastructure/repositories/area-repository.js';
 import * as challengeRepository from '../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../src/shared/infrastructure/repositories/competence-repository.js';
@@ -101,10 +102,12 @@ afterEach(async function () {
   missionRepository.clearCache();
   await featureToggles.resetDefaults();
   await datamartBuilder.clean();
+  await clearMutex();
   return databaseBuilder.clean();
 });
 
 after(async function () {
+  await quitMutex();
   return await disconnect();
 });
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -435,12 +435,16 @@ const preventStubsToBeCalledUnexpectedly = (stubs) => {
   }
 };
 
-function waitForStreamFinalizationToBeDone() {
+function wait(ms) {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve();
-    }, 500);
+    }, ms);
   });
+}
+
+function waitForStreamFinalizationToBeDone() {
+  return wait(500);
 }
 // eslint-disable-next-line mocha/no-exports
 export {
@@ -479,5 +483,6 @@ export {
   sinon,
   streamToPromise,
   toStream,
+  wait,
   waitForStreamFinalizationToBeDone,
 };

--- a/api/worker.js
+++ b/api/worker.js
@@ -14,6 +14,7 @@ import { config, schema as configSchema } from './src/shared/config.js';
 import { learningContentCache } from './src/shared/infrastructure/caches/learning-content-cache.js';
 import { JobQueue } from './src/shared/infrastructure/jobs/JobQueue.js';
 import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
+import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
 import { importNamedExportFromFile } from './src/shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { child } from './src/shared/infrastructure/utils/logger.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
@@ -160,6 +161,7 @@ async function main() {
 
   process.on('SIGINT', async () => {
     await quitAllStorages();
+    await quitMutex();
     await metrics.clearMetrics();
     await databaseConnections.disconnect();
     await learningContentCache.quit();


### PR DESCRIPTION
## 🔆 Problème

L'endpoint de prompt déclenche une action qui peut être longue. Il est donc nécessaire de sécuriser ce endpoint pour éviter d'avoir plusieurs requêtes essayant d'éditer la même conversation.

## ⛱️ Proposition
Mise en place d'un mutex (implémenté à l'aide de Redis) pour gérer les problèmes de concurrence.
Lorsqu'on rentre dans le usecase de prompt :
- verrouillage de la ressource via un mutex identifié par ID de chat
- récupération du chat
- inférence etc... fin de stream
- sauvegarde du chat et des nouveaux messages
- déverrouillage 

Donc, désormais, si deux requêtes concurrentes essayent d'intéragir avec la même conversation, ce sera premier  arrivé permier servi. La deuxième requête partira en 409 Conflit

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
