### PR TITLE
[BUGFIX] Gérer le cas où le token de réinitialisation du mot de passe a expiré (PIX-19474).

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -778,6 +778,12 @@ REFRESH_TOKEN_LIFESPAN=7d
 # default: '7d'
 SAML_ACCESS_TOKEN_LIFESPAN=7d
 
+# Password reset token lifespan
+# presence: optional
+# type: String
+# default: '1h'
+PASSWORD_RESET_TOKEN_LIFESPAN=1h
+
 # ========
 # TESTS
 # ========

--- a/api/src/identity-access-management/application/http-error-mapper-configuration.js
+++ b/api/src/identity-access-management/application/http-error-mapper-configuration.js
@@ -7,6 +7,7 @@ import {
   MissingOrInvalidCredentialsError,
   MissingUserAccountError,
   PasswordResetDemandNotFoundError,
+  PasswordResetTokenInvalidOrExpired,
   PixAdminLoginFromPasswordDisabledError,
   UserCantBeCreatedError,
   UserShouldChangePasswordError,
@@ -15,6 +16,10 @@ import {
 const authenticationDomainErrorMappingConfiguration = [
   {
     name: AuthenticationKeyExpired.name,
+    httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
+  },
+  {
+    name: PasswordResetTokenInvalidOrExpired.name,
     httpErrorFn: (error) => new HttpErrors.UnauthorizedError(error.message, error.code),
   },
   {

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -6,6 +6,15 @@ class AuthenticationKeyExpired extends DomainError {
   }
 }
 
+class PasswordResetTokenInvalidOrExpired extends DomainError {
+  constructor() {
+    super(
+      'The password reset token has expired, retry connecting with temporary password',
+      'PASSWORD_RESET_TOKEN_INVALID_OR_EXPIRED',
+    );
+  }
+}
+
 class DifferentExternalIdentifierError extends DomainError {
   constructor(
     message = "La valeur de l'externalIdentifier de la méthode de connexion ne correspond pas à celui reçu par le partenaire.",
@@ -126,6 +135,7 @@ export {
   OrganizationLearnerNotBelongToOrganizationIdentityError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
+  PasswordResetTokenInvalidOrExpired,
   PixAdminLoginFromPasswordDisabledError,
   RevokeUntilMustBeAnInstanceOfDate,
   UserCantBeCreatedError,

--- a/api/src/identity-access-management/domain/usecases/update-expired-password.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-expired-password.usecase.js
@@ -5,6 +5,7 @@ const { get } = lodash;
 import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import { PasswordResetTokenInvalidOrExpired } from '../errors.js';
 import { PasswordExpirationToken } from '../models/PasswordExpirationToken.js';
 
 const updateExpiredPassword = async function ({
@@ -15,6 +16,9 @@ const updateExpiredPassword = async function ({
   userRepository,
 }) {
   const { userId } = PasswordExpirationToken.decode(passwordExpirationToken);
+  if (!userId) {
+    throw new PasswordResetTokenInvalidOrExpired();
+  }
 
   let foundUser;
   try {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -204,7 +204,7 @@ const configuration = (function () {
       refreshTokenLifespanMs: ms(process.env.REFRESH_TOKEN_LIFESPAN || '7d'),
       revokedUserAccessLifespanMs: ms(process.env.REVOKED_USER_ACCESS_LIFESPAN || '7d'),
       tokenForStudentReconciliationLifespan: '1h',
-      passwordResetTokenLifespan: '1h',
+      passwordResetTokenLifespan: process.env.PASSWORD_RESET_TOKEN_LIFESPAN || '1h',
       permitPixAdminLoginFromPassword: toBoolean(process.env.PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED),
     },
     authenticationSession: {

--- a/mon-pix/app/components/update-expired-password-form.gjs
+++ b/mon-pix/app/components/update-expired-password-form.gjs
@@ -95,6 +95,7 @@ export default class UpdateExpiredPasswordForm extends Component {
   @service intl;
   @service session;
   @service url;
+  @service errorMessages;
 
   @tracked validation = VALIDATION_MAP.default;
   @tracked newPassword = null;
@@ -159,7 +160,9 @@ export default class UpdateExpiredPasswordForm extends Component {
   _manageErrorsApi(error) {
     const statusCode = get(error, 'status');
     const code = get(error, 'code');
-    if (statusCode === '400') {
+    if (code === 'PASSWORD_RESET_TOKEN_INVALID_OR_EXPIRED') {
+      this.errorMessage = this.errorMessages.getAuthenticationErrorMessage(error);
+    } else if (statusCode === '400') {
       this.validation = VALIDATION_MAP.error;
     } else if (statusCode === '404' && code === 'USER_ACCOUNT_NOT_FOUND') {
       this.errorMessage = this.intl.t('common.error');

--- a/mon-pix/app/services/error-messages.js
+++ b/mon-pix/app/services/error-messages.js
@@ -16,6 +16,9 @@ const AUTHENTICATION_ERROR_CODES_MAPPING = {
   EXPIRED_AUTHENTICATION_KEY: {
     i18nKey: 'pages.login-or-register-oidc.error.expired-authentication-key',
   },
+  PASSWORD_RESET_TOKEN_INVALID_OR_EXPIRED: {
+    i18nKey: 'pages.login-or-register-oidc.error.password-reset-token-invalid-or-expired',
+  },
   USER_IS_TEMPORARY_BLOCKED: {
     getI18nKey: (error) => {
       if (error.meta?.isLoginFailureWithUsername) {
@@ -73,9 +76,7 @@ export default class ErrorMessagesService extends Service {
 
   getAuthenticationErrorMessage(originalError) {
     const error = get(originalError, 'errors[0]') || originalError;
-
     const message = AUTHENTICATION_ERROR_CODES_MAPPING[error?.code];
-
     if (!message) {
       return this.getHttpErrorMessage(originalError, AUTHENTICATION_DEFAULT_MESSAGE);
     }
@@ -90,6 +91,7 @@ export default class ErrorMessagesService extends Service {
     if (getI18nKey) {
       return this.intl.t(getI18nKey(error), options);
     }
+
     return this.intl.t(i18nKey, options);
   }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1628,7 +1628,8 @@
         "error-message": "Please agree to the terms and conditions of use.",
         "expired-authentication-key": "Your authentication demand has expired.",
         "invalid-email": "Your email address is invalid.",
-        "login-unauthorized-error": "There was an error in the email address or password entered."
+        "login-unauthorized-error": "There was an error in the email address or password entered.",
+        "password-reset-token-invalid-or-expired":  "Too much time has elapsed to validate your new password. Return to the login page to re-enter your username and temporary password."
       },
       "login-form": {
         "button": "Log in",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1540,7 +1540,8 @@
         "error-message": "Debes aceptar las condiciones de uso de Pix.",
         "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
         "invalid-email": "Tu dirección de correo electrónico no es válida.",
-        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
+        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
       },
       "login-form": {
         "button": "Iniciar sesión",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1543,7 +1543,8 @@
         "error-message": "Debes aceptar las condiciones de uso de Pix.",
         "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
         "invalid-email": "Tu dirección de correo electrónico no es válida.",
-        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
+        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
       },
       "login-form": {
         "button": "Iniciar sesión",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1636,7 +1636,8 @@
         "error-message": "Vous devez accepter les conditions d’utilisation de Pix.",
         "expired-authentication-key": "Votre demande d'authentification a expiré.",
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
-        "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects."
+        "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
+        "password-reset-token-invalid-or-expired": "Il s'est écoulé trop de temps pour valider votre nouveau mot de passe. Revenez à la page de connexion pour saisir à nouveau votre identifiant et votre mot de passe temporaire."
       },
       "login-form": {
         "button": "Je me connecte",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1547,7 +1547,8 @@
         "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
         "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
         "invalid-email": "Je e-mailadres is ongeldig.",
-        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist."
+        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist.",
+        "password-reset-token-invalid-or-expired": "Er is te veel tijd verstreken om uw nieuwe wachtwoord te valideren. Ga terug naar de inlogpagina om uw gebruikersnaam en tijdelijke wachtwoord opnieuw in te voeren."
       },
       "login-form": {
         "button": "Inloggen",


### PR DESCRIPTION
## 🔆 Problème
Des erreurs 500 sont survenues dans le cas où des élèves dont le mot de passe avait été réinitialisé par leur professeur avaient laissé passer trop de temps (1 heure) entre la saisie de l'ID/Mot de passe temporaire et la soumission d'un nouveau mot de passe. 

## ⛱️ Proposition
Gérer le cas et afficher un message d'erreur invitant l'utilisateur à retourner à l'étape précédente et rentrer à nouveau son ID et mot de passe temporaire.

## Remarque
Nous avons ajouté une nouvelle variable d'environnement régissant la durée de validité du token de réinitialisation du mot de passe. Celle-ci est nommée PASSWORD_RESET_TOKEN_LIFESPAN.

## 🏄 Pour tester
- Aller sur Pix Orga avec une Orga SCO qui gère des élèves
- Aller dans la liste des élèves et cliquer sur Gérer le compte
- Réinitialiser le mot de passe d'un élève choisi
- Aller sur Pix App et se connecter avec l'élève choisi avec son mot de passe temporaire
- Laisser lascivement s'écouler le temps, au moins dans la limite du délai imparti (par défaut 1h)
- Tenter de modifier le mot de passe
- Constater l'apparition du nouveau message informant l'élève du délai dépassé et l'invitant à retenter avec son mot de passe temporaire à l'étape précédente
