### PR TITLE
[BUGFIX] Ne pas afficher le message informatif du repasser quand on ne peut pas repasser (PIX-19852)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block.gjs
@@ -71,20 +71,17 @@ export default class EvaluationResultsHeroRetryOrResetBlock extends Component {
   }
 
   get retryOrResetExplanation() {
-    const { campaignParticipationResult } = this.args;
+    const { canRetry, canReset } = this.args.campaignParticipationResult;
     const isAutoShareEnabled = this.featureToggles?.featureToggles?.isAutoShareEnabled || false;
+    const suffix = isAutoShareEnabled ? 'notification-with-auto-share' : 'notification';
 
-    if (campaignParticipationResult.canReset && campaignParticipationResult.canRetry) {
-      if (isAutoShareEnabled) {
-        return this.intl.t('pages.skill-review.reset.notification-with-auto-share');
-      }
-      return this.intl.t('pages.skill-review.reset.notification');
-    }
-
-    if (isAutoShareEnabled) {
-      return this.intl.t('pages.skill-review.retry.notification-with-auto-share');
-    }
-    return this.intl.t('pages.skill-review.retry.notification');
+    if (canReset && canRetry) {
+      return this.intl.t(`pages.skill-review.retry-and-reset.${suffix}`);
+    } else if (!canReset && canRetry) {
+      return this.intl.t(`pages.skill-review.retry.${suffix}`);
+    } else if (canReset && !canRetry) {
+      return this.intl.t(`pages.skill-review.reset.${suffix}`);
+    } else return '';
   }
 
   <template>

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block-test.js
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/retry-or-reset-block-test.js
@@ -125,6 +125,23 @@ module(
       test('should display reset message with auto share', async function (assert) {
         //given
         this.set('campaign', { code: 'CODECAMPAIGN' });
+        this.set('campaignParticipationResult', { canRetry: false, canReset: true });
+
+        //when
+        const screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+        );
+
+        //then
+        assert.ok(screen.getByText(t('pages.skill-review.reset.notification-with-auto-share')));
+      });
+
+      test('should display reset and retry message with auto share', async function (assert) {
+        //given
+        this.set('campaign', { code: 'CODECAMPAIGN' });
         this.set('campaignParticipationResult', { canRetry: true, canReset: true });
 
         //when
@@ -136,16 +153,17 @@ module(
         );
 
         //then
-        assert.dom(screen.getByText(t('pages.skill-review.reset.notification-with-auto-share'))).exists();
+        assert.dom(screen.getByText(t('pages.skill-review.retry-and-reset.notification-with-auto-share'))).exists();
       });
     });
 
-    module('when user can retry the assessment', function () {
-      test('displays a retry link', async function (assert) {
-        // given
+    module('when user can only retry the assessment', function (hooks) {
+      hooks.beforeEach(function () {
         this.set('campaign', { code: 'CODECAMPAIGN' });
         this.set('campaignParticipationResult', { canRetry: true, canReset: false });
+      });
 
+      test('displays a retry link and not reset button', async function (assert) {
         // when
         const screen = await render(
           hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
@@ -158,62 +176,20 @@ module(
         const retryLink = screen.getByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') });
         assert.dom(retryLink).exists();
         assert.dom(retryLink).hasAttribute('href', '/campagnes/CODECAMPAIGN?retry=true');
-
         assert
           .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') }))
           .doesNotExist();
         assert.dom(screen.getByText(t('pages.skill-review.retry.notification'))).exists();
       });
-
-      module('with auto share enabled', function (hooks) {
-        hooks.beforeEach(function () {
-          const featureToggles = this.owner.lookup('service:featureToggles');
-          sinon.stub(featureToggles, 'featureToggles').value({ isAutoShareEnabled: true });
-        });
-
-        test('should display retry message with auto share', async function (assert) {
-          //given
-          this.set('campaign', { code: 'CODECAMPAIGN' });
-          this.set('campaignParticipationResult', { canRetry: true, canReset: false });
-
-          //when
-          const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-/>`,
-          );
-
-          //then
-          assert.dom(screen.getByText(t('pages.skill-review.retry.notification-with-auto-share'))).exists();
-        });
-
-        test('should display reset message with auto share', async function (assert) {
-          //given
-          this.set('campaign', { code: 'CODECAMPAIGN' });
-          this.set('campaignParticipationResult', { canRetry: true, canReset: true });
-
-          //when
-          const screen = await render(
-            hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
-  @campaign={{this.campaign}}
-  @campaignParticipationResult={{this.campaignParticipationResult}}
-/>`,
-          );
-
-          //then
-          assert.dom(screen.getByText(t('pages.skill-review.reset.notification-with-auto-share'))).exists();
-        });
-      });
     });
 
-    module('when user can reset the assessment', function (hooks) {
+    module('when user can only reset the assessment', function (hooks) {
       let screen;
 
       hooks.beforeEach(async function () {
         // given
         this.set('campaign', { code: 'CODECAMPAIGN', targetProfileName: 'targetProfileName' });
-        this.set('campaignParticipationResult', { canRetry: true, canReset: true });
+        this.set('campaignParticipationResult', { canRetry: false, canReset: true });
 
         // when
         screen = await render(
@@ -226,7 +202,9 @@ module(
 
       test('it should display a reset button', async function (assert) {
         // then
-        assert.dom(screen.getByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).exists();
+        assert
+          .dom(screen.queryByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') }))
+          .doesNotExist();
         assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') })).exists();
         assert.dom(screen.getByText(t('pages.skill-review.reset.notification'))).exists();
       });
@@ -245,6 +223,31 @@ module(
         assert.dom(linkButton).exists();
         assert.dom(linkButton).hasAttribute('href', '/campagnes/CODECAMPAIGN?reset=true');
         assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      });
+    });
+
+    module('when user can retry and reset the assessment', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        // given
+        this.set('campaign', { code: 'CODECAMPAIGN', targetProfileName: 'targetProfileName' });
+        this.set('campaignParticipationResult', { canRetry: true, canReset: true });
+
+        // when
+        screen = await render(
+          hbs`<Campaigns::Assessment::Results::EvaluationResultsHero::RetryOrResetBlock
+  @campaign={{this.campaign}}
+  @campaignParticipationResult={{this.campaignParticipationResult}}
+/>`,
+        );
+      });
+
+      test('it should display a retry and reset button', async function (assert) {
+        // then
+        assert.dom(screen.getByRole('link', { name: t('pages.skill-review.hero.retry.actions.retry') })).exists();
+        assert.dom(screen.getByRole('button', { name: t('pages.skill-review.hero.retry.actions.reset') })).exists();
+        assert.dom(screen.getByText(t('pages.skill-review.retry-and-reset.notification'))).exists();
       });
     });
   },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2068,14 +2068,18 @@
           "text": "You are about to reset and restart your customised test <strong>{targetProfileName}</strong>, in order to try to improve your results. At the end of this customised test, you can submit your results.",
           "warning-text": "Your pix score, levels and eligibility for certification obtained during this customised test will be deleted."
         },
-        "notification": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.",
-        "notification-with-auto-share": "Retry the failed questions to improve your result or reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
+        "notification": "If you choose to reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.",
+        "notification-with-auto-share": "Reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
       },
       "retry": {
         "button": "Retake my customised test",
         "message": "{organizationName} encourages you to retake your test to measure your progress.",
         "notification": "Retake the failed questions to improve your result and continue to progress. You will need to send in your results again so that they can be counted by the organiser. The organiser will continue to have access to your previously submitted results.",
         "notification-with-auto-share": "Retake the failed questions to improve your result and continue to progress. The organiser will continue to have access to your previously submitted results."
+      },
+      "retry-and-reset":{
+        "notification": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.",
+        "notification-with-auto-share": "Retry the failed questions to improve your result or reset and restart from the beginning. The organiser will continue to have access to your previously submitted results."
       },
       "send-results": "Don't forget to submit your results.",
       "send-status": {

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -2051,14 +2051,18 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Si pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
+        "notification-with-auto-share": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "retry": {
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
         "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
         "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+      },
+      "retry-and-reset":{
+        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
+        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2055,14 +2055,18 @@
           "text": "Estás a punto de poner a cero el test <strong>{targetProfileName}</strong>, para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
           "warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este test se van a eliminar."
         },
-        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
-        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
+        "notification": "Si pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
+        "notification-with-auto-share": "Vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "retry": {
         "button": "Repetir el test",
         "message": "{organizationName} te invita a repetir este test para mejorar tus resultados y seguir progresando.",
         "notification": "Vuelva a realizar las preguntas fallidas para mejorar su resultado y seguir progresando. Deberá enviar de nuevo sus resultados para que el organizador pueda contabilizarlos. El organizador seguirá teniendo acceso a tus resultados enviados anteriormente.",
         "notification-with-auto-share": "Repite las preguntas fallidas para mejorar tu resultado y seguir progresando. El organizador seguirá teniendo acceso a tus resultados anteriores."
+      },
+      "retry-and-reset":{
+        "notification": "Si vuelves a intentar las preguntas fallidas o pones a cero para volver a intentarlo todo, tu organización ya no podrá ver tu último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo.",
+        "notification-with-auto-share": "Repita las preguntas fallidas o vuelva a cero para intentarlo de nuevo. El organizador seguirá teniendo acceso a sus resultados anteriores."
       },
       "send-results": "No olvides enviar tus resultados al organizador del test.",
       "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2076,14 +2076,18 @@
           "text": "Vous êtes sur le point de remettre à zéro votre parcours <strong>{targetProfileName}</strong>, afin de tenter d’améliorer votre niveau. A la fin du parcours, vous pourrez à nouveau envoyer vos résultats.",
           "warning-text": "Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés."
         },
-        "notification": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
-        "notification-with-auto-share": "Repassez les questions échouées ou remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
+        "notification": "Si vous remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
+        "notification-with-auto-share": "Remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "retry": {
         "button": "Repasser mon parcours",
         "message": "{organizationName} vous invite à repasser ce parcours afin d'améliorer votre résultat et de continuer à progresser.",
         "notification": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. Vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilités par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
         "notification-with-auto-share": "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
+      },
+      "retry-and-reset":{
+        "notification": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.",
+        "notification-with-auto-share": "Repassez les questions échouées ou remettez à zéro pour tout retenter. L'organisateur continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-status": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2059,14 +2059,18 @@
           "text": "Je staat op het punt om je <strong>{targetProfileName}</strong> cursus te resetten in een poging om je niveau te verbeteren. Aan het einde van de cursus kun je je resultaten weer insturen.",
           "warning-text": "Je Pix, niveaus en certificeerbaarheid verkregen tijdens deze cursus zullen worden verwijderd."
         },
-        "notification": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen.",
-        "notification-with-auto-share": "Herhaal mislukte vragen of stel in op nul om het opnieuw te proberen. De organisator blijft toegang houden tot je eerder ingediende resultaten."
+        "notification": "Als u alles op nul zet om opnieuw te beginnen, kan uw organisatie uw laatste resultaat niet meer zien. Om uw resultaat door de organisator van de test te laten meetellen, moet u het opnieuw indienen.",
+        "notification-with-auto-share": "Zet alles op nul om opnieuw te beginnen. De organisator blijft toegang hebben tot uw eerder ingediende resultaten."
       },
       "retry": {
         "button": "Mijn reis naspelen",
         "message": "{organizationName} nodigt je uit om deze test opnieuw te doen om je resultaat te verbeteren en vooruitgang te blijven boeken.",
         "notification": "Herhaal de vragen waarvoor je gezakt bent om je resultaat te verbeteren en verder te komen. Je moet je resultaten opnieuw insturen zodat ze kunnen worden geteld door de organisator. De organisator blijft toegang houden tot je eerder ingestuurde resultaten.",
         "notification-with-auto-share": "Herhaal mislukte vragen om je resultaat te verbeteren en verder te gaan. De organisator blijft toegang houden tot je eerder ingediende resultaten."
+      },
+      "retry-and-reset":{
+        "notification": "Als je de mislukte vragen opnieuw probeert of alles op nul zet om alles opnieuw te proberen, kan je organisatie je laatste resultaat niet meer zien. Om je resultaat mee te laten tellen door de organisator van de test, moet je het opnieuw insturen.",
+        "notification-with-auto-share": "Herhaal mislukte vragen of stel in op nul om het opnieuw te proberen. De organisator blijft toegang houden tot je eerder ingediende resultaten."
       },
       "send-results": "Vergeet niet je resultaten naar de cursusorganisator te sturen.",
       "send-status": {


### PR DESCRIPTION
## ☔ Problème

En jouant une campagne à envoi multiple avec remise à zéro possible je me rends compte que même avec un score de 100% s'affiche le message "Repassez les questions échouées afin d'améliorer votre résultat et de continuer à progresser.", qui est du coup un peu confusant.

<img width="1488" height="847" alt="bug-image" src="https://github.com/user-attachments/assets/57f88122-d91e-40f3-8923-e85fc90051c8" />


## 🧥 Proposition

Corriger le bug

## 🍂 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎃 Pour tester

- créer un PC qui autorise le reset avec peu de questions
- le rattacher à une orga
- depuis l'orga, créer une campagne d'eval à envoi multiple en se basant sur le PC tout juste créé
- depuis PixApp participer à la campagne et avoir tout bon
- vérifier la bannière affichée

(pour être ceinture bretelle, faite de même en ayant pas tout bon pour voir la bannière et pareil avec un PC qui n'autorise pas le reset en ne réussissant pas tout puis en réussissant tout)
