### PR TITLE
[FEATURE] Ajouter le caractère obligatoire du champ "Équipe en charge" lors de la modification d'une orga (PIX-19677)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -19,6 +19,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @service store;
   @service oidcIdentityProviders;
   @service intl;
+  @service pixToast;
 
   @tracked isEditMode = false;
   @tracked showArchivingConfirmationModal = false;
@@ -106,6 +107,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
     const { validations } = await this.form.validate();
     if (!validations.isValid) {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.organizations.editing.required-fields-error'),
+      });
       return;
     }
 

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -68,6 +68,12 @@ export default class OrganizationInformationSectionEditionMode extends Component
     return options;
   }
 
+  get translatedAdministrationTeamIdErrorMessage() {
+    return this.form.administrationTeamIdError.message
+      ? this.intl.t(this.form.administrationTeamIdError.message)
+      : null;
+  }
+
   @action
   onChangeIdentityProvider(newIdentityProvider) {
     this.form.identityProviderForCampaigns = newIdentityProvider;
@@ -147,7 +153,6 @@ export default class OrganizationInformationSectionEditionMode extends Component
       identityProviderForCampaigns:
         this.args.organization.identityProviderForCampaigns ?? this.noIdentityProviderOption.value,
       features: structuredClone(this.args.organization.features),
-      // TODO: delete this logic when administration team is mandatory
       administrationTeamId: this.args.organization.administrationTeamId
         ? `${this.args.organization.administrationTeamId}`
         : null,
@@ -195,6 +200,11 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
         <div class="form-field">
           <PixSelect
+            required
+            @aria-required={{true}}
+            @requiredLabel={{t "common.forms.mandatory"}}
+            @errorMessage={{this.translatedAdministrationTeamIdErrorMessage}}
+            @validationStatus={{this.form.administrationTeamIdError.status}}
             @options={{this.administrationTeamsOptions}}
             @value={{this.form.administrationTeamId}}
             @onChange={{this.onChangeAdministrationTeam}}

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -25,7 +25,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked toggleLockPlaces = false;
   @tracked administrationTeams = [];
 
-  noIdentityProviderOption = { label: 'Aucun', value: 'None' };
+  noIdentityProviderOption = { label: this.intl.t('common.words.none'), value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
 
   constructor() {
@@ -166,13 +166,13 @@ export default class OrganizationInformationSectionEditionMode extends Component
         <div class="form-field">
           <PixInput
             required={{true}}
-            @requiredLabel="obligatoire"
+            @requiredLabel={{t "common.forms.mandatory"}}
             @errorMessage={{this.form.nameError.message}}
             @validationStatus={{this.form.nameError.status}}
             @value={{this.form.name}}
             {{on "input" (fn this.updateFormValue "name")}}
           ><:label>
-              Nom
+              {{t "components.organizations.editing.name.label"}}
             </:label></PixInput>
         </div>
 
@@ -182,7 +182,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.externalIdError.status}}
             @value={{this.form.externalId}}
             {{on "input" (fn this.updateFormValue "externalId")}}
-          ><:label>Identifiant externe</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.external-id"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -191,7 +191,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.provinceCodeError.status}}
             @value={{this.form.provinceCode}}
             {{on "input" (fn this.updateFormValue "provinceCode")}}
-          ><:label>Département (en 3 chiffres)</:label></PixInput>
+          ><:label>{{t "components.organizations.editing.province-code.label"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -218,7 +218,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.dataProtectionOfficerFirstNameError.status}}
             @value={{this.form.dataProtectionOfficerFirstName}}
             {{on "input" (fn this.updateFormValue "dataProtectionOfficerFirstName")}}
-          ><:label>Prénom du DPO</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.dpo-firstname"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -227,7 +227,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.dataProtectionOfficerLastNameError.status}}
             @value={{this.form.dataProtectionOfficerLastName}}
             {{on "input" (fn this.updateFormValue "dataProtectionOfficerLastName")}}
-          ><:label>Nom du DPO</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.dpo-lastname"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -236,7 +236,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.dataProtectionOfficerEmailError.status}}
             @value={{this.form.dataProtectionOfficerEmail}}
             {{on "input" (fn this.updateFormValue "dataProtectionOfficerEmail")}}
-          ><:label>Adresse e-mail du DPO</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.dpo-email"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -246,7 +246,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.creditError.status}}
             @value={{this.form.credit}}
             {{on "input" (fn this.updateFormValue "credit")}}
-          ><:label>Crédits</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.credits"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -255,7 +255,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.documentationUrlError.status}}
             @value={{this.form.documentationUrl}}
             {{on "input" (fn this.updateFormValue "documentationUrl")}}
-          ><:label>Lien vers la documentation</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.documentation-link"}}</:label></PixInput>
         </div>
 
         <div class="form-field">
@@ -266,7 +266,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @hideDefaultOption={{true}}
             class="admin-form__select"
           >
-            <:label>SSO</:label>
+            <:label>{{t "components.organizations.information-section-view.sso"}}</:label>
           </PixSelect>
         </div>
 
@@ -276,7 +276,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @validationStatus={{this.form.emailError.status}}
             @value={{this.form.email}}
             {{on "input" (fn this.updateFormValue "email")}}
-          ><:label>Adresse e-mail d'activation SCO</:label></PixInput>
+          ><:label>{{t "components.organizations.information-section-view.sco-activation-email"}}</:label></PixInput>
         </div>
 
         <FeaturesForm

--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -27,10 +27,6 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   noIdentityProviderOption = { label: 'Aucun', value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
-  noAdministrationTeamOption = {
-    label: this.intl.t('components.organizations.editing.administration-team.selector.none-option'),
-    value: 'None',
-  };
 
   constructor() {
     super(...arguments);

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -24,10 +24,11 @@ export default class OrganizationInformationSection extends Component {
     <div class="organization__data">
       {{#if @organization.isArchived}}
         <PixNotificationAlert class="organization-information-section__archived-message" @type="warning">
-          Archivée le
-          {{@organization.archivedFormattedDate}}
-          par
-          {{@organization.archivistFullName}}.
+          {{t
+            "components.organizations.information-section-view.is-archived-warning"
+            archivedAt=@organization.archivedFormattedDate
+            archivedBy=@organization.archivistFullName
+          }}
         </PixNotificationAlert>
       {{/if}}
 
@@ -41,7 +42,7 @@ export default class OrganizationInformationSection extends Component {
             </PixButton>
             {{#unless @organization.isArchived}}
               <PixButton @variant="error" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>
-                Archiver l'organisation
+                {{t "components.organizations.information-section-view.archive-organization"}}
               </PixButton>
             {{/unless}}
           </div>
@@ -53,6 +54,7 @@ export default class OrganizationInformationSection extends Component {
 
 class OrganizationDescription extends Component {
   @service oidcIdentityProviders;
+  @service intl;
 
   get identityProviderName() {
     const GARIdentityProvider = { code: 'GAR', organizationName: 'GAR' };
@@ -61,77 +63,77 @@ class OrganizationDescription extends Component {
       (identityProvider) => identityProvider.code === this.args.organization.identityProviderForCampaigns,
     );
     const identityProviderName = identityProvider?.organizationName;
-    return identityProviderName || 'Aucun';
+    return identityProviderName || this.intl.t('common.words.none');
   }
 
   <template>
     <DescriptionList>
       <DescriptionList.Divider />
 
-      <DescriptionList.Item @label="Type">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.type"}}>
         {{@organization.type}}
       </DescriptionList.Item>
-      <DescriptionList.Item @label="Créée par">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.created-by"}}>
         {{@organization.creatorFullName}}
         ({{@organization.createdBy}})
       </DescriptionList.Item>
-      <DescriptionList.Item @label="Créée le">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.created-at"}}>
         {{@organization.createdAtFormattedDate}}
       </DescriptionList.Item>
       {{#if @organization.externalId}}
-        <DescriptionList.Item @label="Identifiant externe">
+        <DescriptionList.Item @label={{t "components.organizations.information-section-view.external-id"}}>
           {{@organization.externalId}}
         </DescriptionList.Item>
       {{/if}}
       {{#if @organization.provinceCode}}
-        <DescriptionList.Item @label="Département">
+        <DescriptionList.Item @label={{t "components.organizations.information-section-view.province-code"}}>
           {{@organization.provinceCode}}
         </DescriptionList.Item>
       {{/if}}
 
       <DescriptionList.Divider />
 
-      <DescriptionList.Item @label="Équipe en charge">
-        {{if @organization.administrationTeamName @organization.administrationTeamName "Non spécifié"}}
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.administration-team"}}>
+        {{if @organization.administrationTeamName @organization.administrationTeamName (t "common.not-specified")}}
       </DescriptionList.Item>
 
       <DescriptionList.Divider />
 
-      <DescriptionList.Item @label="Nom du DPO">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.dpo-name"}}>
         {{@organization.dataProtectionOfficerFullName}}
       </DescriptionList.Item>
-      <DescriptionList.Item @label="Adresse e-mail du DPO">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.dpo-email"}}>
         {{@organization.dataProtectionOfficerEmail}}
       </DescriptionList.Item>
 
       <DescriptionList.Divider />
 
-      <DescriptionList.Item @label="Crédits">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.credits"}}>
         {{@organization.credit}}
       </DescriptionList.Item>
-      <DescriptionList.Item @label="Lien vers la documentation">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.documentation-link"}}>
         {{#if @organization.documentationUrl}}
           <a href="{{@organization.documentationUrl}}" target="_blank" rel="noopener noreferrer">
             {{@organization.documentationUrl}}
           </a>
         {{else}}
-          Non spécifié
+          {{t "common.not-specified"}}
         {{/if}}
       </DescriptionList.Item>
-      <DescriptionList.Item @label="SSO">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.sso"}}>
         {{this.identityProviderName}}
       </DescriptionList.Item>
 
       <DescriptionList.Divider />
 
-      <DescriptionList.Item @label="Adresse e-mail d'activation SCO">
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.sco-activation-email"}}>
         {{@organization.email}}
       </DescriptionList.Item>
 
       {{#if @organization.code}}
         <DescriptionList.Divider />
 
-        <DescriptionList.Item @label="Code">
+        <DescriptionList.Item @label={{t "components.organizations.information-section-view.code"}}>
           {{@organization.code}}
         </DescriptionList.Item>
       {{/if}}

--- a/admin/app/components/organizations/information-section.gjs
+++ b/admin/app/components/organizations/information-section.gjs
@@ -82,7 +82,7 @@ export default class OrganizationInformationSection extends Component {
         </div>
 
         <div class="organization__title">
-          <h2 class="organization__name">{{@organization.name}}</h2>
+          <h1 class="organization__name">{{@organization.name}}</h1>
 
           <ul class="organization-tags-list">
             {{#if this.hasChildren}}

--- a/admin/app/models/organization-form.js
+++ b/admin/app/models/organization-form.js
@@ -94,6 +94,15 @@ const Validations = buildValidations({
       }),
     ],
   },
+  administrationTeamId: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        ignoreBlank: true,
+        message: 'components.organizations.editing.administration-team.selector.error-message',
+      }),
+    ],
+  },
 });
 
 export default class OrganizationForm extends Model.extend(Validations) {
@@ -112,7 +121,10 @@ export default class OrganizationForm extends Model.extend(Validations) {
   #getErrorAttribute(name) {
     const nameAttribute = this.validations.attrs.get(name);
     if (nameAttribute.isInvalid) {
-      return { message: nameAttribute.message, status: 'error' };
+      return {
+        message: nameAttribute.message,
+        status: 'error',
+      };
     }
     return { message: null, status: null };
   }
@@ -151,5 +163,9 @@ export default class OrganizationForm extends Model.extend(Validations) {
 
   get provinceCodeError() {
     return this.#getErrorAttribute('provinceCode');
+  }
+
+  get administrationTeamIdError() {
+    return this.#getErrorAttribute('administrationTeamId');
   }
 }

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -28,6 +28,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           SHOW_SKILLS: { active: false },
           IS_MANAGING_STUDENTS: { active: false },
         },
+        administrationTeamId: 456,
       });
       this.server.create('organization', { id: '1234' });
 

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -1,6 +1,7 @@
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import { module, test } from 'qunit';
@@ -45,9 +46,39 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await clickByName('Enregistrer', { exact: true });
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 2 })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 1 })).exists();
       assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Bru No');
       assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('bru.no@example.net');
+    });
+
+    test('should display an error toast if administration team is not filled in', async function (assert) {
+      // given
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        features: {
+          PLACES_MANAGEMENT: { active: false },
+          LEARNER_IMPORT: { active: false },
+          MULTIPLE_SENDING_ASSESSMENT: { active: false },
+          COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false },
+          ATTESTATIONS_MANAGEMENT: { active: false },
+          SHOW_NPS: { active: false },
+          SHOW_SKILLS: { active: false },
+          IS_MANAGING_STUDENTS: { active: false },
+        },
+        administrationTeamId: null,
+      });
+
+      this.server.create('organization', { id: '1234' });
+
+      const screen = await visit(`/organizations/${organization.id}`);
+
+      await clickByName('Modifier');
+
+      // when
+      await clickByName('Enregistrer', { exact: true });
+
+      // then
+      assert.dom(screen.getByText(t('components.organizations.editing.required-fields-error'))).exists();
     });
   });
 

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -43,7 +43,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await fillByLabel('Nom du DPO', 'No');
       await fillByLabel('Adresse e-mail du DPO', 'bru.no@example.net');
 
-      await clickByName('Enregistrer', { exact: true });
+      await clickByName('Enregistrer');
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 1 })).exists();
@@ -75,7 +75,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await clickByName('Modifier');
 
       // when
-      await clickByName('Enregistrer', { exact: true });
+      await clickByName('Enregistrer');
 
       // then
       assert.dom(screen.getByText(t('components.organizations.editing.required-fields-error'))).exists();

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -150,6 +150,33 @@ module('Integration | Component | organizations/information-section-edit', funct
       assert.dom(screen.getByText("Le lien n'est pas valide.")).exists();
     });
 
+    test("it should show error message if organization's administration is empty", async function (assert) {
+      const organizationWithoutAdministrationTeam = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: null,
+      });
+
+      // when
+      const screen = await render(
+        <template><InformationSectionEdit @organization={{organizationWithoutAdministrationTeam}} /></template>,
+      );
+
+      const administrationTeamIdErrorMessage = screen.getByText(
+        t('components.organizations.editing.administration-team.selector.error-message'),
+      );
+
+      // then
+      assert.ok(administrationTeamIdErrorMessage);
+    });
+
     module('#features', function () {
       test('should display place management features as deactivated', async function (assert) {
         organization.features = {
@@ -219,13 +246,6 @@ module('Integration | Component | organizations/information-section-edit', funct
   module('administration teams select', function () {
     test('it should display select with options loaded', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
-      store.findAll = () =>
-        Promise.resolve([
-          store.createRecord('administration-team', { id: '123', name: 'Équipe 1' }),
-          store.createRecord('administration-team', { id: '456', name: 'Équipe 2' }),
-        ]);
-
       const organization = EmberObject.create({
         id: 1,
         name: 'Organization SCO',
@@ -242,7 +262,9 @@ module('Integration | Component | organizations/information-section-edit', funct
       //when
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
       await click(
-        screen.getByRole('button', { name: t('components.organizations.editing.administration-team.selector.label') }),
+        screen.getByRole('button', {
+          name: `${t('components.organizations.editing.administration-team.selector.label')} *`,
+        }),
       );
       const listbox = await screen.findByRole('listbox');
 
@@ -270,7 +292,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       assert.ok(
         within(
           screen.getByRole('button', {
-            name: t('components.organizations.editing.administration-team.selector.label'),
+            name: `${t('components.organizations.editing.administration-team.selector.label')} *`,
           }),
         ).getByText('Équipe 2'),
       );
@@ -298,7 +320,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       assert.ok(
         within(
           screen.getByRole('button', {
-            name: t('components.organizations.editing.administration-team.selector.label'),
+            name: `${t('components.organizations.editing.administration-team.selector.label')} *`,
           }),
         ).getByText(t('components.organizations.editing.administration-team.selector.placeholder')),
       );

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -45,7 +45,10 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillIn(screen.getByLabelText('Nom *', { exact: false }), '');
+      await fillIn(
+        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
+        '',
+      );
 
       // then
       assert.dom(screen.getByText('Le nom ne peut pas être vide')).exists();
@@ -56,7 +59,10 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillIn(screen.getByLabelText('Nom *', { exact: false }), 'a'.repeat(256));
+      await fillIn(
+        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
+        'a'.repeat(256),
+      );
 
       // then
       assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();
@@ -67,7 +73,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Identifiant externe', 'a'.repeat(256));
+      await fillByLabel(t('components.organizations.information-section-view.external-id'), 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'identifiant externe ne doit pas excéder 255 caractères")).exists();
@@ -78,7 +84,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Département (en 3 chiffres)', 'a'.repeat(256));
+      await fillByLabel(t('components.organizations.editing.province-code.label'), 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText('La longueur du département ne doit pas excéder 255 caractères')).exists();
@@ -89,7 +95,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Adresse e-mail du DPO', 'a'.repeat(256));
+      await fillByLabel(t('components.organizations.information-section-view.dpo-email'), 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'email ne doit pas excéder 255 caractères.")).exists();
@@ -100,7 +106,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Adresse e-mail du DPO', 'not-valid-email-format');
+      await fillByLabel(t('components.organizations.information-section-view.dpo-email'), 'not-valid-email-format');
 
       // then
       assert.dom(screen.getByText("L'e-mail n'a pas le bon format.")).exists();
@@ -111,7 +117,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel("Adresse e-mail d'activation SCO", 'a'.repeat(256));
+      await fillByLabel(t('components.organizations.information-section-view.sco-activation-email'), 'a'.repeat(256));
 
       // then
       assert.dom(screen.getByText("La longueur de l'email ne doit pas excéder 255 caractères.")).exists();
@@ -122,7 +128,10 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel("Adresse e-mail d'activation SCO", 'not-valid-email-format');
+      await fillByLabel(
+        t('components.organizations.information-section-view.sco-activation-email'),
+        'not-valid-email-format',
+      );
 
       // then
       assert.dom(screen.getByText("L'e-mail n'a pas le bon format.")).exists();
@@ -133,7 +142,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Crédits', 'credit');
+      await fillByLabel(t('components.organizations.information-section-view.credits'), 'credit');
 
       // then
       assert.dom(screen.getByText('Le nombre de crédits doit être un nombre supérieur ou égal à 0.')).exists();
@@ -144,7 +153,10 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel('Lien vers la documentation', 'not-valid-url-format');
+      await fillByLabel(
+        t('components.organizations.information-section-view.documentation-link'),
+        'not-valid-url-format',
+      );
 
       // then
       assert.dom(screen.getByText("Le lien n'est pas valide.")).exists();

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -198,10 +198,7 @@ module('Integration | Component | organizations/information-section', function (
 
       await clickByName(t('common.actions.edit'));
 
-      await fillIn(
-        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
-        'new name',
-      );
+      await fillIn(screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`), 'new name');
       await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
       await fillByLabel(t('components.organizations.editing.province-code.label'), 'new provinceCode');
       await clickByName(t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'));
@@ -277,10 +274,7 @@ module('Integration | Component | organizations/information-section', function (
       );
       await clickByName(t('common.actions.edit'));
 
-      await fillIn(
-        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
-        'new name',
-      );
+      await fillIn(screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`), 'new name');
       await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
       await fillByLabel(t('components.organizations.editing.province-code.label'), '');
       await fillByLabel(t('components.organizations.information-section-view.credits'), 50);
@@ -354,10 +348,7 @@ module('Integration | Component | organizations/information-section', function (
       );
       await clickByName(t('common.actions.edit'));
 
-      await fillIn(
-        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
-        '',
-      );
+      await fillIn(screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`), '');
 
       // when
       await clickByName(t('common.actions.save'));

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -89,7 +89,9 @@ module('Integration | Component | organizations/information-section', function (
         const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Organisation mère')).exists();
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.parent-organization')))
+          .exists();
       });
     });
 
@@ -111,7 +113,9 @@ module('Integration | Component | organizations/information-section', function (
         const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Organisation fille de')).exists();
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.child-organization')))
+          .exists();
         assert.dom(screen.getByRole('link', { name: 'Shibusen' })).exists();
       });
     });
@@ -129,7 +133,9 @@ module('Integration | Component | organizations/information-section', function (
         const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.queryByText('Organisation mère')).doesNotExist();
+        assert
+          .dom(screen.queryByText(t('components.organizations.information-section-view.parent-organization')))
+          .doesNotExist();
       });
     });
   });
@@ -153,50 +159,70 @@ module('Integration | Component | organizations/information-section', function (
       const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
 
       // when
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: 'Nom *' })).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: `${t('components.organizations.editing.name.label')} *` }))
+        .exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: t('components.organizations.information-section-view.external-id') }))
+        .exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.cancel') })).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.save') })).exists();
     });
 
     test('it should toggle display mode on click to cancel button', async function (assert) {
       // given
       const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
       // when
-      await clickByName('Annuler');
+      await clickByName(t('common.actions.cancel'));
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-      assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('components.organizations.information-section-view.archive-organization'),
+          }),
+        )
+        .exists();
     });
 
     test('it should revert changes on click to cancel button', async function (assert) {
       // given
       const screen = await render(<template><InformationSection @organization={{organization}} /></template>);
 
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
-      await fillIn(screen.getByLabelText('Nom *', { exact: false }), 'new name');
-      await fillByLabel('Identifiant externe', 'new externalId');
-      await fillByLabel('Département (en 3 chiffres)', 'new provinceCode');
-      await clickByName("Gestion d'élèves/étudiants");
-      await fillByLabel('Lien vers la documentation', 'new documentationUrl');
-      await clickByName("Affichage des acquis dans l'export de résultats");
-      await clickByName("Envoi multiple sur les campagnes d'évaluation");
+      await fillIn(
+        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
+        'new name',
+      );
+      await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
+      await fillByLabel(t('components.organizations.editing.province-code.label'), 'new provinceCode');
+      await clickByName(t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'));
+      await fillByLabel(
+        t('components.organizations.information-section-view.documentation-link'),
+        'new documentationUrl',
+      );
+      await clickByName(t('components.organizations.information-section-view.features.SHOW_SKILLS'));
+      await clickByName(t('components.organizations.information-section-view.features.MULTIPLE_SENDING_ASSESSMENT'));
 
       // when
-      await clickByName('Annuler');
+      await clickByName(t('common.actions.cancel'));
 
       // then
       assert.dom(screen.getByRole('heading', { name: organization.name })).exists();
-      assert.dom(screen.getByText('Identifiant externe').nextElementSibling).hasText(organization.externalId);
-      assert.dom(screen.getByText('Département').nextElementSibling).hasText(organization.provinceCode);
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.external-id')).nextElementSibling)
+        .hasText(organization.externalId);
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.province-code')).nextElementSibling)
+        .hasText(organization.provinceCode);
       assert.dom(screen.getByRole('link', { name: organization.documentationUrl })).exists();
       assert
         .dom(
@@ -249,30 +275,44 @@ module('Integration | Component | organizations/information-section', function (
       const screen = await render(
         <template><InformationSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
       );
-      await clickByName('Modifier');
+      await clickByName(t('common.actions.edit'));
 
-      await fillIn(screen.getByLabelText('Nom *', { exact: false }), 'new name');
-      await fillByLabel('Identifiant externe', 'new externalId');
-      await fillByLabel('Département (en 3 chiffres)', '');
-      await fillByLabel('Crédits', 50);
-      await clickByName("Gestion d'élèves/étudiants");
-      await fillByLabel('Lien vers la documentation', 'https://pix.fr/');
-      await clickByName('SSO');
+      await fillIn(
+        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
+        'new name',
+      );
+      await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
+      await fillByLabel(t('components.organizations.editing.province-code.label'), '');
+      await fillByLabel(t('components.organizations.information-section-view.credits'), 50);
+      await clickByName(t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'));
+      await fillByLabel(t('components.organizations.information-section-view.documentation-link'), 'https://pix.fr/');
+      await clickByName(t('components.organizations.information-section-view.sso'));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'organization 2' }));
-      await clickByName("Affichage des acquis dans l'export de résultats");
-      await clickByName("Envoi multiple sur les campagnes d'évaluation");
-      await clickByName('Affichage de la page Places sur PixOrga');
+      await clickByName(t('components.organizations.information-section-view.features.SHOW_SKILLS'));
+      await clickByName(t('components.organizations.information-section-view.features.MULTIPLE_SENDING_ASSESSMENT'));
+      await clickByName(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'));
 
       // when
-      await clickByName('Enregistrer');
+      await clickByName(t('common.actions.save'));
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'new name' })).exists();
-      assert.dom(screen.getByText('Identifiant externe').nextElementSibling).hasText('new externalId');
-      assert.dom(screen.queryByText('Département')).doesNotExist();
-      assert.dom(screen.getByText('Équipe en charge').nextElementSibling).hasText('Équipe 1');
-      assert.dom(screen.getByText('Crédits').nextElementSibling).hasText('50');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.external-id')).nextElementSibling)
+        .hasText('new externalId');
+      assert
+        .dom(screen.queryByText(t('components.organizations.information-section-view.province-code')))
+        .doesNotExist();
+      assert
+        .dom(
+          screen.getByText(t('components.organizations.information-section-view.administration-team'))
+            .nextElementSibling,
+        )
+        .hasText('Équipe 1');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.credits')).nextElementSibling)
+        .hasText('50');
       assert
         .dom(
           screen.getByLabelText(
@@ -283,7 +323,9 @@ module('Integration | Component | organizations/information-section', function (
         )
         .exists();
       assert.dom(screen.getByRole('link', { name: 'https://pix.fr/' })).exists();
-      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('organization 2');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
+        .hasText('organization 2');
       assert
         .dom(
           screen.getByLabelText(
@@ -312,7 +354,10 @@ module('Integration | Component | organizations/information-section', function (
       );
       await clickByName(t('common.actions.edit'));
 
-      await fillIn(screen.getByLabelText('Nom *', { exact: false }), '');
+      await fillIn(
+        screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`, { exact: false }),
+        '',
+      );
 
       // when
       await clickByName(t('common.actions.save'));

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -21,8 +21,8 @@ module('Integration | Component | organizations/information-section', function (
     const store = this.owner.lookup('service:store');
     store.findAll = () =>
       Promise.resolve([
-        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
+        store.createRecord('administration-team', { id: '123', name: 'Équipe 1' }),
+        store.createRecord('administration-team', { id: '456', name: 'Équipe 2' }),
       ]);
   });
 
@@ -145,6 +145,7 @@ module('Integration | Component | organizations/information-section', function (
       credit: 0,
       documentationUrl: 'https://pix.fr/',
       features: {},
+      administrationTeamId: 123,
     });
 
     test('it should toggle edition mode on click to edit button', async function (assert) {
@@ -270,6 +271,7 @@ module('Integration | Component | organizations/information-section', function (
       assert.dom(screen.getByRole('heading', { name: 'new name' })).exists();
       assert.dom(screen.getByText('Identifiant externe').nextElementSibling).hasText('new externalId');
       assert.dom(screen.queryByText('Département')).doesNotExist();
+      assert.dom(screen.getByText('Équipe en charge').nextElementSibling).hasText('Équipe 1');
       assert.dom(screen.getByText('Crédits').nextElementSibling).hasText('50');
       assert
         .dom(
@@ -300,6 +302,25 @@ module('Integration | Component | organizations/information-section', function (
           ),
         )
         .exists();
+    });
+
+    test('it should not submit the form if there is an error', async function (assert) {
+      // given
+      const onSubmit = () => {};
+      const screen = await render(
+        <template><InformationSection @organization={{organization}} @onSubmit={{onSubmit}} /></template>,
+      );
+      await clickByName(t('common.actions.edit'));
+
+      await fillIn(screen.getByLabelText('Nom *', { exact: false }), '');
+
+      // when
+      await clickByName(t('common.actions.save'));
+
+      // then
+      assert.ok(screen.getByRole('button', { name: t('common.actions.cancel') }));
+      assert.ok(screen.getByRole('button', { name: t('common.actions.save') }));
+      assert.notOk(screen.queryByRole('button', { name: t('common.actions.edit') }));
     });
   });
 });

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -277,12 +277,24 @@ module('Integration | Component | organizations/information-section', function (
       await fillIn(screen.getByLabelText(`${t('components.organizations.editing.name.label')} *`), 'new name');
       await fillByLabel(t('components.organizations.information-section-view.external-id'), 'new externalId');
       await fillByLabel(t('components.organizations.editing.province-code.label'), '');
+
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.editing.administration-team.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Équipe 2' }));
+
       await fillByLabel(t('components.organizations.information-section-view.credits'), 50);
       await clickByName(t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'));
       await fillByLabel(t('components.organizations.information-section-view.documentation-link'), 'https://pix.fr/');
+
       await clickByName(t('components.organizations.information-section-view.sso'));
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'organization 2' }));
+      const ssoOption = await screen.findByRole('option', { name: 'organization 2' });
+      await click(ssoOption);
+
       await clickByName(t('components.organizations.information-section-view.features.SHOW_SKILLS'));
       await clickByName(t('components.organizations.information-section-view.features.MULTIPLE_SENDING_ASSESSMENT'));
       await clickByName(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'));
@@ -303,7 +315,7 @@ module('Integration | Component | organizations/information-section', function (
           screen.getByText(t('components.organizations.information-section-view.administration-team'))
             .nextElementSibling,
         )
-        .hasText('Équipe 1');
+        .hasText('Équipe 2');
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.credits')).nextElementSibling)
         .hasText('50');

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -54,12 +54,27 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByText('Type').nextElementSibling).hasText('SUP');
-      assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Justin Ptipeu');
-      assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('justin.ptipeu@example.net');
-      assert.dom(screen.getByText('Créée par').nextElementSibling).hasText('Gilles Parbal (1)');
-      assert.dom(screen.getByText('Créée le').nextElementSibling).hasText('02/09/2022');
-      assert.dom(screen.getByText('Équipe en charge').nextElementSibling).hasText('team Rocket');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.type')).nextElementSibling)
+        .hasText('SUP');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.dpo-name')).nextElementSibling)
+        .hasText('Justin Ptipeu');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.dpo-email')).nextElementSibling)
+        .hasText('justin.ptipeu@example.net');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.created-by')).nextElementSibling)
+        .hasText('Gilles Parbal (1)');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.created-at')).nextElementSibling)
+        .hasText('02/09/2022');
+      assert
+        .dom(
+          screen.getByText(t('components.organizations.information-section-view.administration-team'))
+            .nextElementSibling,
+        )
+        .hasText('team Rocket');
       assert
         .dom(
           screen.getByLabelText(
@@ -67,11 +82,19 @@ module('Integration | Component | organizations/information-section-view', funct
           ),
         )
         .exists();
-      assert.dom(screen.getByText('Crédits').nextElementSibling).hasText('350');
-      assert.dom(screen.getByText('Lien vers la documentation').nextElementSibling).hasText('https://pix.fr');
-      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('super-sso');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.credits')).nextElementSibling)
+        .hasText('350');
+      assert
+        .dom(
+          screen.getByText(t('components.organizations.information-section-view.documentation-link'))
+            .nextElementSibling,
+        )
+        .hasText('https://pix.fr');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
+        .hasText('super-sso');
     });
-
     test('it renders GAR identity provider correctly', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -98,7 +121,9 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByText('SSO').nextElementSibling).hasText('GAR');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
+        .hasText('GAR');
     });
 
     module('data protection officer information', function () {
@@ -126,8 +151,12 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('Justin Ptipeu');
-        assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('justin.ptipeu@example.net');
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.dpo-name')).nextElementSibling)
+          .hasText('Justin Ptipeu');
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.dpo-email')).nextElementSibling)
+          .hasText('justin.ptipeu@example.net');
       });
 
       test('it renders without DPO information', async function (assert) {
@@ -155,8 +184,12 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Nom du DPO').nextElementSibling).hasText('');
-        assert.dom(screen.getByText('Adresse e-mail du DPO').nextElementSibling).hasText('');
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.dpo-name')).nextElementSibling)
+          .hasText('');
+        assert
+          .dom(screen.getByText(t('components.organizations.information-section-view.dpo-email')).nextElementSibling)
+          .hasText('');
       });
     });
 
@@ -168,8 +201,14 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
-      assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('components.organizations.information-section-view.archive-organization'),
+          }),
+        )
+        .exists();
     });
 
     test('it should display empty documentation link message', async function (assert) {
@@ -180,7 +219,12 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.getByText('Lien vers la documentation').nextElementSibling).hasText('Non spécifié');
+      assert
+        .dom(
+          screen.getByText(t('components.organizations.information-section-view.documentation-link'))
+            .nextElementSibling,
+        )
+        .hasText(t('common.not-specified'));
     });
 
     module('when organization is archived', function () {
@@ -194,7 +238,16 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Archivée le 22/02/2022 par Rob Lochon.')).exists();
+        assert
+          .dom(
+            screen.getByText(
+              t('components.organizations.information-section-view.is-archived-warning', {
+                archivedAt: '22/02/2022',
+                archivedBy: 'Rob Lochon',
+              }),
+            ),
+          )
+          .exists();
       });
     });
 
@@ -256,7 +309,13 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
         // then
-        assert.dom(screen.queryByRole('checkbox', { name: 'Gestion d’élèves/étudiants' })).doesNotExist();
+        assert
+          .dom(
+            screen.queryByRole('checkbox', {
+              name: t('components.organizations.information-section-view.features.IS_MANAGING_STUDENTS'),
+            }),
+          )
+          .doesNotExist();
       });
     });
 
@@ -428,8 +487,14 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Modifier' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: "Archiver l'organisation" })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: t('common.actions.edit') })).doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: t('components.organizations.information-section-view.archive-organization'),
+          }),
+        )
+        .doesNotExist();
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -80,6 +80,7 @@
       "send-new-confirm": "An email has been sent to {invitationEmail}",
       "send-new-label": "Resend the invitation to {invitationEmail}"
     },
+    "not-specified": "Not specified",
     "notifications": {
       "close-button": {
         "extra-information": "Close notification"
@@ -97,6 +98,7 @@
     },
     "words": {
       "no": "No",
+      "none": "None",
       "yes": "Yes"
     }
   },
@@ -570,10 +572,28 @@
             "label": "Administration team",
             "placeholder": "Choose an administration team"
           }
+        },
+        "name": {
+          "label": "Name"
+        },
+        "province-code": {
+          "label": "Province code (3 digits)"
         }
       },
       "information-section-view": {
+        "administration-team": "Administration team",
+        "archive-organization": "Archive organization",
         "child-organization": "Child organization of",
+        "code": "Code",
+        "created-at": "Created on",
+        "created-by": "Created by",
+        "credits": "Credits",
+        "documentation-link": "Link to the documentation",
+        "dpo-email": "DPO's e-mail address",
+        "dpo-firstname": "DPO's firstname",
+        "dpo-lastname": "DPO's lastname",
+        "dpo-name": "DPO's name",
+        "external-id": "External identifier",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Automatic certificability",
@@ -590,7 +610,12 @@
           },
           "title": "Features"
         },
-        "parent-organization": "Parent organization"
+        "is-archived-warning": "Archived at {archivedAt} by {archivedBy}.",
+        "parent-organization": "Parent organization",
+        "province-code": "Province code",
+        "sco-activation-email": "SCO activation e-mail address",
+        "sso": "SSO",
+        "type": "Type"
       },
       "invitations": {
         "table": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -578,7 +578,8 @@
         },
         "province-code": {
           "label": "Province code (3 digits)"
-        }
+        },
+        "required-fields-error": "Please fill in all required fields."
       },
       "information-section-view": {
         "administration-team": "Administration team",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -566,6 +566,7 @@
       "editing": {
         "administration-team": {
           "selector": {
+            "error-message": "Administration team is required",
             "label": "Administration team",
             "placeholder": "Choose an administration team"
           }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -80,6 +80,7 @@
       "send-new-confirm": "Un email a bien été renvoyé à {invitationEmail}",
       "send-new-label": "Renvoyer l'invitation à {invitationEmail}"
     },
+    "not-specified": "Non spécifié",
     "notifications": {
       "close-button": {
         "extra-information": "Fermer la notification"
@@ -97,6 +98,7 @@
     },
     "words": {
       "no": "Non",
+      "none": "Aucun",
       "yes": "Oui"
     }
   },
@@ -571,10 +573,28 @@
             "label": "Équipe en charge",
             "placeholder": "Sélectionner une équipe en charge"
           }
+        },
+        "name": {
+          "label": "Nom"
+        },
+        "province-code": {
+          "label": "Département (en 3 chiffres)"
         }
       },
       "information-section-view": {
+        "administration-team": "Équipe en charge",
+        "archive-organization": "Archiver l'organisation",
         "child-organization": "Organisation fille de",
+        "code": "Code",
+        "created-at": "Créée le",
+        "created-by": "Créée par",
+        "credits": "Crédits",
+        "documentation-link": "Lien vers la documentation",
+        "dpo-email": "Adresse e-mail du DPO",
+        "dpo-firstname": "Prénom du DPO",
+        "dpo-lastname": "Nom du DPO",
+        "dpo-name": "Nom du DPO",
+        "external-id": "Identifiant externe",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Certificabilité automatique",
@@ -591,7 +611,12 @@
           },
           "title": "Fonctionnalités"
         },
-        "parent-organization": "Organisation mère"
+        "is-archived-warning": "Archivée le {archivedAt} par {archivedBy}.",
+        "parent-organization": "Organisation mère",
+        "province-code": "Département",
+        "sco-activation-email": "Adresse e-mail d'activation SCO",
+        "sso": "SSO",
+        "type": "Type"
       },
       "invitations": {
         "table": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -567,6 +567,7 @@
       "editing": {
         "administration-team": {
           "selector": {
+            "error-message": "L'équipe en charge est requise",
             "label": "Équipe en charge",
             "placeholder": "Sélectionner une équipe en charge"
           }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -579,7 +579,8 @@
         },
         "province-code": {
           "label": "Département (en 3 chiffres)"
-        }
+        },
+        "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "information-section-view": {
         "administration-team": "Équipe en charge",

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,6 +1,15 @@
-const updateOrganizationInformation = async function ({ organization, organizationForAdminRepository, tagRepository }) {
+import { AdministrationTeamNotFound } from '../errors.js';
+
+const updateOrganizationInformation = async function ({
+  organization,
+  organizationForAdminRepository,
+  tagRepository,
+  administrationTeamRepository,
+}) {
   const existingOrganization = await organizationForAdminRepository.get({ organizationId: organization.id });
   const tagsToUpdate = await tagRepository.findByIds(organization.tagIds);
+
+  await _checkAdministrationTeamExists(organization.administrationTeamId, administrationTeamRepository);
 
   existingOrganization.updateWithDataProtectionOfficerAndTags(
     organization,
@@ -12,5 +21,17 @@ const updateOrganizationInformation = async function ({ organization, organizati
 
   return organizationForAdminRepository.get({ organizationId: organization.id });
 };
+
+async function _checkAdministrationTeamExists(administrationTeamId, administrationTeamRepository) {
+  const existingAdministrationTeam = await administrationTeamRepository.getById(administrationTeamId);
+
+  if (!existingAdministrationTeam) {
+    throw new AdministrationTeamNotFound({
+      meta: {
+        administrationTeamId: administrationTeamId,
+      },
+    });
+  }
+}
 
 export { updateOrganizationInformation };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -587,6 +587,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   describe('PATCH /api/admin/organizations/{organizationId}', function () {
     it('should return the updated organization and status code 200', async function () {
       // given
+      const administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+
       const organizationAttributes = {
         externalId: '0446758F',
         provinceCode: '044',
@@ -606,6 +608,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             'province-code': organizationAttributes.provinceCode,
             email: organizationAttributes.email,
             credit: organizationAttributes.credit,
+            'administration-team-id': administrationTeamId,
           },
         },
       };

--- a/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
+++ b/api/tests/organizational-entities/integration/application/organization-administration.controller.test.js
@@ -6,8 +6,11 @@ import { databaseBuilder, expect, hFake, knex } from '../../../test-helper.js';
 describe('Integration | Organizational Entities | Application | Controller | Organization Administration', function () {
   let organization;
   let featureId;
+  let administrationTeamId;
 
   beforeEach(async function () {
+    administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+
     organization = databaseBuilder.factory.buildOrganization({
       name: 'organization name',
       type: 'SCO',
@@ -20,6 +23,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
       documentationUrl: 'overthere',
       showSkills: false,
       identityProviderForCampaigns: 'POLE_EMPLOI',
+      administrationTeamId: administrationTeamId,
     });
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
     featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT).id;
@@ -46,6 +50,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
               'documentation-url': 'here',
               'show-skills': true,
               'identity-provider-for-campaigns': 'genericOidcProviderCode',
+              'administration-team-id': administrationTeamId,
             },
           },
         },
@@ -72,6 +77,9 @@ describe('Integration | Organizational Entities | Application | Controller | Org
       expect(response.source.data.attributes['identity-provider-for-campaigns']).to.equal(
         savedOrganization.identityProviderForCampaigns,
       );
+      expect(response.source.data.attributes['administration-team-id']).to.equal(
+        savedOrganization.administrationTeamId,
+      );
     });
   });
 
@@ -88,7 +96,9 @@ describe('Integration | Organizational Entities | Application | Controller | Org
       payload: {
         data: {
           id: organization.id,
-          attributes: {},
+          attributes: {
+            'administration-team-id': administrationTeamId,
+          },
           relationships: {
             tags: {
               data: [{ type: 'tags', id: newTag.id }],
@@ -125,6 +135,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
         data: {
           id: organization.id,
           attributes: {
+            'administration-team-id': administrationTeamId,
             'data-protection-officer-first-name': 'updated first name',
             'data-protection-officer-last-name': 'updated last name',
             'data-protection-officer-email': 'updatedEmail',
@@ -152,6 +163,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
         data: {
           id: organization.id,
           attributes: {
+            'administration-team-id': administrationTeamId,
             features: {
               [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
             },
@@ -185,6 +197,7 @@ describe('Integration | Organizational Entities | Application | Controller | Org
         data: {
           id: organization.id,
           attributes: {
+            'administration-team-id': administrationTeamId,
             features: {
               [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
             },

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -1,5 +1,8 @@
+import { AdministrationTeamNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
+import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import {
+  catchErr,
   databaseBuilder,
   domainBuilder,
   expect,
@@ -7,10 +10,12 @@ import {
 } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCases | update-organization', function () {
+  beforeEach(async function () {
+    await insertMultipleSendingFeatureForNewOrganization();
+  });
+
   it('updates organization information', async function () {
     // given
-    await insertMultipleSendingFeatureForNewOrganization();
-
     const organizationId = databaseBuilder.factory.buildOrganization().id;
 
     const newAdministrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
@@ -29,7 +34,30 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
     });
 
     // then
+    expect(updatedOrganization).to.be.instanceOf(OrganizationForAdmin);
     expect(updatedOrganization.name).to.equal("Nouveau nom d'organization");
     expect(updatedOrganization.administrationTeamId).to.equal(newAdministrationTeamId);
+  });
+
+  context('when administration team does not exist', function () {
+    it('throws an AdministrationTeamNotFound error', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+
+      const organizationNewInformations = domainBuilder.buildOrganizationForAdmin({
+        id: organizationId,
+        administrationTeamId: 123,
+      });
+
+      // when
+      const error = await catchErr(usecases.updateOrganizationInformation)({
+        organization: organizationNewInformations,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AdministrationTeamNotFound);
+    });
   });
 });

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
@@ -1,4 +1,3 @@
-import { AdministrationTeamNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -83,37 +82,6 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-    });
-
-    it('should reject with an AdministrationTeamNotFound (DomainError) when the administrationTeam does not exist', async function () {
-      // given
-      const givenOrganization = domainBuilder.buildOrganizationForAdmin({ administrationTeamId: 123 });
-
-      const existingOrganizationForAdmin = domainBuilder.buildOrganizationForAdmin({
-        organizationId: givenOrganization.id,
-      });
-      sinon.stub(existingOrganizationForAdmin, 'updateWithDataProtectionOfficerAndTags');
-
-      organizationForAdminRepository.get.onCall(0).returns(existingOrganizationForAdmin);
-
-      const updatedOrganization = domainBuilder.buildOrganizationForAdmin({ organizationId: givenOrganization.id });
-      organizationForAdminRepository.get.onCall(1).returns(updatedOrganization);
-
-      const tagsToUpdate = Symbol('tagsToUpdate');
-      tagRepository.findByIds.withArgs(givenOrganization.tagIds).resolves(tagsToUpdate);
-
-      administrationTeamRepository.getById.withArgs(givenOrganization.administrationTeamId).resolves(null);
-
-      // when
-      const error = await catchErr(usecases.updateOrganizationInformation)({
-        organization: givenOrganization,
-        organizationForAdminRepository,
-        tagRepository,
-        administrationTeamRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(AdministrationTeamNotFound);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
@@ -1,10 +1,11 @@
+import { AdministrationTeamNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Domain | UseCase | update-organization-information', function () {
-  let organizationForAdminRepository, tagRepository;
+  let organizationForAdminRepository, tagRepository, administrationTeamRepository;
 
   beforeEach(function () {
     organizationForAdminRepository = {
@@ -14,30 +15,49 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
     tagRepository = {
       findByIds: sinon.stub(),
     };
+    administrationTeamRepository = {
+      getById: sinon.stub(),
+    };
   });
 
   it('should update organization information', async function () {
     // given
-    const givenOrganization = domainBuilder.buildOrganizationForAdmin();
+    const givenOrganization = domainBuilder.buildOrganizationForAdmin({
+      administrationTeamId: Symbol('administrationTeamId'),
+    });
 
     const existingOrganizationForAdmin = domainBuilder.buildOrganizationForAdmin({
       organizationId: givenOrganization.id,
     });
-    sinon.stub(existingOrganizationForAdmin, 'updateWithDataProtectionOfficerAndTags');
     organizationForAdminRepository.get.onCall(0).returns(existingOrganizationForAdmin);
+
+    sinon.stub(existingOrganizationForAdmin, 'updateWithDataProtectionOfficerAndTags');
+
     const updatedOrganization = domainBuilder.buildOrganizationForAdmin({ organizationId: givenOrganization.id });
     organizationForAdminRepository.get.onCall(1).returns(updatedOrganization);
+
     const tagsToUpdate = Symbol('tagsToUpdate');
     tagRepository.findByIds.withArgs(givenOrganization.tagIds).resolves(tagsToUpdate);
+
+    const existingAdministrationTeam = Symbol('existingAdministrationTeam');
+
+    administrationTeamRepository.getById
+      .withArgs(givenOrganization.administrationTeamId)
+      .resolves(existingAdministrationTeam);
+
     // when
     const result = await usecases.updateOrganizationInformation({
       organization: givenOrganization,
       organizationForAdminRepository,
       tagRepository,
+      administrationTeamRepository,
     });
 
     // then
     expect(organizationForAdminRepository.get).to.have.been.calledWithExactly({ organizationId: givenOrganization.id });
+
+    expect(administrationTeamRepository.getById).to.have.been.calledWithExactly(givenOrganization.administrationTeamId);
+
     expect(existingOrganizationForAdmin.updateWithDataProtectionOfficerAndTags).to.have.been.calledWithExactly(
       givenOrganization,
       givenOrganization.dataProtectionOfficer,
@@ -63,6 +83,37 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should reject with an AdministrationTeamNotFound (DomainError) when the administrationTeam does not exist', async function () {
+      // given
+      const givenOrganization = domainBuilder.buildOrganizationForAdmin({ administrationTeamId: 123 });
+
+      const existingOrganizationForAdmin = domainBuilder.buildOrganizationForAdmin({
+        organizationId: givenOrganization.id,
+      });
+      sinon.stub(existingOrganizationForAdmin, 'updateWithDataProtectionOfficerAndTags');
+
+      organizationForAdminRepository.get.onCall(0).returns(existingOrganizationForAdmin);
+
+      const updatedOrganization = domainBuilder.buildOrganizationForAdmin({ organizationId: givenOrganization.id });
+      organizationForAdminRepository.get.onCall(1).returns(updatedOrganization);
+
+      const tagsToUpdate = Symbol('tagsToUpdate');
+      tagRepository.findByIds.withArgs(givenOrganization.tagIds).resolves(tagsToUpdate);
+
+      administrationTeamRepository.getById.withArgs(givenOrganization.administrationTeamId).resolves(null);
+
+      // when
+      const error = await catchErr(usecases.updateOrganizationInformation)({
+        organization: givenOrganization,
+        organizationForAdminRepository,
+        tagRepository,
+        administrationTeamRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AdministrationTeamNotFound);
     });
   });
 });


### PR DESCRIPTION
## ☔ Problème

Sur Pix Admin, il faut rendre obligatoire le champ "Équipe en charge" lors de la modification d'une orga.

## 🧥 Proposition

Ajouter une indication visuelle sur le champ indiquant que celui-ci est obligatoire, empêcher la soumission du formulaire si celui-ci n'est pas renseigné, afficher un message d'erreur sur le champ et un toast.

## 🍂 Remarques

- Ce champ n'est pour le moment pas obligatoire en BDD, mais il l'est à la création d'une orga.
- Un commit optionnel remplace les textes _en dur_ par des clés de traduction dans les composants de détail d'une orga et le formulaire d'édition.

## 🎃 Pour tester

Sur Pix Admin:
- choisir une orga "legacy" sans équipe en charge
- constater que le menu déroulant Équipe en charge incite à choisir une équipe
- sans en sélectionner, tenter de valider le formulaire
- constater que celui-ci ne se soumet pas et constater les message d'erreur (sur le champ + toast)
