### PR TITLE
[BUGFIX] Un logger.error() se déclenche en fin de stream même lorsque tout s'est bien passé

### DIFF
--- a/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
+++ b/api/src/llm/infrastructure/streaming/transforms/response-object-to-event-stream-transform.js
@@ -24,7 +24,6 @@ export function getTransform(streamCapture) {
 
       if (wasModerated) {
         streamCapture.wasModerated = true;
-        streamCapture.done = true;
         data += events.getMessageModerated();
       }
 
@@ -35,13 +34,13 @@ export function getTransform(streamCapture) {
 
       if (error) {
         streamCapture.errorOccurredDuringStream = error;
-        streamCapture.done = true;
         data += events.getError();
       }
 
       if (usage) {
         streamCapture.inputTokens = usage?.input_tokens ?? streamCapture.inputTokens;
         streamCapture.outputTokens = usage?.output_tokens ?? streamCapture.outputTokens;
+        streamCapture.done = true;
       }
 
       if (data) callback(null, data);

--- a/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
+++ b/api/tests/llm/unit/infrastructure/streaming/transforms/response-object-to-event-stream-transform_test.js
@@ -214,12 +214,12 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 0,
           outputTokens: 0,
           wasModerated: false,
-          done: false,
+          done: true,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
 
-      it('should capture the inputTokens and outputTokens values in "usage" key if present', async function () {
+      it('should capture the inputTokens and outputTokens values in "usage" key if present and set done to true', async function () {
         // given
         const input = [
           { message: 'Coucou les amis \ncomment ça va ?' },
@@ -244,12 +244,12 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           inputTokens: 2_000,
           outputTokens: 5_000,
           wasModerated: false,
-          done: false,
+          done: true,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
 
-      it('should capture the wasModerated flag if present and set streamCapture as done', async function () {
+      it('should capture the wasModerated flag if present', async function () {
         // given
         const input = [
           { message: 'Coucou les amis \ncomment ça va ?' },
@@ -280,7 +280,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?Et toi ?');
       });
 
-      it('should capture the error content if error was present and set streamCapture as done', async function () {
+      it('should capture the error content if error was present', async function () {
         // given
         const input = [
           { message: 'Coucou les amis \ncomment ça va ?' },
@@ -302,7 +302,7 @@ describe('LLM | Unit | Infrastructure | Streaming | Transforms | ResponseObjectT
           outputTokens: 0,
           wasModerated: false,
           errorOccurredDuringStream: 'je me suis cassé un ongle',
-          done: true,
+          done: false,
         });
         expect(streamCapture.LLMMessageParts.join('')).to.equal('Coucou les amis \ncomment ça va ?');
       });


### PR DESCRIPTION
## ☔ Problème

Un logger.error() se déclenche à chaque fois, même quand tout est OK

## 🧥 Proposition

La manière de flag le streamCapture.done n'était pas la bonne.
Maintenant, on regarde si on a reçu l'usage (toujours envoyé, en erreur comme en succès).

## 🍂 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎃 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
