### PR TITLE
[FEATURE] Ajouter les feedbacks pour les QCU déclaratif en mode preview (PIX-19892).

### DIFF
--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -11,6 +11,7 @@ export default class ModuleQcuDeclarative extends ModuleElement {
   @tracked selectedProposalId = null;
   @tracked shouldDisplayFeedback = false;
   @service passageEvents;
+  @service modulixPreviewMode;
 
   get selectedProposalFeedback() {
     return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
@@ -64,6 +65,11 @@ export default class ModuleQcuDeclarative extends ModuleElement {
               @isDisabled={{this.isAnswered}}
               @isSelected={{this.isProposalSelected proposal.id}}
             />
+            {{#if this.modulixPreviewMode.isEnabled}}
+              <div class="element-qcu-declarative__feedback" role="status" tabindex="-1">
+                {{htmlUnsafe proposal.feedback.diagnosis}}
+              </div>
+            {{/if}}
           {{/each}}
         </div>
       </fieldset>

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import ModuleQcuDeclarative from 'mon-pix/components/module/element/qcu-declarative';
 import { module, test } from 'qunit';
@@ -57,6 +58,7 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
         },
       });
     });
+
     test('it should call "onAnswer" function pass as argument', async function (assert) {
       // given
       const passageEventService = this.owner.lookup('service:passageEvents');
@@ -78,6 +80,25 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
         element: qcuDeclarativeElement,
       });
       assert.ok(true);
+    });
+  });
+
+  module('when preview mode is enabled', function () {
+    test('should display all feedbacks, without answering', async function (assert) {
+      // given
+      class PreviewModeServiceStub extends Service {
+        isEnabled = true;
+      }
+      this.owner.register('service:modulixPreviewMode', PreviewModeServiceStub);
+      const qcuDeclarativeElement = _getQcuDeclarativeElement();
+
+      // when
+      const screen = await render(<template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} /></template>);
+
+      // then
+      assert.dom(screen.getByText("C'est l'approche de la plupart des gens.")).exists();
+      assert.dom(screen.getByText('Possible, mais attention à ne pas faire une rafarinade !')).exists();
+      assert.dom(screen.getByText('Digne des plus grands acrobates !')).exists();
     });
   });
 });


### PR DESCRIPTION
## ☔ Problème
Actuellement, il n'y a pas possibilité de visualiser les feedbacks en mode preview pour les QCU déclaratif.

## 🧥 Proposition
Afficher les feedbacks.


## 🎃 Pour tester
- Ouvrir [en preview le bac-a-sable](https://app-pr13807.review.pix.fr/modules/preview/bac-a-sable)
- Afficher un QCUD et constater l'affichage des feedbacks pour chaque proposition

<img width="633" height="504" alt="Capture d’écran 2025-10-06 à 15 01 13" src="https://github.com/user-attachments/assets/6a100bbb-7e9f-4c8f-839f-d78a185c4df7" />
