### PR TITLE
[FEATURE] Ajouter une table `combined_courses` pour isoler les données n'appartenant pas aux quêtes (Pix-19673).

### DIFF
--- a/api/db/migrations/20251002120922_add-combined-courses-table.js
+++ b/api/db/migrations/20251002120922_add-combined-courses-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'combined_courses';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains data specific to combined courses.');
+    table.increments('id').primary().notNullable();
+    table
+      .string('name')
+      .notNullable()
+      .comment('The name of the combined course, used on the landing page of the combined course');
+    table.string('code').unique().notNullable().comment('The code that is necessary to access the combined course.');
+    table.integer('organizationId').references('organizations.id').index().notNullable();
+    table.integer('questId').references('quests.id').index().notNullable();
+    table.text('description').comment('This description is used on the landing page of the combined course.');
+    table.text('illustration').comment('This illustration is used on the landing page of the combined course.');
+    table.dateTime('createdAt').defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🔆 Problème

Actuellement les données des parcours combinés sont enregistrées dans la tables `quests` . Ce qui n'est pas l'idéal puisque ce ne sont pas des données appartenant à ce domaine.

## ⛱️ Proposition

Ajouter une table `combined_courses` repertoriant toutes les données nécessaire au bon fonctionnement du parcours combiné