### PR TITLE
[BUGFIX] Ne sélectionner que des challenges calibrés dans une certification Pix+ (PIX-19895).

### DIFF
--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -158,6 +158,8 @@ async function _findValidChallengesForComplementaryCertification({ complementary
   const complementaryCertificationChallenges = await knex
     .from('certification-frameworks-challenges')
     .where({ complementaryCertificationKey })
+    .whereNotNull('discriminant')
+    .whereNotNull('difficulty')
     .andWhere('version', '=', closestVersion);
 
   const complementaryCertificationChallengesIds = complementaryCertificationChallenges.map(

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1718,7 +1718,7 @@ describe('Integration | Repository | challenge-repository', function () {
     });
 
     context('when complementary certification given', function () {
-      it('returns only valid flash compatible challenge that link to complementary', async function () {
+      it('returns only valid calibrated flash compatible challenges that link to complementary', async function () {
         // given
         const candidateReconciliationDate = new Date('2025-01-01');
 
@@ -1729,6 +1729,12 @@ describe('Integration | Repository | challenge-repository', function () {
 
         challengesLC.push(
           domainBuilder.buildChallenge({ id: 'challengeForComplementaryCertification', status: 'validé' }),
+        );
+        challengesLC.push(
+          domainBuilder.buildChallenge({
+            id: 'otherChallengeForComplementaryCertification',
+            status: 'validé',
+          }),
         );
         challengesLC.push(domainBuilder.buildChallenge({ id: 'toto', status: 'archivé' }));
 
@@ -1751,6 +1757,15 @@ describe('Integration | Repository | challenge-repository', function () {
         databaseBuilder.factory.buildCertificationFrameworksChallenge({
           complementaryCertificationKey: complementaryCertification.key,
           challengeId: challengesLC[3].id,
+          version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
+        });
+
+        // valid complementary challenge without calibration
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: complementaryCertification.key,
+          challengeId: challengesLC[4].id,
+          discriminant: null,
+          difficulty: null,
           version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
         });
 


### PR DESCRIPTION
## ☔ Problème

Les challenges enregsitrés dans la table `certification-frameworks-challenges` peuvent ne pas être calibrés.
Ils ne doivent pas être joués dans un test (ou simulation)

## 🧥 Proposition

Exclure les challenges non calibrés lors du choix de questions dans la requête SQL

## 🍂 Remarques

~~en attente de https://github.com/1024pix/pix/pull/13800~~

## 🎃 Pour tester

(NB: Toute l'opération SQL ci-dessous a déjà été réalisée en RA avec le référentiel de certification **Pix+ Droit** si vous ne souhaitez pas vous embêter)

- Choisir un référentiel de certification
- Sélectionner l'intégralité des ID d'épreuves de celui-ci

```sql
select "challengeId" from "certification-frameworks-challenges" where "complementaryCertificationKey" = <SCOPE>;
```

- Mettre à jour l'intégralité des difficultés et discriminants de ces challenges à `null` à l'exception d'un seul challenge

```sql
update "certification-frameworks-challenges" set difficulty = 2.1 where "challengeId" = <ID_DE_CHALLENGE_DU_SCOPE>;

update "certification-frameworks-challenges" set discriminant = 1 where "challengeId" = <ID_DE_CHALLENGE_DU_SCOPE>;
```

---

- Créer une session de certification (veiller à habiliter le centre utilisé si ce n'est pas le cas)
- Ajouter un candidat  en l'inscrivant à la certification Pix+ du scope désiré
- Rentrer en certification
- Vérifier que le test ne contient qu'une seule question

--- 
SIMULATION 

Exécuter le cURL suivant: 

```bash
TOKEN=$(curl --insecure 'https://admin-pr13814.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13814.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "complementaryCertificationKey": "DROIT", "locale": "fr-fr", "stopAtChallenge": 1 }' | jq '.'
```
- Vérifier que vous obtenez une simulation de déroulé
- Vérifier que vous n'obtenez pas de simulation de déroulé avec la même requête contenant le paramètre ` "stopAtChallenge": 2`