### PR TITLE
[FEATURE] Animation et couleurs des feedbacks (PIX-19327).

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -22,25 +22,24 @@
   }
 
   @media (not (prefers-reduced-motion: reduce)) {
-    animation:
-      0.4s slide-in ease-in-out,
-      0.5s fade-in ease-in-out;
+    animation: 0.75s zoom-in-zoom-out ease;
 
-    @keyframes slide-in {
+    @keyframes zoom-in-zoom-out {
       0% {
         height: 0;
         max-height: 0;
-        padding: 0 var(--pix-spacing-6x);
+        scale: 100%;
         overflow: hidden;
       }
 
-      60% {
+      50% {
         max-height: 100%;
-        padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
+        scale: 110%;
       }
 
       100% {
         max-height: 100%;
+        scale: 100%;
       }
     }
   }

--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -11,9 +11,9 @@
   }
 
   &--error {
-    --modulix-feedback-state-color: var(--pix-error-700);
+    --modulix-feedback-state-color: var(--pix-warning-700);
 
-    background-color: var(--pix-error-50);
+    background-color: var(--pix-warning-50);
   }
 
   &__state {
@@ -26,19 +26,15 @@
 
     @keyframes zoom-in-zoom-out {
       0% {
-        height: 0;
-        max-height: 0;
         scale: 100%;
         overflow: hidden;
       }
 
       50% {
-        max-height: 100%;
         scale: 110%;
       }
 
       100% {
-        max-height: 100%;
         scale: 100%;
       }
     }

--- a/mon-pix/app/components/module/element/_qcm.scss
+++ b/mon-pix/app/components/module/element/_qcm.scss
@@ -23,6 +23,26 @@
           color 0.25s 0.25s;
       }
     }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-error {
+      color: var(--pix-warning-700);
+      background-color: var(--state-background-color);
+      border-color: var(--pix-warning-700);
+
+      --state-background-color: var(--pix-warning-50);
+    }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-success {
+      color: var(--pix-success-700);
+      background-color: var(--state-background-color);
+      border-color: var(--pix-success-700);
+
+      --state-background-color: var(--pix-success-50);
+    }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled .pix-label-wrapped__state-icon {
+      background-color: var(--state-background-color);
+    }
   }
 
   &__required-field-missing {

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -21,6 +21,6 @@
 
   &__feedback {
     color: var(--pix-neutral-800);
-    background: var(--pix-orga-50);
+    background: var(--pix-info-100);
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -20,9 +20,7 @@
   }
 
   &__feedback {
-    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     color: var(--pix-neutral-800);
     background: var(--pix-orga-50);
-    border-radius: 16px;
   }
 }

--- a/mon-pix/app/components/module/element/_qcu.scss
+++ b/mon-pix/app/components/module/element/_qcu.scss
@@ -23,6 +23,26 @@
           color 0.25s 0.25s;
       }
     }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-error {
+      color: var(--pix-warning-700);
+      background-color: var(--state-background-color);
+      border-color: var(--pix-warning-700);
+
+      --state-background-color: var(--pix-warning-50);
+    }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-success {
+      color: var(--pix-success-700);
+      background-color: var(--state-background-color);
+      border-color: var(--pix-success-700);
+
+      --state-background-color: var(--pix-success-50);
+    }
+
+    .pix-label-wrapped--variant-tile.pix-label-wrapped--disabled .pix-label-wrapped__state-icon {
+      background-color: var(--state-background-color);
+    }
   }
 
   &__required-field-missing {

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -23,7 +23,7 @@
 
   &__feedback {
     color: var(--pix-neutral-800);
-    background: var(--pix-orga-50);
+    background: var(--pix-info-100);
   }
 
   &__retry-button {

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -22,28 +22,8 @@
   }
 
   &__feedback {
-    padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
     color: var(--pix-neutral-800);
     background: var(--pix-orga-50);
-    border-radius: 16px;
-
-    @media (not (prefers-reduced-motion: reduce)) {
-      animation: 0.5s fade-in ease-in-out;
-
-      @keyframes fade-in {
-        0% {
-          opacity: 0;
-        }
-
-        33% {
-          opacity: 0;
-        }
-
-        100% {
-          opacity: 1;
-        }
-      }
-    }
   }
 
   &__retry-button {

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -179,7 +179,7 @@ export default class ModuleQab extends ModuleElement {
       </fieldset>
     </form>
     {{#if this.shouldDisplayFeedback}}
-      <div class="element-qab__feedback" role="status" tabindex="-1">
+      <div class="feedback element-qab__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.feedback}}
       </div>
     {{/if}}

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -77,7 +77,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
       </fieldset>
     </form>
     {{#if this.shouldDisplayFeedback}}
-      <div class="element-qcu-discovery__feedback" role="status" tabindex="-1">
+      <div class="feedback element-qcu-discovery__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.selectedProposalFeedback}}
       </div>
     {{/if}}


### PR DESCRIPTION
## ☔ Problème

Des améliorations sur le feedbacks sont à faire.

## 🧥 Proposition

Modifier l'animation des feedbacks et les couleurs des propositions et feedback incorrects (on passe de `error` à `warning`)

## 🍂 Remarques

- PR réalisée avec la team design
- On a dû surcharger le CSS de PIX-UI pour afficher les propositions avec les bonnes couleurs (ex: `.pix-label-wrapped--variant-tile.pix-label-wrapped--disabled.pix-label-wrapped--state-error`)
     - C'est un état temporaire, en attendant des retours des panels
     - Si cette apparence persiste, on créera les variants pour le composant `PixRadioButton` correspondant et on enlèvera le CSS qui surcharge la classe

## 🎃 Pour tester

- Se rendre sur https://app-pr13801.review.pix.org/modules/bac-a-sable
- Répondre faux à la première question et constater : 
  - que le feedback apparaît avec une nouvelle animation (il pop en scalant puis retrouve sa taille normale)
  - que le feedback incorrect apparaît en jaune (fini le rouge)
  - que la proposition coché (fausse) apparaît avec du orange (fini le rouge) + background aussi
- répondre correctement et constater la même chose pour le vert dans la proposition sélectionné
- constater que l'animation des feedbacks se fait partout SAUF sur les QCU déclaratif


<img width="701" height="776" alt="Capture d’écran 2025-10-06 à 14 14 37" src="https://github.com/user-attachments/assets/0069c46e-34c8-4c55-a025-a52a36989d45" />
<img width="701" height="729" alt="Capture d’écran 2025-10-06 à 14 14 46" src="https://github.com/user-attachments/assets/ac8f2d60-2b70-4196-ac94-910acbb7db6c" />

