### PR TITLE
[FEATURE] Enregistrer l'équipe en charge lors de la modification d'organisations en masse (PIX-19602)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -1,6 +1,7 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
 import {
+  AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
   ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,
@@ -47,6 +48,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   },
   {
     name: ArchiveOrganizationsInBatchError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: AdministrationTeamNotFound.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
+++ b/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
@@ -11,6 +11,7 @@ export class OrganizationBatchUpdateDTO {
    * @param {string|undefined} data.dataProtectionOfficerLastName
    * @param {string|undefined} data.dataProtectionOfficerFirstName
    * @param {string|undefined} data.dataProtectionOfficerEmail
+   * @param {string|undefined} data.administrationTeamId
    */
   constructor(data) {
     this.id = data.id;
@@ -23,5 +24,6 @@ export class OrganizationBatchUpdateDTO {
     this.dataProtectionOfficerLastName = data.dataProtectionOfficerLastName ?? '';
     this.dataProtectionOfficerFirstName = data.dataProtectionOfficerFirstName ?? '';
     this.dataProtectionOfficerEmail = data.dataProtectionOfficerEmail ?? '';
+    this.administrationTeamId = data.administrationTeamId ?? '';
   }
 }

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -12,6 +12,14 @@ class UnableToAttachChildOrganizationToParentOrganizationError extends DomainErr
   }
 }
 
+class AdministrationTeamNotFound extends DomainError {
+  constructor({ code = 'ADMINISTRATION_TEAM_NOT_FOUND', message = 'Administration team does not exist', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class ArchiveCertificationCentersInBatchError extends DomainError {
   constructor({ code = 'ARCHIVE_CERTIFICATION_CENTERS_IN_BATCH_ERROR', meta } = {}) {
     super();
@@ -75,6 +83,7 @@ class FeatureParamsNotProcessable extends DomainError {
 }
 
 export {
+  AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
   ArchiveOrganizationsInBatchError,
   DpoEmailInvalid,

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -184,6 +184,8 @@ class OrganizationForAdmin {
     if (organizationBatchUpdateDto.dataProtectionOfficerEmail)
       dataProtectionOfficer.email = organizationBatchUpdateDto.dataProtectionOfficerEmail;
     this.dataProtectionOfficer.updateInformation(dataProtectionOfficer);
+    if (organizationBatchUpdateDto.administrationTeamId)
+      this.administrationTeamId = organizationBatchUpdateDto.administrationTeamId;
   }
 
   updateParentOrganizationId(parentOrganizationId) {

--- a/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/administration-team-repository.js
@@ -7,10 +7,20 @@ const findAll = async function () {
   return administrationTeams.map(_toDomain);
 };
 
+const getById = async function (id) {
+  const administrationTeam = await knex.select('id', 'name').from('administration_teams').where({ id }).first();
+
+  if (!administrationTeam) {
+    return null;
+  }
+
+  return _toDomain(administrationTeam);
+};
+
 const _toDomain = function (administrationTeamDTO) {
   return new AdministrationTeam({
     ...administrationTeamDTO,
   });
 };
 
-export { findAll };
+export { findAll, getById };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1181,6 +1181,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       let firstOrganization, otherOrganization;
 
       beforeEach(async function () {
+        databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
         firstOrganization = databaseBuilder.factory.buildOrganization({ name: 'first organization', type: 'PRO' });
         otherOrganization = databaseBuilder.factory.buildOrganization({ name: 'other organization', type: 'PRO' });
 
@@ -1189,9 +1190,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       it('responds with a 204 - no content', async function () {
         // given
-        const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail
-      ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;
-      ${otherOrganization.id};APPL;;;;;;;Cali;`;
+        const input = `Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID
+      ${firstOrganization.id};MSFT;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234
+      ${otherOrganization.id};APPL;;;;;;;Cali;;1234`;
 
         const options = {
           method: 'POST',

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/administration-team-repository_test.js
@@ -33,4 +33,31 @@ describe('Integration | Repository | administration-team-repository', function (
       expect(result).to.deep.equal([]);
     });
   });
+
+  describe('#getById', function () {
+    it('should return the administration team when it exists', async function () {
+      // given
+      const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await administrationTeamRepository.getById(administrationTeam.id);
+
+      // then
+      expect(result).to.deep.equal(
+        domainBuilder.buildAdministrationTeam({
+          id: administrationTeam.id,
+          name: administrationTeam.name,
+        }),
+      );
+    });
+
+    it('should return null when the administration team does not exist', async function () {
+      // when
+      const result = await administrationTeamRepository.getById(456);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
 });

--- a/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
+++ b/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
@@ -9,6 +9,7 @@ describe('Unit | Organizational Entities | Domain | DTO | OrganizationBatchUpdat
         id: '1',
         name: 'Mon Orga',
         dataProtectionOfficerEmail: 'adam.troisjour@example.net',
+        administrationTeamId: '1234',
       };
 
       // when
@@ -27,6 +28,7 @@ describe('Unit | Organizational Entities | Domain | DTO | OrganizationBatchUpdat
         dataProtectionOfficerLastName: '',
         dataProtectionOfficerFirstName: '',
         dataProtectionOfficerEmail: 'adam.troisjour@example.net',
+        administrationTeamId: '1234',
       });
     });
   });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -888,5 +888,21 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organizationToUpdate.dataProtectionOfficer.email).to.equal(dataProtectionOfficerEmail);
       expect(organizationToUpdate).to.deep.equal(expectedOrganization);
     });
+
+    it('updates the organization administration team id', function () {
+      // given
+      const administrationTeamId = 42;
+      const organizationToUpdate = domainBuilder.buildOrganizationForAdmin();
+
+      // when
+      organizationToUpdate.updateFromOrganizationBatchUpdateDto(
+        new OrganizationBatchUpdateDTO({ id: '1', administrationTeamId }),
+      );
+
+      // then
+      const expectedOrganization = domainBuilder.buildOrganizationForAdmin({ administrationTeamId });
+      expect(organizationToUpdate.administrationTeamId).to.equal(administrationTeamId);
+      expect(organizationToUpdate).to.deep.equal(expectedOrganization);
+    });
   });
 });


### PR DESCRIPTION
## ☔ Problème

On doit pouvoir renseigner une équipe en charge lors de la modification en masse via csv.

## 🧥 Proposition

- Créer  la colonne dans le fichier csv : Administration Team ID
- En tenir compte lors de la modification en masse


## 🎃 Pour tester

```
Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID
1;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234
```

- Depuis pix-admin
- Se connecter avec le compte [superadmin@example.net](mailto:superadmin@example.net)
- Dans l'onglet Administration > Déploiement
- Importer un csv de modification en masse selon l'exemple ci dessus complété avec les infos d'une orga à modifier et un administrationTeamId valide
- Constater que l'organisation a bien été modifiée et que l'équipe en charge a bien été prise en compte