### PR TITLE
[BUGFIX] Corriger le bug d'affichage de la flashcard lorsqu'elle co-existe avec un stepper horizontal (PIX-19845)

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/flashcards.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards.gjs
@@ -146,7 +146,7 @@ export default class ModulixFlashcards extends Component {
     await this.goToNextCard();
 
     const elementToFocus = document.querySelector('.element-flashcards');
-    elementToFocus.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'start' });
+    elementToFocus.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
   }
 
   <template>


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'on est sur un module avec un stepper horizontal et des flashcard, qu'on répond à une flashcard ("oui", "peut-être", "non"), un scroll se fait pour centrer la flashcard sur l'écran mais décale tout le contenu.

## ⛱️ Proposition

La flashcard utilise https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView, une méthode permettant de placer l'élément au centre de l'écran après avoir répondu aux boutons de feedback.

Cette méthode propose plusieurs paramètre selon les besoins dont le inline. Nous l'avons modifié pour ne plus décaler l'entièreté du contenu.



## 🏄 Pour tester

1er test : vérifier que la flashcard ne décale plus le contenu 

- https://app-pr13774.review.pix.fr/modules/bac-a-sable (il y a un stepper avant le flashcard)
- Aller jusqu'à la flashcard et répondre jusqu'à avoir les trois boutons
- en sélectionner un
- le contenu ne se décale pas ✅ 


2ème test : Non régression avec une flashcard SANS stepper horizontal aux alentours

- https://app-pr13774.review.pix.fr/modules/galerie/
- Aller jusqu'à la flashcard (aucun stepper horizontal avant du coup)
- répondre jusqu'à avoir les trois boutons
- en sélectionner un
- le contenu ne se décale pas ✅ 
