### PR TITLE
[FEATURE] Ajouter un feature toggle pour le nouveau design des pages d'authentification de Pix Orga (PIX-19794)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -74,4 +74,11 @@ export default {
     devDefaultValues: { test: true, reviewApp: true },
     tags: ['frontend', 'team-prescription'],
   },
+  usePixOrgaNewAuthDesign: {
+    type: 'boolean',
+    description: 'Displays the new design of authentication pages',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['frontend', 'team-acces', 'pix-orga'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
             'use-locale': false,
+            'use-pix-orga-new-auth-design': false,
           },
         },
       };

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') usePixOrgaNewAuthDesign;
+}


### PR DESCRIPTION
## ☔ Problème

On souhaite mettre en place un nouveau design pour les pages d'authentification de Pix Orga. On ne souhaite pas impacter les pages existantes avant la fin de réalisation de l'epic. 

## 🧥 Proposition

Ajouter un feature toggle pour activer cette fonctionnalité lorsqu'elle sera prête

## 🍂 Remarques

RAS

## 🎃 Pour tester

- En local ou RA, lancer la commande `npm run toggles -- --key=usePixOrgaNewAuthDesign --value=true` sur l'API
-    Aller sur la RA de Pix Orga ou sur https://orga.dev.pix.fr
-    Ouvrir l'onglet network
-    Constater que la réponse de l'appel `/feature-toggles` contient bien le nouveau champ à true