### PR TITLE
[TECH] Logger le prompt en cas d'erreur LLM.

### DIFF
--- a/api/src/llm/domain/usecases/prompt-chat.js
+++ b/api/src/llm/domain/usecases/prompt-chat.js
@@ -84,6 +84,7 @@ export async function promptChat({
       onStreamDone: finalize(chat, message, shouldSendMessageToLLM, chatRepository, redisMutex),
       attachmentMessageType,
       shouldSendDebugData: chat.isPreview,
+      prompt: message,
     });
   } catch (error) {
     await redisMutex.release(chatId);

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -22,6 +22,7 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  * @property {number} outputTokens
  * @property {boolean} wasModerated
  * @property {string=} errorOccurredDuringStream
+ * @property {boolean} done - Indicates whether all data have been received from ChatPix or not
  */
 
 /**
@@ -64,6 +65,7 @@ export async function fromLLMResponse({
     inputTokens: 0,
     outputTokens: 0,
     wasModerated: false,
+    done: !llmResponse,
   };
   pipeline(
     readableStream,
@@ -72,8 +74,8 @@ export async function fromLLMResponse({
     sendDebugDataTransform.getTransform(streamCapture, shouldSendDebugData),
     writableStream,
     async (err) => {
-      if (err) {
-        logger.error({ err, prompt }, 'error in pipeline');
+      if (err || !streamCapture.done || streamCapture.errorOccurredDuringStream) {
+        logger.error({ err, prompt }, 'error in stream');
         if (!writableStream.closed && !writableStream.errored) {
           writableStream.end(events.getError());
         }

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -38,12 +38,19 @@ export const ATTACHMENT_MESSAGE_TYPES = {
  * @param {OnStreamDoneCallback} params.onStreamDone
  * @param {string} params.attachmentMessageType
  * @param {boolean} params.shouldSendDebugData
+ * @param {string} params.prompt
  * @returns {Promise<module:stream.internal.PassThrough>}
  */
-export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMessageType, shouldSendDebugData }) {
+export async function fromLLMResponse({
+  llmResponse,
+  onStreamDone,
+  attachmentMessageType,
+  shouldSendDebugData,
+  prompt,
+}) {
   const writableStream = new PassThrough();
   writableStream.on('error', (err) => {
-    logger.error(`error while streaming response: ${err}`);
+    logger.error({ err, prompt }, 'error while streaming response');
   });
   if (attachmentMessageType !== ATTACHMENT_MESSAGE_TYPES.NONE) {
     writableStream.write(getAttachmentEventMessage(attachmentMessageType === ATTACHMENT_MESSAGE_TYPES.IS_VALID));
@@ -65,7 +72,7 @@ export async function fromLLMResponse({ llmResponse, onStreamDone, attachmentMes
     writableStream,
     async (err) => {
       if (err) {
-        logger.error(`error in pipeline: ${err}`);
+        logger.error({ err, prompt }, 'error in pipeline');
         if (!writableStream.closed && !writableStream.errored) {
           writableStream.end('Error while streaming response from LLM');
         }

--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -76,9 +76,6 @@ export async function fromLLMResponse({
     async (err) => {
       if (err || !streamCapture.done || streamCapture.errorOccurredDuringStream) {
         logger.error({ err, prompt }, 'error in stream');
-        if (!writableStream.closed && !writableStream.errored) {
-          writableStream.end(events.getError());
-        }
       }
       await onStreamDone(streamCapture, !err);
     },

--- a/api/src/llm/infrastructure/streaming/transforms/events.js
+++ b/api/src/llm/infrastructure/streaming/transforms/events.js
@@ -1,0 +1,19 @@
+export function getVictoryConditionsSuccess() {
+  return 'event: victory-conditions-success\ndata: \n\n';
+}
+
+export function getMessageModerated() {
+  return 'event: user-message-moderated\ndata: \n\n';
+}
+
+export function getPing() {
+  return 'event: ping\ndata: \n\n';
+}
+
+export function getError() {
+  return 'event: error\ndata: \n\n';
+}
+
+export function getAttachmentMessage(isValid) {
+  return 'event: attachment-' + (isValid ? 'success' : 'failure') + '\ndata: \n\n';
+}

--- a/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
@@ -24,6 +24,7 @@ export function getTransform(streamCapture) {
 
       if (wasModerated) {
         streamCapture.wasModerated = true;
+        streamCapture.done = true;
         data += events.getMessageModerated();
       }
 
@@ -34,6 +35,7 @@ export function getTransform(streamCapture) {
 
       if (error) {
         streamCapture.errorOccurredDuringStream = error;
+        streamCapture.done = true;
         data += events.getError();
       }
 

--- a/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
@@ -1,5 +1,7 @@
 import { Transform } from 'node:stream';
 
+import * as events from './events.js';
+
 /**
  * @param {StreamCapture} streamCapture Structure that will hold state, such as the accumulated LLM response
  * @returns {module:stream.internal.Transform}
@@ -12,17 +14,17 @@ export function getTransform(streamCapture) {
       let data = '';
 
       if (ping) {
-        data += getPingEvent();
+        data += events.getPing();
       }
 
       if (isValid) {
         streamCapture.haveVictoryConditionsBeenFulfilled = true;
-        data += getVictoryConditionsSuccessEvent();
+        data += events.getVictoryConditionsSuccess();
       }
 
       if (wasModerated) {
         streamCapture.wasModerated = true;
-        data += getMessageModeratedEvent();
+        data += events.getMessageModerated();
       }
 
       if (message) {
@@ -32,7 +34,7 @@ export function getTransform(streamCapture) {
 
       if (error) {
         streamCapture.errorOccurredDuringStream = error;
-        data += getErrorEvent();
+        data += events.getError();
       }
 
       if (usage) {
@@ -49,20 +51,4 @@ export function getTransform(streamCapture) {
 function getFormattedMessage(message) {
   const formattedMessage = message.replaceAll('\n', '\ndata: ');
   return `data: ${formattedMessage}\n\n`;
-}
-
-function getVictoryConditionsSuccessEvent() {
-  return 'event: victory-conditions-success\ndata: \n\n';
-}
-
-function getMessageModeratedEvent() {
-  return 'event: user-message-moderated\ndata: \n\n';
-}
-
-function getPingEvent() {
-  return 'event: ping\ndata: \n\n';
-}
-
-function getErrorEvent() {
-  return 'event: error\ndata: \n\n';
 }

--- a/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
+++ b/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
@@ -16,6 +16,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
         inputTokens: 0,
         outputTokens: 0,
         wasModerated: false,
+        done: false,
       };
     });
 
@@ -182,6 +183,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 0,
           outputTokens: 0,
           wasModerated: false,
+          done: false,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
@@ -212,6 +214,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 0,
           outputTokens: 0,
           wasModerated: false,
+          done: false,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
@@ -241,11 +244,12 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 2_000,
           outputTokens: 5_000,
           wasModerated: false,
+          done: false,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
 
-      it('should capture the wasModerated flag if present', async function () {
+      it('should capture the wasModerated flag if present and set streamCapture as done', async function () {
         // given
         const input = [
           { message: 'Coucou les amis \ncomment ça va ?' },
@@ -271,11 +275,12 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 0,
           outputTokens: 0,
           wasModerated: true,
+          done: true,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
 
-      it('should capture the error content if error was present', async function () {
+      it('should capture the error content if error was present and set streamCapture as done', async function () {
         // given
         const input = [
           { message: 'Coucou les amis \ncomment ça va ?' },
@@ -297,6 +302,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           outputTokens: 0,
           wasModerated: false,
           errorOccurredDuringStream: 'je me suis cassé un ongle',
+          done: true,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?');
       });


### PR DESCRIPTION
## :fallen_leaf: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lorsque l'API ChatPix échoue, on n'a pas d'information sur le prompt d'origine, ce qui rend complexe la recherche de cause racine pour le déboggage.

## :chestnut: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Logger le prompt lors d'une erreur pendant la communication avec ChatPix.

## :jack_o_lantern: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On retire également le fait d'écrire dans le stream l'erreur en cas d'erreur dans la pipeline, car ce code n'aurait jamais fonctionné puisque la pipeline déclenche la fermeture de tous les streams et de toutes les transforms lorsque le readable a fini d'émettre

## :wood: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
