### PR TITLE
[FEATURE] QAB front - placer les attributs width/height (PIX-19848)

### DIFF
--- a/mon-pix/app/components/module/element/qab/qab-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-card.gjs
@@ -2,12 +2,18 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class QabCard extends Component {
+  static MAX_HEIGHT = 190;
+
   get isError() {
     return this.args.status === 'error';
   }
 
   get isSuccess() {
     return this.args.status === 'success';
+  }
+
+  get hasDimensions() {
+    return this.args.card.image.information.width > 0 && this.args.card.image.information.height > 0;
   }
 
   get hasImage() {
@@ -17,6 +23,22 @@ export default class QabCard extends Component {
   get userPrefersReducedMotion() {
     const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     return userPrefersReducedMotion.matches;
+  }
+
+  get height() {
+    if (this.args.card.image.information && this.hasDimensions) {
+      return QabCard.MAX_HEIGHT;
+    }
+    return null;
+  }
+
+  get width() {
+    if (this.args.card.image.information && this.hasDimensions) {
+      return Math.round(
+        (QabCard.MAX_HEIGHT * this.args.card.image.information.width) / this.args.card.image.information.height,
+      );
+    }
+    return null;
   }
 
   <template>
@@ -36,7 +58,13 @@ export default class QabCard extends Component {
       <div class="qab-card__container">
         <div class="qab-card-container-content {{if this.hasImage 'qab-card-container-content--with-image'}}">
           {{#if this.hasImage}}
-            <img class="qab-card-container-content__image" src={{@card.image.url}} alt={{@card.image.altText}} />
+            <img
+              class="qab-card-container-content__image"
+              src={{@card.image.url}}
+              alt={{@card.image.altText}}
+              height={{this.height}}
+              width={{this.width}}
+            />
           {{/if}}
           <p class="qab-card-container-content__text">{{@card.text}}</p>
         </div>

--- a/mon-pix/tests/integration/components/module/qab-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/qab-card_test.gjs
@@ -7,33 +7,64 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | QabCard', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display a text and an image', async function (assert) {
-    // given
-    const card = _getQabCard();
+  module('when image is provided', function () {
+    test('it should display a text and an image', async function (assert) {
+      // given
+      const card = _getQabCard();
 
-    // when
-    const screen = await render(<template><QabCard @card={{card}} /></template>);
+      // when
+      const screen = await render(<template><QabCard @card={{card}} /></template>);
 
-    // then
-    assert.ok(screen.getByText('Les boules de pétanques sont creuses.'));
-    assert.ok(screen.getByRole('img', { name: card.image.altText }).hasAttribute('src', card.image.url));
+      // then
+      assert.ok(screen.getByText('Les boules de pétanques sont creuses.'));
+      assert.ok(screen.getByRole('img', { name: card.image.altText }).hasAttribute('src', card.image.url));
+    });
+
+    module('when width and height are available', function () {
+      test('should set them to the image', async function (assert) {
+        // given
+        const card = {
+          ..._getQabCard(),
+          image: {
+            url: 'https://assets.pix.org/modules/bac-a-sable/boules-de-petanque.jpg',
+            alt: 'alt text',
+            information: {
+              width: '300',
+              height: '400',
+            },
+          },
+        };
+        const expectedWidth = Math.round(
+          (QabCard.MAX_HEIGHT * card.image.information.width) / card.image.information.height,
+        );
+
+        // when
+        const screen = await render(<template><QabCard @card={{card}} /></template>);
+
+        // then
+        assert.dom(screen.getByRole('img')).hasAttribute('height', QabCard.MAX_HEIGHT.toString());
+        assert.dom(screen.getByRole('img')).hasAttribute('width', expectedWidth.toString());
+      });
+    });
   });
 
-  test('it should not display an image when there is no image url', async function (assert) {
-    // given
-    const card = {
-      ..._getQabCard(),
-      image: {
-        url: '',
-        alt: 'alt text',
-      },
-    };
+  module('when image is not provided', function () {
+    test('it should not display an image', async function (assert) {
+      // given
+      const card = {
+        ..._getQabCard(),
+        image: {
+          url: '',
+          alt: 'alt text',
+        },
+      };
 
-    // when
-    const screen = await render(<template><QabCard @card={{card}} /></template>);
+      // when
+      const screen = await render(<template><QabCard @card={{card}} /></template>);
 
-    // then
-    assert.notOk(screen.queryByRole('img'));
+      // then
+      assert.notOk(screen.queryByRole('img'));
+    });
   });
 
   module('when status is success', function () {


### PR DESCRIPTION
## 🍂 Problème

L'API renvoie les metadonnées des images dans les Card QAB, mais on ne les utilise pas côté PixApp.

## 🌰 Proposition

Utiliser width et height renvoyées par l’API dans les cards de QAB.

## 🍁 Remarques

- Dans `_qab.scss`, une `min-height` est explicité dans une classe appliquée à l'élément img d'une Card. Je l'ai donc utilisée comme **MAX_HEIGHT** dans `QabCard.gjs`.
- En conséquence, j'applique un produit en croix pour trouver la largeur à appliquer à l'image récupérée dans pix-assets, si celle-ci possède des metadata. 

## 🪵 Pour tester

- Ouvrir le module [deepfake](https://app-pr13830.review.pix.fr/modules/tmp-ia-deepfakes) et le commencer
- Se mette en hors ligne
- Afficher le QAB
- Vérifier qu'un espace est alloué à l'image de la Card, sans que l'image ne soit affichée
- Vérifier qu'il est toujours possible de répondre aux questions du QAB
