### PR TITLE
[FEATURE] Enregistrer la nouvelle équipe en charge lors de la modification d'une organisation (PIX-19599)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -147,7 +147,10 @@ export default class OrganizationInformationSectionEditionMode extends Component
       identityProviderForCampaigns:
         this.args.organization.identityProviderForCampaigns ?? this.noIdentityProviderOption.value,
       features: structuredClone(this.args.organization.features),
-      administrationTeamId: `${this.args.organization.administrationTeamId}`,
+      // TODO: delete this logic when administration team is mandatory
+      administrationTeamId: this.args.organization.administrationTeamId
+        ? `${this.args.organization.administrationTeamId}`
+        : null,
     });
   }
 

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -221,6 +221,7 @@ class OrganizationForAdmin {
     };
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
+    if (organization.administrationTeamId) this.administrationTeamId = organization.administrationTeamId;
   }
 }
 

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -1,0 +1,35 @@
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import {
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  insertMultipleSendingFeatureForNewOrganization,
+} from '../../../../test-helper.js';
+
+describe('Integration | Organizational Entities | Domain | UseCases | update-organization', function () {
+  it('updates organization information', async function () {
+    // given
+    await insertMultipleSendingFeatureForNewOrganization();
+
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+    const newAdministrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+
+    await databaseBuilder.commit();
+
+    const organizationNewInformations = domainBuilder.buildOrganizationForAdmin({
+      id: organizationId,
+      name: "Nouveau nom d'organization",
+      administrationTeamId: newAdministrationTeamId,
+    });
+
+    // when
+    const updatedOrganization = await usecases.updateOrganizationInformation({
+      organization: organizationNewInformations,
+    });
+
+    // then
+    expect(updatedOrganization.name).to.equal("Nouveau nom d'organization");
+    expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
+  });
+});

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -319,6 +319,34 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(givenOrganization.provinceCode).to.equal(newProvinceCode);
     });
 
+    it('updates organization administration team id', function () {
+      // given
+      const initialAdministrationTeamId = Symbol('initial id');
+      const newAdministrationTeamId = Symbol('new id');
+
+      const organization = new OrganizationForAdmin({ administrationTeamId: initialAdministrationTeamId });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({ administrationTeamId: newAdministrationTeamId, features });
+
+      // then
+      expect(organization.administrationTeamId).to.equal(newAdministrationTeamId);
+    });
+
+    it('does not update organization administration team id if empty value', function () {
+      // given
+      const initialAdministrationTeamId = Symbol('initial id');
+      const newAdministrationTeamId = '';
+
+      const organization = new OrganizationForAdmin({ administrationTeamId: initialAdministrationTeamId });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({ administrationTeamId: newAdministrationTeamId, features });
+
+      // then
+      expect(organization.administrationTeamId).to.equal(initialAdministrationTeamId);
+    });
+
     context('updates organization isManagingStudents', function () {
       it('updates organization isManagingStudents when LEARNER_IMPORT feature does not exist', function () {
         // given


### PR DESCRIPTION
## 🔆 Problème

Sur Pix Admin lors de la modification d'une organisation, le choix d'une équipe en charge doit être enregistré.

## ⛱️ Proposition

Ajouter cette information à mettre à jour dans la méthode de mise à jour du modèle.

## 🌊 Remarques

Afin de faciliter la transition vers une future obligation de renseigner une équipe en charge d'une orga, on ne laisse pas la possibilité de ne pas assigner d'équipe à une orga, sauf si celle-ci est déjà sans équipe. Autrement dit, pour une orga avec équipe, il n'est pas possible de la lui retirer.

## 🏄 Pour tester

Sur Pix Admin :
- créer une organisation avec une équipe en charge
- modifier cette orga et changer son équipe
- lorsqu'on est est redirigé vers la page de détail de l'orga, vérifier que la nouvelle équipe est bien affichée

Pour tester le cas évoqué dans la remarque
- utiliser un client HTTP pour requêter la route PATCH  `https://admin-pr13767.review.pix.fr/api/admin/organizations/<id-de-l'orga-à-modifier>` en utilisant une orga avec équipe
- passer le payload suivant :
```
{
  "data": {
    "id": "id-de-l'orga-à-modifier",
    "attributes": {
      "administration-team-id": null
    },
    "type": "organizations"
  }
}
```
- constater dans la réponse que l'id de l'administration-team n'a pas été mis à jour à `null`
- on peut aussi tester avec une chaîne vide `""`
