### PR TITLE
[FEATURE] Rendre plus robuste les API LLM demandant un chatId en entrée (PIX-19841)

### DIFF
--- a/api/src/devcomp/application/passages/passage-route.js
+++ b/api/src/devcomp/application/passages/passage-route.js
@@ -117,7 +117,7 @@ const register = async function (server) {
         validate: {
           params: Joi.object({
             passageId: identifiersType.passageId.required(),
-            chatId: Joi.string().required(),
+            chatId: identifiersType.chatId,
           }).required(),
           payload: Joi.object({
             prompt: Joi.string().optional().allow('', null),

--- a/api/src/evaluation/application/assessments/assessment-routes.js
+++ b/api/src/evaluation/application/assessments/assessment-routes.js
@@ -66,7 +66,7 @@ const register = async function (server) {
         validate: {
           params: Joi.object({
             assessmentId: identifiersType.assessmentId.required(),
-            chatId: Joi.string().required(),
+            chatId: identifiersType.chatId,
           }).required(),
           payload: Joi.object({
             prompt: Joi.string().optional().allow('', null),

--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { jwtApplicationAuthenticationStrategyName } from '../../shared/infrastructure/authentication-strategy-names.js';
 import { llmPreviewController } from './llm-preview-controller.js';
 import { checkLLMChatIsEnabled } from './pre-handlers/index.js';
@@ -62,7 +63,7 @@ export async function register(server) {
         pre: [{ method: checkLLMChatIsEnabled }],
         validate: {
           params: Joi.object({
-            chatId: Joi.string().required(),
+            chatId: identifiersType.chatId,
           }).required(),
         },
         handler: llmPreviewController.getChat,
@@ -78,7 +79,7 @@ export async function register(server) {
         pre: [{ method: checkLLMChatIsEnabled }],
         validate: {
           params: Joi.object({
-            chatId: Joi.string().required(),
+            chatId: identifiersType.chatId,
           }).required(),
           payload: Joi.object({
             prompt: Joi.string().optional().allow('', null),

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -10,6 +10,7 @@ const implementationType = {
   positiveInteger64bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceInt64BitEnd),
   alphanumeric255: Joi.string().max(255),
   alphanumeric: Joi.string(),
+  uuid: Joi.string().uuid(),
 };
 
 const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
@@ -83,6 +84,8 @@ const typesPositiveInteger32bits = [
 
 const typesPositiveInteger64bits = ['answerId'];
 
+const typesUuid = ['chatId'];
+
 const typesAlphanumeric = ['courseId', 'tutorialId'];
 const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'code', 'skillId'];
 
@@ -90,6 +93,7 @@ _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInte
 _assignValueToExport(typesPositiveInteger64bits, implementationType.positiveInteger64bits);
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);
 _assignValueToExport(typesAlphanumeric255, implementationType.alphanumeric255);
+_assignValueToExport(typesUuid, implementationType.uuid);
 
 paramsToExport.positiveInteger32bits = {
   min: postgreSQLSequenceDefaultStart,

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -342,10 +342,13 @@ describe('Acceptance | Controller | passage-controller', function () {
         });
 
         it('should throw a 503 status code', async function () {
+          // given
+          const uuid = randomUUID();
+
           // when
           const response = await server.inject({
             method: 'POST',
-            url: '/api/passages/111/embed/llm/chats/cSomeChatId123/messages',
+            url: `/api/passages/111/embed/llm/chats/${uuid}/messages`,
             payload: { prompt: 'Quelle est la recette de la ratatouille ?' },
             headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
           });

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -832,10 +832,13 @@ describe('Acceptance | Controller | assessment-controller', function () {
         });
 
         it('should throw a 503 status code', async function () {
+          // given
+          const chatId = randomUUID();
+
           // when
           const response = await server.inject({
             method: 'POST',
-            url: '/api/assessments/111/embed/llm/chats/cSomeChatId123/messages',
+            url: `/api/assessments/111/embed/llm/chats/${chatId}/messages`,
             payload: { prompt: 'Quelle est la recette de la ratatouille ?' },
             headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
           });


### PR DESCRIPTION
## 🔆 Problème

Sur les routes LLM, on veut éviter de renvoyer des erreurs 500 dans le cas où le chatId n'a pas le bon format.

## ⛱️ Proposition

Changer la validation du format du chatId en UUID.

## 🌊 Remarques

On en profite pour ajouter ce type dans le fichier `identifiers-type.js`

## 🏄 Pour tester
- Appeler la route /api/llm/preview/embed/llm/chats/{chatId} en mettant un chatId qui n'est pas un uuid.
- Constater qu'une erreur 500 est maintenant bien renvoyée.
