### PR TITLE
[FEATURE] Copie des données de certification-configurations vers certification_versions (PIX-19671).

### DIFF
--- a/api/db/migrations/20250930143048_copy-certif-configurations-to-certif-versions.js
+++ b/api/db/migrations/20250930143048_copy-certif-configurations-to-certif-versions.js
@@ -1,0 +1,57 @@
+const SOURCE_TABLE = 'certification-configurations';
+const TARGET_TABLE = 'certification_versions';
+const FRAMEWORKS_TABLE = 'certification-frameworks-challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  const pixPlusScopes = await knex(FRAMEWORKS_TABLE)
+    .select('complementaryCertificationKey')
+    .distinct('complementaryCertificationKey')
+    .whereNotNull('complementaryCertificationKey')
+    .pluck('complementaryCertificationKey');
+
+  const currentConfig = await knex(SOURCE_TABLE)
+    .select(
+      'startingDate',
+      'expirationDate',
+      'globalScoringConfiguration',
+      'competencesScoringConfiguration',
+      'challengesConfiguration',
+    )
+    .whereNull('expirationDate')
+    .first();
+
+  for (const scope of pixPlusScopes) {
+    await knex(TARGET_TABLE).insert({
+      scope,
+      startDate: currentConfig.startingDate,
+      expirationDate: currentConfig.expirationDate,
+      assessmentDuration: 0,
+      globalScoringConfiguration: JSON.stringify(currentConfig.globalScoringConfiguration),
+      competencesScoringConfiguration: JSON.stringify(currentConfig.competencesScoringConfiguration),
+      challengesConfiguration: JSON.stringify(currentConfig.challengesConfiguration),
+    });
+  }
+
+  for (const scope of pixPlusScopes) {
+    const versionId = await knex(TARGET_TABLE).select('id').where('scope', scope).first();
+
+    await knex(FRAMEWORKS_TABLE).where('complementaryCertificationKey', scope).update({
+      versionId: versionId.id,
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex(FRAMEWORKS_TABLE).update({ versionId: null });
+  await knex(TARGET_TABLE).del();
+};
+
+export { down, up };


### PR DESCRIPTION
🍂 Problème
-----------

Migration de données de l'ancienne table `certification-configurations` vers la nouvelle table `certification_versions` dans le cadre de la mise en place du système de versioning des certifications.

Le but est de creer la notion de millesime, ce qui implique 
* Une version par scope
* Une periode start - expiration par scope, sans chevauchement
* La config, avant partage (relation 1..N) est unique a chaque millesime (relation 1..1)
* La duree du test est pour le moment a zero, elle sera remplie + tard

🌰 Proposition
--------------

### Migration `up()`
1. Récupération de tous les scopes PIX+ depuis `certification-frameworks-challenges`
2. Récupération de la configuration actuelle (où `expirationDate` est NULL)
  a. la feature n'etant pas en PROD et encore en construction on peut prendre ce raccourci de migration
4. Création d'une version pour chaque scope PIX+ avec la configuration actuelle 
6. Mise à jour de `certification-frameworks-challenges.versionId` pour lier chaque challenge à sa version correspondante
  a. l'idee sera donc bien d'inverser le paradigme, la table version est le "root aggregate" et on ira chercher les enfants lie a ce millesime 

### Migration `down()`
1. Réinitialisation de tous les `versionId` à NULL dans `certification-frameworks-challenges`
2. Suppression de toutes les entrées dans `certification_versions`

🎃 Remarques
------------

* C'est la premiere etape qui assure une retrocompatibilite totale avec le code existant.
* J'ai deja fait un "rollback:latest" + "db:migrate" pour peupler au moins une fois la nouvelle table
  * les seeds pour la nouvelle table seront fait une fois cette migration en PROD pour assurer la retrocompatibilite du code 


🪵 Pour tester
--------------

@1024pix/team-certification bien verifier la tete de la BDD visuellement !

- Migration testée avec `npm run db:migrate`
- Rollback testé avec `npm run db:rollback:latest`
- Re-migration testée pour vérifier l'idempotence

SQL utile de verification

```sql
SELECT certification_versions."id", certification_versions."scope", count("versionId")
FROM public.certification_versions
inner join "certification-frameworks-challenges" on "certification-frameworks-challenges"."versionId" = certification_versions.id
group by certification_versions."id", "scope"

--- doit correspondre au nombre cote "certification-frameworks-challenges"

SELECT "complementaryCertificationKey", "version", count(*)
FROM public."certification-frameworks-challenges"
group by "complementaryCertificationKey", "version";
```