### PR TITLE
[BUGFIX] Réparer la création d'orga dans les seeds certif

### DIFF
--- a/api/db/seeds/data/team-certification/shared/common-organisations.js
+++ b/api/db/seeds/data/team-certification/shared/common-organisations.js
@@ -22,11 +22,15 @@ export class CommonOrganizations {
       this.sco = {};
       const organizationMember = await new CommonOrganizations({ databaseBuilder }).#initOrgaMember();
 
+      const administrationTeam = databaseBuilder.factory.buildAdministrationTeam({ name: 'Sco administration team' });
+      await databaseBuilder.commit();
+
       const organization = new OrganizationForAdmin({
         name: 'Certification SCO Managing students organization',
         type: CenterTypes.SCO,
         isManagingStudents: true,
         externalId: 'SCO_MANAGING_STUDENTS_EXTERNAL_ID',
+        administrationTeamId: administrationTeam.id,
       });
 
       const scoOrganization = await organizationalEntitiesUsecases.createOrganization({
@@ -55,11 +59,15 @@ export class CommonOrganizations {
       this.pro = {};
       const organizationMember = await new CommonOrganizations({ databaseBuilder }).#initOrgaMember();
 
+      const administrationTeam = databaseBuilder.factory.buildAdministrationTeam({ name: 'Pro administration team' });
+      await databaseBuilder.commit();
+
       const organization = new OrganizationForAdmin({
         name: 'Certification PRO organization',
         type: CenterTypes.PRO,
         isManagingStudents: false,
         externalId: 'PRO_EXTERNAL_ID',
+        administrationTeamId: administrationTeam.id,
       });
 
       const proOrganization = await organizationalEntitiesUsecases.createOrganization({


### PR DESCRIPTION
## ☔ Problème

Depuis l'[ajout du prérequis](https://github.com/1024pix/pix/commit/89ef66c6ff014d24f281065382bfacf6b3f41cae) de la propriété `administrationTeamId` lors de la création d'une organisation, les seeds certif ne fonctionnaient plus.

## 🧥 Proposition

Ajouter la propriété dans la création des seeds certif.

## 🎃 Pour tester

✅ Lancer les seeds
