### PR TITLE
[TECH] Ajouter une transaction lors de l'archivage d'organisation (PIX-19756)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/archive-organization.usecase.js
@@ -1,6 +1,12 @@
-const archiveOrganization = async function ({ organizationId, userId, organizationForAdminRepository }) {
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const archiveOrganization = withTransaction(async function ({
+  organizationId,
+  userId,
+  organizationForAdminRepository,
+}) {
   await organizationForAdminRepository.archive({ id: organizationId, archivedBy: userId });
   return await organizationForAdminRepository.get({ organizationId });
-};
+});
 
 export { archiveOrganization };

--- a/api/src/prescription/campaign/application/api/campaigns-api.js
+++ b/api/src/prescription/campaign/application/api/campaigns-api.js
@@ -1,5 +1,4 @@
 import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { DEFAULT_PAGINATION } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { AssessmentCampaignParticipation } from '../../domain/read-models/CampaignParticipation.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { Campaign } from './models/Campaign.js';
@@ -238,21 +237,7 @@ export const getCampaignParticipations = async function ({ campaignId, page, sin
  * @param {DeleteActiveCampaignPayload} payload
  * @returns {Promise<void>}
  */
-export const deleteActiveCampaigns = withTransaction(
-  async ({
-    userId,
-    organizationId,
-    page = { size: DEFAULT_PAGINATION.PAGE_SIZE, number: DEFAULT_PAGINATION.PAGE },
-  }) => {
-    let campaignIdsToDelete = [];
-    let results;
-    do {
-      results = await usecases.findPaginatedCampaignManagements({ organizationId, page });
-      campaignIdsToDelete = campaignIdsToDelete.concat(
-        results.models.flatMap(({ id, deletedAt }) => (deletedAt ? [] : [id])),
-      );
-      page.number = results.meta.page + 1;
-    } while (results.models.length > 0);
-    await usecases.deleteCampaigns({ userId, organizationId, campaignIds: campaignIdsToDelete });
-  },
-);
+export const deleteActiveCampaigns = withTransaction(async ({ userId, organizationId }) => {
+  const campaignIdsToDelete = await usecases.findActiveCampaignIdsByOrganization({ organizationId });
+  await usecases.deleteCampaigns({ userId, organizationId, campaignIds: campaignIdsToDelete });
+});

--- a/api/src/prescription/campaign/domain/models/CampaignsDestructor.js
+++ b/api/src/prescription/campaign/domain/models/CampaignsDestructor.js
@@ -21,7 +21,7 @@ class CampaignsDestructor {
    * @param {Array<CampaignParticipation>} params.campaignParticipationsToDelete - campaigns participations object to be deleted
    * @param {number} params.userId - userId for deletedBy
    * @param {number} params.organizationId - organizationId to check if campaigns belongs to given organizationId
-   * @param {OrganizationMembership} params.membership - class with property isAdmin to check is user is admin in organization or not
+   * @param {OrganizationMembership} params.membership - class with property isAdmin to check if user is admin in organization or not
    */
   constructor({ campaignsToDelete, campaignParticipationsToDelete, userId, organizationId, membership, pixAdminRole }) {
     this.#campaignsToDelete = campaignsToDelete;

--- a/api/src/prescription/campaign/domain/usecases/find-active-campaign-ids-by-organization.js
+++ b/api/src/prescription/campaign/domain/usecases/find-active-campaign-ids-by-organization.js
@@ -1,0 +1,5 @@
+const findActiveCampaignIdsByOrganization = function ({ organizationId, campaignManagementRepository }) {
+  return campaignManagementRepository.findActiveCampaignIdsByOrganization({ organizationId });
+};
+
+export { findActiveCampaignIdsByOrganization };

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -92,6 +92,7 @@ import { computeCampaignCollectiveResult } from './compute-campaign-collective-r
 import { createCampaign } from './create-campaign.js';
 import { createCampaigns } from './create-campaigns.js';
 import { deleteCampaigns } from './delete-campaigns.js';
+import { findActiveCampaignIdsByOrganization } from './find-active-campaign-ids-by-organization.js';
 import { findAssessmentParticipationResultList } from './find-assessment-participation-result-list.js';
 import { findCampaignProfilesCollectionParticipationSummaries } from './find-campaign-profiles-collection-participation-summaries.js';
 import { findCampaignSkillIdsForCampaignParticipations } from './find-campaign-skill-ids-for-campaign-participations.js';
@@ -130,6 +131,7 @@ const usecasesWithoutInjectedDependencies = {
   createCampaign,
   createCampaigns,
   deleteCampaigns,
+  findActiveCampaignIdsByOrganization,
   findAssessmentParticipationResultList,
   findCampaignProfilesCollectionParticipationSummaries,
   findCampaignSkillIdsForCampaignParticipations,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-management-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../shared/domain/constants.js';
 import { CampaignManagement } from '../../domain/models/CampaignManagement.js';
@@ -118,4 +119,9 @@ function _mapToParticipationByStatus(row = {}, campaignType) {
   return participationByStatus;
 }
 
-export { findPaginatedCampaignManagements, get };
+const findActiveCampaignIdsByOrganization = async ({ organizationId }) => {
+  const knexConn = await DomainTransaction.getConnection();
+  return knexConn('campaigns').where('organizationId', organizationId).whereNull('deletedAt').pluck('id');
+};
+
+export { findActiveCampaignIdsByOrganization, findPaginatedCampaignManagements, get };

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-active-campaign-ids-by-organization_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-active-campaign-ids-by-organization_test.js
@@ -1,0 +1,96 @@
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
+
+describe('Integration | UseCase | find-active-campaign-ids-by-organization', function () {
+  let organizationId;
+
+  beforeEach(async function () {
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    await databaseBuilder.commit();
+  });
+
+  it('should return active campaign IDs for the organization', async function () {
+    // given
+    const activeCampaign1 = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: null,
+    });
+    const activeCampaign2 = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await knex.transaction(async (trx) => {
+      return usecases.findActiveCampaignIdsByOrganization({ organizationId }, { knex: trx });
+    });
+
+    // then
+    expect(result).to.have.members([activeCampaign1.id, activeCampaign2.id]);
+  });
+
+  it('should not return deleted campaigns', async function () {
+    // given
+    const activeCampaign = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: null,
+    });
+    databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: new Date('2024-01-01'),
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await knex.transaction(async (trx) => {
+      return usecases.findActiveCampaignIdsByOrganization({ organizationId }, { knex: trx });
+    });
+
+    // then
+    expect(result).to.deep.equal([activeCampaign.id]);
+  });
+
+  it('should not return campaigns from other organizations', async function () {
+    // given
+    const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+    const ownCampaign = databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: null,
+    });
+    databaseBuilder.factory.buildCampaign({
+      organizationId: otherOrganizationId,
+      deletedAt: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await knex.transaction(async (trx) => {
+      return usecases.findActiveCampaignIdsByOrganization({ organizationId }, { knex: trx });
+    });
+
+    // then
+    expect(result).to.deep.equal([ownCampaign.id]);
+  });
+
+  it('should return an empty array when no active campaigns exist', async function () {
+    // given
+    databaseBuilder.factory.buildCampaign({
+      organizationId,
+      deletedAt: new Date('2024-01-01'),
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await knex.transaction(async (trx) => {
+      return usecases.findActiveCampaignIdsByOrganization({ organizationId }, { knex: trx });
+    });
+
+    // then
+    expect(result).to.deep.equal([]);
+  });
+});

--- a/api/tests/prescription/campaign/unit/domain/usecases/find-active-campaign-ids-by-organization_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/find-active-campaign-ids-by-organization_test.js
@@ -1,0 +1,25 @@
+import { findActiveCampaignIdsByOrganization } from '../../../../../../src/prescription/campaign/domain/usecases/find-active-campaign-ids-by-organization.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | find-active-campaign-ids-by-organization', function () {
+  it('should return active campaign IDs for the organization', async function () {
+    // given
+    const organizationId = 123;
+    const expectedCampaignIds = [1, 2, 3];
+    const campaignManagementRepository = {
+      findActiveCampaignIdsByOrganization: sinon.stub().resolves(expectedCampaignIds),
+    };
+
+    // when
+    const result = await findActiveCampaignIdsByOrganization({
+      organizationId,
+      campaignManagementRepository,
+    });
+
+    // then
+    expect(campaignManagementRepository.findActiveCampaignIdsByOrganization).to.have.been.calledOnceWithExactly({
+      organizationId,
+    });
+    expect(result).to.deep.equal(expectedCampaignIds);
+  });
+});


### PR DESCRIPTION
## 🔆 Problème
Lors de l'archivage d'une organisation, les campagnes actives sont supprimées mais l'opération n'était pas encapsulée dans une transaction, ce qui pouvait causer des incohérences en cas d'erreur.

## ⛱️ Proposition
- Encapsuler `deleteActiveCampaigns` dans une transaction avec `withTransaction`
- En bonus : optimiser la récupération des IDs de campagnes actives
  - Créer un nouveau use case `findActiveCampaignIdsByOrganization` qui retourne uniquement un tableau d'IDs
  - Créer une méthode repository utilisant `.pluck('id')` pour récupérer directement les IDs
  - Supprimer l'utilisation de la pagination
## 🏄 Pour tester

Tests 🆗 