### PR TITLE
[BUGFIX] Les logs issus de child loggers ne portent pas les données de corrélation telles que le user_id ou le request_id

### DIFF
--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -31,8 +31,8 @@ export const loggerPino = pino(
   prettyPrint,
 );
 
-function buildLogWrapper(context, mergingObject, message) {
-  const loggerChild = loggerPino.child(getCorrelationContext());
+function buildLogWrapper(context, mergingObject, message, extraBindings = {}, extraOptions = undefined) {
+  const loggerChild = loggerPino.child({ ...getCorrelationContext(), ...extraBindings }, extraOptions);
   loggerChild[context](mergingObject, message);
 }
 
@@ -73,7 +73,30 @@ export function child(section, bindings, options) {
   if (micromatch.isMatch(section, logging.debugSections)) {
     optionsOverride.level = 'debug';
   }
-  return loggerPino.child(bindings, { ...options, ...optionsOverride });
+  const extraOptions = { ...options, ...optionsOverride };
+  return {
+    trace: (mergingObject, message) => {
+      buildLogWrapper('trace', mergingObject, message, bindings, extraOptions);
+    },
+    debug: (mergingObject, message) => {
+      buildLogWrapper('debug', mergingObject, message, bindings, extraOptions);
+    },
+    info: (mergingObject, message) => {
+      buildLogWrapper('info', mergingObject, message, bindings, extraOptions);
+    },
+    warn: (mergingObject, message) => {
+      buildLogWrapper('warn', mergingObject, message, bindings, extraOptions);
+    },
+    error: (mergingObject, message) => {
+      buildLogWrapper('error', mergingObject, message, bindings, extraOptions);
+    },
+    fatal: (mergingObject, message) => {
+      buildLogWrapper('fatal', mergingObject, message, bindings, extraOptions);
+    },
+    silent: (mergingObject, message) => {
+      buildLogWrapper('silent', mergingObject, message, bindings, extraOptions);
+    },
+  };
 }
 
 export const SCOPES = {


### PR DESCRIPTION
## 🔆 Problème

Il existe une méthode `child()` exportée depuis le fichier `logger.js`. Cette méthode permet d'instancier un child logger. Elle est utilisée lorsqu'on veut instancier un logger avec un binding supplémentaire (souvent `{ event: 'scope-du-code' }`) permettant d'exprimer le scope du log.
Malheureusement, à ce jour, les child loggers n'affichent pas les bindings, pourtant portés par le logger général, comportant les données dites de corrélation. 
Ces données (user_id et request_id) sont essentielles pour grouper des logs et débugger efficacement une séquence d'appels API, en particulier sur Datadog.

## ⛱️ Proposition

Une petite pirouette existe en réalité aujourd'hui pour que le logger principal affiche les données de corrélation.
En réalité, lorsque vous utilisez le `logger` exporté depuis le fichier `logger.js`, vous n'utilisez pas un **logger** singleton, mais en fait un **child logger** ! C'est même plus que ça, à chaque appel du style `logger.info(...)`, un child logger est instancié spécifiquement pour cet appel. Dans ce child logger, les bindings de données de corrélation lui sont associés. C'était nécessaire pour pouvoir justement avoir les bons bindings de corrélation.

Or, les **child loggers** _intentionnels_, instanciés depuis la méthode exportée `child()`, n'ont pas ces bindings.

Je sais ce que vous vous dites ! "La solution est simple ! je vais ajouter les bindings de corrélation dans la méthode `child()` et basta !". J'ai pensé la même chose ! Mais ce n'est pas possible car l'usage commun d'un child logger c'est d'être instancié dans le scope global du fichier dans lequel il est utilisé (un singleton par fichier donc). De fait, impossible d'y accoller des données de corrélation, celles-ci changeant à chaque requête !

J'ai donc imité la manière de faire du logger général : un child logger est désormais un ensemble de fonctions qui, à l'appel, instancient réellement un child logger pour l'occasion, avec les bindings spécifiques + les bindings de corrélation

## 🌊 Remarques
**AVANT**
<img width="1854" height="307" alt="image" src="https://github.com/user-attachments/assets/0438b830-f43f-497e-92fd-26b3c4717185" />

**APRES** 
<img width="1382" height="488" alt="image" src="https://github.com/user-attachments/assets/048c0bdc-fef8-4bd6-8ba8-213811851d9f" />


## 🏄 Pour tester

Faire en sorte d'exécuter du code qui utilise un child logger et constater que avant il n'y avait pas les infos de corrélation, et après oui
Pour les screens j'ai ajouté un child logger dans un handler de controller, juste pour le test.
