### PR TITLE
[BUGFIX] Retourner une erreur dans le getProgression lorsque l'assessment ne contient plus de campaignParticipationId (PIX-19817).

### DIFF
--- a/api/src/evaluation/domain/usecases/get-progression.js
+++ b/api/src/evaluation/domain/usecases/get-progression.js
@@ -1,3 +1,4 @@
+import { ForbiddenAccess } from '../../../shared/domain/errors.js';
 import { Progression } from '../models/Progression.js';
 
 const getProgression = async function ({
@@ -17,6 +18,8 @@ const getProgression = async function ({
   let progression;
 
   if (assessment.isForCampaign()) {
+    if (!assessment.campaignParticipationId) throw new ForbiddenAccess('Campaign does not accept any answer.');
+
     const campaignParticipation = await campaignParticipationRepository.get(assessment.campaignParticipationId);
 
     const skillIds = await campaignRepository.findSkillIds({ campaignId: campaignParticipation.campaignId });

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { getI18nFromRequest } from '../../../shared/infrastructure/i18n/i18n.js';


### PR DESCRIPTION
## 🔆 Problème

Si une participation est supprimé, sa campaignParticipationId n'est plus présent sur l'assesment. or nous l'utilisons sans vergogne dans getProgression du context evaluation
 
## ⛱️ Proposition

Ajouter un garde fou 🃏 . Retourner une erreur lorsque la campaignParticipationId n'existe pas.

## 🌊 Remarques

Utiliser la méthode unlink de node:fr/promises et non node:fs qui n'a pas la même signature et lance une erreur si on ne lui passe pas de callback

## 🏄 Pour tester

