### PR TITLE
[TECH] Mettre à jour le fichier CODEOWNERS pour prendre en compte la nouvelle team-acquisition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+
+# Directories maintained by team Devcomp
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
 /api/scripts/modulix/ @1024pix/team-devcomp
 /api/src/devcomp/application/ @1024pix/team-devcomp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,13 +51,9 @@
 
 /api/src/authorization/ @1024pix/team-acces
 /api/src/identity-access-management/ @1024pix/team-acces
-/api/src/organizational-entities/ @1024pix/team-acces
-/api/src/team/ @1024pix/team-acces
 
 /api/tests/authorization/ @1024pix/team-acces
 /api/tests/identity-access-management/ @1024pix/team-acces
-/api/tests/organizational-entities/ @1024pix/team-acces
-/api/tests/team/ @1024pix/team-acces
 
 /mon-pix/app/authenticators/ @1024pix/team-acces
 /mon-pix/app/components/sign* @1024pix/team-acces
@@ -84,6 +80,15 @@
 /admin/app/services/locale.js @1024pix/team-acces
 /admin/app/services/session.js @1024pix/team-acces
 /admin/app/services/url-base.js @1024pix/team-acces
+
+
+# Directories maintained by team Acquisition
+/api/src/organizational-entities/ @1024pix/team-acquisition
+/api/src/team/ @1024pix/team-acquisition
+
+/api/tests/organizational-entities/ @1024pix/team-acquisition
+/api/tests/team/ @1024pix/team-acquisition
+
 
 # Directories maintained by team Captains
 /api/db/migrations/ @1024pix/team-captains


### PR DESCRIPTION
## 🍂 Problème

L’équipe @1024pix/team-acquisition a été créée et elle s’occupe de domaines précédemment gérés par @1024pix/team-acces. Et quand les devs de @1024pix/team-acquisition modifient certains fichiers du monorepo, c’est l’équipe @1024pix/team-acces qui se trouve suggérée pour les revues et qui reçoit potentiellement des notifcations.

## 🌰 Proposition

Mettre à jour le fichier `CODEOWNERS` pour faire correspondre certains chemins, précédemment dans les domaines de @1024pix/team-acces, à @1024pix/team-acquisition.

## 🍁 Remarques

RAS

## 🪵 Pour tester

1. Vérifier que la CI passe,
2. Lire le fichier `CODEOWNERS` et se prononcer sur les chemins qui sont maintenant gérés par @1024pix/team-acquisition (sachant que nous mettons collectivement à jour ce fichier en fonction des changements d’organisation et de structure de code).