### PR TITLE
[FEATURE] Ajouter un délai sur le bouton "Suivant" du stepper horizontal (PIX-19424).

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -18,6 +18,8 @@ import SeparatorElement from 'mon-pix/components/module/element/separator';
 import TextElement from 'mon-pix/components/module/element/text';
 import VideoElement from 'mon-pix/components/module/element/video';
 
+export const VERIFY_RESPONSE_DELAY = 500;
+
 export default class ModulixElement extends Component {
   @action
   getLastCorrectionForElement() {

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -14,6 +14,9 @@ import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import { inc } from 'mon-pix/helpers/inc';
 
 import didInsert from '../../../modifiers/modifier-did-insert';
+import { VERIFY_RESPONSE_DELAY } from './element';
+
+export const NEXT_STEP_BUTTON_DELAY = VERIFY_RESPONSE_DELAY + 500;
 
 export default class ModulixStepper extends Component {
   @service modulixAutoScroll;
@@ -24,10 +27,6 @@ export default class ModulixStepper extends Component {
   );
 
   @tracked stepsToDisplay = this._initialStepsToDisplay;
-  get _initialStepsToDisplay() {
-    const firstDisplayableStep = this.displayableSteps[0];
-    return this.modulixPreviewMode.isEnabled ? this.displayableSteps : [firstDisplayableStep];
-  }
 
   @tracked displayedStepIndex = 0;
 
@@ -35,6 +34,12 @@ export default class ModulixStepper extends Component {
   preventScrollAndFocus = false;
 
   @tracked shouldAppearToRight = false;
+  @tracked shouldDisplayHorizontalNextButton = this.shouldDisplayNextButton;
+
+  get _initialStepsToDisplay() {
+    const firstDisplayableStep = this.displayableSteps[0];
+    return this.modulixPreviewMode.isEnabled ? this.displayableSteps : [firstDisplayableStep];
+  }
 
   @action
   stepIsActive(index) {
@@ -76,6 +81,7 @@ export default class ModulixStepper extends Component {
 
   @action
   displayNextStep() {
+    this.shouldDisplayHorizontalNextButton = false;
     const currentStepPosition = this.lastDisplayedStepIndex + 1;
     const nextStep = this.displayableSteps[currentStepPosition];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
@@ -125,13 +131,13 @@ export default class ModulixStepper extends Component {
     });
   }
 
-  get shouldDisplayHorizontalNextButton() {
+  get shouldDisplayNextButton() {
     return this.hasNextStep && this.allAnswerableElementsAreAnsweredInCurrentStep;
   }
 
   @action
   shouldDisplayVerticalNextButton(currentIndex) {
-    return this.shouldDisplayHorizontalNextButton && this.stepIsActive(currentIndex);
+    return this.shouldDisplayNextButton && this.stepIsActive(currentIndex);
   }
 
   get totalSteps() {
@@ -158,6 +164,19 @@ export default class ModulixStepper extends Component {
     return this.isHorizontalDirection
       ? ModuleGrain.STEPPER_DIRECTION.HORIZONTAL
       : ModuleGrain.STEPPER_DIRECTION.VERTICAL;
+  }
+
+  @action
+  async onElementAnswer(...args) {
+    await this.waitFor(NEXT_STEP_BUTTON_DELAY);
+
+    await this.args.onElementAnswer(...args);
+
+    this.shouldDisplayHorizontalNextButton = this.shouldDisplayNextButton;
+  }
+
+  async waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
   <template>
@@ -221,7 +240,7 @@ export default class ModulixStepper extends Component {
                 @step={{step}}
                 @currentStep={{inc index}}
                 @totalSteps={{this.totalSteps}}
-                @onElementAnswer={{@onElementAnswer}}
+                @onElementAnswer={{this.onElementAnswer}}
                 @onElementRetry={{@onElementRetry}}
                 @getLastCorrectionForElement={{@getLastCorrectionForElement}}
                 @isActive={{this.stepIsActive index}}

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -10,9 +10,8 @@ import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
-
-export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcm extends ModuleElement {
   @service passageEvents;

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -10,9 +10,8 @@ import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
-
-export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcu extends ModuleElement {
   @tracked selectedAnswerId = null;

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -3,8 +3,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click, find, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
-import { VERIFY_RESPONSE_DELAY as QCM_VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcm';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -623,7 +622,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           await click(screen.getByLabelText('checkbox2'));
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
@@ -648,11 +647,11 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).doesNotHaveAttribute('aria-disabled');
         });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -2,7 +2,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ApplicationAdapter from 'mon-pix/adapters/application';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModulePassage from 'mon-pix/components/module/passage';
 import { module, test } from 'qunit';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -3,7 +3,8 @@ import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcm, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcm';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import ModulixQcm from 'mon-pix/components/module/element/qcm';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -3,7 +3,8 @@ import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcu, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import ModulixQcu from 'mon-pix/components/module/element/qcu';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -85,7 +85,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
       });
 
-      module('When step contains answerable elements', function (hooks) {
+      module('When step contains answerable elements', function () {
         module('When the only answerable element is unanswered', function () {
           test('should not display the Next button', async function (assert) {
             // given
@@ -809,134 +809,133 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           }),
         });
         assert.dom(title).exists();
-        await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
-        assert
-          .dom(
-            screen.getByRole('paragraph', {
-              name: t('pages.modulix.stepper.step.aria-label', {
-                currentStep: 2,
-                totalSteps: 2,
-              }),
-            }),
-          )
-          .exists();
       });
 
-      test('should display the first step with the button Next', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
+      module('on the first step', function () {
+        test('should display disabled controls buttons', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
 
-        // when
-        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+          // when
+          const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
 
-        // then
-        assert
-          .dom(
-            screen.getByRole('group', {
-              name: t('pages.modulix.stepper.step.aria-label', {
-                currentStep: 1,
-                totalSteps: 2,
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
+            .hasAria('disabled', 'true');
+          assert
+            .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
+            .hasAria('disabled', 'true');
+        });
+
+        test('should not be able to navigate to negative step', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+
+          // when
+          const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+
+          // then
+          await click(
+            screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+          );
+          assert
+            .dom(
+              screen.getByRole('group', {
+                name: t('pages.modulix.stepper.step.aria-label', {
+                  currentStep: 1,
+                  totalSteps: 2,
+                }),
               }),
-            }),
-          )
-          .exists();
-        assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') })).exists();
+            )
+            .exists();
+        });
       });
 
-      test('should display disabled controls buttons', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
+      module('on the last step', function () {
+        test('should not display the Next button', async function (assert) {
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
 
-        // when
-        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+          function stepperIsFinished() {}
 
-        // then
-        assert
-          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
-          .hasAria('disabled', 'true');
-        assert
-          .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
-          .hasAria('disabled', 'true');
-      });
+          function onStepperNextStepStub() {}
 
-      test('should not be able to navigate to negative step', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                type: 'text',
-                content: '<p>Text 1</p>',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-              },
-            ],
-          },
-        ];
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @direction="horizontal"
+                @steps={{steps}}
+                @stepperIsFinished={{stepperIsFinished}}
+                @onStepperNextStep={{onStepperNextStepStub}}
+              />
+            </template>,
+          );
 
-        // when
-        const screen = await render(<template><ModulixStepper @steps={{steps}} @direction="horizontal" /></template>);
+          // when
+          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
 
-        // then
-        await click(
-          screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
-        );
-        assert
-          .dom(
-            screen.getByRole('group', {
-              name: t('pages.modulix.stepper.step.aria-label', {
-                currentStep: 1,
-                totalSteps: 2,
-              }),
-            }),
-          )
-          .exists();
+          //then
+          assert
+            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+            .doesNotExist();
+        });
       });
 
       module('When step contains answerable elements', function () {
@@ -1054,7 +1053,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           });
         });
 
-        module('When we retry an answerable element', function (hooks) {
+        module('When we retry an answerable element', function () {
           test('should call the onElementRetry action', async function (assert) {
             // given
             const passageEventService = this.owner.lookup('service:passage-events');
@@ -1195,7 +1194,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
           });
         });
 
-        module('When all answerable elements are answered', function (hooks) {
+        module('When all answerable elements are answered', function () {
           test('should display the next button', async function (assert) {
             // given
             const steps = [
@@ -1512,9 +1511,10 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
             await click(
               screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
-            ),
-              // then
-              assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
+            );
+
+            // then
+            assert.strictEqual(screen.getAllByRole('group', { name: '1 sur 2' }).length, 1);
             assert
               .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }))
               .isFocused();
@@ -1623,52 +1623,6 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 .isFocused();
             });
           });
-        });
-
-        test('should not display the Next button when there are no steps left', async function (assert) {
-          const steps = [
-            {
-              elements: [
-                {
-                  id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-                  type: 'text',
-                  content: '<p>Text 1</p>',
-                },
-              ],
-            },
-            {
-              elements: [
-                {
-                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                  type: 'text',
-                  content: '<p>Text 2</p>',
-                },
-              ],
-            },
-          ];
-
-          function stepperIsFinished() {}
-
-          function onStepperNextStepStub() {}
-
-          const screen = await render(
-            <template>
-              <ModulixStepper
-                @direction="horizontal"
-                @steps={{steps}}
-                @stepperIsFinished={{stepperIsFinished}}
-                @onStepperNextStep={{onStepperNextStepStub}}
-              />
-            </template>,
-          );
-
-          // when
-          await clickByName(t('pages.modulix.buttons.stepper.next.ariaLabel'));
-
-          //then
-          assert
-            .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
-            .doesNotExist();
         });
       });
     });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -4,7 +4,7 @@ import Service from '@ember/service';
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixStepper from 'mon-pix/components/module/component/stepper';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 


### PR DESCRIPTION
## 🍂 Problème

Pour améliorer l'expérience des modules, on souhaite avoir des affichages différés entre les feedbacks et les boutons.

## 🌰 Proposition

Pour le stepper horizontal, afficher le bouton "Suivant" après l'affichage du feedback.

## 🪵 Pour tester

Cas du stepper horizontal SANS question :
- il possède un bouton Suivant déjà présent

https://app-pr13833.review.pix.fr/modules/tmp-ia-def-ind

Cas du stepper horizontal AVEC questions :
- il n'a pas de bouton Suivant tant que la question n'a pas été répondu
- Le feedback apparaît
- Puis le bouton Suivant apparaît à son tour
- Passer au step suivant
- Constater que le bouton Suivant du nouveau step n'apparaît pas tant qu'on a pas rep à cette nouvelle question

https://app-pr13833.review.pix.fr/modules/bac-a-sable


Vérifier le comportement d'un stepper vertical (ça doit fonctionner)

https://app-pr13833.review.pix.fr/modules/utiliser-souris-ordinateur-2/

<img width="423" height="344" alt="Capture d’écran 2025-10-09 à 17 52 51" src="https://github.com/user-attachments/assets/2740107a-e3e3-4064-9694-364276fcf77d" />
