### PR TITLE
[FEATURE] Afficher les boutons des campagnes sur la page de parcours combinés (PIX-19799)

### DIFF
--- a/orga/app/components/activity-type.gjs
+++ b/orga/app/components/activity-type.gjs
@@ -15,7 +15,7 @@ export default class ActivityType extends Component {
       case 'EXAM':
         return { icon: 'school', class: 'activity-type__icon--exam' };
       case 'COMBINED_COURSE':
-        return { icon: 'brick', class: 'activity-type__icon--combined-course' };
+        return { icon: 'studyLesson', class: 'activity-type__icon--combined-course' };
       default:
         return { icon: 'close', class: '' };
     }

--- a/orga/app/components/combined-course/combined-course.gjs
+++ b/orga/app/components/combined-course/combined-course.gjs
@@ -1,3 +1,4 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIndicatorCard from '@1024pix/pix-ui/components/pix-indicator-card';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
@@ -30,6 +31,10 @@ export default class CombinedCourse extends Component {
     ];
   }
 
+  getCampaignIndex(index) {
+    return index + 1;
+  }
+
   <template>
     <PageTitle>
       <:breadcrumb>
@@ -40,9 +45,22 @@ export default class CombinedCourse extends Component {
         <span class="page-title__name">{{@model.name}}</span>
       </:title>
       <:subtitle>
-
-        <p class="campaign-page__page-subtext">{{t "pages.combined-course.introduction"}}</p>
-
+        <div class="combined-course-page__header">
+          <p class="combined-course-page__header-body">{{t "pages.combined-course.introduction"}}</p>
+          {{#if @model.campaignIds.length}}
+            <div class="combined-course-page__campaigns">
+              {{#each @model.campaignIds as |campaignId index|}}
+                <PixButtonLink @route="authenticated.campaigns.campaign" @model={{campaignId}} @variant="primary">
+                  {{t
+                    "pages.combined-course.campaigns"
+                    count=@model.campaignIds.length
+                    index=(this.getCampaignIndex index)
+                  }}
+                </PixButtonLink>
+              {{/each}}
+            </div>
+          {{/if}}
+        </div>
       </:subtitle>
       <:tools>
         <dl class="campaign-header-title__details">

--- a/orga/app/components/combined-course/combined-course.gjs
+++ b/orga/app/components/combined-course/combined-course.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import ActivityType from 'pix-orga/components/activity-type';
+import EmptyState from 'pix-orga/components/campaign/empty-state';
 import CopyPasteButton from 'pix-orga/components/copy-paste-button';
 import Breadcrumb from 'pix-orga/components/ui/breadcrumb';
 import PageTitle from 'pix-orga/components/ui/page-title';
@@ -100,41 +101,44 @@ export default class CombinedCourse extends Component {
         <:default>{{@model.combinedCourseStatistics.completedParticipationsCount}}</:default>
       </PixIndicatorCard>
     </div>
+    {{#if @model.combinedCourseParticipations.length}}
+      <PixTable
+        @variant="orga"
+        @caption={{t "pages.combined-course.table.description"}}
+        @data={{@model.combinedCourseParticipations}}
+        class="table"
+      >
+        <:columns as |participation context|>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.combined-course.table.column.last-name"}}
+            </:header>
+            <:cell>
+              {{participation.lastName}}
+            </:cell>
+          </PixTableColumn>
 
-    <PixTable
-      @variant="orga"
-      @caption={{t "pages.combined-course.table.description"}}
-      @data={{@model.combinedCourseParticipations}}
-      class="table"
-    >
-      <:columns as |participation context|>
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "pages.combined-course.table.column.last-name"}}
-          </:header>
-          <:cell>
-            {{participation.lastName}}
-          </:cell>
-        </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.combined-course.table.column.first-name"}}
+            </:header>
+            <:cell>
+              {{participation.firstName}}
+            </:cell>
+          </PixTableColumn>
 
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "pages.combined-course.table.column.first-name"}}
-          </:header>
-          <:cell>
-            {{participation.firstName}}
-          </:cell>
-        </PixTableColumn>
-
-        <PixTableColumn @context={{context}}>
-          <:header>
-            {{t "pages.combined-course.table.column.status"}}
-          </:header>
-          <:cell>
-            <ParticipationStatus @status={{participation.status}} />
-          </:cell>
-        </PixTableColumn>
-      </:columns>
-    </PixTable>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "pages.combined-course.table.column.status"}}
+            </:header>
+            <:cell>
+              <ParticipationStatus @status={{participation.status}} />
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{else}}
+      <EmptyState />
+    {{/if}}
   </template>
 }

--- a/orga/app/styles/components/activity-type.scss
+++ b/orga/app/styles/components/activity-type.scss
@@ -25,7 +25,7 @@
     }
 
     &--combined-course {
-      fill: var(--pix-warning-500);
+      fill: var(--pix-certif-500);
     }
 
     &--big {

--- a/orga/app/styles/pages/authenticated/combined-course.scss
+++ b/orga/app/styles/pages/authenticated/combined-course.scss
@@ -1,7 +1,25 @@
+@use 'pix-design-tokens/typography';
+
 .combined-course-page {
   &__statistics {
     display: flex;
     gap: var(--pix-spacing-4x);
     margin-bottom: var(--pix-spacing-8x);
+  }
+
+  &__header {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    justify-content: space-between;
+  }
+
+  &__header-body {
+    @extend %pix-body-s;
+  }
+
+  &__campaigns {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
   }
 }

--- a/orga/tests/integration/components/combined-course/combined-course-test.gjs
+++ b/orga/tests/integration/components/combined-course/combined-course-test.gjs
@@ -10,7 +10,7 @@ module('Integration | Component | CombinedCourse', function (hooks) {
     id: 1,
     name: 'Parcours MagiPix',
     code: '1234PixTest',
-    campaignIds: [123],
+    campaignIds: [123, 234],
     combinedCourseParticipations: [
       {
         id: 123,
@@ -41,6 +41,53 @@ module('Integration | Component | CombinedCourse', function (hooks) {
     assert.ok(within(title).getByRole('img', { name: t('components.activity-type.explanation.COMBINED_COURSE') }));
     assert.ok(within(title).getByText('Parcours MagiPix'));
     assert.ok(screen.getByText('1234PixTest'));
+  });
+
+  module('combine course campaign link', function () {
+    test('it should display a link button for each associated campaign', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        name: 'Parcours MagiPix',
+        code: '1234PixTest',
+        campaignIds: [123, 234],
+        combinedCourseParticipations: [
+          store.createRecord('combined-course-participation', {
+            id: 123,
+            firstName: 'TOTO',
+            lastName: 'Cornichon',
+            status: 'STARTED',
+          }),
+        ],
+      });
+
+      // when
+      const screen = await render(<template><CombinedCourse @model={{combinedCourse}} /></template>);
+
+      // then
+      const link1 = screen.getByRole('link', { name: t('pages.combined-course.campaigns', { count: 2, index: 1 }) });
+      assert.ok(link1.getAttribute('href').endsWith('campagnes/123'));
+      const link2 = screen.getByRole('link', { name: t('pages.combined-course.campaigns', { count: 2, index: 2 }) });
+      assert.ok(link2.getAttribute('href').endsWith('campagnes/234'));
+    });
+    test('it should not display a campaign link button if no associated campaign', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        name: 'Parcours MagiPix',
+        code: '1234PixTest',
+        campaignIds: [],
+        combinedCourseParticipations: [],
+      });
+
+      // when
+      const screen = await render(<template><CombinedCourse @model={{combinedCourse}} /></template>);
+
+      // then
+      assert.notOk(screen.queryByRole('link', { name: t('pages.combined-course.campaigns', { count: 0, index: 0 }) }));
+    });
   });
 
   test('it should have a caption to describe the table ', async function (assert) {

--- a/orga/tests/integration/components/combined-course/combined-course-test.gjs
+++ b/orga/tests/integration/components/combined-course/combined-course-test.gjs
@@ -143,6 +143,22 @@ module('Integration | Component | CombinedCourse', function (hooks) {
     );
   });
 
+  test('it should display empty state', async function (assert) {
+    // given
+    const emptyCombinedCourse = {
+      id: 1,
+      name: 'Parcours MagiPix',
+      code: '1234PixTest',
+      campaignIds: [123, 234],
+      combinedCourseParticipations: [],
+    };
+    // when
+    const screen = await render(<template><CombinedCourse @model={{emptyCombinedCourse}} /></template>);
+
+    assert.notOk(screen.queryByRole('table'));
+    assert.ok(screen.getByText(t('pages.campaign.empty-state')));
+  });
+
   module('combined course code display', function () {
     test('it should display combined course code', async function (assert) {
       // given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1023,6 +1023,7 @@
       "title": "Certification results"
     },
     "combined-course": {
+      "campaigns": "{count, plural, =1 {See campaign details} other {See details of campaign no. {index}}}",
       "introduction": "text d'intro",
       "statistics": {
         "completed-participations": "Completed participations",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1011,6 +1011,7 @@
       "title": "Résultats de certification"
     },
     "combined-course": {
+      "campaigns": "{count, plural, =1 {Voir le détail de la campagne} other {Voir le détail de la campagne n°{index}}}",
       "introduction": "Un parcours apprenant est un parcours qui mixe campagnes d'évaluation et modules de formations. La selection des modules de formation sera adapter au niveau du prescrit",
       "statistics": {
         "completed-participations": "Participations complétées",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1011,6 +1011,7 @@
       "title": "Resultaten certificering"
     },
     "combined-course": {
+      "campaigns": "{count, plural, =1 {Bekijk de details van de campagne} other {Bekijk de details van campagne nr. {index}}}",
       "introduction": "text d'intro",
       "statistics": {
         "completed-participations": "Voltooide deelnames",


### PR DESCRIPTION
## ☔ Problème

On souhaite faciliter l'accès aux campagnes d'un parcours combiné.

## 🧥 Proposition

On rajoute un bouton lien vers les campagnes issues d'un parcours combiné.

## 🍂 Remarques

On profite de la PR pour 
- modifier les ActivityType avec la couleur et le bon logo
- On affiche un état vide lorsqu'il n'y a aucune participation à un parcours combinés

## 🎃 Pour tester

1.
- Se connecter sur orga
- Afficher la page du parcours combiné en passant par la campagne sans code de l'orga PROCLASSIC
- Voir la nouvelle icône et la couleur verte

2.
- Voir le bouton de la campagne et cliquer dessus
- Observer que le bloc indiquant qu'il n'y a aucune participation s'affiche à la place du tableau des participations

3.
- Depuis MonPix, participer au parcours combiné COMBINIX2
- Afficher la page du parcours combiné dans Orga
- Voir le tableau avec la participation
