### PR TITLE
[BUGFIX] Empêcher d'envoyer un email à un destinaire des résultats si le candidat n'a pas de certif-course (PIX-19805).

### DIFF
--- a/api/src/certification/session-management/domain/usecases/publish-session.js
+++ b/api/src/certification/session-management/domain/usecases/publish-session.js
@@ -24,7 +24,7 @@ const publishSession = async function ({
   sessionPublicationService,
 }) {
   return DomainTransaction.execute(async function () {
-    const session = await sessionPublicationService.publishSession({
+    const { session, startedCertificationCoursesUserIds } = await sessionPublicationService.publishSession({
       sessionId,
       publishedAt,
       certificationRepository,
@@ -35,6 +35,7 @@ const publishSession = async function ({
 
     await sessionPublicationService.manageEmails({
       session,
+      startedCertificationCoursesUserIds,
       publishedAt,
       certificationCenterRepository,
       sessionRepository,

--- a/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
+++ b/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
@@ -18,7 +18,7 @@ const publishSessionsInBatch = async function ({
   for (const sessionId of sessionIds) {
     try {
       await DomainTransaction.execute(async () => {
-        const session = await sessionPublicationService.publishSession({
+        const { session, startedCertificationCoursesUserIds } = await sessionPublicationService.publishSession({
           sessionId,
           publishedAt,
           certificationRepository,
@@ -29,6 +29,7 @@ const publishSessionsInBatch = async function ({
 
         await sessionPublicationService.manageEmails({
           session,
+          startedCertificationCoursesUserIds,
           publishedAt,
           certificationCenterRepository,
           sessionRepository,

--- a/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/certification-repository.js
@@ -6,6 +6,7 @@ const getStatusesBySessionId = async function (sessionId) {
   return knexConn('certification-courses')
     .select({
       certificationCourseId: 'certification-courses.id',
+      userId: 'certification-courses.userId',
       pixCertificationStatus: 'assessment-results.status',
     })
     .where('certification-courses.sessionId', sessionId)

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-repository_test.js
@@ -7,12 +7,16 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
     it('should get status information', async function () {
       // given
       const sessionId = 200;
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const userId2 = databaseBuilder.factory.buildUser().id;
+      const userId3 = databaseBuilder.factory.buildUser().id;
+      const userId4 = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildSession({ id: sessionId + 1 });
       databaseBuilder.factory.buildSession({ id: sessionId });
-      _buildValidatedCertification({ id: 1, sessionId, isPublished: false });
-      _buildValidatedCertification({ id: 2, sessionId: sessionId + 1, isPublished: false });
-      _buildRejectedCertification({ id: 3, sessionId, isPublished: false });
-      _buildCancelledCertification({ id: 4, sessionId, isPublished: false });
+      _buildValidatedCertification({ id: 1, sessionId, isPublished: false, userId: userId1 });
+      _buildValidatedCertification({ id: 2, sessionId: sessionId + 1, isPublished: false, userId: userId2 });
+      _buildRejectedCertification({ id: 3, sessionId, isPublished: false, userId: userId3 });
+      _buildCancelledCertification({ id: 4, sessionId, isPublished: false, userId: userId4 });
       await databaseBuilder.commit();
 
       // when
@@ -24,14 +28,17 @@ describe('Certification | Session-management | Integration | Infrastructure | Re
       expect(statuses).to.have.deep.members([
         {
           certificationCourseId: 1,
+          userId: userId1,
           pixCertificationStatus: AssessmentResult.status.VALIDATED,
         },
         {
           certificationCourseId: 3,
+          userId: userId3,
           pixCertificationStatus: AssessmentResult.status.REJECTED,
         },
         {
           certificationCourseId: 4,
+          userId: userId4,
           pixCertificationStatus: AssessmentResult.status.CANCELLED,
         },
       ]);
@@ -136,20 +143,20 @@ function _buildStartedCertification({ id, sessionId, isPublished }) {
   _buildCertification({ id, sessionId, isPublished, status: null });
 }
 
-function _buildValidatedCertification({ id, sessionId, isPublished }) {
-  _buildCertification({ id, sessionId, isPublished, status: status.VALIDATED });
+function _buildValidatedCertification({ id, sessionId, isPublished, userId }) {
+  _buildCertification({ id, sessionId, isPublished, userId, status: status.VALIDATED });
 }
 
-function _buildRejectedCertification({ id, sessionId, isPublished }) {
-  _buildCertification({ id, sessionId, isPublished, status: status.REJECTED });
+function _buildRejectedCertification({ id, sessionId, isPublished, userId }) {
+  _buildCertification({ id, sessionId, isPublished, userId, status: status.REJECTED });
 }
 
-function _buildCancelledCertification({ id, sessionId, isPublished }) {
-  _buildCertification({ id, sessionId, isPublished, status: status.CANCELLED });
+function _buildCancelledCertification({ id, sessionId, isPublished, userId }) {
+  _buildCertification({ id, sessionId, isPublished, userId, status: status.CANCELLED });
 }
 
-function _buildCertification({ id, sessionId, status, isPublished }) {
-  databaseBuilder.factory.buildCertificationCourse({ id, sessionId, isPublished });
+function _buildCertification({ id, sessionId, status, isPublished, userId }) {
+  databaseBuilder.factory.buildCertificationCourse({ id, sessionId, isPublished, userId });
   databaseBuilder.factory.buildAssessment({ id, certificationCourseId: id });
   if (status) {
     // not the latest

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
@@ -22,7 +22,7 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
       publishSession: sinon.stub(),
       manageEmails: sinon.stub(),
     };
-    sessionPublicationService.publishSession.resolves(session);
+    sessionPublicationService.publishSession.resolves({ session, startedCertificationCoursesUserIds: [123] });
 
     // when
     const result = await publishSession({
@@ -47,6 +47,7 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session,
+      startedCertificationCoursesUserIds: [123],
       publishedAt,
       certificationCenterRepository,
       sessionRepository,

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -30,9 +30,15 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     const session1 = domainBuilder.certification.sessionManagement.buildSession({ id: 1 });
     const session2 = domainBuilder.certification.sessionManagement.buildSession({ id: 2 });
     const publishedAt = Symbol('a publication date');
+    const startedCertificationCoursesUserIds1 = [101, 102];
+    const startedCertificationCoursesUserIds2 = [201, 202];
 
-    sessionPublicationService.publishSession.onCall(0).resolves(session1);
-    sessionPublicationService.publishSession.onCall(1).resolves(session2);
+    sessionPublicationService.publishSession
+      .onCall(0)
+      .resolves({ session: session1, startedCertificationCoursesUserIds: startedCertificationCoursesUserIds1 });
+    sessionPublicationService.publishSession
+      .onCall(1)
+      .resolves({ session: session2, startedCertificationCoursesUserIds: startedCertificationCoursesUserIds2 });
 
     // when
     await publishSessionsInBatch({
@@ -58,6 +64,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session: session1,
+      startedCertificationCoursesUserIds: startedCertificationCoursesUserIds1,
       publishedAt,
       certificationCenterRepository,
       sessionRepository,
@@ -73,6 +80,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session: session2,
+      startedCertificationCoursesUserIds: startedCertificationCoursesUserIds2,
       publishedAt,
       certificationCenterRepository,
       sessionRepository,
@@ -85,6 +93,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       const session1 = domainBuilder.certification.sessionManagement.buildSession({ id: 1 });
       const session2 = domainBuilder.certification.sessionManagement.buildSession({ id: 2 });
       const publishedAt = Symbol('a publication date');
+      const startedCertificationCoursesUserIds2 = [201, 202];
 
       sessionPublicationService.publishSession
         .withArgs({
@@ -96,7 +105,9 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
           sharedSessionRepository,
         })
         .rejects(new Error('an error'));
-      sessionPublicationService.publishSession.onCall(1).resolves(session2);
+      sessionPublicationService.publishSession
+        .onCall(1)
+        .resolves({ session: session2, startedCertificationCoursesUserIds: startedCertificationCoursesUserIds2 });
 
       // when
       await publishSessionsInBatch({
@@ -121,6 +132,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       });
       expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
         session: session2,
+        startedCertificationCoursesUserIds: startedCertificationCoursesUserIds2,
         publishedAt,
         certificationCenterRepository,
         sessionRepository,


### PR DESCRIPTION
## 🔆 Problème

Dans une session de certification contenant plusieurs candidats : 
- Si l'un des candidats a été enregistré avec un email de destinataire des résultats mais qu'il n'a pas démarré son test, le destinataire recevra quand même un email de résultats

## ⛱️ Proposition

N'envoyer un mail aux destinataires de résultats qu'aux candidats ayant démarré leur test de certification.

## 🌊 Remarques

SEMI-VIBE CLAUDÉ

## 🏄 Pour tester

- Créer une session
- Ajouter deux candidats : un avec destinataire de résultats et un sans.
- Passer un test avec le candidat qui n'a pas de destinataire de résultat
- Finaliser et publier la session
- Vérifier qu'aucun mail n'a été envoyé

--- 

- Créer une autre session
- Ajouter deux candidats avec le même destinataire de résultats
- Passer un test avec un seul des deux candidats
- Finaliser et publier la session
- Vérifier qu'un seul mail a été envoyé