### PR TITLE
[BUGFIX] Corriger la validation des réponses d'un QCM dans un stepper (PIX-19921)

### DIFF
--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -61,6 +61,7 @@ export default class ModulixStep extends Component {
               @onVideoTranscriptionOpen={{@onVideoTranscriptionOpen}}
               @onFileDownload={{@onFileDownload}}
               @onExpandToggle={{@onExpandToggle}}
+              @updateSkipButton={{@updateSkipButton}}
             />
           </div>
         {{/each}}

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -234,6 +234,7 @@ export default class ModulixStepper extends Component {
                 @shouldDisplayNextButton={{this.shouldDisplayHorizontalNextButton}}
                 @preventScrollAndFocus={{this.preventScrollAndFocus}}
                 @shouldAppearToRight={{this.shouldAppearToRight}}
+                @updateSkipButton={{@updateSkipButton}}
                 @nextButtonName={{t "pages.modulix.buttons.stepper.next.horizontal.name"}}
               />
             {{/each}}
@@ -257,6 +258,7 @@ export default class ModulixStepper extends Component {
               @onExpandToggle={{@onExpandToggle}}
               @onNextButtonClick={{this.displayNextStep}}
               @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
+              @updateSkipButton={{@updateSkipButton}}
               @nextButtonName={{t "pages.modulix.buttons.stepper.next.vertical.name"}}
             />
           {{/each}}

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -77,9 +77,9 @@ export default class ModuleQcm extends ModuleElement {
 
   @action
   async onAnswer(event) {
+    event.preventDefault();
     this.args.updateSkipButton(true);
     this.isAnswering = true;
-    event.preventDefault();
     await this.waitFor(VERIFY_RESPONSE_DELAY);
 
     super.onAnswer(event);


### PR DESCRIPTION
## 🍂 Problème

Lorsqu’on veut vérifier la réponse d’un QCM dans un stepper, alors la page du module est rechargée.
Le problème vient de la feature pour désactiver le bouton passer lors de l’apparition des feedback côté QCM.

## 🌰 Proposition

Corriger cela.

## 🍁 Remarques

La fonction updateSkipButton n'était pas passée jusqu’au composant Step.

## 🪵 Pour tester

- Aller sur le module `J'améliore mes prompts`
- Passer les grains jusqu'au stepper horizontal
- Vérifier qu'on peut maintenant bien vérifier les réponses sans que la page se recharge 🎉 
