### PR TITLE
[BUGFIX] Ne pas vider le cache redis s'il n'est pas démarré après chaque test (PIX-19840)

### DIFF
--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -46,7 +46,7 @@ export function quitMutex() {
 
 export function clearMutex() {
   const status = redisMutex._client.status;
-  if (!['close', 'end'].includes(status)) {
+  if (status === 'ready') {
     return redisMutex.clearAll();
   }
 }


### PR DESCRIPTION
## 🔆 Problème

L'équipe Devcomp nous a remonté une erreur sur la Github Action test-modulix-content côté monorepo  : 
```
"after each" hook for "should return all modules with ids list in parameters":
     MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20). Refer to "maxRetriesPerRequest" option for details.
      at Socket.<anonymous> (node_modules/ioredis/built/redis/event_handler.js:182:37)
      at Object.onceWrapper (node:events:634:26)
      at Socket.emit (node:events:519:28)
      at TCP.<anonymous> (node:net:346:12)
```
Après investigation, cela est causée par la [PR](https://github.com/1024pix/pix/pull/13746/files#diff-d05a1ce773f6f8ee4a1f0147b3b927af5a171c095cc6a123c9d17ebc34bcdf29R105) suivante. Après chaque test, un vidage du cache est fait même si le redis n’est pas démarré ce qui occasionne un timeout.

Ce qui est le cas sur la Github Action qui ne démarre ni de Postgres ni de Redis.

## ⛱️ Proposition

Vider le cache uniquement quand le status du client redis est à `ready`

## 🌊 Remarques

RAS

## 🏄 Pour tester

### En local 
- Stopper le container redis
- Lancer la commande npm run modulix:test
- Vérifier que les tests passent.

### CI
Constater que la Github action test-modulix-content fonctionne bien !