### PR TITLE
[TECH] Passer l'id de corrélation de requête à ChatPix pour faciliter le regroupement des logs et le débuggage sur Datadog

### DIFF
--- a/api/src/llm/infrastructure/repositories/prompt-repository.js
+++ b/api/src/llm/infrastructure/repositories/prompt-repository.js
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 
 import { config } from '../../../shared/config.js';
+import { getCorrelationContext } from '../../../shared/infrastructure/monitoring-tools.js';
 import { child, SCOPES } from '../../../shared/infrastructure/utils/logger.js';
 import { LLMApiError } from '../../domain/errors.js';
 
@@ -34,6 +35,7 @@ export async function prompt({ message, chat }) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Request-ID': getCorrelationContext().request_id,
         authorization: `Bearer ${jwt.sign(
           {
             client_id: 'pix-api',


### PR DESCRIPTION
## 🔆 Problème

Quand sur Datadog on debug pour comprendre ce qu'il s'est passé, d'un côté on a les logs de ChatPix avec un correlationId A et les logs de API Pix avec un correlationId B (chacun fourni par les Nginx respectifs)

## ⛱️ Proposition

Lorsque l'API Pix appelle ChatPix, il passe en header "x-request-id" son propre "x-request-id". Ainsi, ils ont tous le même et sur Datadog ce sera super simple de voir la grappe


## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Tout lancer en local, vérifier que le request_id côté API Pix dans les logs est le même que le request_id dans les logs de l'API ChatPix
