### PR TITLE
[TECH] Supprimer les erreurs de connexion à Redis pour Maddo

### DIFF
--- a/api/index.maddo.js
+++ b/api/index.maddo.js
@@ -4,10 +4,7 @@ import { databaseConnections } from './db/database-connections.js';
 import { createMaddoServer } from './server.maddo.js';
 import { JobGroup } from './src/shared/application/jobs/job-controller.js';
 import { config, schema as configSchema } from './src/shared/config.js';
-import { quitAllStorages } from './src/shared/infrastructure/key-value-storages/index.js';
-import { quitMutex } from './src/shared/infrastructure/mutex/RedisMutex.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
-import { redisMonitor } from './src/shared/infrastructure/utils/redis-monitor.js';
 import { validateEnvironmentVariables } from './src/shared/infrastructure/validate-environment-variables.js';
 import { registerJobs } from './worker.js';
 
@@ -31,12 +28,6 @@ async function _exitOnSignal(signal) {
   }
   logger.info('Closing connections to databases...');
   await databaseConnections.disconnect();
-  logger.info('Closing connections to cache...');
-  await quitAllStorages();
-  logger.info('Closing connections to redis mutex...');
-  await quitMutex();
-  logger.info('Closing connections to redis monitor...');
-  await redisMonitor.quit();
   logger.info('Exiting process...');
 }
 

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -3,7 +3,9 @@ import { RedisClient } from '../utils/RedisClient.js';
 
 class RedisMutex {
   constructor({ redisUrl }) {
-    this._client = new RedisClient(redisUrl, { name: 'mutex', prefix: 'mutex:' });
+    if (redisUrl) {
+      this._client = new RedisClient(redisUrl, { name: 'mutex', prefix: 'mutex:' });
+    }
   }
 
   /**
@@ -27,7 +29,7 @@ class RedisMutex {
   }
 
   async quit() {
-    await this._client.quit();
+    await this._client?.quit();
   }
 
   async clearAll() {
@@ -45,7 +47,7 @@ export function quitMutex() {
 }
 
 export function clearMutex() {
-  const status = redisMutex._client.status;
+  const status = redisMutex._client?.status;
   if (status === 'ready') {
     return redisMutex.clearAll();
   }


### PR DESCRIPTION
## ☔ Problème
Depuis la MEP de la version 5.223.0 nous avons des erreurs de connexion à Redis pour Maddo (voir les erreurs [ici](https://app.datadoghq.eu/logs?query=service%3Apix-api-maddo-production&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1759735516140&to_ts=1759736416140&live=true). Or, maddo ne possède pas de Redis.

## 🧥 Proposition
- Vérifier la présence de la variable REDIS_URL avant d'instancier un client redis dans la class RedisMutex.
- Supprimer les appels aux méthodes `quit()` des clients Redis lors de l'extinction d'un serveur Maddo.