### PR TITLE
[FEATURE] Créer des organization_learner_participations au démarrage d'un Parcours Combiné (PIX-19889).

### DIFF
--- a/api/db/database-builder/factory/build-combined-course-participation.js
+++ b/api/db/database-builder/factory/build-combined-course-participation.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import { CombinedCourseParticipationStatuses } from '../../../src/prescription/shared/domain/constants.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildCombinedCourse } from './build-combined-course.js';
 import { buildOrganizationLearner } from './build-organization-learner.js';
 import { buildQuest } from './build-quest.js';
 
@@ -14,9 +15,12 @@ const buildCombinedCourseParticipation = function ({
   status = STARTED,
   createdAt = new Date(),
   updatedAt = new Date(),
+  combinedCourseId,
+  organizationLearnerParticipationId = null,
 } = {}) {
   organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
   questId = _.isUndefined(questId) ? buildQuest().id : questId;
+  combinedCourseId = _.isUndefined(combinedCourseId) ? buildCombinedCourse().id : combinedCourseId;
 
   const values = {
     id,
@@ -25,6 +29,8 @@ const buildCombinedCourseParticipation = function ({
     status,
     createdAt,
     updatedAt,
+    combinedCourseId,
+    organizationLearnerParticipationId,
   };
 
   databaseBuffer.pushInsertable({
@@ -39,6 +45,8 @@ const buildCombinedCourseParticipation = function ({
     status,
     createdAt,
     updatedAt,
+    combinedCourseId,
+    organizationLearnerParticipationId,
   };
 };
 

--- a/api/db/database-builder/factory/build-organization-learner-participation.js
+++ b/api/db/database-builder/factory/build-organization-learner-participation.js
@@ -1,11 +1,14 @@
 import _ from 'lodash';
 
+import { OrganizationLearnerParticipationTypes } from '../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildCombinedCourseParticipation } from './build-combined-course-participation.js';
+import { buildOrganizationLearnerPassageParticipation } from './build-organization-learner-passage-participation.js';
 import { buildOrganizationLearner } from './prescription/organization-learners/build-organization-learner.js';
 
 const buildOrganizationLearnerParticipation = function ({
   id = databaseBuffer.getNextId(),
-  type = 'passage',
+  type = OrganizationLearnerParticipationTypes.PASSAGE,
   createdAt = new Date(),
   updatedAt = new Date(),
   completedAt = null,
@@ -14,6 +17,8 @@ const buildOrganizationLearnerParticipation = function ({
   organizationLearnerId,
   status,
   moduleId,
+  combinedCourseId,
+  questId,
 } = {}) {
   organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
 
@@ -33,13 +38,31 @@ const buildOrganizationLearnerParticipation = function ({
     tableName: 'organization_learner_participations',
     values,
   });
+  let organizationLearnerPassageId, organizationLearnerCombinedCourseParticipationId;
+  if (type === OrganizationLearnerParticipationTypes.PASSAGE) {
+    organizationLearnerPassageId = buildOrganizationLearnerPassageParticipation({
+      moduleId,
+      organizationLearnerParticipationId: organizationLearnerParticipation.id,
+    }).id;
+  }
 
-  databaseBuffer.pushInsertable({
-    tableName: 'organization_learner_passage_participations',
-    values: { id, moduleId, organizationLearnerParticipationId: organizationLearnerParticipation.id },
-  });
+  if (type === OrganizationLearnerParticipationTypes.COMBINED_COURSE) {
+    organizationLearnerCombinedCourseParticipationId = buildCombinedCourseParticipation({
+      organizationLearnerId,
+      questId,
+      combinedCourseId,
+      status,
+      createdAt,
+      updatedAt,
+      organizationLearnerParticipationId: organizationLearnerParticipation.id,
+    }).id;
+  }
 
-  return organizationLearnerParticipation;
+  return {
+    ...organizationLearnerParticipation,
+    organizationLearnerPassageId,
+    organizationLearnerCombinedCourseParticipationId,
+  };
 };
 
 export { buildOrganizationLearnerParticipation };

--- a/api/db/database-builder/factory/build-organization-learner-participation.js
+++ b/api/db/database-builder/factory/build-organization-learner-participation.js
@@ -19,6 +19,7 @@ const buildOrganizationLearnerParticipation = function ({
   moduleId,
   combinedCourseId,
   questId,
+  addAttributes = true,
 } = {}) {
   organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
 
@@ -32,6 +33,7 @@ const buildOrganizationLearnerParticipation = function ({
     deletedBy,
     organizationLearnerId,
     status,
+    attributes: addAttributes ? JSON.stringify({ id: moduleId ?? combinedCourseId }) : null,
   };
 
   const organizationLearnerParticipation = databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/build-organization-learner-passage-participation.js
+++ b/api/db/database-builder/factory/build-organization-learner-passage-participation.js
@@ -1,0 +1,14 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildOrganizationLearnerPassageParticipation = function ({
+  id = databaseBuffer.getNextId(),
+  moduleId,
+  organizationLearnerParticipationId,
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'organization_learner_passage_participations',
+    values: { id, moduleId, organizationLearnerParticipationId },
+  });
+};
+
+export { buildOrganizationLearnerPassageParticipation };

--- a/api/src/devcomp/application/api/models/ModuleStatus.js
+++ b/api/src/devcomp/application/api/models/ModuleStatus.js
@@ -1,10 +1,13 @@
 export class ModuleStatus {
-  constructor({ id, slug, title, status, duration, image }) {
+  constructor({ id, slug, title, status, duration, image, createdAt, updatedAt, terminatedAt }) {
     this.id = id;
     this.slug = slug;
     this.title = title;
     this.status = status;
     this.duration = duration;
     this.image = image;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.terminatedAt = terminatedAt;
   }
 }

--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -45,6 +45,9 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
       slug,
       title,
       status: userModuleStatus.status,
+      createdAt: userModuleStatus.createdAt,
+      updatedAt: userModuleStatus.updatedAt,
+      terminatedAt: userModuleStatus.terminatedAt,
       duration,
       image,
     });

--- a/api/src/devcomp/domain/models/module/UserModuleStatus.js
+++ b/api/src/devcomp/domain/models/module/UserModuleStatus.js
@@ -23,8 +23,8 @@ class UserModuleStatus {
 
     this.status = this.#computeStatus();
 
-    this.createdAt = this.#referencePassage?.createdAt ?? null;
-    this.updatedAt = this.#referencePassage?.updatedAt ?? null;
+    this.createdAt = this.#referencePassage?.createdAt ?? new Date();
+    this.updatedAt = this.#referencePassage?.updatedAt ?? new Date();
     this.terminatedAt = this.#referencePassage?.terminatedAt ?? null;
   }
 

--- a/api/src/quest/domain/models/CombinedCourseParticipation.js
+++ b/api/src/quest/domain/models/CombinedCourseParticipation.js
@@ -10,7 +10,6 @@ export class CombinedCourseParticipation {
     status,
     updatedAt,
     createdAt,
-    combinedCourseId,
     organizationLearnerParticipationId = null,
   }) {
     this.id = id;
@@ -22,7 +21,6 @@ export class CombinedCourseParticipation {
     this.firstName = firstName;
     this.lastName = lastName;
     this.organizationLearnerParticipationId = organizationLearnerParticipationId;
-    this.combinedCourseId = combinedCourseId;
   }
 
   complete() {

--- a/api/src/quest/domain/models/CombinedCourseParticipation.js
+++ b/api/src/quest/domain/models/CombinedCourseParticipation.js
@@ -1,7 +1,17 @@
 import { CombinedCourseParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
 
 export class CombinedCourseParticipation {
-  constructor({ id, firstName, lastName, questId, organizationLearnerId, status, updatedAt, createdAt }) {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    questId,
+    organizationLearnerId,
+    status,
+    updatedAt,
+    createdAt,
+    organizationLearnerParticipationId = null,
+  }) {
     this.id = id;
     this.questId = questId;
     this.organizationLearnerId = organizationLearnerId;
@@ -10,6 +20,7 @@ export class CombinedCourseParticipation {
     this.updatedAt = updatedAt;
     this.firstName = firstName;
     this.lastName = lastName;
+    this.organizationLearnerParticipationId = organizationLearnerParticipationId;
   }
 
   complete() {

--- a/api/src/quest/domain/models/CombinedCourseParticipation.js
+++ b/api/src/quest/domain/models/CombinedCourseParticipation.js
@@ -10,6 +10,7 @@ export class CombinedCourseParticipation {
     status,
     updatedAt,
     createdAt,
+    combinedCourseId,
     organizationLearnerParticipationId = null,
   }) {
     this.id = id;
@@ -21,6 +22,7 @@ export class CombinedCourseParticipation {
     this.firstName = firstName;
     this.lastName = lastName;
     this.organizationLearnerParticipationId = organizationLearnerParticipationId;
+    this.combinedCourseId = combinedCourseId;
   }
 
   complete() {

--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -2,6 +2,7 @@ import { StatusesEnumValues } from '../../../devcomp/domain/models/module/UserMo
 
 export const OrganizationLearnerParticipationTypes = {
   PASSAGE: 'PASSAGE',
+  COMBINED_COURSE: 'COMBINED_COURSE',
 };
 
 export const OrganizationLearnerParticipationStatuses = {

--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -1,4 +1,5 @@
 import { StatusesEnumValues } from '../../../devcomp/domain/models/module/UserModuleStatus.js';
+import { CombinedCourseParticipationStatuses } from '../../../prescription/shared/domain/constants.js';
 
 export const OrganizationLearnerParticipationTypes = {
   PASSAGE: 'PASSAGE',
@@ -67,6 +68,28 @@ export class OrganizationLearnerParticipation {
       status: participationStatus,
       type: OrganizationLearnerParticipationTypes.PASSAGE,
       attributes: JSON.stringify({ id: moduleId }),
+    });
+  }
+
+  static buildFromCombinedCourseParticipation({
+    id,
+    organizationLearnerId,
+    status,
+    createdAt,
+    updatedAt,
+    combinedCourseId,
+  }) {
+    return new OrganizationLearnerParticipation({
+      id,
+      organizationLearnerId,
+      createdAt,
+      updatedAt,
+      completedAt: status === CombinedCourseParticipationStatuses.COMPLETED ? updatedAt : null,
+      deletedAt: null,
+      deletedBy: null,
+      status,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      attributes: JSON.stringify({ id: combinedCourseId }),
     });
   }
 }

--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -12,7 +12,18 @@ export const OrganizationLearnerParticipationStatuses = {
 };
 
 export class OrganizationLearnerParticipation {
-  constructor({ id, organizationLearnerId, createdAt, updatedAt, completedAt, deletedAt, deletedBy, status, type }) {
+  constructor({
+    id,
+    organizationLearnerId,
+    createdAt,
+    updatedAt,
+    completedAt,
+    deletedAt,
+    deletedBy,
+    status,
+    type,
+    attributes,
+  }) {
     this.id = id;
     this.organizationLearnerId = organizationLearnerId;
     this.createdAt = createdAt;
@@ -22,6 +33,7 @@ export class OrganizationLearnerParticipation {
     this.deletedBy = deletedBy;
     this.status = status;
     this.type = type;
+    this.attributes = attributes;
   }
 
   static buildFromPassage({
@@ -33,6 +45,7 @@ export class OrganizationLearnerParticipation {
     deletedAt,
     deletedBy,
     status,
+    moduleId,
   }) {
     let participationStatus;
 
@@ -53,6 +66,7 @@ export class OrganizationLearnerParticipation {
       deletedBy,
       status: participationStatus,
       type: OrganizationLearnerParticipationTypes.PASSAGE,
+      attributes: JSON.stringify({ id: moduleId }),
     });
   }
 }

--- a/api/src/quest/domain/services/combined-course-details-service.js
+++ b/api/src/quest/domain/services/combined-course-details-service.js
@@ -66,7 +66,6 @@ async function getCombinedCourseDetails({
       });
     }
   }
-
   const modules = await moduleRepository.getByUserIdAndModuleIds({ userId, moduleIds });
 
   const combinedCourseUrl = '/parcours/' + combinedCourseDetails.code;

--- a/api/src/quest/domain/usecases/start-combined-course.js
+++ b/api/src/quest/domain/usecases/start-combined-course.js
@@ -15,5 +15,9 @@ export async function startCombinedCourse({
     organizationLearner: { firstName: user.firstName, lastName: user.lastName },
   });
 
-  await combinedCourseParticipationRepository.save({ organizationLearnerId, questId: combinedCourse.questId });
+  await combinedCourseParticipationRepository.save({
+    organizationLearnerId,
+    questId: combinedCourse.questId,
+    combinedCourseId: combinedCourse.id,
+  });
 }

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -44,6 +44,7 @@ export const getByUserId = async function ({ userId, questId }) {
       'combined_course_participations.status',
       'combined_course_participations.createdAt',
       'combined_course_participations.updatedAt',
+      'combined_course_participations.organizationLearnerParticipationId',
     )
     .join(
       'view-active-organization-learners',

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -22,6 +22,7 @@ export const save = async function ({ organizationLearnerId, questId, combinedCo
       organizationLearnerId,
       status: OrganizationLearnerParticipationStatuses.STARTED,
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      attributes: JSON.stringify({ id: combinedCourseId }),
     })
     .returning('id');
 

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -46,7 +46,6 @@ export const getByUserId = async function ({ userId, questId }) {
       'combined_course_participations.createdAt',
       'combined_course_participations.updatedAt',
       'combined_course_participations.organizationLearnerParticipationId',
-      'combined_course_participations.combinedCourseId',
     )
     .join(
       'view-active-organization-learners',
@@ -75,12 +74,15 @@ export const update = async function ({ combinedCourseParticipation }) {
     status: combinedCourseParticipation.status,
     createdAt: combinedCourseParticipation.createdAt,
     updatedAt: combinedCourseParticipation.updatedAt,
-    combinedCourseId: combinedCourseParticipation.combinedCourseId,
   });
   if (combinedCourseParticipation.organizationLearnerParticipationId) {
     await knexConnection('organization_learner_participations')
       .where({ id: combinedCourseParticipation.organizationLearnerParticipationId })
-      .update(organizationLearnerParticipation);
+      .update({
+        updatedAt: organizationLearnerParticipation.updatedAt,
+        status: combinedCourseParticipation.status,
+        completedAt: organizationLearnerParticipation.completedAt,
+      });
   }
   const [updatedRow] = await knexConnection('combined_course_participations')
     .where({ id: combinedCourseParticipation.id })

--- a/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
@@ -34,6 +34,7 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
       status: modulePassage.status,
       updatedAt: modulePassage.updatedAt,
       terminatedAt: modulePassage.terminatedAt,
+      moduleId: modulePassage.id,
     });
 
     if (organizationLearnerPassageParticipation.id) {

--- a/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-passage-participation-repository.js
@@ -12,6 +12,7 @@ export const synchronize = async ({ organizationLearnerId, moduleIds, modulesApi
   const modulePassages = await modulesApi.getUserModuleStatuses({ userId: learner.userId, moduleIds });
 
   const learnerParticipationsByModule = await knexConn('organization_learner_participations')
+    .select('organization_learner_participations.id', 'moduleId')
     .join(
       'organization_learner_passage_participations',
       'organization_learner_participations.id',

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -29,12 +29,16 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
         moduleId: existingModuleId2,
         userId,
         terminatedAt: null,
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-02-01'),
       });
 
       databaseBuilder.factory.buildPassage({
         moduleId: existingModuleId3,
         userId,
         terminatedAt: now,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-02-01'),
       });
 
       await databaseBuilder.commit();
@@ -51,6 +55,9 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
           duration: 5,
           status: 'NOT_STARTED',
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          createdAt: now,
+          updatedAt: now,
+          terminatedAt: null,
         },
         {
           id: existingModuleId2,
@@ -59,6 +66,9 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
           duration: 10,
           status: 'IN_PROGRESS',
           image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          createdAt: new Date('2023-01-01'),
+          updatedAt: new Date('2023-02-01'),
+          terminatedAt: null,
         },
         {
           id: existingModuleId3,
@@ -67,6 +77,9 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
           duration: 10,
           status: 'COMPLETED',
           image: 'https://assets.pix.org/modules/placeholder-details.svg',
+          terminatedAt: now,
+          createdAt: new Date('2020-01-01'),
+          updatedAt: new Date('2020-02-01'),
         },
       ];
 

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -1259,6 +1259,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           userId,
           updatedAt: new Date('2022-01-01'),
           status: CombinedCourseParticipationStatuses.STARTED,
+          combinedCourseId: combinedCourse.id,
         });
         const expectedSecondParticipation = databaseBuilder.factory.buildCombinedCourseParticipation({
           questId: secondCombinedCourse.questId,
@@ -1266,6 +1267,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           userId,
           updatedAt: new Date('2022-02-02'),
           status: CombinedCourseParticipationStatuses.COMPLETED,
+          combinedCourseId: secondCombinedCourse.id,
         });
 
         await databaseBuilder.commit();

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1494,6 +1494,7 @@ describe('Integration | Repository | Campaign Participation', function () {
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId: combinedCourse.questId,
+        combinedCourseId: combinedCourse.id,
       });
 
       await databaseBuilder.commit();

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -196,7 +196,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId }).id;
-      const { questId } = databaseBuilder.factory.buildCombinedCourse({
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBINIX1',
         organizationId,
         successRequirements: [],
@@ -207,6 +207,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
         createdAt: new Date('2022-01-01'),
         updatedAt: new Date('2022-01-01'),
         status: CombinedCourseParticipationStatuses.STARTED,
+        combinedCourseId,
       });
       await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -19,12 +19,16 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId,
+      combinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
-    const { questId: anotherquestId } = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' });
+    const { questId: anotherquestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+      code: 'COMBI2',
+    });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId: anotherquestId,
+      combinedCourseId: anotherCombinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
 
@@ -45,6 +49,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         createdAt: participation1.createdAt,
         updatedAt: participation1.updatedAt,
         organizationLearnerId: learner.id,
+        organizationLearnerParticipationId: null,
         questId,
       },
     ]);
@@ -64,6 +69,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId,
+      combinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
     const anotherLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -74,12 +80,16 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     const anotherParticipation = databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: anotherLearner.id,
       questId,
+      combinedCourseId,
       status: CombinedCourseParticipationStatuses.STARTED,
     });
-    const { questId: anotherquestId } = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' });
+    const { questId: anotherquestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+      code: 'COMBI2',
+    });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId: anotherquestId,
+      combinedCourseId: anotherCombinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
 
@@ -101,6 +111,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         firstName: anotherLearner.firstName,
         lastName: anotherLearner.lastName,
         status: CombinedCourseParticipationStatuses.STARTED,
+        organizationLearnerParticipationId: null,
         createdAt: anotherParticipation.createdAt,
         updatedAt: anotherParticipation.updatedAt,
         organizationLearnerId: anotherLearner.id,

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-statistics_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-statistics_test.js
@@ -24,18 +24,23 @@ describe('Quest | Integration | Domain | Usecases | getCombinedCourseStatistics'
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId,
+      combinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner2.id,
       questId,
+      combinedCourseId,
       status: CombinedCourseParticipationStatuses.STARTED,
     });
 
-    const anotherquestId = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' }).questId;
+    const { questId: anotherquestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+      code: 'COMBI2',
+    });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       organizationLearnerId: learner.id,
       questId: anotherquestId,
+      combinedCourseId: anotherCombinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
@@ -37,13 +37,16 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     databaseBuilder.factory.buildCombinedCourseParticipation({
       questId: quest1,
       organizationLearnerId: organizationLearnerId1,
+      combinedCourseId: combinedCourseId1,
     });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       questId: quest1,
+      combinedCourseId: combinedCourseId1,
       organizationLearnerId: organizationLearnerId2,
     });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       questId: quest2,
+      combinedCourseId: combinedCourseId2,
       organizationLearnerId: organizationLearnerId3,
     });
 
@@ -160,10 +163,12 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
 
     databaseBuilder.factory.buildCombinedCourseParticipation({
       questId: quest1,
+      combinedCourseId: combinedCourseId1,
       organizationLearnerId: organizationLearnerId1,
     });
     databaseBuilder.factory.buildCombinedCourseParticipation({
       questId: quest2,
+      combinedCourseId: combinedCourseId2,
       organizationLearnerId: organizationLearnerId2,
     });
 

--- a/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/start-combined-course_test.js
@@ -8,7 +8,10 @@ describe('Integration | Combined course | Domain | UseCases | start-combined-cou
       //given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
-      const { questId } = databaseBuilder.factory.buildCombinedCourse({ organizationId, code: 'COMBINIX8' });
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+        organizationId,
+        code: 'COMBINIX8',
+      });
       await databaseBuilder.commit();
 
       //when
@@ -18,21 +21,39 @@ describe('Integration | Combined course | Domain | UseCases | start-combined-cou
       });
 
       //then
-      const [participation] = await knex('combined_course_participations').where({
-        questId,
-        organizationLearnerId: organizationLearner.id,
-      });
-      expect(participation.id).to.be.finite;
+      const [participation] = await knex('organization_learner_participations')
+        .select(
+          'questId',
+          'organization_learner_participations.organizationLearnerId',
+          'combined_course_participations.organizationLearnerId AS ccpOrganizationLearnerId',
+          'combined_course_participations.status AS ccpStatus',
+          'organization_learner_participations.status',
+          'combinedCourseId',
+        )
+        .join(
+          'combined_course_participations',
+          'combined_course_participations.organizationLearnerParticipationId',
+          'organization_learner_participations.id',
+        )
+        .where({
+          questId,
+          'organization_learner_participations.organizationLearnerId': organizationLearner.id,
+        });
+
       expect(participation.questId).to.deep.equal(questId);
+      expect(participation.combinedCourseId).to.equal(combinedCourseId);
       expect(participation.organizationLearnerId).to.deep.equal(organizationLearner.id);
       expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+
+      expect(participation.ccpOrganizationLearnerId).to.equal(organizationLearner.id);
+      expect(participation.ccpStatus).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
     });
     describe('when organization learner does not exist', function () {
       it('should also create organization learner', async function () {
         //given
         const user = databaseBuilder.factory.buildUser();
         const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const { questId } = databaseBuilder.factory.buildCombinedCourse({ organizationId, code: 'COMBINIX8' });
+        databaseBuilder.factory.buildCombinedCourse({ organizationId, code: 'COMBINIX8' });
 
         await databaseBuilder.commit();
 
@@ -48,20 +69,17 @@ describe('Integration | Combined course | Domain | UseCases | start-combined-cou
         });
 
         //then
-        const createdOrganizationLearner = await knex('organization-learners')
-          .where({ firstName: organizationLearner.firstName, lastName: organizationLearner.lastName })
-          .first();
-        expect(createdOrganizationLearner).not.to.be.undefined;
-
-        const [participation] = await knex('combined_course_participations').where({
-          questId,
-          organizationLearnerId: createdOrganizationLearner.id,
+        const createdOrganizationLearner = await knex('organization-learners').where({
+          firstName: organizationLearner.firstName,
+          lastName: organizationLearner.lastName,
         });
 
-        expect(participation.id).to.be.finite;
-        expect(participation.questId).to.deep.equal(questId);
-        expect(participation.organizationLearnerId).to.deep.equal(createdOrganizationLearner.id);
-        expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+        const [participation] = await knex('organization_learner_participations').where({
+          organizationLearnerId: createdOrganizationLearner[0].id,
+        });
+
+        expect(createdOrganizationLearner).lengthOf(1);
+        expect(participation.organizationLearnerId).to.deep.equal(createdOrganizationLearner[0].id);
       });
     });
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -2,43 +2,78 @@ import sinon from 'sinon';
 
 import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import * as combinedCourseParticipationRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-participation-repository.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Infrastructure | repositories | Combined-Course-Participation', function () {
   describe('#save', function () {
-    it('should insert combined course participation', async function () {
+    it('should insert organization learner participations of type combined course', async function () {
       //given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const { questId } = databaseBuilder.factory.buildCombinedCourse();
+      const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
 
       await databaseBuilder.commit();
 
       //when
       await combinedCourseParticipationRepository.save({
         organizationLearnerId,
+        combinedCourseId,
         questId,
       });
 
       //then
-      const [participation] = await knex('combined_course_participations').where({
-        organizationLearnerId,
-        questId,
-      });
-      expect(participation.id).to.be.finite;
-      expect(participation.questId).to.deep.equal(questId);
-      expect(participation.organizationLearnerId).to.deep.equal(organizationLearnerId);
-      expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.STARTED);
+      const participations = await knex('organization_learner_participations')
+        .select(
+          'organization_learner_participations.*',
+          'combined_course_participations.id as combinedCourseParticipationId',
+          'combined_course_participations.combinedCourseId as combinedCourseParticipationsCombinedCourseId',
+          'combined_course_participations.organizationLearnerParticipationId as combinedCourseParticipationsOrganizationLearnerParticipationId',
+          'combined_course_participations.status as combinedCourseParticipationStatus',
+          'combined_course_participations.organizationLearnerId as combinedCourseParticipationsOrganizationLearnerId',
+          'combined_course_participations.questId as combinedCourseParticipationsQuestId',
+          'combined_course_participations.createdAt as combinedCourseParticipationsCreatedAt',
+          'combined_course_participations.updatedAt as combinedCourseParticipationsUpdatedAt',
+        )
+        .join(
+          'combined_course_participations',
+          'combined_course_participations.organizationLearnerParticipationId',
+          'organization_learner_participations.id',
+        )
+        .where({
+          'organization_learner_participations.organizationLearnerId': organizationLearnerId,
+          combinedCourseId,
+        });
+
+      expect(participations).to.have.lengthOf(1);
+
+      const participation = participations[0];
+      expect(participation.combinedCourseParticipationsQuestId).equal(questId);
+      expect(participation.combinedCourseParticipationsCombinedCourseId).equal(combinedCourseId);
+
+      expect(participation.combinedCourseParticipationsOrganizationLearnerParticipationId).equal(participation.id);
+
+      expect(participation.status).equal(OrganizationLearnerParticipationStatuses.STARTED);
+      expect(participation.combinedCourseParticipationStatus).equal(CombinedCourseParticipationStatuses.STARTED);
+
+      expect(participation.type).equal(OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+
+      expect(participation.organizationLearnerId).equal(organizationLearnerId);
+      expect(participation.combinedCourseParticipationsOrganizationLearnerId).equal(organizationLearnerId);
     });
 
     it('should left intact combined course participation for given organization learner and quest ids', async function () {
       // given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const { questId } = databaseBuilder.factory.buildCombinedCourse();
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
+        combinedCourseId,
         status: CombinedCourseParticipationStatuses.COMPLETED,
       });
       await databaseBuilder.commit();
@@ -47,14 +82,18 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       await combinedCourseParticipationRepository.save({ organizationLearnerId, questId });
 
       // then
-      const [participation] = await knex('combined_course_participations').where({
+      const participations = await knex('combined_course_participations').where({
         organizationLearnerId,
+        combinedCourseId,
         questId,
       });
-      expect(participation.id).to.be.finite;
-      expect(participation.questId).to.deep.equal(questId);
-      expect(participation.organizationLearnerId).to.deep.equal(organizationLearnerId);
-      expect(participation.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
+
+      expect(participations).to.have.lengthOf(1);
+      expect(participations[0].id).to.be.finite;
+      expect(participations[0].questId).to.deep.equal(questId);
+      expect(participations[0].organizationLearnerId).to.deep.equal(organizationLearnerId);
+      expect(participations[0].status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
+      expect(participations[0].combinedCourseId).to.deep.equal(combinedCourseId);
     });
   });
 
@@ -63,11 +102,12 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
-      const { questId } = databaseBuilder.factory.buildCombinedCourse();
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
         status: CombinedCourseParticipationStatuses.COMPLETED,
+        combinedCourseId,
       });
       await databaseBuilder.commit();
 
@@ -112,13 +152,14 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     it('should update only status and updatedAt for given id', async function () {
       //given
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
-      const { questId } = databaseBuilder.factory.buildCombinedCourse();
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
       const combinedCourseParticipationFromDB = databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId,
         questId,
         status: CombinedCourseParticipationStatuses.STARTED,
         createdAt: new Date('2022-01-01'),
         updatedAt: new Date('2022-01-01'),
+        combinedCourseId,
       });
 
       await databaseBuilder.commit();
@@ -144,6 +185,131 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(updatedParticipation.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
       expect(updatedParticipation.updatedAt).to.deep.equal(now);
     });
+
+    describe('when organizationLearnerParticipationId is filled', function () {
+      it('should not update completedAt from organization_learner_participations when participation is started', async function () {
+        //given
+        const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+        const { id: organizationLearnerParticipationId } =
+          databaseBuilder.factory.buildOrganizationLearnerParticipation({
+            type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+            status: CombinedCourseParticipationStatuses.STARTED,
+            combinedCourseId,
+            questId,
+            organizationLearnerId,
+          });
+        await databaseBuilder.commit();
+
+        const combinedCourseParticipation = await knex('combined_course_participations')
+          .where({
+            organizationLearnerParticipationId,
+          })
+          .first();
+
+        const expectedCombinedCourseParticipation = new CombinedCourseParticipation(combinedCourseParticipation);
+
+        // when
+        await combinedCourseParticipationRepository.update({
+          combinedCourseParticipation: expectedCombinedCourseParticipation,
+        });
+
+        //then
+        const result = await knex('organization_learner_participations')
+          .where('id', organizationLearnerParticipationId)
+          .first();
+
+        expect(result.completedAt).to.be.null;
+      });
+
+      it('should update completedAt / updatedAt / status from organization_learner_participations when participation is completed', async function () {
+        //given
+        const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+        const { id: organizationLearnerParticipationId } =
+          databaseBuilder.factory.buildOrganizationLearnerParticipation({
+            type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+            status: CombinedCourseParticipationStatuses.STARTED,
+            combinedCourseId,
+            questId,
+            organizationLearnerId,
+            createdAt: new Date('2024-01-01'),
+            updatedAt: new Date('2024-05-01'),
+            completedAt: null,
+          });
+        await databaseBuilder.commit();
+
+        const combinedCourseParticipation = await knex('combined_course_participations')
+          .where({
+            organizationLearnerParticipationId,
+          })
+          .first();
+
+        const expectedCombinedCourseParticipation = new CombinedCourseParticipation(combinedCourseParticipation);
+        expectedCombinedCourseParticipation.complete();
+        // when
+        await combinedCourseParticipationRepository.update({
+          combinedCourseParticipation: expectedCombinedCourseParticipation,
+        });
+
+        //then
+        const result = await knex('organization_learner_participations')
+          .where('id', organizationLearnerParticipationId)
+          .first();
+
+        expect(result.completedAt).deep.equal(now);
+        expect(result.updatedAt).deep.equal(now);
+        expect(result.status).equal(OrganizationLearnerParticipationStatuses.COMPLETED);
+      });
+
+      it('should update organization_learner_participations given id', async function () {
+        //given
+        const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
+        const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+        const { id: organizationLearnerParticipationId, organizationLearnerCombinedCourseParticipationId } =
+          databaseBuilder.factory.buildOrganizationLearnerParticipation({
+            type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+            status: CombinedCourseParticipationStatuses.STARTED,
+            combinedCourseId,
+            questId,
+            organizationLearnerId,
+            createdAt: new Date('2024-01-01'),
+            updatedAt: new Date('2024-05-01'),
+            completedAt: null,
+          });
+        const { id: anotherOrganizationLearnerParticipationId } =
+          databaseBuilder.factory.buildOrganizationLearnerParticipation({
+            type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+            status: CombinedCourseParticipationStatuses.STARTED,
+            combinedCourseId,
+            questId,
+            organizationLearnerId: databaseBuilder.factory.buildOrganizationLearner().id,
+            createdAt: new Date('2024-01-01'),
+            updatedAt: new Date('2024-05-01'),
+            completedAt: null,
+          });
+        await databaseBuilder.commit();
+
+        // when
+        await combinedCourseParticipationRepository.update({
+          combinedCourseParticipation: {
+            id: organizationLearnerCombinedCourseParticipationId,
+            organizationLearnerParticipationId,
+            updatedAt: new Date('2025-10-20'),
+            status: OrganizationLearnerParticipationStatuses.COMPLETED,
+          },
+        });
+
+        //then
+        const result = await knex('organization_learner_participations')
+          .where('id', anotherOrganizationLearnerParticipationId)
+          .first();
+
+        expect(result.completedAt).null;
+        expect(result.updatedAt).deep.equal(new Date('2024-05-01'));
+        expect(result.status).equal(OrganizationLearnerParticipationStatuses.STARTED);
+      });
+    });
   });
 
   describe('#findByCombinedCourseIds', function () {
@@ -160,7 +326,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         code: 'COMBI2',
         organizationId,
       });
-      const { questId: questId3 } = databaseBuilder.factory.buildCombinedCourse({
+      const { questId: questId3, id: combinedCourseId3 } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBI3',
       });
 
@@ -179,17 +345,20 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         organizationLearnerId: learner1.id,
         questId: questId1,
         status: CombinedCourseParticipationStatuses.COMPLETED,
+        combinedCourseId: combinedCourseId1,
       });
       const participation2 = databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner2.id,
         questId: questId2,
         status: CombinedCourseParticipationStatuses.STARTED,
+        combinedCourseId: combinedCourseId2,
       });
       // Participation that should not be included
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner1.id,
         questId: questId3,
         status: CombinedCourseParticipationStatuses.COMPLETED,
+        combinedCourseId: combinedCourseId3,
       });
 
       await databaseBuilder.commit();
@@ -217,6 +386,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
           updatedAt: participation1.updatedAt,
           organizationLearnerId: learner1.id,
           questId: questId1,
+          organizationLearnerParticipationId: null,
         },
         {
           id: participation2.id,
@@ -227,6 +397,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
           updatedAt: participation2.updatedAt,
           organizationLearnerId: learner2.id,
           questId: questId2,
+          organizationLearnerParticipationId: null,
         },
       ]);
     });
@@ -261,7 +432,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         code: 'COMBI2',
         organizationId,
       });
-      const { questId: questId3 } = databaseBuilder.factory.buildCombinedCourse({
+      const { id: combinedCourseId3, questId: questId3 } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBI3',
       });
 
@@ -279,17 +450,20 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner1.id,
         questId: questId1,
+        combinedCourseId: combinedCourseId1,
         status: CombinedCourseParticipationStatuses.COMPLETED,
       });
       const participation2 = databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner2.id,
         questId: questId2,
+        combinedCourseId: combinedCourseId2,
         status: CombinedCourseParticipationStatuses.STARTED,
       });
       // Participation that should not be included
       databaseBuilder.factory.buildCombinedCourseParticipation({
         organizationLearnerId: learner1.id,
         questId: questId3,
+        combinedCourseId: combinedCourseId3,
         status: CombinedCourseParticipationStatuses.COMPLETED,
       });
       await databaseBuilder.commit();
@@ -312,6 +486,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
           firstName: learner2.firstName,
           lastName: learner2.lastName,
           status: CombinedCourseParticipationStatuses.STARTED,
+          organizationLearnerParticipationId: null,
           createdAt: participation2.createdAt,
           updatedAt: participation2.updatedAt,
           organizationLearnerId: learner2.id,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -38,6 +38,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
           'combined_course_participations.questId as combinedCourseParticipationsQuestId',
           'combined_course_participations.createdAt as combinedCourseParticipationsCreatedAt',
           'combined_course_participations.updatedAt as combinedCourseParticipationsUpdatedAt',
+          'attributes',
         )
         .join(
           'combined_course_participations',
@@ -64,6 +65,8 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
       expect(participation.organizationLearnerId).equal(organizationLearnerId);
       expect(participation.combinedCourseParticipationsOrganizationLearnerId).equal(organizationLearnerId);
+
+      expect(participation.attributes).to.deep.equal({ id: combinedCourseId });
     });
 
     it('should left intact combined course participation for given organization learner and quest ids', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -121,6 +121,27 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(result.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
     });
 
+    it('should organizationLearnerParticipationId when combined_course_particiaptions is linked', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
+      const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+      const organizationLearnerParticipationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        questId,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+        combinedCourseId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.getByUserId({ userId, questId });
+
+      // then
+      expect(result.organizationLearnerParticipationId).equal(organizationLearnerParticipationId);
+    });
+
     it('should throw NotFound error when quest participation does not exist for given user and quest', async function () {
       // given
       const userId = 1;

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -122,7 +122,6 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(result.questId).to.deep.equal(questId);
       expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
       expect(result.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
-      expect(result.combinedCourseId).to.deep.equal(combinedCourseId);
     });
 
     it('should return organizationLearnerParticipationId when combined_course_participations is linked', async function () {
@@ -247,7 +246,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         expect(result.completedAt).to.be.null;
       });
 
-      it('should update completedAt / updatedAt / status and attributes from organization_learner_participations when participation is completed', async function () {
+      it('should update completedAt / updatedAt / status from organization_learner_participations when participation is completed', async function () {
         //given
         const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
         const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
@@ -285,6 +284,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         expect(result.completedAt).deep.equal(now);
         expect(result.updatedAt).deep.equal(now);
         expect(result.status).equal(OrganizationLearnerParticipationStatuses.COMPLETED);
+        expect(result.attributes).to.deep.equal({ id: combinedCourseId });
       });
 
       it('should update organization_learner_participations given id', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -122,9 +122,10 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(result.questId).to.deep.equal(questId);
       expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
       expect(result.status).to.deep.equal(CombinedCourseParticipationStatuses.COMPLETED);
+      expect(result.combinedCourseId).to.deep.equal(combinedCourseId);
     });
 
-    it('should organizationLearnerParticipationId when combined_course_particiaptions is linked', async function () {
+    it('should return organizationLearnerParticipationId when combined_course_participations is linked', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
@@ -246,7 +247,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
         expect(result.completedAt).to.be.null;
       });
 
-      it('should update completedAt / updatedAt / status from organization_learner_participations when participation is completed', async function () {
+      it('should update completedAt / updatedAt / status and attributes from organization_learner_participations when participation is completed', async function () {
         //given
         const { id: combinedCourseId, questId } = databaseBuilder.factory.buildCombinedCourse();
         const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
@@ -70,7 +70,7 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
     });
 
     it('should update passage when participation already exists', async function () {
-      const learnerParcipationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      const learnerParticipationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
         status: 'STARTED',
         type: OrganizationLearnerParticipationTypes.PASSAGE,
         organizationLearnerId: organizationLearner.id,
@@ -113,7 +113,7 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
         .where({ organizationLearnerId: organizationLearner.id });
 
       expect(result).lengthOf(1);
-      expect(result[0].id).equal(learnerParcipationId);
+      expect(result[0].id).equal(learnerParticipationId);
       expect(result[0].status).deep.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
       expect(result[0].updatedAt).deep.equal(now);
       expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
@@ -66,6 +66,7 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       expect(result[0].updatedAt).deep.equal(now);
       expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());
       expect(result[0].completedAt).equal(null);
+      expect(result[0].attributes).deep.equal({ id: 1234 });
     });
 
     it('should update passage when participation already exists', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
@@ -2,6 +2,10 @@ import dayjs from 'dayjs';
 import sinon from 'sinon';
 
 import { StatusesEnumValues } from '../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
 import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
@@ -65,19 +69,21 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
     });
 
     it('should update passage when participation already exists', async function () {
-      databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      const learnerParcipationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
         status: 'STARTED',
-        moduleId: 1234,
+        type: OrganizationLearnerParticipationTypes.PASSAGE,
+        organizationLearnerId: organizationLearner.id,
+        moduleId: '1234-abcdef',
         createdAt: dayjs().subtract('40', 'days').toDate(),
         updatedAt: dayjs().subtract('35', 'days').toDate(),
         completedAt: null,
-      });
+      }).id;
 
       await databaseBuilder.commit();
 
       const moduleApiResponse = [
         {
-          id: 1234,
+          id: '1234-abcdef',
           status: 'COMPLETED',
           createdAt: dayjs().subtract('30', 'days').toDate(),
           updatedAt: now,
@@ -85,18 +91,19 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
         },
       ];
       modulesApi.getUserModuleStatuses
-        .withArgs({ userId: organizationLearner.userId, moduleIds: [1234] })
+        .withArgs({ userId: organizationLearner.userId, moduleIds: ['1234-abcdef'] })
         .resolves(moduleApiResponse);
 
       // when
       await repositories.organizationLearnerPassageParticipationRepository.synchronize({
         organizationLearnerId: organizationLearner.id,
-        moduleIds: [1234],
+        moduleIds: ['1234-abcdef'],
         modulesApi,
       });
 
       // then
       const result = await knex('organization_learner_participations')
+        .select('organization_learner_participations.id', 'updatedAt', 'createdAt', 'completedAt', 'status')
         .join(
           'organization_learner_passage_participations',
           'organization_learner_participations.id',
@@ -105,6 +112,8 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
         .where({ organizationLearnerId: organizationLearner.id });
 
       expect(result).lengthOf(1);
+      expect(result[0].id).equal(learnerParcipationId);
+      expect(result[0].status).deep.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
       expect(result[0].updatedAt).deep.equal(now);
       expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());
       expect(result[0].completedAt).deep.equal(now);

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -19,6 +19,7 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
         deletedAt: new Date('2025-03-01'),
         deletedBy: 13,
         status: StatusesEnumValues.IN_PROGRESS,
+        moduleId: 'abcdef-42',
       });
 
       // then
@@ -30,6 +31,7 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
       expect(organizationLearnerParticipation.deletedAt).deep.to.equal(new Date('2025-03-01'));
       expect(organizationLearnerParticipation.deletedBy).to.equal(13);
       expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.PASSAGE);
+      expect(organizationLearnerParticipation.attributes).deep.equal(JSON.stringify({ id: 'abcdef-42' }));
     });
 
     describe('status', function () {

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -1,4 +1,5 @@
 import { StatusesEnumValues } from '../../../../../src/devcomp/domain/models/module/UserModuleStatus.js';
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import {
   OrganizationLearnerParticipation,
   OrganizationLearnerParticipationStatuses,
@@ -64,6 +65,50 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
         // then
         expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.NOT_STARTED);
       });
+    });
+  });
+  describe('buildFromCombinedCourseParticipation', function () {
+    it('should instantiate an OrganizationLearnerParticipation with combined course participaiton data', function () {
+      // given && when
+      const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourseParticipation({
+        id: 12,
+        organizationLearnerId: 15,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-01-01'),
+        status: CombinedCourseParticipationStatuses.STARTED,
+        combinedCourseId: 1,
+      });
+
+      // then
+      expect(organizationLearnerParticipation.id).to.equal(12);
+      expect(organizationLearnerParticipation.organizationLearnerId).to.equal(15);
+      expect(organizationLearnerParticipation.createdAt).deep.to.equal(new Date('2024-01-01'));
+      expect(organizationLearnerParticipation.updatedAt).deep.to.equal(new Date('2025-01-01'));
+      expect(organizationLearnerParticipation.completedAt).to.equal(null);
+      expect(organizationLearnerParticipation.deletedAt).to.equal(null);
+      expect(organizationLearnerParticipation.deletedBy).to.equal(null);
+      expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+      expect(organizationLearnerParticipation.attributes).deep.equal(JSON.stringify({ id: 1 }));
+    });
+  });
+  describe('when participation is completed', function () {
+    it('it should insert updatedAt date into completedAt', function () {
+      // given && when
+      const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourseParticipation({
+        id: 12,
+        organizationLearnerId: 15,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-02-01'),
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+        combinedCourseId: 1,
+      });
+
+      // then
+      expect(organizationLearnerParticipation.id).to.equal(12);
+      expect(organizationLearnerParticipation.organizationLearnerId).to.equal(15);
+      expect(organizationLearnerParticipation.createdAt).deep.to.equal(new Date('2024-01-01'));
+      expect(organizationLearnerParticipation.updatedAt).deep.to.equal(new Date('2025-02-01'));
+      expect(organizationLearnerParticipation.completedAt).deep.to.equal(new Date('2025-02-01'));
     });
   });
 });


### PR DESCRIPTION
## ☔ Problème

Faire et refaire des tables de participations, c'est long fastidieux. et chronophage. 

## 🧥 Proposition

Maintenant que nous avons créer une table "learner_participations". faire la migrations des combined_course_participations à l'intérieur

## 🎃 Pour tester

Faire un parcours combiné et vérifier que nous alimentons et mettons à jour la table organization_learner_participations