### PR TITLE
[FEATURE] Afficher la liste des parcours apprenants (PIX-19814)

### DIFF
--- a/orga/app/components/campaign/list-header.gjs
+++ b/orga/app/components/campaign/list-header.gjs
@@ -42,6 +42,11 @@ export default class List extends Component {
         <LinkTo @route="authenticated.campaigns.list.my-campaigns">
           {{t "pages.campaigns-list.tabs.my-campaigns"}}
         </LinkTo>
+        {{#if this.currentUser.hasCombinedCourses}}
+          <LinkTo @route="authenticated.campaigns.combined-courses">
+            {{t "pages.campaign.tab.combined-courses"}}
+          </LinkTo>
+        {{/if}}
         <LinkTo @route="authenticated.campaigns.list.all-campaigns">
           {{t "pages.campaigns-list.tabs.all-campaigns"}}
         </LinkTo>

--- a/orga/app/components/combined-course/combined-course.gjs
+++ b/orga/app/components/combined-course/combined-course.gjs
@@ -17,8 +17,12 @@ export default class CombinedCourse extends Component {
   get breadcrumbLinks() {
     return [
       {
-        route: 'authenticated.campaigns',
+        route: 'authenticated.campaigns.list.my-campaigns',
         label: this.intl.t('navigation.main.campaigns'),
+      },
+      {
+        route: 'authenticated.campaigns.combined-courses',
+        label: this.intl.t('navigation.main.combined-courses'),
       },
       {
         label: this.args.model.name,

--- a/orga/app/components/combined-course/list.gjs
+++ b/orga/app/components/combined-course/list.gjs
@@ -1,0 +1,78 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import ActivityType from 'pix-orga/components/activity-type';
+
+const stopPropagation = (event) => {
+  event.stopPropagation();
+};
+
+export default class CombinedCourseList extends Component {
+  @service router;
+
+  @action
+  goToCombinedCourse({ id }) {
+    this.router.transitionTo('authenticated.combined-course', id);
+  }
+
+  <template>
+    <PixTable
+      @variant="orga"
+      @caption={{t "pages.combined-courses.table.caption"}}
+      @data={{@combinedCourses}}
+      class="table"
+      @onRowClick={{this.goToCombinedCourse}}
+    >
+      <:columns as |combinedCourse context|>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.combined-courses.table.column.name"}}
+          </:header>
+          <:cell>
+            <span class="table__link-cell">
+              <ActivityType @type="COMBINED_COURSE" @hideLabel={{true}} />
+              <LinkTo @route="authenticated.combined-course" @model={{combinedCourse.id}}>
+                {{combinedCourse.name}}
+              </LinkTo>
+            </span>
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "pages.combined-courses.table.column.code"}}
+          </:header>
+          <:cell>
+            <span {{on "click" stopPropagation}}>
+              {{combinedCourse.code}}
+            </span>
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}} @type="number">
+          <:header>
+            {{t "pages.combined-courses.table.column.participants"}}
+          </:header>
+          <:cell>
+
+            {{combinedCourse.participationsCount}}
+          </:cell>
+        </PixTableColumn>
+
+        <PixTableColumn @context={{context}} @type="number">
+          <:header>
+            {{t "pages.combined-courses.table.column.completed"}}
+          </:header>
+          <:cell>
+            {{combinedCourse.completedParticipationsCount}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  </template>
+}

--- a/orga/app/models/combined-course.js
+++ b/orga/app/models/combined-course.js
@@ -3,7 +3,10 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class CombinedCourse extends Model {
   @attr('string') name;
   @attr('string') code;
+  @attr('number') participationsCount;
+  @attr('number') completedParticipationsCount;
   @attr({ defaultValue: () => [] }) campaignIds;
+
   @hasMany('combined-course-participation', { async: true, inverse: null }) combinedCourseParticipations;
   @belongsTo('combined-course-statistic', { async: true, inverse: null }) combinedCourseStatistics;
 }

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -79,6 +79,7 @@ Router.map(function () {
         });
         this.route('settings', { path: '/parametres' });
       });
+      this.route('combined-courses', { path: '/parcours-apprenants' });
     });
     this.route('certifications');
     this.route('attestations');

--- a/orga/app/routes/authenticated/campaigns/combined-courses.js
+++ b/orga/app/routes/authenticated/campaigns/combined-courses.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class CampaignCombinedCoursesRoute extends Route {
+  @service store;
+  @service currentUser;
+  @service router;
+
+  async model() {
+    return {
+      combinedCourses: this.currentUser.combinedCourses || [],
+    };
+  }
+}

--- a/orga/app/templates/authenticated/campaigns/combined-courses.gjs
+++ b/orga/app/templates/authenticated/campaigns/combined-courses.gjs
@@ -1,0 +1,14 @@
+import { t } from 'ember-intl';
+import { pageTitle } from 'ember-page-title';
+import ListHeader from 'pix-orga/components/campaign/list-header';
+import CombinedCourseList from 'pix-orga/components/combined-course/list';
+
+<template>
+  {{pageTitle (t "pages.campaign.tab.combined-courses")}}
+
+  <article>
+    <ListHeader />
+
+    <CombinedCourseList @combinedCourses={{@model.combinedCourses}} />
+  </article>
+</template>

--- a/orga/tests/integration/components/campaign/list-header-test.gjs
+++ b/orga/tests/integration/components/campaign/list-header-test.gjs
@@ -9,6 +9,44 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Campaign | ListHeader', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  module('Combined courses tab', function () {
+    test('it displays combined courses tab when user has combined courses', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      sinon.stub(currentUser, 'combinedCourses').value([{ id: 1 }]);
+
+      // when
+      const screen = await render(<template><ListHeader /></template>);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: t('pages.campaign.tab.combined-courses') })).exists();
+    });
+
+    test('it does not display combined courses tab when user has no combined courses', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      sinon.stub(currentUser, 'combinedCourses').value([]);
+
+      // when
+      const screen = await render(<template><ListHeader /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: t('pages.campaign.tab.combined-courses') })).doesNotExist();
+    });
+
+    test('it does not display combined courses tab when combined courses is undefined', async function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      sinon.stub(currentUser, 'combinedCourses').value(undefined);
+
+      // when
+      const screen = await render(<template><ListHeader /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: t('pages.campaign.tab.combined-courses') })).doesNotExist();
+    });
+  });
+
   module('when places limit feature is inactive', function () {
     test('it displays a disabled link', async function (assert) {
       // given

--- a/orga/tests/integration/components/combined-course/list-test.gjs
+++ b/orga/tests/integration/components/combined-course/list-test.gjs
@@ -1,0 +1,155 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CombinedCourseList from 'pix-orga/components/combined-course/list';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | CombinedCourse | List', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a table with caption', async function (assert) {
+    // given
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+    ];
+
+    // when
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('table', { name: t('pages.combined-courses.table.caption') })).exists();
+  });
+
+  test('it should display column headers', async function (assert) {
+    // given
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+    ];
+
+    // when
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    const table = screen.getByRole('table');
+
+    // then
+    assert.ok(within(table).getByRole('columnheader', { name: t('pages.combined-courses.table.column.name') }));
+    assert.ok(within(table).getByRole('columnheader', { name: t('pages.combined-courses.table.column.code') }));
+    assert.ok(within(table).getByRole('columnheader', { name: t('pages.combined-courses.table.column.participants') }));
+    assert.ok(within(table).getByRole('columnheader', { name: t('pages.combined-courses.table.column.completed') }));
+  });
+
+  test('it should display combined course details', async function (assert) {
+    // given
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+      {
+        id: '2',
+        name: 'Parcours Avancé',
+        code: 'DEF456',
+        participationsCount: 20,
+        completedParticipationsCount: 15,
+      },
+    ];
+
+    // when
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    const table = screen.getByRole('table');
+
+    // then
+    assert.ok(within(table).getByRole('link', { name: 'Parcours Débutant' }));
+    assert.ok(within(table).getByRole('link', { name: 'Parcours Avancé' }));
+    assert.ok(within(table).getByRole('cell', { name: 'ABC123' }));
+    assert.ok(within(table).getByRole('cell', { name: 'DEF456' }));
+    assert.ok(within(table).getByRole('cell', { name: '10' }));
+    assert.ok(within(table).getByRole('cell', { name: '20' }));
+    assert.ok(within(table).getByRole('cell', { name: '5' }));
+    assert.ok(within(table).getByRole('cell', { name: '15' }));
+  });
+
+  test('it should display activity type icon', async function (assert) {
+    // given
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+    ];
+
+    // when
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('img', { name: t('components.activity-type.explanation.COMBINED_COURSE') }));
+  });
+
+  test('it should display a link to combined course detail page', async function (assert) {
+    // given
+    this.owner.setupRouter();
+
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+    ];
+
+    // when
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    // then
+    assert.ok(screen.getByRole('link', { name: 'Parcours Débutant' }));
+  });
+
+  test('it should navigate to combined course detail page when clicking on row', async function (assert) {
+    // given
+    const routerService = this.owner.lookup('service:router');
+    sinon.stub(routerService, 'transitionTo');
+
+    const combinedCourses = [
+      {
+        id: '1',
+        name: 'Parcours Débutant',
+        code: 'ABC123',
+        participationsCount: 10,
+        completedParticipationsCount: 5,
+      },
+    ];
+
+    const screen = await render(<template><CombinedCourseList @combinedCourses={{combinedCourses}} /></template>);
+
+    // when
+    const row = screen.getByRole('row', { name: /Parcours Débutant/ });
+    await click(row);
+
+    // then
+    assert.ok(routerService.transitionTo.calledWith('authenticated.combined-course', '1'));
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -469,6 +469,7 @@
       "campaigns": "Campaigns",
       "certifications": "Certifications",
       "close": "Close navigation",
+      "combined-courses": "Learning courses",
       "documentation": "Documentation",
       "home": "Home",
       "missions": "Missions",
@@ -615,6 +616,7 @@
       "name": "Name of the campaign",
       "tab": {
         "activity": "Activity",
+        "combined-courses": "Learning courses",
         "results": "Results ({count, number})",
         "review": "Review",
         "settings": "Settings"
@@ -679,6 +681,18 @@
       },
       "second-title": "Results Analysis",
       "title": "Analysis"
+    },
+    "campaign-combined-courses": {
+      "empty": "No learning courses found for this campaign",
+      "table": {
+        "column": {
+          "code": "Course code",
+          "name": "Course name",
+          "participants": "Number of participants"
+        },
+        "description": "List of learning courses associated with this campaign"
+      },
+      "title": "Learning courses"
     },
     "campaign-creation": {
       "actions": {
@@ -1020,7 +1034,19 @@
           "last-name": "Last name",
           "status": "Status"
         },
-        "description": "List of the combined course participations"
+        "description": "List of learning courses participations"
+      }
+    },
+    "combined-courses": {
+      "empty-state": "No learning program available at the moment.",
+      "table": {
+        "caption": "List of learning programs",
+        "column": {
+          "code": "Code",
+          "completed": "Participants who completed",
+          "name": "Program name",
+          "participants": "Participants"
+        }
       }
     },
     "index": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -469,6 +469,7 @@
       "campaigns": "Campagnes",
       "certifications": "Certifications",
       "close": "Fermer la navigation",
+      "combined-courses": "Parcours apprenants",
       "documentation": "Documentation",
       "home": "Accueil",
       "missions": "Missions",
@@ -615,6 +616,7 @@
       "name": "Nom de la campagne",
       "tab": {
         "activity": "Activité",
+        "combined-courses": "Parcours apprenants",
         "results": "Résultats ({count, number})",
         "review": "Analyse",
         "settings": "Paramètres"
@@ -1021,6 +1023,18 @@
           "status": "Statut"
         },
         "description": "Listes des participations au parcours"
+      }
+    },
+    "combined-courses": {
+      "empty-state": "Aucun parcours apprenant disponible pour l'instant.",
+      "table": {
+        "caption": "Liste des parcours apprenants",
+        "column": {
+          "code": "Code",
+          "completed": "Participants ayant terminé",
+          "name": "Nom du parcours",
+          "participants": "Participants"
+        }
       }
     },
     "index": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -469,6 +469,7 @@
       "campaigns": "Campagnes",
       "certifications": "Certificeringen",
       "close": "Sluit de navigatie",
+      "combined-courses": "Leerprogramma's",
       "documentation": "Documentatie",
       "home": "Home",
       "missions": "Opdrachten",
@@ -615,6 +616,7 @@
       "name": "Naam Campagne",
       "tab": {
         "activity": "Activiteit",
+        "combined-courses": "Leerprogramma's",
         "results": "Resultaten ({count, number})",
         "review": "Analyse",
         "settings": "Instellingen"
@@ -1021,6 +1023,18 @@
           "status": "Status"
         },
         "description": "List of the combined course participations"
+      }
+    },
+    "combined-courses": {
+      "empty-state": "Geen leerprogramma beschikbaar op dit moment.",
+      "table": {
+        "caption": "Lijst van leerprogramma's",
+        "column": {
+          "code": "Code",
+          "completed": "Deelnemers die voltooid hebben",
+          "name": "Naam van het programma",
+          "participants": "Deelnemers"
+        }
       }
     },
     "index": {


### PR DESCRIPTION
## ☔ Problème

Les utilisateurs de Pix Orga ont besoin de visualiser la liste des parcours apprenants (combined courses) auxquels ils ont accès.

## 🧥 Proposition

Ajout d'une nouvelle page permettant de visualiser la liste des parcours apprenants avec les informations suivantes :
- Nom du parcours
- Code du parcours
- Nombre de participants
- Nombre de participants ayant terminé

### Pix Orga

- Ajout d'un nouvel onglet "Parcours apprenants" dans la navigation des campagnes (uniquement visible si l'utilisateur a des parcours combinés)
- Création d'une nouvelle route `authenticated.campaigns.combined-courses`
- Création du composant `combined-course/list` pour afficher le tableau des parcours
- Ajout de la propriété `hasCombinedCourses` dans le composant `campaign/list-header`
- Mise à jour du modèle `combined-course` avec les propriétés `participationsCount` et `completedParticipationsCount`

## 🍂 Remarques

- L'onglet "Parcours apprenants" n'est visible que si l'utilisateur a au moins un parcours combiné (`currentUser.combinedCourses.length > 0`)
- Le clic sur une ligne du tableau navigue vers la page de détail du parcours combiné

## 🎃 Pour tester

1. Se connecter à Pix Orga avec un utilisateur ayant accès à des parcours combinés ( Pro Classic )
2. Aller dans la section "Campagnes"
3. Vérifier la présence de l'onglet "Parcours apprenants"
4. Cliquer sur l'onglet pour accéder à la liste des parcours
5. Vérifier l'affichage du tableau avec les colonnes : Nom, Code, Participants, Participants ayant terminé
6. Cliquer sur une ligne pour accéder au détail du parcours