### PR TITLE
[BUGFIX] Ajouter la locale es-419 manquante dans Pix API CHALLENGE_LOCALES (PIX-19820)

### DIFF
--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -6,7 +6,7 @@ const SPANISH_SPOKEN = 'es';
 const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
 const DEFAULT_CHALLENGE_LOCALE = 'fr-fr';
-const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'it', 'de'];
+const CHALLENGE_LOCALES = ['en', 'fr', 'fr-fr', 'nl', 'es', 'es-419', 'it', 'de'];
 
 const DEFAULT_LOCALE = 'fr';
 const SUPPORTED_LOCALES = ['en', 'es', 'es-419', 'fr', 'nl', 'fr-BE', 'fr-FR', 'nl-BE'];


### PR DESCRIPTION
## 🔆 Problème

Un utilisateur avec la locale `es-419` rentrant dans une campagne liée à un PC contenant des épreuves dont la locale est `es-419` ne se voit proposé aucune épreuve. 

## ⛱️ Proposition

Ajouter la locale `es-419` manquante dans Pix API `CHALLENGE_LOCALES`. La cause en est un simple oubli lors de la PR #13650.

## 🌊 Remarques

RAS

## 🏄 Pour tester

Comme nous n’avons pour l’instant aucun challenge avec la locale `es-419` il n’y a pas de moyen de tester cette PR ni en local, ni en RA.
