### PR TITLE
[BUGFIX] Corriger le fond violet sur la page de récap (PIX-19912)

### DIFF
--- a/mon-pix/app/components/module/instruction/_recap.scss
+++ b/mon-pix/app/components/module/instruction/_recap.scss
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-height: inherit;
   padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);
   background-color: var(--pix-primary-10);
 


### PR DESCRIPTION
## 🍂 Problème

Le fond violet de la page de récap ne prend pas toute la page

## 🌰 Proposition

Corriger cela. En utilisant le même `min-height` que le parent (100vh)

## 🍁 Remarques
RAS

## 🪵 Pour tester

- Ouvrir la console navigateur et cliquer sur la vue adaptative
- Choisir une résolution 1920x1080

### Reproduire le bug
- Aller sur https://app.recette.pix.fr/modules/demo-combinix-1 et sur la page de récap.
- Vérifier que le fond violet ne prend pas toute la page

### Tester la correction
- Aller sur https://app-pr13826.review.pix.fr/modules/demo-combinix-1 et passer le module jusqu'au récap
- Vérifier que le fond violet prend maintenant toute la page 😄 
