### PR TITLE
[TECH] Ne pas rendre l'id de l'équipe en charge obligatoire lors de l'update en masse (PIX-19925)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -147,16 +147,18 @@ async function _checkOrganizationUpdate({
     });
   }
 
-  const administrationTeam = await administrationTeamRepository.getById(
-    organizationBatchUpdateDto.administrationTeamId,
-  );
+  if (organizationBatchUpdateDto.administrationTeamId) {
+    const administrationTeam = await administrationTeamRepository.getById(
+      organizationBatchUpdateDto.administrationTeamId,
+    );
 
-  if (!administrationTeam) {
-    throw new AdministrationTeamNotFound({
-      meta: {
-        administrationTeamId: organizationBatchUpdateDto.administrationTeamId,
-      },
-    });
+    if (!administrationTeam) {
+      throw new AdministrationTeamNotFound({
+        meta: {
+          administrationTeamId: organizationBatchUpdateDto.administrationTeamId,
+        },
+      });
+    }
   }
 
   return organization;


### PR DESCRIPTION
## ☔ Problème

On doit pouvoir renseigner une équipe en charge lors de la modification en masse via csv mais ce n'est pas obligatoire.

## 🧥 Proposition

- Vérifier la présence de l'équipe en base uniquement si l'id est renseignée dans le csv


## 🎃 Pour tester

```
Organization ID;Organization Name;Organization External ID;Organization Parent ID;Organization Identity Provider Code;Organization Documentation URL;Organization Province Code;DPO Last Name;DPO First Name;DPO E-mail;Administration Team ID
1;;12;;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;
2;;12;;OIDC_EXAMPLE_NET;https://doc.url;;;Adam;;1234
```

- Depuis pix-admin
- Se connecter avec le compte [superadmin@example.net](mailto:superadmin@example.net)
- Dans l'onglet Administration > Déploiement
- Importer un csv de modification en masse selon l'exemple ci dessus complété avec les infos d'une orga à modifier sans administrationTeamId et une autre orga avec administrationTeamId
- Constater que l'organisation a bien été modifiée