### PR TITLE
[TECH] :truck: Déplace le répository `complementaryCertificationRepository` vers le  contexte `certification/configuration/` (PIX-19836)

### DIFF
--- a/api/src/certification/complementary-certification/domain/usecases/index.js
+++ b/api/src/certification/complementary-certification/domain/usecases/index.js
@@ -2,17 +2,15 @@
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as complementaryCertificationForTargetProfileAttachmentRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js';
 import * as organizationRepository from '../../../complementary-certification/infrastructure/repositories/organization-repository.js';
+import * as complementaryCertificationRepository from '../../../configuration/infrastructure/repositories/complementary-certification-repository.js';
 import { mailService } from '../../../shared/domain/services/mail-service.js';
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../infrastructure/repositories/complementary-certification-badge-repository.js';
-import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
-
 /**
  *
  * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
  *
  * @typedef {complementaryCertificationBadgesRepository} ComplementaryCertificationBadgesRepository
- * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {complementaryCertificationForTargetProfileAttachmentRepository} ComplementaryCertificationForTargetProfileAttachmentRepository
  * @typedef {targetProfileHistoryRepository} TargetProfileHistoryRepository
  * @typedef {organizationRepository} OrganizationRepository
@@ -20,10 +18,10 @@ import * as complementaryCertificationRepository from '../../infrastructure/repo
  **/
 const dependencies = {
   complementaryCertificationBadgesRepository,
-  complementaryCertificationRepository,
   complementaryCertificationForTargetProfileAttachmentRepository,
   targetProfileHistoryRepository,
   organizationRepository,
+  complementaryCertificationRepository,
   mailService,
 };
 

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -2,13 +2,13 @@ import * as challengeRepository from '../../../../shared/infrastructure/reposito
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
-import * as complementaryCertificationRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../../configuration/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as sharedFlashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as activeCalibratedChallengeRepository from '../../infrastructure/repositories/active-calibrated-challenge-repository.js';
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
+import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
 import * as consolidatedFrameworkRepository from '../../infrastructure/repositories/consolidated-framework-repository.js';
 import * as learningContentRepository from '../../infrastructure/repositories/learning-content-repository.js';
 

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
@@ -5,8 +5,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 
 function _toDomain(row) {
   const hasComplementaryReferential = row.key !== ComplementaryCertificationKeys.CLEA;

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-repository.js
@@ -1,3 +1,0 @@
-import * as complementaryCertificationRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
-
-export { complementaryCertificationRepository };

--- a/api/tests/certification/complementary-certification/integration/domain/usecases/get-by-id_test.js
+++ b/api/tests/certification/complementary-certification/integration/domain/usecases/get-by-id_test.js
@@ -1,5 +1,5 @@
 import { getById } from '../../../../../../src/certification/complementary-certification/domain/usecases/get-by-id.js';
-import * as complementaryCertificationRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
+import * as complementaryCertificationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/complementary-certification-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/complementary-certification-repository_test.js
@@ -1,4 +1,4 @@
-import * as complementaryCertificationRepository from '../../../../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js';
+import * as complementaryCertificationRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 


### PR DESCRIPTION
## 🔆 Problème

Le `complementaryCertificationRepository` est dans le contexte `certification/complementary-certification/` qui doit disparaitre.

## ⛱️ Proposition

Déplace le repository vers le contexte `certification/configuration/`.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Dérouler une complémentaire (?)
