### PR TITLE
[FEATURE] Ajouter les parcours apprenants au chargement de PixOrga (pix-19813)

### DIFF
--- a/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -67,6 +67,7 @@ const serialize = function (prescriber) {
           'participationStatistics',
           'groups',
           'schoolCode',
+          'combinedCourses',
           'sessionExpirationDate',
         ],
         memberships: {
@@ -129,6 +130,16 @@ const serialize = function (prescriber) {
           relationshipLinks: {
             related: function (record, current, parent) {
               return `/api/organizations/${parent.id}/participation-statistics`;
+            },
+          },
+        },
+        combinedCourses: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          nullIfMissing: true,
+          relationshipLinks: {
+            related: function (record, current, parent) {
+              return `/api/organizations/${parent.id}/combined-courses`;
             },
           },
         },

--- a/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
+++ b/api/tests/team/acceptance/application/prescriber-informations.controller.test.js
@@ -66,6 +66,11 @@ describe('Acceptance | Team | Application | Controller | prescriber-informations
             type: organization.type,
           },
           relationships: {
+            'combined-courses': {
+              links: {
+                related: `/api/organizations/${organization.id}/combined-courses`,
+              },
+            },
             divisions: {
               links: {
                 related: `/api/organizations/${organization.id}/divisions`,

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -314,6 +314,11 @@ function createExpectedPrescriberSerializedWithOneMoreField({
               related: `/api/organizations/${organization.id}/target-profiles`,
             },
           },
+          'combined-courses': {
+            links: {
+              related: `/api/organizations/${organization.id}/combined-courses`,
+            },
+          },
         },
       },
       {
@@ -426,6 +431,11 @@ function createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSe
           'target-profiles': {
             links: {
               related: `/api/organizations/${organization.id}/target-profiles`,
+            },
+          },
+          'combined-courses': {
+            links: {
+              related: `/api/organizations/${organization.id}/combined-courses`,
             },
           },
         },

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -12,6 +12,7 @@ export default class Organization extends Model {
   @attr('string') schoolCode;
   @attr('date') sessionExpirationDate;
 
+  @hasMany('combined-course', { async: true, inverse: null }) combinedCourses;
   @hasMany('campaign', { async: true, inverse: 'organization' }) campaigns;
   @hasMany('target-profile', { async: true, inverse: null }) targetProfiles;
   @hasMany('organization-invitation', { async: true, inverse: 'organization' }) organizationInvitations;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -15,6 +15,7 @@ export default class CurrentUserService extends Service {
   @tracked isGarAuthenticationMethod;
   @tracked organizationPlaceStatistics;
   @tracked participationStatistics;
+  @tracked combinedCourses;
 
   get canAccessImportPage() {
     return Boolean(
@@ -57,6 +58,14 @@ export default class CurrentUserService extends Service {
 
   get placeStatistics() {
     return this.organizationPlaceStatistics;
+  }
+
+  async loadCombinedCourses() {
+    this.combinedCourses = await this.organization.combinedCourses;
+  }
+
+  get hasCombinedCourses() {
+    return Boolean(this.combinedCourses && this.combinedCourses.length > 0);
   }
 
   async loadPlaceStatistics() {
@@ -119,6 +128,7 @@ export default class CurrentUserService extends Service {
     this.isAgriculture = organization.isAgriculture;
     this.organization = organization;
     await this.loadPlaceStatistics();
+    await this.loadCombinedCourses();
     await this.loadParticipationStatistics();
   }
 }

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -560,6 +560,56 @@ module('Unit | Service | current-user', function (hooks) {
         assert.false(currentUserService.canEditLearnerName);
       });
     });
+
+    module('#loadCombinedCourses', function () {
+      test('should load combined courses from organization', async function (assert) {
+        // given
+        const combinedCourse1 = Object.create({ id: 1 });
+        const combinedCourse2 = Object.create({ id: 2 });
+        const combinedCourses = [combinedCourse1, combinedCourse2];
+        currentUserService.organization = Object.create({ combinedCourses: resolve(combinedCourses) });
+
+        // when
+        await currentUserService.loadCombinedCourses();
+
+        // then
+        assert.deepEqual(currentUserService.combinedCourses, combinedCourses);
+      });
+    });
+
+    module('#hasCombinedCourses', function () {
+      test('should return true when combined courses exist', function (assert) {
+        // given
+        currentUserService.combinedCourses = [Object.create({ id: 1 })];
+
+        // then
+        assert.true(currentUserService.hasCombinedCourses);
+      });
+
+      test('should return false when combined courses is empty array', function (assert) {
+        // given
+        currentUserService.combinedCourses = [];
+
+        // then
+        assert.false(currentUserService.hasCombinedCourses);
+      });
+
+      test('should return false when combined courses is null', function (assert) {
+        // given
+        currentUserService.combinedCourses = null;
+
+        // then
+        assert.false(currentUserService.hasCombinedCourses);
+      });
+
+      test('should return false when combined courses is undefined', function (assert) {
+        // given
+        currentUserService.combinedCourses = undefined;
+
+        // then
+        assert.false(currentUserService.hasCombinedCourses);
+      });
+    });
   });
 
   module('user is not authenticated', function () {


### PR DESCRIPTION
## 🔆 Problème

Nous ne souhaitons pas afficher l'onglet aux organisations qui n'ont pas de parcours apprenants. Nous avons fait le choix de ne pas utiliser d'`organization-features` pour conditionner l'affichage donc nous devons trouver une autre solution.

## ⛱️ Proposition

Nous avons donc decide d'appeler la route `organizations/{organizationId}/combined-courses` le plus tot possible dans le chargement de l'application pour conditionner l'affichage de l'onglet.

## 🌊 Remarques

Je persiste à penser que c'est une très mauvaise idée et qu'une feature serait beaucoup plus adaptée.

## 🏄 Pour tester

Demarrer l'application et regarder les appels effectues.
Verifier la presence de l'appel vers `organizations/{organizationId}/combined-courses` et etudier le resulat de l'appel, seule l'organisation ProClassic devrait avoir des parcours apprenants.
L'appel doit etre effectue derechef au changement d'organisation.