### PR TITLE
[FEATURE] Renseigner la table combined_courses (PIX-19865).

### DIFF
--- a/api/db/database-builder/factory/build-combined-course.js
+++ b/api/db/database-builder/factory/build-combined-course.js
@@ -1,0 +1,54 @@
+import isUndefined from 'lodash/isUndefined.js';
+
+import { databaseBuffer } from '../database-buffer.js';
+import { buildOrganization } from './build-organization.js';
+import { buildQuestForCombinedCourse } from './build-quest.js';
+
+const buildCombinedCourse = function ({
+  id = databaseBuffer.getNextId(),
+  eligibilityRequirements = [],
+  successRequirements = [],
+  code = 'COMBINIX1',
+  name = 'Mon parcours combiné',
+  organizationId,
+  description = 'Le but de ma quête',
+  illustration = 'images/illustration.svg',
+  createdAt = new Date(),
+  updatedAt,
+} = {}) {
+  organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
+
+  const questId = buildQuestForCombinedCourse({
+    illustration,
+    eligibilityRequirements,
+    successRequirements,
+    organizationId,
+    code,
+    name,
+    description,
+  }).id;
+
+  const values = {
+    id,
+    code,
+    name,
+    description,
+    illustration,
+    organizationId,
+    createdAt,
+    updatedAt: updatedAt ?? createdAt,
+    questId,
+  };
+
+  const insertedValues = databaseBuffer.pushInsertable({
+    tableName: 'combined_courses',
+    values,
+  });
+  return {
+    ...insertedValues,
+    // TODO: remove when use combined course id instead of quest.id to retrieve combined course
+    id: questId,
+  };
+};
+
+export { buildCombinedCourse };

--- a/api/db/database-builder/factory/build-quest.js
+++ b/api/db/database-builder/factory/build-quest.js
@@ -55,12 +55,19 @@ const buildQuestForCombinedCourse = function ({
   organizationId,
   description = 'Le but de ma quête',
   illustration = 'images/illustration.svg',
-  rewardId = null,
-  rewardType = null,
   ...args
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
-  return buildQuest({ ...args, code, name, organizationId, description, illustration, rewardId, rewardType });
+  return buildQuest({
+    ...args,
+    code,
+    name,
+    organizationId,
+    description,
+    illustration,
+    rewardId: null,
+    rewardType: null,
+  });
 };
 
 export { buildQuest, buildQuestForCombinedCourse };

--- a/api/db/migrations/20251002134252_migrate-data-from-quests-to-combined_courses.js
+++ b/api/db/migrations/20251002134252_migrate-data-from-quests-to-combined_courses.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+const up = async function (knex) {
+  const dataToInsert = await knex('quests')
+    .select('id AS questId', 'code', 'organizationId', 'name', 'description', 'illustration', 'createdAt', 'updatedAt')
+    .whereNotNull('organizationId');
+
+  if (dataToInsert.length === 0) return;
+
+  return knex('combined_courses').insert(dataToInsert);
+};
+
+const down = async function () {
+  // We do not want to rollback the migration because we insert data.
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -76,10 +76,8 @@ function buildCombinedCourseQuest(databaseBuilder, organizationId) {
     locale: 'fr',
   });
 
-  databaseBuilder.factory.buildQuestForCombinedCourse({
+  databaseBuilder.factory.buildCombinedCourse({
     name: 'Combinix',
-    rewardType: null,
-    rewardId: null,
     code: 'COMBINIX1',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
@@ -195,10 +193,8 @@ function buildProCombinedCourseQuest(databaseBuilder, organizationId) {
     }),
   );
 
-  databaseBuilder.factory.buildQuestForCombinedCourse({
+  databaseBuilder.factory.buildCombinedCourse({
     name: 'Combinix',
-    rewardType: null,
-    rewardId: null,
     code: 'COMBINIX2',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -863,7 +863,7 @@ describe('Acceptance | API | Campaign Participations', function () {
       sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
 
       const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
-      databaseBuilder.factory.buildQuestForCombinedCourse({
+      databaseBuilder.factory.buildCombinedCourse({
         name: 'Combinix',
         rewardType: null,
         rewardId: null,

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -913,7 +913,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         const campaign = databaseBuilder.factory.buildCampaign();
 
         const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildQuestForCombinedCourse({
+        databaseBuilder.factory.buildCombinedCourse({
           name: 'Combinix',
           rewardType: null,
           rewardId: null,
@@ -1243,12 +1243,12 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           userId,
           organizationId,
         }).id;
-        const combinedCourse = databaseBuilder.factory.buildQuestForCombinedCourse({
+        const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
           name: 'Combinix1',
           code: 'ABCD',
           organizationId,
         });
-        const secondCombinedCourse = databaseBuilder.factory.buildQuestForCombinedCourse({
+        const secondCombinedCourse = databaseBuilder.factory.buildCombinedCourse({
           name: 'Combinix2',
           code: 'EFGH',
           organizationId,

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1453,7 +1453,7 @@ describe('Integration | Repository | Campaign Participation', function () {
     it('should return true user linked to a combined course', async function () {
       const campaignInCombinedCourse = databaseBuilder.factory.buildCampaign();
 
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({
+      const questId = databaseBuilder.factory.buildCombinedCourse({
         name: 'Combinix',
         rewardType: null,
         rewardId: null,
@@ -1520,7 +1520,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         organizationLearnerId,
         userId,
       });
-      databaseBuilder.factory.buildQuestForCombinedCourse({
+      databaseBuilder.factory.buildCombinedCourse({
         successRequirements: [
           {
             requirement_type: 'campaignParticipations',

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
@@ -82,7 +82,7 @@ describe('Integration | Repository | Participations-For-User-Management', functi
           userId,
         });
         const combinedCourseCampaign = databaseBuilder.factory.buildCampaign();
-        databaseBuilder.factory.buildQuestForCombinedCourse({
+        databaseBuilder.factory.buildCombinedCourse({
           code: 'ABCDE1234',
           name: 'Mon parcours Combiné',
           organizationId: combinedCourseCampaign.organizationId,

--- a/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
+++ b/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
@@ -14,7 +14,7 @@ describe('Integration | Campaign | Application | Usecases | checkCampaignBelongs
 
   it('should throw if a campaign belongs to combined course', async function () {
     // given
-    databaseBuilder.factory.buildQuestForCombinedCourse({
+    databaseBuilder.factory.buildCombinedCourse({
       code: 'ABCDE1234',
       name: 'Mon parcours Combiné',
       organizationId,
@@ -43,7 +43,7 @@ describe('Integration | Campaign | Application | Usecases | checkCampaignBelongs
   it('should not throw if campaign does not belongs to combined course', async function () {
     const anotherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
 
-    databaseBuilder.factory.buildQuestForCombinedCourse({
+    databaseBuilder.factory.buildCombinedCourse({
       code: 'ABCDE1234',
       name: 'Mon parcours Combiné',
       organizationId,

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -648,7 +648,7 @@ describe('Integration | UseCases | delete-campaign', function () {
       buildMembership({ userId, organizationId, organizationRole: Membership.roles.ADMIN });
       const campaignId = buildCampaign({ organizationId }).id;
 
-      databaseBuilder.factory.buildQuestForCombinedCourse({
+      databaseBuilder.factory.buildCombinedCourse({
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -24,7 +24,7 @@ describe('Integration | UseCase | get-campaign', function () {
 
     it('should return combinedCourse info when a combined course is associated with a campaign', async function () {
       // given
-      const combinedCourseId = databaseBuilder.factory.buildQuestForCombinedCourse({
+      const combinedCourseId = databaseBuilder.factory.buildCombinedCourse({
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1072,7 +1072,7 @@ describe('Integration | Repository | Campaign-Report', function () {
         // given
         const campaignInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
         const campaignNotInQuest = databaseBuilder.factory.buildCampaign({ organizationId });
-        databaseBuilder.factory.buildQuestForCombinedCourse({
+        databaseBuilder.factory.buildCombinedCourse({
           code: 'ABCDE1234',
           name: 'Mon parcours Combiné',
           organizationId,

--- a/api/tests/quest/acceptance/application/api/combined-course-api_test.js
+++ b/api/tests/quest/acceptance/application/api/combined-course-api_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | Quest | Application | combined-course-api', function () {
     organizationId = databaseBuilder.factory.buildOrganization().id;
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     combinedCourseName = 'Mon parcours Combiné';
-    combinedCourseId = databaseBuilder.factory.buildQuestForCombinedCourse({
+    combinedCourseId = databaseBuilder.factory.buildCombinedCourse({
       code: 'ABCDE1234',
       name: combinedCourseName,
       organizationId,
@@ -60,7 +60,7 @@ describe('Acceptance | Quest | Application | combined-course-api', function () {
     //given
     const organizationId = databaseBuilder.factory.buildOrganization().id;
 
-    databaseBuilder.factory.buildQuestForCombinedCourse({
+    databaseBuilder.factory.buildCombinedCourse({
       code: 'QWERTY123',
       name: combinedCourseName,
       organizationId,

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -188,7 +188,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
-      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+      const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBINIX1',
         organizationId,
         successRequirements: [],
@@ -222,7 +222,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,
@@ -287,7 +287,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+        const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,

--- a/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-authorization-to-access-combined-course_test.js
@@ -9,7 +9,7 @@ describe('Integration | Application | Usecases | checkAuthorizationToAccessCombi
       const code = 'COMBINIX1';
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
       databaseBuilder.factory.buildOrganizationLearner({ organizationId, userId });
       await databaseBuilder.commit();
 
@@ -27,7 +27,7 @@ describe('Integration | Application | Usecases | checkAuthorizationToAccessCombi
       const code = 'COMBINIX1';
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
       await databaseBuilder.commit();
 
       // when
@@ -41,7 +41,7 @@ describe('Integration | Application | Usecases | checkAuthorizationToAccessCombi
       const code = 'COMBINIX1';
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true }).id;
-      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
       await databaseBuilder.commit();
 
       // when
@@ -60,7 +60,7 @@ describe('Integration | Application | Usecases | checkAuthorizationToAccessCombi
         organizationId,
         featureId: importFeature.id,
       });
-      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/quest/integration/application/usecases/check-user-can-manage-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-user-can-manage-combined-course_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Usecases | checkUserCanManageCombinedCours
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      const questId = databaseBuilder.factory.buildCombinedCourse({ organizationId }).id;
       databaseBuilder.factory.buildMembership({ userId, organizationId });
       await databaseBuilder.commit();
 
@@ -25,7 +25,7 @@ describe('Integration | Application | Usecases | checkUserCanManageCombinedCours
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      const questId = databaseBuilder.factory.buildCombinedCourse({ organizationId }).id;
       await databaseBuilder.commit();
 
       // when
@@ -58,7 +58,7 @@ describe('Integration | Application | Usecases | checkUserCanManageCombinedCours
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse({ organizationId }).id;
+      const questId = databaseBuilder.factory.buildCombinedCourse({ organizationId }).id;
       databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
       await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-or-update-quests-in-batch_test.js
@@ -42,7 +42,7 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
 
   it('should not delete the passed quests in file if they correspond to a combined course', async function () {
     // given
-    const id = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    const id = databaseBuilder.factory.buildCombinedCourse().id;
     await databaseBuilder.commit();
 
     filePath = await createTempFile(
@@ -62,7 +62,7 @@ describe('Integration | Quest | Domain | UseCases | create-or-update-quests-in-b
   });
   it('should not update the passed quests in file if they correspond to a combined course', async function () {
     // given
-    const id = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    const id = databaseBuilder.factory.buildCombinedCourse().id;
     await databaseBuilder.commit();
 
     filePath = await createTempFile(

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-campaign-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-campaign-id_test.js
@@ -11,7 +11,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-campa
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
     const code = 'ABCDE1234';
     const name = 'Mon parcours Combiné';
-    courseId = databaseBuilder.factory.buildQuestForCombinedCourse({
+    courseId = databaseBuilder.factory.buildCombinedCourse({
       code,
       name,
       organizationId,

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -7,13 +7,13 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
   it('should return  CombinedCourseParticipations', async function () {
     // given
     const learner = databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Paul', lastName: 'Azerty' });
-    const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    const questId = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI1' }).id;
     const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
-    const anotherquestId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+    const anotherquestId = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' }).id;
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId: anotherquestId,

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -44,7 +44,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
       const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
       const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
 
-      const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+      const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
         successRequirements: [
@@ -133,6 +133,254 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
         },
       ]);
+      expect(result.id).to.equal(questId);
+      expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
+      expect(result.items[0]).instanceOf(CombinedCourseItem);
+      expect(result.items[1]).instanceOf(CombinedCourseItem);
+      expect(result.items[2]).instanceOf(CombinedCourseItem);
+    });
+
+    it('should return started combined course for given userId', async function () {
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+      const { id: organizationLearnerId, userId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId,
+        organizationLearnerId,
+        status: 'SHARED',
+      });
+      const training1 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
+      const training2 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
+      databaseBuilder.factory.buildTraining({
+        type: 'modulix',
+        link: '/modules/bien-ecrire-son-adresse-mail',
+      });
+      const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
+      const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training1.id,
+      });
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training2.id,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        trainingId: training1.id,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      databaseBuilder.factory.buildPassage({ moduleId: moduleId1, userId, terminatedAt: new Date() });
+
+      const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
+        code,
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId2,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId3,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+
+      databaseBuilder.factory.buildCombinedCourseParticipation({ questId, organizationLearnerId });
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getCombinedCourseByCode({ code, userId });
+
+      expect(result.items).to.be.deep.equal([
+        {
+          id: campaign.id,
+          reference: campaign.code,
+          title: campaign.title,
+          type: COMBINED_COURSE_ITEM_TYPES.CAMPAIGN,
+          redirection: undefined,
+          isCompleted: true,
+          isLocked: false,
+          duration: undefined,
+          image: undefined,
+        },
+        {
+          id: moduleId1,
+          reference: 'bac-a-sable',
+          title: 'Bac à sable',
+          type: COMBINED_COURSE_ITEM_TYPES.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: true,
+          isLocked: false,
+          duration: 5,
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
+        },
+        {
+          id: moduleId3,
+          reference: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire une adresse mail',
+          type: COMBINED_COURSE_ITEM_TYPES.MODULE,
+          redirection: 'encryptedUrl',
+          isCompleted: false,
+          isLocked: false,
+          duration: 10,
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+        },
+      ]);
+      expect(result).to.be.instanceOf(CombinedCourse);
+      expect(result.id).to.equal(questId);
+      expect(result.status).to.equal(CombinedCourseStatuses.STARTED);
+      expect(result.items[0]).instanceOf(CombinedCourseItem);
+      expect(result.items[1]).instanceOf(CombinedCourseItem);
+      expect(result.items[2]).instanceOf(CombinedCourseItem);
+    });
+  });
+  describe('when there is no organization learner yet', function () {
+    it('should return correct data for a not started combined course participation', async function () {
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const training1 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bac-a-sable' });
+      const training2 = databaseBuilder.factory.buildTraining({ type: 'modulix', link: '/modules/bases-clavier-1' });
+      databaseBuilder.factory.buildTraining({
+        type: 'modulix',
+        link: '/modules/bien-ecrire-son-adresse-mail',
+      });
+      const moduleId1 = '6282925d-4775-4bca-b513-4c3009ec5886';
+      const moduleId2 = '654c44dc-0560-4acc-9860-4a67c923577f';
+      const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training1.id,
+      });
+      databaseBuilder.factory.buildTargetProfileTraining({
+        targetProfileId: targetProfile.id,
+        trainingId: training2.id,
+      });
+
+      const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
+        code,
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaign.id,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId2,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId3,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await usecases.getCombinedCourseByCode({ code, userId });
+      expect(result).to.be.instanceOf(CombinedCourse);
       expect(result.id).to.equal(questId);
       expect(result.status).to.equal(CombinedCourseStatuses.NOT_STARTED);
       expect(result.items[0]).instanceOf(CombinedCourseItem);

--- a/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
@@ -40,7 +40,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
       campaignParticipationId,
     });
     databaseBuilder.factory.buildPassage({ userId, moduleId, terminatedAt: new Date() });
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+    const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
       successRequirements: [
@@ -114,7 +114,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     databaseBuilder.factory.buildPassage({ userId, moduleId, terminatedAt: new Date() });
     databaseBuilder.factory.buildPassage({ userId, module2Id, terminatedAt: null });
 
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+    const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
       successRequirements: [
@@ -189,7 +189,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
     const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
 
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+    const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
       successRequirements: [
@@ -227,7 +227,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
     const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
 
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+    const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
       successRequirements: [
@@ -260,7 +260,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId });
     const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id, organizationId });
 
-    const { id: questId } = databaseBuilder.factory.buildQuestForCombinedCourse({
+    const { id: questId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
       successRequirements: [

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -11,7 +11,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should insert combined course participation', async function () {
       //given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const questId = databaseBuilder.factory.buildCombinedCourse().id;
       await databaseBuilder.commit();
 
       //when
@@ -34,7 +34,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should left intact combined course participation for given organization learner and quest ids', async function () {
       // given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const questId = databaseBuilder.factory.buildCombinedCourse().id;
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
@@ -61,7 +61,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const questId = databaseBuilder.factory.buildCombinedCourse().id;
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
@@ -109,7 +109,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should update only status and updatedAt for given id', async function () {
       //given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const questId = databaseBuilder.factory.buildCombinedCourse().id;
       const combinedCourseParticipationFromDB = databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
@@ -146,7 +146,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should return participations for a given questId', async function () {
       // given
       const learner = databaseBuilder.factory.buildOrganizationLearner({ firstName: 'Paul', lastName: 'Azerty' });
-      const questId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const questId = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI1' }).id;
       const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner.id,
         questId,
@@ -161,7 +161,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         questId,
         status: CombinedCourseParticipationStatuses.STARTED,
       });
-      const anotherquestId = databaseBuilder.factory.buildQuestForCombinedCourse().id;
+      const anotherquestId = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' }).id;
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: anotherlearner.id,
         questId: anotherquestId,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -37,13 +37,12 @@ describe('Quest | Integration | Repository | combined-course', function () {
   describe('#getById', function () {
     it('should return a quest if quest id exists', async function () {
       // given
-      const id = 1;
       const { id: organizationId } = databaseBuilder.factory.buildOrganization();
-      const quest = databaseBuilder.factory.buildQuestForCombinedCourse({ id: 1, code: 'COMBINIX1', organizationId });
+      const quest = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBINIX1', organizationId });
       await databaseBuilder.commit();
 
       // when
-      const combinedCourseResult = await combinedCourseRepository.getById({ id });
+      const combinedCourseResult = await combinedCourseRepository.getById({ id: quest.id });
 
       // then
       expect(combinedCourseResult).to.be.an.instanceof(CombinedCourse);
@@ -140,7 +139,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
       const name = 'Mon parcours Combiné';
       const description = 'Le but de ma quête';
       const illustration = 'images/illustration.svg';
-      quest = databaseBuilder.factory.buildQuestForCombinedCourse({
+      quest = databaseBuilder.factory.buildCombinedCourse({
         code,
         name,
         organizationId,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -192,7 +192,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
   });
 
   describe('#saveInBatch', function () {
-    it('should save given combined course', async function () {
+    it('should save given combined course on quests', async function () {
       // given
       const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
       const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -237,18 +237,82 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await combinedCourseRepository.saveInBatch({ combinedCourses: [firstCombinedCourse, secondCombinedCourse] });
 
       // then
-      const firstSavedCombinedCourse = await knex('quests').where('organizationId', firstOrganizationId).first();
-      const secondSavedCombinedCourse = await knex('quests').where('organizationId', secondOrganizationId).first();
+      const firstSavedQuest = await knex('quests').where('organizationId', firstOrganizationId).first();
+      const secondSavedQuest = await knex('quests').where('organizationId', secondOrganizationId).first();
+
+      expect(firstSavedQuest.name).to.equal('firstCombinedCourse');
+      expect(firstSavedQuest.successRequirements).to.deep.equal(successRequirements);
+      expect(firstSavedQuest.code).equal('firstCode');
+      expect(firstSavedQuest.description).equal('ma description');
+      expect(firstSavedQuest.illustration).equal('mon_illu.svg');
+
+      expect(secondSavedQuest.name).to.equal('secondCombinedCourse');
+      expect(secondSavedQuest.successRequirements).to.deep.equal(successRequirements);
+      expect(secondSavedQuest.code).equal('secondCode');
+      expect(secondSavedQuest.description).null;
+      expect(secondSavedQuest.illustration).null;
+    });
+
+    it('should save given combined course on combined_courses', async function () {
+      // given
+      const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const successRequirements = [
+        {
+          requirement_type: 'campaignParticipations',
+          comparison: 'all',
+          data: {
+            targetProfileId: {
+              data: 1,
+              comparison: 'equal',
+            },
+          },
+        },
+      ];
+      await databaseBuilder.commit();
+
+      const quest = new Quest({
+        successRequirements,
+        eligibilityRequirements: [],
+      });
+      const firstCombinedCourse = new CombinedCourse(
+        {
+          name: 'firstCombinedCourse',
+          code: 'firstCode',
+          organizationId: firstOrganizationId,
+          illustration: 'mon_illu.svg',
+          description: 'ma description',
+        },
+        quest,
+      );
+      const secondCombinedCourse = new CombinedCourse(
+        {
+          name: 'secondCombinedCourse',
+          code: 'secondCode',
+          organizationId: secondOrganizationId,
+        },
+        quest,
+      );
+
+      // when
+      await combinedCourseRepository.saveInBatch({ combinedCourses: [firstCombinedCourse, secondCombinedCourse] });
+
+      // then
+      const firstSavedQuest = await knex('quests').where('organizationId', firstOrganizationId).first();
+      const secondSavedQuest = await knex('quests').where('organizationId', secondOrganizationId).first();
+
+      const firstSavedCombinedCourse = await knex('combined_courses').where('questId', firstSavedQuest.id).first();
+      const secondSavedCombinedCourse = await knex('combined_courses').where('questId', secondSavedQuest.id).first();
 
       expect(firstSavedCombinedCourse.name).to.equal('firstCombinedCourse');
-      expect(firstSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
       expect(firstSavedCombinedCourse.description).equal('ma description');
       expect(firstSavedCombinedCourse.illustration).equal('mon_illu.svg');
+      expect(firstSavedCombinedCourse.code).equal('firstCode');
 
       expect(secondSavedCombinedCourse.name).to.equal('secondCombinedCourse');
-      expect(secondSavedCombinedCourse.successRequirements).to.deep.equal(successRequirements);
       expect(secondSavedCombinedCourse.description).null;
       expect(secondSavedCombinedCourse.illustration).null;
+      expect(secondSavedCombinedCourse.code).equal('secondCode');
     });
   });
 });

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -44,7 +44,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
 
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-      databaseBuilder.factory.buildQuestForCombinedCourse({
+      databaseBuilder.factory.buildCombinedCourse({
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,
@@ -620,7 +620,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
       const code = 'COMBINIX1';
       userId = databaseBuilder.factory.buildUser().id;
       organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildQuestForCombinedCourse({ code, organizationId });
+      databaseBuilder.factory.buildCombinedCourse({ code, organizationId });
 
       server.route({
         method: 'GET',

--- a/api/tests/shared/integration/infrastructure/repositories/access-code-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/access-code-repository_test.js
@@ -17,7 +17,7 @@ describe('#isCodeAvailable', function () {
   });
 
   it('should return false if code is already used in a combined course', async function () {
-    databaseBuilder.factory.buildQuestForCombinedCourse({ code: 'USEDCODE1' });
+    databaseBuilder.factory.buildCombinedCourse({ code: 'USEDCODE1' });
     await databaseBuilder.commit();
 
     const isCodeAvailable = await accessCodeRepository.isCodeAvailable('USEDCODE1');


### PR DESCRIPTION
## 🔆 Problème

La table combined_course est crée, mais elle n'est pas peuplé. 

## ⛱️ Proposition

Faire une migration qui enregistre les données dans la table. et à chaque création de nouveau combined_course. enregistrer les données dans la table dédié

## 🌊 Remarques

Pour le moment nous dupliquons la donnes dans quests et combined_courses, le temps de faire la migration des usages des différentes routes. 

## 🏄 Pour tester

Vérifier qu'à la création d'un parcours combiné nous avons maintenant tout de dupliqué dans combined_courses