### PR TITLE
[BUGFIX] Sélectionner uniquement les challenges validés durant une certif Pix+ (PIX-19883).

### DIFF
--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -134,7 +134,7 @@ export async function findActiveFlashCompatible({
   if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
     const version = getVersionNumber(date);
 
-    challengeDtos = await _findChallengesForComplementaryCertification({
+    challengeDtos = await _findValidChallengesForComplementaryCertification({
       complementaryCertificationKey,
       cacheKey,
       version,
@@ -148,7 +148,7 @@ export async function findActiveFlashCompatible({
   );
 }
 
-async function _findChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, version }) {
+async function _findValidChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, version }) {
   const { closestVersion } = await knex('certification-frameworks-challenges')
     .where({ complementaryCertificationKey })
     .andWhere('version', '<=', version)
@@ -169,9 +169,10 @@ async function _findChallengesForComplementaryCertification({ complementaryCerti
   };
 
   const challengeDtos = await getInstance().find(cacheKey, findCallback);
+  const validChallengeDtos = challengeDtos.filter((challenge) => challenge.status === VALIDATED_STATUS);
 
   return decorateWithCertificationCalibration({
-    challengeDtos,
+    validChallengeDtos,
     complementaryCertificationChallenges,
   });
 }
@@ -192,8 +193,8 @@ function _findChallengesForCoreCertification({ locale, accessibilityAdjustmentNe
   return getInstance().find(cacheKey, findCallback);
 }
 
-function decorateWithCertificationCalibration({ challengeDtos, complementaryCertificationChallenges }) {
-  return challengeDtos.map((challenge) => {
+function decorateWithCertificationCalibration({ validChallengeDtos, complementaryCertificationChallenges }) {
+  return validChallengeDtos.map((challenge) => {
     const { discriminant, difficulty } = complementaryCertificationChallenges.find(
       ({ challengeId }) => challengeId === challenge.id,
     );

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1718,7 +1718,7 @@ describe('Integration | Repository | challenge-repository', function () {
     });
 
     context('when complementary certification given', function () {
-      it('returns flash compatible challenge that link to complementary', async function () {
+      it('returns only valid flash compatible challenge that link to complementary', async function () {
         // given
         const candidateReconciliationDate = new Date('2025-01-01');
 
@@ -1727,7 +1727,10 @@ describe('Integration | Repository | challenge-repository', function () {
           {},
         );
 
-        challengesLC.push(domainBuilder.buildChallenge({ id: 'toto' }));
+        challengesLC.push(
+          domainBuilder.buildChallenge({ id: 'challengeForComplementaryCertification', status: 'validé' }),
+        );
+        challengesLC.push(domainBuilder.buildChallenge({ id: 'toto', status: 'archivé' }));
 
         databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
@@ -1740,6 +1743,13 @@ describe('Integration | Repository | challenge-repository', function () {
         // other complementary challenge
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
           complementaryCertificationKey: otherComplementaryCertification.key,
+          challengeId: challengesLC[4].id,
+          version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
+        });
+
+        // valid complementary challenge
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: complementaryCertification.key,
           challengeId: challengesLC[3].id,
           version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
         });
@@ -1769,7 +1779,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
         // then
         expect(flashCompatibleChallenges).to.have.lengthOf(1);
-        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[0].id);
+        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[3].id);
         expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.difficulty);
         expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.discriminant);
       });
@@ -1784,6 +1794,7 @@ describe('Integration | Repository | challenge-repository', function () {
         );
 
         challengesLC.push(domainBuilder.buildChallenge({ id: 'toto' }));
+        challengesLC.push(domainBuilder.buildChallenge({ id: 'recChallenge' }));
 
         databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
 
@@ -1796,6 +1807,12 @@ describe('Integration | Repository | challenge-repository', function () {
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
           complementaryCertificationKey: otherComplementaryCertification.key,
           challengeId: challengesLC[3].id,
+          version: '20250423125634',
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: complementaryCertification.key,
+          challengeId: challengesLC[4].id,
           version: '20250423125634',
         });
 
@@ -1816,7 +1833,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
         // then
         expect(flashCompatibleChallenges).to.have.lengthOf(1);
-        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[0].id);
+        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[4].id);
         expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.difficulty);
         expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.discriminant);
       });


### PR DESCRIPTION
## ☔ Problème

Nous créons les référentiels de certifications Pix+ en ne sélectionnant que les épreuves validés mais le référentiel vit sa vie et rien n'empêche que certaines épreuves considées comme `validé` au moment de la création d'un référentiel ne passent au statut `périmé` ou `archivé` à posteriori.

## 🧥 Proposition

Ne sélectionner que les épreuves au statut `validé` durant le déroulé d'une certification Pix+

## 🍂 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎃 Pour tester

(NB: Toute l'opération SQL ci-dessous a déjà été réalisée en RA avec le référentiel de certification **Pix+ Droit** si vous ne souhaitez pas vous embêter)

- Choisir un référentiel de certification
- Sélectionner l'intégralité des ID d'épreuves de celui-ci

```sql
select "challengeId" from "certification-frameworks-challenges" where "complementaryCertificationKey" = <SCOPE>;
```

- Mettre à jour l'intégralité des statuts de ces challenges à `périmé` et/ou `validé` à l'exception d'un seul challenge

```sql
update learningcontent.challenges set status = 'périmé' where id in (<ID_DE_CHALLENGES_RECUPERES_PRECEDEMMENT);
```

---

- Créer une session de certification (veiller à habiliter le centre utilisé si ce n'est pas le cas)
- Ajouter un candidat  en l'inscrivant à la certification Pix+ du scope désiré
- Rentrer en certification
- Vérifier que le test ne contient qu'une seule question