### PR TITLE
[FEATURE] Afficher les durées des certifications Pix+ sur les écrans d'entrée (PIX-19589)

### DIFF
--- a/mon-pix/app/components/certification-instructions/step-two.gjs
+++ b/mon-pix/app/components/certification-instructions/step-two.gjs
@@ -9,7 +9,7 @@ import { t } from 'ember-intl';
         {{t "pages.certification-instructions.steps.2.legend.strong-text"}}
       </p>
 
-      <p class="instructions-content__legend">{{t "pages.certification-instructions.steps.2.legend.text"}}</p>
+      <p class="instructions-content__legend">{{@durationLegend}}</p>
     </div>
 
     <div class="instructions-content__text">
@@ -18,7 +18,7 @@ import { t } from 'ember-intl';
       </p>
 
       <p>
-        {{t "pages.certification-instructions.steps.2.paragraphs.2" htmlSafe=true}}
+        {{t "pages.certification-instructions.steps.2.paragraphs.2" duration=@durationText htmlSafe=true}}
 
         <br />
         <span class="instructions-content__paragraph--light">

--- a/mon-pix/app/components/certification-instructions/steps.gjs
+++ b/mon-pix/app/components/certification-instructions/steps.gjs
@@ -44,6 +44,13 @@ export default class Steps extends Component {
     return false;
   }
 
+  _formatDuration(minutes) {
+    return {
+      hours: Math.floor(minutes / 60),
+      remainingMinutes: minutes % 60,
+    };
+  }
+
   get certificationName() {
     const complementaryKey = this.args.candidate?.complementaryCertificationKey;
     if (this._isPixPlus()) {
@@ -96,9 +103,9 @@ export default class Steps extends Component {
   }
 
   get certificationDurationInMinutes() {
-    const complementaryKey = this.args.candidate?.complementaryCertificationKey;
+    const complementaryKey = this.args.candidate.complementaryCertificationKey;
 
-    if (!complementaryKey || complementaryKey === 'CLEA') {
+    if (!complementaryKey) {
       return PIX_STANDARD_DURATION;
     }
 
@@ -118,8 +125,7 @@ export default class Steps extends Component {
 
   get durationLegend() {
     const minutes = this.certificationDurationInMinutes;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
+    const { hours, remainingMinutes } = this._formatDuration(minutes);
 
     if (hours === 0) {
       return `${minutes} min`;
@@ -132,8 +138,7 @@ export default class Steps extends Component {
 
   get durationText() {
     const minutes = this.certificationDurationInMinutes;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
+    const { hours, remainingMinutes } = this._formatDuration(minutes);
 
     if (hours === 0) {
       return `${minutes}min`;

--- a/mon-pix/app/components/certification-instructions/steps.gjs
+++ b/mon-pix/app/components/certification-instructions/steps.gjs
@@ -15,6 +15,14 @@ import StepOne from './step-one';
 import StepThree from './step-three';
 import StepTwo from './step-two';
 
+const PIX_PLUS_DURATIONS = {
+  DROIT: 45,
+  PRO_SANTE: 45,
+  EDU: 90,
+};
+
+const PIX_STANDARD_DURATION = 105;
+
 export default class Steps extends Component {
   @service intl;
   @tracked pageId = 1;
@@ -87,6 +95,55 @@ export default class Steps extends Component {
     });
   }
 
+  get certificationDurationInMinutes() {
+    const complementaryKey = this.args.candidate?.complementaryCertificationKey;
+
+    if (!complementaryKey || complementaryKey === 'CLEA') {
+      return PIX_STANDARD_DURATION;
+    }
+
+    switch (complementaryKey) {
+      case 'DROIT':
+        return PIX_PLUS_DURATIONS.DROIT;
+      case 'PRO_SANTE':
+        return PIX_PLUS_DURATIONS.PRO_SANTE;
+      case 'EDU_1ER_DEGRE':
+      case 'EDU_2ND_DEGRE':
+      case 'EDU_CPE':
+        return PIX_PLUS_DURATIONS.EDU;
+      default:
+        return PIX_STANDARD_DURATION;
+    }
+  }
+
+  get durationLegend() {
+    const minutes = this.certificationDurationInMinutes;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+
+    if (hours === 0) {
+      return `${minutes} min`;
+    }
+    if (remainingMinutes === 0) {
+      return `${hours} H`;
+    }
+    return `${hours} H ${remainingMinutes.toString().padStart(2, '0')} min`;
+  }
+
+  get durationText() {
+    const minutes = this.certificationDurationInMinutes;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+
+    if (hours === 0) {
+      return `${minutes}min`;
+    }
+    if (remainingMinutes === 0) {
+      return `${hours}h`;
+    }
+    return `${hours}h${remainingMinutes.toString().padStart(2, '0')}`;
+  }
+
   focus(element) {
     element.focus();
   }
@@ -136,7 +193,7 @@ export default class Steps extends Component {
       />
     {{/if}}
     {{#if (eq this.pageId 2)}}
-      <StepTwo />
+      <StepTwo @durationLegend={{this.durationLegend}} @durationText={{this.durationText}} />
     {{/if}}
     {{#if (eq this.pageId 3)}}
       <StepThree />

--- a/mon-pix/tests/integration/components/steps-test.gjs
+++ b/mon-pix/tests/integration/components/steps-test.gjs
@@ -13,8 +13,10 @@ module('Integration | Component | steps', function (hooks) {
     module('on first page', function () {
       test('should display instructions', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
 
         // then
         assert
@@ -40,8 +42,10 @@ module('Integration | Component | steps', function (hooks) {
 
       test('should not display the previous button', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
 
         // then
         assert
@@ -55,8 +59,10 @@ module('Integration | Component | steps', function (hooks) {
     module('on second page', function () {
       test('should display instructions', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
         await click(
           screen.getByRole('button', { name: t('pages.certification-instructions.buttons.continuous.aria-label') }),
         );
@@ -84,8 +90,10 @@ module('Integration | Component | steps', function (hooks) {
     module('on third page', function () {
       test('should display instructions', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
         await click(
           screen.getByRole('button', { name: t('pages.certification-instructions.buttons.continuous.aria-label') }),
         );
@@ -123,8 +131,10 @@ module('Integration | Component | steps', function (hooks) {
     module('on fourth page', function () {
       test('should display instructions', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
         for (let i = 0; i < 3; i++) {
           await click(
             screen.getByRole('button', { name: t('pages.certification-instructions.buttons.continuous.aria-label') }),
@@ -150,8 +160,10 @@ module('Integration | Component | steps', function (hooks) {
     module('on the last page', function () {
       test('should display information', async function (assert) {
         // given
+        const candidate = { complementaryCertificationKey: null };
+
         // when
-        const screen = await render(<template><Steps /></template>);
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
         await _goToLastPage(screen);
 
         // then
@@ -178,7 +190,8 @@ module('Integration | Component | steps', function (hooks) {
 
       test('should change the continue aria label button', async function (assert) {
         // given
-        const screen = await render(<template><Steps /></template>);
+        const candidate = { complementaryCertificationKey: null };
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
 
         // when
         await _goToLastPage(screen);
@@ -195,7 +208,8 @@ module('Integration | Component | steps', function (hooks) {
 
       test('should disable the continue button', async function (assert) {
         // given
-        const screen = await render(<template><Steps /></template>);
+        const candidate = { complementaryCertificationKey: null };
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
 
         // when
         await _goToLastPage(screen);
@@ -213,7 +227,8 @@ module('Integration | Component | steps', function (hooks) {
       module('when the checkbox is checked', function () {
         test('should enable the continue button', async function (assert) {
           // given
-          const screen = await render(<template><Steps /></template>);
+          const candidate = { complementaryCertificationKey: null };
+          const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
           await _goToLastPage(screen);
 
           // when
@@ -238,7 +253,8 @@ module('Integration | Component | steps', function (hooks) {
     module('on all pages except the first', function () {
       test('should display the previous button', async function (assert) {
         // given
-        const screen = await render(<template><Steps /></template>);
+        const candidate = { complementaryCertificationKey: null };
+        const screen = await render(<template><Steps @candidate={{candidate}} /></template>);
 
         // when
         await click(

--- a/mon-pix/tests/unit/components/certification-instructions/steps-test.js
+++ b/mon-pix/tests/unit/components/certification-instructions/steps-test.js
@@ -157,4 +157,166 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       );
     });
   });
+
+  module('#certificationDurationInMinutes', function () {
+    test('should return 105 minutes for standard Pix certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: null,
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 105);
+    });
+
+    test('should return 105 minutes for CLEA certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'CLEA',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 105);
+    });
+
+    test('should return 45 minutes for Pix+ Droit certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'DROIT',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 45);
+    });
+
+    test('should return 45 minutes for Pix+ Pro Santé certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'PRO_SANTE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 45);
+    });
+
+    test('should return 90 minutes for Pix+ Édu 1er degré certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'EDU_1ER_DEGRE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 90);
+    });
+
+    test('should return 90 minutes for Pix+ Édu 2nd degré certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'EDU_2ND_DEGRE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 90);
+    });
+
+    test('should return 90 minutes for Pix+ Édu CPE certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'EDU_CPE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.certificationDurationInMinutes, 90);
+    });
+  });
+
+  module('#durationLegend', function () {
+    test('should return "1 H 45 min" for standard Pix certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: null,
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationLegend, '1 H 45 min');
+    });
+
+    test('should return "45 min" for Pix+ Droit certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'DROIT',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationLegend, '45 min');
+    });
+
+    test('should return "1 H 30 min" for Pix+ Édu certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'EDU_1ER_DEGRE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationLegend, '1 H 30 min');
+    });
+  });
+
+  module('#durationText', function () {
+    test('should return "1h45" for standard Pix certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: null,
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationText, '1h45');
+    });
+
+    test('should return "45min" for Pix+ Droit certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'DROIT',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationText, '45min');
+    });
+
+    test('should return "1h30" for Pix+ Édu certification', function (assert) {
+      // given
+      const component = createGlimmerComponent('certification-instructions/steps', {
+        candidate: {
+          complementaryCertificationKey: 'EDU_2ND_DEGRE',
+        },
+      });
+
+      // then
+      assert.strictEqual(component.durationText, '1h30');
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/certification-instructions/steps-test.js
+++ b/mon-pix/tests/unit/components/certification-instructions/steps-test.js
@@ -12,6 +12,9 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       test('should change the pageId', async function (assert) {
         // given
         const component = createGlimmerComponent('certification-instructions/steps');
+        component.args.candidate = {
+          complementaryCertificationKey: null,
+        };
 
         component.pageId = 1;
         component.pageCount = 2;
@@ -58,11 +61,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#certificationName', function () {
     test('should return Pix when no complementary certification key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: null,
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: null,
+      };
 
       // then
       assert.strictEqual(component.certificationName, 'Pix');
@@ -70,11 +72,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return complementary certification name when has key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'DROIT',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'DROIT',
+      };
 
       // then
       assert.strictEqual(component.certificationName, 'Pix+ Droit');
@@ -82,11 +83,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return Pix when has CLEA key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'CLEA',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'CLEA',
+      };
 
       // then
       assert.strictEqual(component.certificationName, 'Pix');
@@ -96,11 +96,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#title', function () {
     test('should use Pix when CLEA complementary certification key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'CLEA',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'CLEA',
+      };
       component.pageId = 1;
 
       // then
@@ -111,11 +110,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#certificationInstructionStep1Paragraph1', function () {
     test('should return default text when no complementary certification key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: null,
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: null,
+      };
 
       // then
       assert.ok(
@@ -127,11 +125,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return default text when CLEA complementary certification key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'CLEA',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'CLEA',
+      };
 
       // then
       assert.ok(
@@ -143,11 +140,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return Pix+ specific text when has complementary certification key', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'DROIT',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'DROIT',
+      };
 
       // then
       assert.ok(
@@ -161,11 +157,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#certificationDurationInMinutes', function () {
     test('should return 105 minutes for standard Pix certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: null,
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: null,
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 105);
@@ -173,11 +168,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 105 minutes for CLEA certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'CLEA',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'CLEA',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 105);
@@ -185,11 +179,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 45 minutes for Pix+ Droit certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'DROIT',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'DROIT',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 45);
@@ -197,11 +190,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 45 minutes for Pix+ Pro Santé certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'PRO_SANTE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'PRO_SANTE',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 45);
@@ -209,11 +201,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 90 minutes for Pix+ Édu 1er degré certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'EDU_1ER_DEGRE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'EDU_1ER_DEGRE',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 90);
@@ -221,11 +212,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 90 minutes for Pix+ Édu 2nd degré certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'EDU_2ND_DEGRE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'EDU_2ND_DEGRE',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 90);
@@ -233,11 +223,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return 90 minutes for Pix+ Édu CPE certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'EDU_CPE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'EDU_CPE',
+      };
 
       // then
       assert.strictEqual(component.certificationDurationInMinutes, 90);
@@ -247,11 +236,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#durationLegend', function () {
     test('should return "1 H 45 min" for standard Pix certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: null,
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: null,
+      };
 
       // then
       assert.strictEqual(component.durationLegend, '1 H 45 min');
@@ -259,11 +247,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return "45 min" for Pix+ Droit certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'DROIT',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'DROIT',
+      };
 
       // then
       assert.strictEqual(component.durationLegend, '45 min');
@@ -271,11 +258,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return "1 H 30 min" for Pix+ Édu certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'EDU_1ER_DEGRE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'EDU_1ER_DEGRE',
+      };
 
       // then
       assert.strictEqual(component.durationLegend, '1 H 30 min');
@@ -285,11 +271,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
   module('#durationText', function () {
     test('should return "1h45" for standard Pix certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: null,
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: null,
+      };
 
       // then
       assert.strictEqual(component.durationText, '1h45');
@@ -297,11 +282,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return "45min" for Pix+ Droit certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'DROIT',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'DROIT',
+      };
 
       // then
       assert.strictEqual(component.durationText, '45min');
@@ -309,11 +293,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     test('should return "1h30" for Pix+ Édu certification', function (assert) {
       // given
-      const component = createGlimmerComponent('certification-instructions/steps', {
-        candidate: {
-          complementaryCertificationKey: 'EDU_2ND_DEGRE',
-        },
-      });
+      const component = createGlimmerComponent('certification-instructions/steps');
+      component.args.candidate = {
+        complementaryCertificationKey: 'EDU_2ND_DEGRE',
+      };
 
       // then
       assert.strictEqual(component.durationText, '1h30');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -754,12 +754,11 @@
         },
         "2": {
           "legend": {
-            "strong-text": "32 QUESTIONS",
-            "text": "1 H 45 min"
+            "strong-text": "32 QUESTIONS"
           },
           "paragraphs": {
             "1": "The certification includes '<strong>'32 questions'</strong>'.",
-            "2": "You have '<strong>'1h45'</strong>' maximum to answer*",
+            "2": "You have '<strong>'{duration}'</strong>' maximum to answer*",
             "3": "*Except those entitled to extra time",
             "4": "If you answer '<strong>'less than 20 questions, we won't be able to give you a score'</strong>'."
           },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -755,12 +755,11 @@
         },
         "2": {
           "legend": {
-            "strong-text": "32 QUESTIONS",
-            "text": "1 H 45 min"
+            "strong-text": "32 QUESTIONS"
           },
           "paragraphs": {
             "1": "Le test de certification est composé de '<strong>'32 questions'</strong>'",
-            "2": "Vous avez au maximum '<strong>'1h45'</strong>' pour y répondre*",
+            "2": "Vous avez au maximum '<strong>'{duration}'</strong>' pour y répondre*",
             "3": "*hors éventuel temps majoré",
             "4": "Si vous traitez '<strong>'moins de 20 questions, nous ne serons pas en mesure de vous délivrer un score'</strong>'."
           },


### PR DESCRIPTION
🍂 Problème
-----------
Actuellement, sur les écrans d'entrée en certif, la durée affichée est fixe et est celle de Pix Cœur (1h45). 

🌰 Proposition
--------------
Implémenter l'affichage dynamique des durées de certification :
- Pix standard/CLEA : 105 minutes (1h45)
- Pix+ Droit/Pro Santé : 45 minutes
- Pix+ Édu : 90 minutes (1h30)

🎃 Remarques
------------

🪵 Pour tester
--------------
1. Naviguer sur les écrans d'entrée de certification
2. Vérifier que les durées sont correctement affichées pour :
   - Certification standard/CLEA
   - Certification Pix+ Droit
   - Certification Pix+ Pro Santé
   - Certification Pix+ Édu