### PR TITLE
[TECH] Migrer les confs de PixCoeur dans la table certification_versions (PIX-19830).

### DIFF
--- a/api/scripts/certification/migrate-certification-configurations-to-versions.js
+++ b/api/scripts/certification/migrate-certification-configurations-to-versions.js
@@ -1,0 +1,102 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { DEFAULT_SESSION_DURATION_MINUTES } from '../../src/certification/shared/domain/constants.js';
+import { Frameworks } from '../../src/certification/shared/domain/models/Frameworks.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const SOURCE_TABLE = 'certification-configurations';
+const TARGET_TABLE = 'certification_versions';
+const FRAMEWORKS_TABLE = 'certification-frameworks-challenges';
+const ASSESSMENT_DURATION = DEFAULT_SESSION_DURATION_MINUTES;
+
+export class MigrateCertificationConfigurationsToVersionsScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Migrate existing CORE certification configurations from certification-configurations table to certification_versions table',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Commit the INSERT or not',
+          default: true,
+        },
+        versions: {
+          type: 'array',
+          describe: 'List of certification framework versions (format "YYYYMMDDHHMMSS") in chronological order',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const { dryRun, versions } = options;
+
+    logger.info({ dryRun, versions });
+    logger.info('Starting migration from certification-configurations to certification_versions...');
+
+    const transaction = await knex.transaction();
+
+    try {
+      const configurations = await transaction(SOURCE_TABLE)
+        .select(
+          'startingDate',
+          'expirationDate',
+          'globalScoringConfiguration',
+          'competencesScoringConfiguration',
+          'challengesConfiguration',
+        )
+        .orderBy('startingDate', 'asc');
+
+      if (configurations.length !== versions.length) {
+        throw new Error('Configurations count should be the same as versions count');
+      }
+
+      logger.info(`Found ${configurations.length} configuration(s) to migrate.`);
+
+      if (configurations.length === 0) {
+        logger.info('No configurations to migrate.');
+        await transaction.rollback();
+        return 0;
+      }
+
+      for (let i = 0; i < configurations.length; i++) {
+        const versionData = {
+          scope: Frameworks.CORE,
+          startDate: configurations[i].startingDate,
+          expirationDate: configurations[i].expirationDate,
+          assessmentDuration: ASSESSMENT_DURATION,
+          globalScoringConfiguration: JSON.stringify(configurations[i].globalScoringConfiguration),
+          competencesScoringConfiguration: JSON.stringify(configurations[i].competencesScoringConfiguration),
+          challengesConfiguration: JSON.stringify(configurations[i].challengesConfiguration),
+        };
+
+        const [{ id: versionId }] = await transaction(TARGET_TABLE).insert(versionData).returning('id');
+
+        await transaction(FRAMEWORKS_TABLE).where('version', versions[i]).update({
+          versionId,
+        });
+
+        logger.info(
+          `Migrated configuration with startDate: ${configurations[i].startingDate}, expirationDate: ${configurations[i].expirationDate || 'NULL'}`,
+        );
+      }
+
+      if (dryRun) {
+        await transaction.rollback();
+        logger.info(`[⏳ Dry run] ${configurations.length} configuration(s) can be migrated.`);
+      } else {
+        await transaction.commit();
+        logger.info(`✅ Migration completed successfully. ${configurations.length} configuration(s) migrated.`);
+      }
+
+      return 0;
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateCertificationConfigurationsToVersionsScript);

--- a/api/src/certification/shared/domain/models/Frameworks.js
+++ b/api/src/certification/shared/domain/models/Frameworks.js
@@ -1,0 +1,13 @@
+/**
+ * Frameworks scopes
+ * @readonly
+ * @enum {string}
+ */
+export const Frameworks = Object.freeze({
+  CORE: 'CORE',
+  PIX_PLUS_DROIT: 'DROIT',
+  PIX_PLUS_EDU_1ER_DEGRE: 'EDU_1ER_DEGRE',
+  PIX_PLUS_EDU_2ND_DEGRE: 'EDU_2ND_DEGRE',
+  PIX_PLUS_EDU_CPE: 'EDU_CPE',
+  PIX_PLUS_PRO_SANTE: 'PRO_SANTE',
+});

--- a/api/tests/integration/scripts/certification/migrate-certification-configurations-to-versions_test.js
+++ b/api/tests/integration/scripts/certification/migrate-certification-configurations-to-versions_test.js
@@ -1,0 +1,179 @@
+import sinon from 'sinon';
+
+import { MigrateCertificationConfigurationsToVersionsScript } from '../../../../scripts/certification/migrate-certification-configurations-to-versions.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | migrate-certification-configurations-to-versions', function () {
+  let script;
+  let logger;
+
+  beforeEach(function () {
+    script = new MigrateCertificationConfigurationsToVersionsScript();
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+    };
+  });
+
+  context('when there are configurations to migrate', function () {
+    it('should migrate configurations from certification-configurations to certification_versions and update frameworks', async function () {
+      // given
+      const startingDate1 = new Date('2020-01-01');
+      const expirationDate1 = new Date('2021-01-01');
+      const startingDate2 = new Date('2021-01-01');
+      const version1 = '20200101000000';
+      const version2 = '20210101000000';
+
+      const challengesConfig = {
+        maximumAssessmentLength: 20,
+        challengesBetweenSameCompetence: 3,
+        limitToOneQuestionPerTube: false,
+        enablePassageByAllCompetences: true,
+        variationPercent: 0.5,
+      };
+
+      const globalScoringConfig = [
+        { bounds: { max: -2.6789, min: -5.12345 }, meshLevel: 0 },
+        { bounds: { max: -0.23456, min: -2.6789 }, meshLevel: 1 },
+      ];
+
+      const competencesScoringConfig = [
+        {
+          competence: '1.1',
+          values: [
+            { bounds: { max: 0, min: -5 }, competenceLevel: 0 },
+            { bounds: { max: 5, min: 0 }, competenceLevel: 1 },
+          ],
+        },
+      ];
+
+      databaseBuilder.factory.buildCertificationConfiguration({
+        startingDate: startingDate1,
+        expirationDate: expirationDate1,
+        challengesConfiguration: challengesConfig,
+        globalScoringConfiguration: globalScoringConfig,
+        competencesScoringConfiguration: competencesScoringConfig,
+      });
+
+      databaseBuilder.factory.buildCertificationConfiguration({
+        startingDate: startingDate2,
+        expirationDate: null,
+        challengesConfiguration: challengesConfig,
+        globalScoringConfiguration: globalScoringConfig,
+        competencesScoringConfiguration: competencesScoringConfig,
+      });
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version1,
+        challengeId: 'recChallenge1',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version: version2,
+        challengeId: 'recChallenge2',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: false, versions: [version1, version2] }, logger });
+
+      // then
+      const versions = await knex('certification_versions').select('*').orderBy('startDate', 'asc');
+
+      expect(versions).to.have.lengthOf(2);
+
+      expect(versions[0]).to.deep.include({
+        scope: 'CORE',
+        assessmentDuration: 105,
+      });
+      expect(versions[0].startDate).to.deep.equal(startingDate1);
+      expect(versions[0].expirationDate).to.deep.equal(expirationDate1);
+      expect(versions[0].challengesConfiguration).to.deep.equal(challengesConfig);
+      expect(versions[0].globalScoringConfiguration).to.deep.equal(globalScoringConfig);
+      expect(versions[0].competencesScoringConfiguration).to.deep.equal(competencesScoringConfig);
+
+      expect(versions[1]).to.deep.include({
+        scope: 'CORE',
+        assessmentDuration: 105,
+      });
+      expect(versions[1].startDate).to.deep.equal(startingDate2);
+      expect(versions[1].expirationDate).to.be.null;
+      expect(versions[1].challengesConfiguration).to.deep.equal(challengesConfig);
+      expect(versions[1].globalScoringConfiguration).to.deep.equal(globalScoringConfig);
+      expect(versions[1].competencesScoringConfiguration).to.deep.equal(competencesScoringConfig);
+
+      const frameworks = await knex('certification-frameworks-challenges')
+        .select('version', 'versionId')
+        .orderBy('version', 'asc');
+
+      expect(frameworks).to.have.lengthOf(2);
+      expect(frameworks[0].version).to.equal(version1);
+      expect(frameworks[0].versionId).to.equal(versions[0].id);
+      expect(frameworks[1].version).to.equal(version2);
+      expect(frameworks[1].versionId).to.equal(versions[1].id);
+    });
+
+    it('should not commit when dryRun is true', async function () {
+      // given
+      const startingDate = new Date('2020-01-01');
+      const version = '20200101000000';
+
+      databaseBuilder.factory.buildCertificationConfiguration({
+        startingDate,
+        expirationDate: null,
+      });
+
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+
+      databaseBuilder.factory.buildCertificationFrameworksChallenge({
+        version,
+        challengeId: 'recChallenge1',
+        complementaryCertificationKey: complementaryCertification.key,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options: { dryRun: true, versions: [version] }, logger });
+
+      // then
+      const versions = await knex('certification_versions').select('*');
+      expect(versions).to.have.lengthOf(0);
+    });
+  });
+
+  context('when there are no configurations to migrate', function () {
+    it('should return 0 without error', async function () {
+      // when
+      const result = await script.handle({ options: { dryRun: false, versions: [] }, logger });
+
+      // then
+      expect(result).to.equal(0);
+      const versions = await knex('certification_versions').select('*');
+      expect(versions).to.have.lengthOf(0);
+    });
+  });
+
+  context('when versions count does not match configurations count', function () {
+    it('should throw an error', async function () {
+      // given
+      const startingDate = new Date('2020-01-01');
+
+      databaseBuilder.factory.buildCertificationConfiguration({
+        startingDate,
+        expirationDate: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when / then
+      await expect(script.handle({ options: { dryRun: false, versions: [] }, logger })).to.be.rejectedWith(
+        'Configurations count should be the same as versions count',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

On ne souhaite plus utiliser l'ancienne table `certifcation-configurations`.

## ⛱️ Proposition

- Créer un script qui récupèrera les données de certification-configurations en prod aujourd’hui pour les dupliquer dans certification_versions.

- Dans le script, gérer les différences avec les colonnes de la nouvelle table certification_versions :
  * `startingDate` → `startDate`
  * `assessmentDuration` : 105 (minutes)
  * `scope` = `'Core'`

## 🏄 Pour tester

- Lancer le script sur la RA
```shell
node scripts/certification/migrate-certification-configurations-to-versions.js --dryRun=true --versions=X Y Z
```
- Vérifier que 3 lignes ont été bien ajoutées dans la table `certification_versions` avec le scope `CORE`
