### PR TITLE
[FEATURE] Ajouter les feedbacks pour les QCU discovery en mode preview (PIX-19859)

### DIFF
--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -11,6 +11,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
   @tracked selectedProposalId = null;
   @tracked shouldDisplayFeedback = false;
   @service passageEvents;
+  @service modulixPreviewMode;
 
   get selectedProposalFeedback() {
     return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
@@ -66,6 +67,11 @@ export default class ModuleQcuDiscovery extends ModuleElement {
               @isSelected={{this.isProposalSelected proposal.id}}
               @isDiscoveryVariant={{true}}
             />
+            {{#if this.modulixPreviewMode.isEnabled}}
+              <div class="element-qcu-discovery__feedback" role="status" tabindex="-1">
+                {{htmlUnsafe proposal.feedback.diagnosis}}
+              </div>
+            {{/if}}
           {{/each}}
         </div>
       </fieldset>

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModuleQcuDiscovery from 'mon-pix/components/module/element/qcu-discovery';
@@ -81,6 +82,42 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
         element: qcuDiscoveryElement,
       });
       assert.ok(true);
+    });
+  });
+
+  module('when preview mode is enabled', function () {
+    test('should display all feedbacks, without answering', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qcuDiscoveryElement = _getQcuDiscoveryElement();
+
+      // when
+      const screen = await render(<template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} /></template>);
+
+      // then
+      assert
+        .dom(screen.getByText('Il n’y a rien de plus réconfortant que des cookies tout juste sortis du four !'))
+        .exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Les éclairs, c’est un peu l’élégance à l’état pur. Légers, crémeux, et surtout irrésistibles.',
+          ),
+        )
+        .exists();
+      assert
+        .dom(screen.getByText('Parfait pour ceux qui préfèrent un goûter plus léger, mais tout aussi délicieux.'))
+        .exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Un gâteau moelleux et gourmand qui se marie parfaitement avec une tasse de thé ou de café.',
+          ),
+        )
+        .exists();
     });
   });
 });


### PR DESCRIPTION
## ☔ Problème
Actuellement, il n'y a pas possibilité de visualiser les feedbacks en mode preview pour les QCUD.

## 🧥 Proposition
Afficher les feedback de la même manière que cela a été fait pour les QCU en mode preview

## 🍂 Remarques


## 🎃 Pour tester
- Ouvrir [en preview le bac-a-sable](https://app-pr13786.review.pix.fr/modules/preview/bac-a-sable)
- Afficher un QCUD et constater l'affichage des feedbacks pour chaque proposition

