### PR TITLE
[FEATURE] QAB : fixer la hauteur des images et temps de transition des cartes (PIX-19618)

### DIFF
--- a/mon-pix/app/components/module/element/qab/_qab-card.scss
+++ b/mon-pix/app/components/module/element/qab/_qab-card.scss
@@ -84,9 +84,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-4x);
-  max-width: 152px;
 
   &__image {
+    max-height: 190px;
     border-radius: var(--pix-spacing-2x);
   }
 
@@ -107,7 +107,6 @@
     max-width: none;
 
     &__image {
-      max-width: 300px;
       margin: auto;
     }
   }

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -12,7 +12,7 @@ import { htmlUnsafe } from '../../../../helpers/html-unsafe';
 import ModuleElement from '../module-element';
 
 const NEXT_CARD_REMOVE_DELAY = 400;
-const NEXT_CARD_TRANSITION_DELAY = 1600;
+const NEXT_CARD_TRANSITION_DELAY = 400;
 export const NEXT_CARD_DELAY = NEXT_CARD_TRANSITION_DELAY + NEXT_CARD_REMOVE_DELAY;
 
 export default class ModuleQab extends ModuleElement {


### PR DESCRIPTION
## ☔ Problème

Aujourd’hui , l'équipe métier à la possibilité d’ajouter des images dans des QAB , hors parfois les images sont trop hautes et élargissent les QAB. De plus, les transitions entre l’apparition des cartes est trop long.

## 🧥 Proposition

- Il faudrait fixer le max-height à 190px pour les QAB pour laptop (vu avec Pierre)
<img width="759" height="691" alt="image" src="https://github.com/user-attachments/assets/f4e903b7-87a3-4bb8-bdd7-6e1399f52413" />

- Raccourcir le temps de transition entre les cartes

## 🍂 Remarques

RAS

## 🎃 Pour tester

- Ouvrir le module [deepfakes](https://app-pr13803.review.pix.org/modules/tmp-ia-deepfakes-alt)
- Atteindre le QAB avec les photos
- Vérifier que les photos apparaissent en taille plus petite qu'avant