### PR TITLE
[FEATURE] Ajouter deux colonnes à la table combined_course_participations : combinedCourseId et organizationLearnerParticipationId

### DIFF
--- a/api/db/migrations/20251006093941_add-combined-course-id-and-organization-learner-participation-id-in-combined_course_participations.js
+++ b/api/db/migrations/20251006093941_add-combined-course-id-and-organization-learner-participation-id-in-combined_course_participations.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'combined_course_participations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer('combinedCourseId').defaultTo(null).index().references('combined_courses.id');
+    table
+      .integer('organizationLearnerParticipationId')
+      .defaultTo(null)
+      .index()
+      .references('organization_learner_participations.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('combinedCourseId');
+    table.dropColumn('organizationLearnerParticipationId');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ☔ Problème
On veut pouvoir relier une participation à un parcours combiné à une table nouvellement créée, combined_courses. On veut également pouvoir faire le lien entre cette table et la table générique qui contient trois types de participations, organization_learner_participations.

## 🧥 Proposition
On ajoute deux clés étrangères :  combinedCourseId et organizationLearnerParticipationId. combined_course_participations. 

## 🍂 Remarques
