### PR TITLE
[FEATURE] :sparkles: Création d'un script pour l'import de la calibration ayant l'ID 1 (pix-19827)

### DIFF
--- a/api/db/migrations/20251002125052_allow-null-complementaryCertificationKey-in-certification-frameworks-challenges.js
+++ b/api/db/migrations/20251002125052_allow-null-complementaryCertificationKey-in-certification-frameworks-challenges.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'complementaryCertificationKey';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };

--- a/api/scripts/certification/create-certification-frameworks-challenges-from-csv.js
+++ b/api/scripts/certification/create-certification-frameworks-challenges-from-csv.js
@@ -1,0 +1,83 @@
+import Joi from 'joi';
+
+import { knex } from '../../db/knex-database-connection.js';
+import { csvFileParser } from '../../src/shared/application/scripts/parsers.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const columnSchemas = [
+  { name: 'challenge_id', schema: Joi.string() },
+  { name: 'delta', schema: Joi.number() },
+  { name: 'alpha', schema: Joi.number() },
+];
+
+export class CreateCertificationFrameworksChallengesFromCsv extends Script {
+  constructor() {
+    super({
+      description: 'Create certification frameworks challenges from csv',
+      permanent: false,
+      options: {
+        file: {
+          type: 'string',
+          describe:
+            'CSV File with `challenge_id`, `alpha` (discriminant) and `delta` (difficulty) columns extracted from `datawarehouse.data_calibrated_challenges`',
+          demandOption: true,
+          coerce: csvFileParser(columnSchemas),
+        },
+        scope: {
+          type: 'string',
+          describe: 'Scope of the certification framework. Null = default framework = CORE',
+          demandOption: false,
+          requiresArg: false,
+        },
+        version: {
+          type: 'string',
+          describe: 'Version of the certification framework (YYYYMMDDHHMMSS)',
+          demandOption: true,
+          requiresArg: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { file: calibratedChallengesFromDatawarehouse, scope, version, dryRun } = options;
+    logger.debug(calibratedChallengesFromDatawarehouse);
+    const calibratedChallengesToInsert = [];
+
+    for (const calibratedChallenge of calibratedChallengesFromDatawarehouse) {
+      calibratedChallengesToInsert.push({
+        challengeId: calibratedChallenge.challenge_id,
+        difficulty: calibratedChallenge.delta,
+        discriminant: calibratedChallenge.alpha,
+        complementaryCertificationKey: scope,
+        version,
+      });
+    }
+
+    const trx = await knex.transaction();
+    try {
+      const result = await trx.batchInsert('certification-frameworks-challenges', calibratedChallengesToInsert);
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`Dry run: ${calibratedChallengesToInsert.length} challenges would be inserted`);
+        return { processed: calibratedChallengesToInsert.length, inserted: 0 };
+      }
+
+      await trx.commit();
+      logger.info(`Inserted ${calibratedChallengesToInsert.length} calibrated challenges`);
+      return result;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CreateCertificationFrameworksChallengesFromCsv);


### PR DESCRIPTION
## 🔆 Problème

Les challenges de la calibration (id  1 côté DATA) sont stocké dans une table du datawarehouse. Cette calibration est celle de la phase pilote qui a "disparue de la PROD" et pourtant est bien le premier millésime avec des certifs pilotes existantes en PROD.

## ⛱️ Proposition

Extraire les données en CSV (ajouté en pièce jointe dans le ticket JIRA).

Créer un script permettant  l'import du fichier CSV dans la table `certification-frameworks-challenges` pour créer le millésime a partir de la copie côté DATA des premières certif pilotes de PROD.

## 🌊 Remarques

Ajout d'un script de migration pour supprimer la contrainte sur le  `complementaryCertificationKey`

Permettre le NULL permet de dire "ce referentiel n'est pas lié à une complémentaire". Comprendre = ref par defaut = CORE.
Cela est temporaire, mais ça nous permet du rétrocompatible.

## 🏄 Pour tester

migration : `npm run db:migrate && npm run db:rollback` sans soucis

import : récupérer le fichier CSV dans le ticket JIRA et executer `cd api && node scripts/certification/create-certification-frameworks-challenges-from-csv.js --file='path/to/csv/file' --version='20231123000000'`

Vérifier que la table `certification-frameworks-challenges` a été garnie avec les données de cette calibration.
