### PR TITLE
[FEATURE] Remonter les métadonnées des images présentes dans les QAB (PIX-19683).

### DIFF
--- a/api/src/devcomp/domain/models/element/qab/QAB.js
+++ b/api/src/devcomp/domain/models/element/qab/QAB.js
@@ -1,12 +1,10 @@
-import { QABCard } from './QABCard.js';
-
 class QAB {
   constructor({ id, type, instruction, cards, feedback }) {
     this.id = id;
     this.type = type;
     this.instruction = instruction;
     this.isAnswerable = true;
-    this.cards = cards.map((card) => new QABCard(card));
+    this.cards = cards;
     this.feedback = feedback;
   }
 }

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -17,6 +17,7 @@ import { Card } from '../../domain/models/element/flashcards/Card.js';
 import { Flashcards } from '../../domain/models/element/flashcards/Flashcards.js';
 import { Image } from '../../domain/models/element/Image.js';
 import { QAB } from '../../domain/models/element/qab/QAB.js';
+import { QABCard } from '../../domain/models/element/qab/QABCard.js';
 import { QCM } from '../../domain/models/element/QCM.js';
 import { QCU } from '../../domain/models/element/QCU.js';
 import { QCUDeclarative } from '../../domain/models/element/QCU-declarative.js';
@@ -236,12 +237,23 @@ export class ModuleFactory {
     });
   }
 
-  static #buildQAB(element) {
+  static async #buildQAB(element) {
     return new QAB({
       id: element.id,
       type: element.type,
       instruction: element.instruction,
-      cards: element.cards,
+      cards: await Promise.all(
+        element.cards.map(async (card) => {
+          return new QABCard({
+            ...card,
+            image: {
+              altText: card.image?.altText,
+              url: card.image?.url,
+              information: card.image?.url ? await getAssetInfos(card.image.url) : {},
+            },
+          });
+        }),
+      ),
       feedback: element.feedback,
     });
   }

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -1222,6 +1222,9 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
 
       it('should instantiate a Module with a ComponentElement which contains a QAB Element', async function () {
         // given
+        nock('https://assets.pix.org')
+          .head('/modulix/didacticiel/ordi-spatial.svg')
+          .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
           slug: 'title',
@@ -1256,6 +1259,10 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                           {
                             id: '4420c9f6-ae21-4401-a16c-41296d898a66',
                             text: 'La Terre est plus proche du Soleil que Mars.',
+                            image: {
+                              url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                              altText: 'coucou',
+                            },
                             proposalA: 'Vrai',
                             proposalB: 'Faux',
                             solution: 'B',
@@ -1284,7 +1291,9 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         const module = await ModuleFactory.build(moduleData);
 
         // then
-        expect(module.sections[0].grains[0].components[0].element).to.be.instanceOf(QAB);
+        const qab = module.sections[0].grains[0].components[0].element;
+        expect(qab).to.be.instanceOf(QAB);
+        expect(qab.cards[0].image.information).to.not.be.undefined;
       });
     });
 


### PR DESCRIPTION
## ☔ Problème

On voudrait pouvoir avoir accès aux métadonnées pour les images présents dans les QAB, afin de palier au layout shift dans les modules.

## 🧥 Proposition

Remonter les métadonnées pour les QAB
<img width="538" height="598" alt="Capture d’écran 2025-10-02 à 18 17 36" src="https://github.com/user-attachments/assets/7e5cf0db-0080-465a-94b3-65e6d2921990" />


## 🍂 Remarques

Une autre PR sera réalisée pour le front.

## 🎃 Pour tester


- https://app-pr13793.review.pix.fr/modules/bac-a-sable
- Ouvrir la console navigateur et constater qu'il y a les infos de la hauteur largeur des images dans les QAB