### PR TITLE
[FEATURE] Empêcher le layout shift sur les images des flashcards (PIX-19842).

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/flashcards-card.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards-card.gjs
@@ -18,7 +18,12 @@ export default class ModulixFlashcardsCard extends Component {
       >
         {{#if this.currentSide.image}}
           <div class="element-flashcards-card__image">
-            <img src={{this.currentSide.image.url}} alt="" />
+            <img
+              src={{this.currentSide.image.url}}
+              width={{this.currentSide.image.information.width}}
+              height={{this.currentSide.image.information.height}}
+              alt=""
+            />
           </div>
         {{/if}}
 

--- a/mon-pix/app/components/module/element/flashcards/flashcards-intro-card.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards-intro-card.gjs
@@ -5,7 +5,12 @@ import { t } from 'ember-intl';
   <div class="element-flashcards-intro-card">
     {{#if @introImage}}
       <div class="element-flashcards-intro-card__image">
-        <img src={{@introImage.url}} alt="" />
+        <img
+          src={{@introImage.url}}
+          width={{@introImage.information.width}}
+          height={{@introImage.information.height}}
+          alt=""
+        />
       </div>
     {{/if}}
 

--- a/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
@@ -40,26 +40,56 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     });
 
-    test('should not display recto image if no one is provided', async function (assert) {
-      // given
-      const card = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
+    module('when the recto image is not provided', function () {
+      test('should not display image', async function (assert) {
+        // given
+        const card = {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        };
 
-      // when
-      const screen = await render(
-        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
-      );
+        // when
+        const screen = await render(
+          <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+        );
 
-      // then
-      assert.dom(screen.queryByRole('img')).doesNotExist();
+        // then
+        assert.dom(screen.queryByRole('img')).doesNotExist();
+      });
+    });
+
+    module('when width and height are available', function () {
+      test('should set them to the image', async function (assert) {
+        // given
+        const card = {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            image: {
+              url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+              information: { height: 400, width: 300 },
+            },
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            text: "Parce que c'est joli",
+          },
+        };
+
+        // when
+        const screen = await render(
+          <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('presentation')).hasAttribute('width', '300');
+        assert.dom(screen.getByRole('presentation')).hasAttribute('height', '400');
+      });
     });
   });
 
@@ -94,26 +124,56 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAgain') })).exists();
     });
 
-    test('should not display verso image if no one is provided', async function (assert) {
-      // given
-      const card = {
-        id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
-        recto: {
-          text: "A quoi sert l'arobase dans mon adresse email ?",
-        },
-        verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
-          text: "Parce que c'est joli",
-        },
-      };
+    module('when the verso image is not provided', function () {
+      test('should not display image', async function (assert) {
+        // given
+        const card = {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            text: "Parce que c'est joli",
+          },
+        };
 
-      // when
-      const screen = await render(
-        <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
-      );
+        // when
+        const screen = await render(
+          <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
+        );
 
-      // then
-      assert.dom(screen.queryByRole('img')).doesNotExist();
+        // then
+        assert.dom(screen.queryByRole('img')).doesNotExist();
+      });
+    });
+
+    module('when width and height are available', function () {
+      test('should set them to the image', async function (assert) {
+        // given
+        const card = {
+          id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
+          recto: {
+            text: "A quoi sert l'arobase dans mon adresse email ?",
+          },
+          verso: {
+            image: {
+              url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+              information: { height: 400, width: 300 },
+            },
+            text: "Parce que c'est joli",
+          },
+        };
+
+        // when
+        const screen = await render(
+          <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('presentation')).hasAttribute('width', '300');
+        assert.dom(screen.getByRole('presentation')).hasAttribute('height', '400');
+      });
     });
   });
 

--- a/mon-pix/tests/integration/components/module/flashcards-intro-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-intro-card_test.gjs
@@ -30,18 +30,20 @@ module('Integration | Component | Module | Flashcards Intro Card', function (hoo
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') })).exists();
   });
 
-  test('should not display image if not provided', async function (assert) {
-    // given
-    const introImage = undefined;
-    const title = 'Introduction à la poésie';
+  module('when the intro image is not provided', function () {
+    test('should not display image', async function (assert) {
+      // given
+      const introImage = undefined;
+      const title = 'Introduction à la poésie';
 
-    // when
-    const screen = await render(
-      <template><ModulixFlashcardsIntroCard @introImage={{introImage}} @title={{title}} /></template>,
-    );
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsIntroCard @introImage={{introImage}} @title={{title}} /></template>,
+      );
 
-    // then
-    assert.dom(screen.queryByRole('img')).doesNotExist();
+      // then
+      assert.dom(screen.queryByRole('img')).doesNotExist();
+    });
   });
 
   module('when we click on "Commencer"', function () {
@@ -62,6 +64,26 @@ module('Integration | Component | Module | Flashcards Intro Card', function (hoo
 
       // then
       assert.true(onStartStub.calledOnce);
+    });
+  });
+
+  module('when width and height are available for intro image', function () {
+    test('should set them to the image', async function (assert) {
+      // given
+      const introImage = {
+        url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        information: { height: 400, width: 300 },
+      };
+      const title = 'Introduction à la poésie';
+
+      // when
+      const screen = await render(
+        <template><ModulixFlashcardsIntroCard @introImage={{introImage}} @title={{title}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('presentation')).hasAttribute('width', '300');
+      assert.dom(screen.getByRole('presentation')).hasAttribute('height', '400');
     });
   });
 });


### PR DESCRIPTION
## ☔ Problème

Lors du processus d'affichage d'une image dans un navigateur, il essaye d'abord de déterminer l'espace nécessaire afin de réserver cet espace dans la page. En cas de mauvaise connexion, par exemple sur mobile dans le train, cet espace ne sera pas occupé tant que le navigateur n'a pas les informations des dimensions. Lors du chargement de l'image, l'espace devient réservé et le reste du contenu est décalé plus bas et donc une mauvaise UX. C'est ce qu'on appelle du [Layout shift](https://web.dev/articles/cls).

## 🧥 Proposition

Utiliser la `width` et `height` retourné par l'API pour les utiliser coté client.

## 🎃 Pour tester

- https://app-pr13785.review.pix.fr/modules/bac-a-sable
- Aller jusqu'à la flashcard
<img width="341" height="493" alt="Capture d’écran 2025-10-03 à 15 20 45" src="https://github.com/user-attachments/assets/16be6242-d2f3-410a-99a6-668ea32c59da" />

- La flashcard se compose : 
  -  d'une carte intro (la première)
  - de cartes recto/verso (celles à l'intérieur)

- Constater que les données de l'API sur les `width` et `height` matchent avec ceux des balises img des flashcards.
- Si vous faites F5 avec une mauvaise connexion, vous aurez les carrés blancs au format de l'image attendu.


https://github.com/user-attachments/assets/1a1e1dcd-0173-4c6f-9e1b-122db98e34ff


