### PR TITLE
[BUGFIX] Permettre au rôle CERTIF d'archiver un centre de certif (PIX-19773)

### DIFF
--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -136,6 +136,7 @@ const register = async function (server) {
             method: (request, h) =>
               securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),

--- a/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
+++ b/api/tests/organizational-entities/unit/application/certification-center/certification-center.admin.route_test.js
@@ -1,0 +1,51 @@
+import { certificationCenterAdminController } from '../../../../../src/organizational-entities/application/certification-center/certification-center.admin.controller.js';
+import * as moduleUnderTest from '../../../../../src/organizational-entities/application/certification-center/certification-center.admin.route.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Certification Center | Application | Route | Admin', function () {
+  describe('when the authenticated user has one of the accepted roles', function () {
+    [
+      'checkAdminMemberHasRoleSuperAdmin',
+      'checkAdminMemberHasRoleCertif',
+      'checkAdminMemberHasRoleSupport',
+      'checkAdminMemberHasRoleMetier',
+    ].forEach((roleMethod) => {
+      it('should call archiveCertificationCenter controller method', async function () {
+        // given
+        sinon.stub(securityPreHandlers, roleMethod).returns(() => true);
+        sinon.stub(usecases, 'archiveCertificationCenter').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        sinon.stub(certificationCenterAdminController, 'archiveCertificationCenter').returns('ok');
+
+        // when
+        await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
+
+        // then
+        sinon.assert.called(certificationCenterAdminController.archiveCertificationCenter);
+      });
+    });
+  });
+
+  describe('when the user authenticated has no role', function () {
+    it('should return 403 HTTP status code', async function () {
+      // given
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .returns((request, h) => h.response().code(403).takeover());
+      sinon.stub(usecases, 'archiveCertificationCenter').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      sinon.stub(certificationCenterAdminController, 'archiveCertificationCenter').returns('ok');
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/certification-centers/1/archive');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      sinon.assert.notCalled(certificationCenterAdminController.archiveCertificationCenter);
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

normalement, les 4 rôles devraient pouvoir archiver un centre de certif. Mais actuellement le rôle CERTIF ne peut pas.

## ⛱️ Proposition

Permettre au rôle CERTIF d'archiver un centre de certif

## 🏄 Pour tester

- Sur pix-admin
  - Se connecter avec certifadmin@example.net
  - Archiver un centre ce certification
  - Constater que le centre est archivé avec succès