### PR TITLE
[BUGFIX] Correction de la durée de la certification Pix+ Édu - espace surveillant (PIX-19903)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -347,7 +347,7 @@ export default class CandidateInList extends Component {
         return PIX_PLUS_DURATIONS.DROIT;
       case label.includes('pro') && label.includes('santé'):
         return PIX_PLUS_DURATIONS.PRO_SANTE;
-      case label.includes('edu'):
+      case label.includes('édu'):
         return PIX_PLUS_DURATIONS.EDU;
       default:
         return null;

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -625,7 +625,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           lastName: 'Durand',
           startDateTime: startTime,
           theoricalEndDateTime: new Date('2022-10-19T10:45:00Z'),
-          enrolledComplementaryCertificationLabel: 'Pix+ Edu 1er Degré',
+          enrolledComplementaryCertificationLabel: 'Pix+ Édu 1er Degré',
           assessmentStatus: 'started',
         });
 
@@ -647,7 +647,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           lastName: 'Bernard',
           startDateTime: startTime,
           theoricalEndDateTime: new Date('2022-10-19T16:00:00Z'),
-          enrolledComplementaryCertificationLabel: 'Pix+ Edu 2nd Degré',
+          enrolledComplementaryCertificationLabel: 'Pix+ Édu 2nd Degré',
           assessmentStatus: 'started',
         });
 
@@ -669,7 +669,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           lastName: 'Moreau',
           startDateTime: startTime,
           theoricalEndDateTime: new Date('2022-10-19T18:15:00Z'),
-          enrolledComplementaryCertificationLabel: 'Pix+ Edu CPE',
+          enrolledComplementaryCertificationLabel: 'Pix+ Édu CPE',
           assessmentStatus: 'started',
         });
 


### PR DESCRIPTION
🍂 Problème
-----------
Durée de certification incorrecte affichée pour les certifications Pix+ Édu dans l'espace surveillant en raison d'une erreur de correspondance d'accent dans l'étiquette.

🌰 Proposition
--------------
Corriger la comparaison d'étiquette pour correspondre correctement à 'Pix+ Édu' (avec accent É) au lieu de 'edu' ou 'Edu'.

🎃 Remarques
------------
Les tests d'intégration existants n'ont pas détecté ce problème car il y manquait aussi l'accent..
🪵 Étapes de test
--------------
1. Créer une session avec des candidats Pix+Edu
2. les faire entrer en certif
3. vérifier que la durée calculer est bien de 1h30