### PR TITLE
[TECH] Gestion du caractère obligatoire du champ administration-team à la création unitaire (PIX-19808)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -32,13 +32,10 @@ export default class OrganizationCreationForm extends Component {
   }
 
   get administrationTeamsOptions() {
-    const options = [];
-    this.administrationTeams?.forEach((administrationTeam) =>
-      options.push({
-        value: administrationTeam.id,
-        label: administrationTeam.name,
-      }),
-    );
+    const options = this.administrationTeams.map((administrationTeam) => ({
+      value: administrationTeam.id,
+      label: administrationTeam.name,
+    }));
     return options;
   }
 
@@ -91,6 +88,7 @@ export default class OrganizationCreationForm extends Component {
             onchange={{this.handleOrganizationNameChange}}
             required={{true}}
             aria-required={{true}}
+            @requiredLabel={{t "common.fields.required-field"}}
           >
             <:label>Nom</:label>
           </PixInput>
@@ -103,6 +101,7 @@ export default class OrganizationCreationForm extends Component {
             @value={{@organization.type}}
             required
             aria-required={{true}}
+            @requiredLabel={{t "common.fields.required-field"}}
           >
             <:label>Sélectionner un type d'organisation</:label>
             <:default as |organizationType|>{{organizationType.label}}</:default>
@@ -114,7 +113,9 @@ export default class OrganizationCreationForm extends Component {
             @placeholder={{t "components.organizations.creation.administration-team.selector.placeholder"}}
             @hideDefaultOption={{true}}
             @value={{@organization.administrationTeamId}}
-            aria-required={{false}}
+            required
+            aria-required={{true}}
+            @requiredLabel={{t "common.fields.required-field"}}
           >
             <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 export default class NewController extends Controller {
   @service pixToast;
   @service router;
+  @service intl;
 
   @action
   goBackToOrganizationList() {
@@ -14,6 +15,14 @@ export default class NewController extends Controller {
   @action
   async addOrganization(event) {
     event.preventDefault();
+
+    if (!this.model.name || !this.model.type || !this.model.administrationTeamId) {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.organizations.creation.administration-team.required-fields-error'),
+      });
+      return;
+    }
+
     try {
       await this.model.save();
       this.pixToast.sendSuccessNotification({ message: 'L’organisation a été créée avec succès.' });

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -29,14 +29,16 @@ module('Acceptance | Organizations | Create', function (hooks) {
     test('it redirects the user on the organization details page on tags tab', async function (assert) {
       // given
       const screen = await visit('/organizations/new');
-      await fillByLabel('Nom', 'Stark Corp.');
+      await fillByLabel('Nom *', 'Stark Corp.');
 
-      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation` }));
+      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
       await click(
-        screen.getByRole('button', { name: t('components.organizations.creation.administration-team.selector.label') }),
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.administration-team.selector.label')} *`,
+        }),
       );
       await screen.findByRole('listbox');
       await click(screen.getByText('Équipe 2'));
@@ -52,6 +54,20 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/organizations/1/all-tags');
+    });
+
+    test('it shows validation errors if form is not correctly filled', async function (assert) {
+      // given
+      const screen = await visit('/organizations/new');
+      await fillByLabel('Nom *', 'Stark Corp.');
+
+      // when
+      await clickByName('Ajouter');
+
+      // then
+      assert
+        .dom(screen.getByText(t('components.organizations.creation.administration-team.required-fields-error')))
+        .exists();
     });
   });
 });

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -28,7 +28,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     );
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Nom *' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
     assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
     assert
@@ -56,7 +56,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
 
       // when
-      await click(screen.getByText("Sélectionner un type d'organisation"));
+      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
@@ -84,7 +84,9 @@ module('Integration | Component | organizations/creation-form', function (hooks)
 
       // when
       await click(
-        screen.getByRole('button', { name: t('components.organizations.creation.administration-team.selector.label') }),
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.administration-team.selector.label')} *`,
+        }),
       );
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Équipe 2' }));

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -28,6 +28,7 @@
       "id": "id",
       "internalName": "internal name",
       "name": "name",
+      "required-field": "Required field",
       "status": "status",
       "target-profile": {
         "category": {
@@ -555,6 +556,7 @@
       },
       "creation": {
         "administration-team": {
+          "required-fields-error": "Please fill in all required fields.",
           "selector": {
             "label": "Choose an administration team",
             "placeholder": "Administration team"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -28,6 +28,7 @@
       "id": "ID",
       "internalName": "nom interne",
       "name": "nom",
+      "required-field": "Champ obligatoire",
       "status": "statut",
       "target-profile": {
         "category": {
@@ -556,6 +557,7 @@
       },
       "creation": {
         "administration-team": {
+          "required-fields-error": "Veuillez remplir tous les champs obligatoires.",
           "selector": {
             "label": "Sélectionner une équipe en charge",
             "placeholder": "Équipe en charge"

--- a/api/src/organizational-entities/domain/validators/organization-creation-validator.js
+++ b/api/src/organizational-entities/domain/validators/organization-creation-validator.js
@@ -17,8 +17,10 @@ const organizationValidationJoiSchema = Joi.object({
   documentationUrl: Joi.string().uri().allow(null).messages({
     'string.uri': 'Le lien vers la documentation n’est pas valide.',
   }),
-  // TODO passer l'administrationTeamId en .required() avant la fin de l'Epix
-  administrationTeamId: Joi.string().allow(null),
+
+  administrationTeamId: Joi.number().required().messages({
+    'any.required': 'L’équipe en charge n’est pas renseignée.',
+  }),
 });
 
 const validate = function (organizationCreationParams) {

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -116,7 +116,7 @@ const deserialize = function (json) {
     dataProtectionOfficerFirstName: attributes['data-protection-officer-first-name'],
     dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
     dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
-    administrationTeamId: attributes['administration-team-id'],
+    administrationTeamId: parseInt(attributes['administration-team-id']),
     features: attributes.features,
     tagIds,
   });

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -304,6 +304,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       it('returns 200 HTTP status code with the created organization', async function () {
         // given
         const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
+        databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
         await databaseBuilder.commit();
 
         // when
@@ -318,6 +319,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                 type: 'PRO',
                 'documentation-url': 'https://kingArthur.com',
                 'data-protection-officer-email': 'justin.ptipeu@example.net',
+                'administration-team-id': 1234,
               },
             },
           },

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -13,6 +13,7 @@ describe('Integration | UseCases | create-organization', function () {
 
   beforeEach(async function () {
     superAdminUserId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
     await insertMultipleSendingFeatureForNewOrganization();
     await databaseBuilder.commit();
   });
@@ -24,6 +25,7 @@ describe('Integration | UseCases | create-organization', function () {
       type: 'PRO',
       documentationUrl: 'https://pix.fr',
       createdBy: superAdminUserId,
+      administrationTeamId: 1234,
     });
 
     // when
@@ -50,6 +52,7 @@ describe('Integration | UseCases | create-organization', function () {
         type: Organization.types.SCO1D,
         documentationUrl: 'https://pix.fr',
         createdBy: superAdminUserId,
+        administrationTeamId: 1234,
       });
 
       // when

--- a/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
@@ -15,7 +15,12 @@ describe('Unit | Domain | Validators | organization-validator', function () {
     context('when validation is successful', function () {
       it('should not throw any error', function () {
         // given
-        const organizationCreationParams = { name: 'ACME', type: 'PRO', documentationUrl: 'https://kingArthur.com' };
+        const organizationCreationParams = {
+          name: 'ACME',
+          type: 'PRO',
+          documentationUrl: 'https://kingArthur.com',
+          administrationTeamId: 1234,
+        };
 
         // when/then
         expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
@@ -30,7 +35,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             attribute: 'name',
             message: 'Le nom n’est pas renseigné.',
           };
-          const organizationCreationParams = { name: MISSING_VALUE, type: 'PRO' };
+          const organizationCreationParams = { name: MISSING_VALUE, type: 'PRO', administrationTeamId: 1234 };
 
           try {
             // when
@@ -57,7 +62,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             },
           ];
 
-          const organizationCreationParams = { name: 'ACME', type: MISSING_VALUE };
+          const organizationCreationParams = { name: 'ACME', type: MISSING_VALUE, administrationTeamId: 1234 };
 
           try {
             // when
@@ -76,7 +81,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             attribute: 'type',
             message: 'Le type de l’organisation doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.',
           };
-          const organizationCreationParams = { name: 'ACME', type: 'PTT' };
+          const organizationCreationParams = { name: 'ACME', type: 'PTT', administrationTeamId: 1234 };
 
           try {
             // when
@@ -91,7 +96,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
         ['SUP', 'SCO', 'PRO', 'SCO-1D'].forEach((type) => {
           it(`should not throw with ${type} as type`, function () {
             // given
-            const organizationCreationParams = { name: 'ACME', type };
+            const organizationCreationParams = { name: 'ACME', type, administrationTeamId: 1234 };
 
             // when/then
             return expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
@@ -102,7 +107,12 @@ describe('Unit | Domain | Validators | organization-validator', function () {
       context('on documentationUrl attribute', function () {
         it('should reject with error when documentationUrl is invalide', async function () {
           // given
-          const organizationCreationParams = { name: 'ACME', type: 'PRO', documentationUrl: 'invalidUrl' };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            documentationUrl: 'invalidUrl',
+            administrationTeamId: 1234,
+          };
           const error = await catchErr(organizationCreationValidator.validate)(organizationCreationParams);
 
           // then
@@ -111,9 +121,33 @@ describe('Unit | Domain | Validators | organization-validator', function () {
         });
       });
 
+      context('on administrationTeamId attribute', function () {
+        it('should reject with error when administrationTeamId is missing', function () {
+          // given
+          const expectedError = {
+            attribute: 'administrationTeamId',
+            message: 'L’équipe en charge n’est pas renseignée.',
+          };
+          const organizationCreationParams = { name: 'ACME', type: 'PRO', administrationTeamId: undefined };
+
+          try {
+            // when
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+      });
+
       it('should reject with errors on all fields (but only once by field) when all fields are missing', function () {
         // given
-        const organizationCreationParams = { name: MISSING_VALUE, type: MISSING_VALUE };
+        const organizationCreationParams = {
+          name: MISSING_VALUE,
+          type: MISSING_VALUE,
+          administrationTeamId: MISSING_VALUE,
+        };
 
         try {
           // when
@@ -121,7 +155,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           expect.fail('should have thrown an error');
         } catch (errors) {
           // then
-          expect(errors.invalidAttributes).to.have.lengthOf(3);
+          expect(errors.invalidAttributes).to.have.lengthOf(4);
         }
       });
     });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -214,7 +214,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerFirstName: organizationAttributes.dataProtectionOfficerFirstName,
         dataProtectionOfficerLastName: organizationAttributes.dataProtectionOfficerLastName,
         dataProtectionOfficerEmail: organizationAttributes.dataProtectionOfficerEmail,
-        administrationTeamId: organizationAttributes.administrationTeamId,
+        administrationTeamId: parseInt(organizationAttributes.administrationTeamId),
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
             active: organizationAttributes.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.active,


### PR DESCRIPTION
## 🔆 Problème

Le champs Équipe en charge doit être obligatoire lors de la création d'une organisation

## ⛱️ Proposition

Ajouter une contrainte "required" côté front et back


## 🏄 Pour tester

- Depuis pix-admin
  - Tenter de créer une organisation sans équipe en charge
  - Constater un message d'erreur
  - Tenter de créer une Organisation avec tous les champs obligatoires
  - Constater que l'organisation est bien crée