### PR TITLE
[TECH] Créer un utilitaire pour redimensionner les images (PIX-19942)

### DIFF
--- a/mon-pix/app/utils/resize-image.js
+++ b/mon-pix/app/utils/resize-image.js
@@ -1,0 +1,65 @@
+/**
+ * Utility function to calculate new width and height for given image information.
+ * You can pass a MAX_WIDTH or a MAX_HEIGHT option, and the function will do the maths.
+ *
+ * @param {Object} imageInformation - The object containing the image information to be resized.
+ * @param {number} [imageInformation.width] - The current width of the image.
+ * @param {number} [imageInformation.height] - The current height of the image.
+ * @param {Object} [options] - The resizing options.
+ * @param {number} [options.MAX_WIDTH] - The maximum desired width (in pixels).
+ * @param {number} [options.MAX_HEIGHT] - The maximum desired height (in pixels).
+
+ * @returns {Object|null} An object containing the new image dimensions with `width` and `height` properties (both numbers)
+ * or `null` if the image information is invalid.
+ */
+export function resizeImage(imageInformation, options) {
+  if (!imageInformation || !hasDimensions(imageInformation)) {
+    return null;
+  }
+
+  if (!validateOptions(options)) {
+    return imageInformation;
+  }
+
+  if (options.MAX_HEIGHT) return resizeByHeight(imageInformation, options.MAX_HEIGHT);
+
+  return resizeByWidth(imageInformation, options.MAX_WIDTH);
+}
+
+export function resizeByHeight(imageInformation, MAX_HEIGHT) {
+  const width = Math.round((MAX_HEIGHT * imageInformation.width) / imageInformation.height);
+  const height = MAX_HEIGHT;
+  return {
+    width,
+    height,
+  };
+}
+
+export function resizeByWidth(imageInformation, MAX_WIDTH) {
+  const height = Math.round((MAX_WIDTH * imageInformation.height) / imageInformation.width);
+  const width = MAX_WIDTH;
+  return {
+    width,
+    height,
+  };
+}
+
+export function hasDimensions(imageInformation) {
+  return imageInformation.width > 0 && imageInformation.height > 0;
+}
+
+export function validateOptions(options) {
+  if (options === undefined) return false;
+
+  const isDimensionsKeysProvided = Object.entries(options).some(([key, value]) => {
+    return ['MAX_WIDTH', 'MAX_HEIGHT'].includes(key) && value;
+  });
+  if (!isDimensionsKeysProvided) return false;
+
+  const { MAX_WIDTH, MAX_HEIGHT } = options;
+
+  if (Number.isInteger(MAX_WIDTH) && MAX_WIDTH < 1) return false;
+  if (Number.isInteger(MAX_HEIGHT) && MAX_HEIGHT < 1) return false;
+
+  return true;
+}

--- a/mon-pix/tests/unit/utils/resize-image-test.js
+++ b/mon-pix/tests/unit/utils/resize-image-test.js
@@ -1,0 +1,164 @@
+import { resizeByHeight, resizeByWidth, resizeImage, validateOptions } from 'mon-pix/utils/resize-image';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | Resize Image', function () {
+  module('#resizeImage', function () {
+    test('should return null if there is no information', function (assert) {
+      // given
+      const imageInformation = null;
+
+      // when
+      const dimensions = resizeImage(imageInformation, { MAX_HEIGHT: 100 });
+
+      // then
+      assert.deepEqual(dimensions, null);
+    });
+
+    test('should return null if image height is equal to 0', function (assert) {
+      // given
+      const imageInformation = { height: 0 };
+
+      // when
+      const dimensions = resizeImage(imageInformation, { MAX_HEIGHT: 100 });
+
+      // then
+      assert.deepEqual(dimensions, null);
+    });
+
+    test('should return null if image width is equal to 0', function (assert) {
+      // given
+      const imageInformation = { width: 0 };
+
+      // when
+      const dimensions = resizeImage(imageInformation, { MAX_HEIGHT: 100 });
+
+      // then
+      assert.deepEqual(dimensions, null);
+    });
+
+    test('should return unchanged width and height when no option is provided', function (assert) {
+      // given
+      const imageInformation = { height: 50, width: 50 };
+
+      // when
+      const dimensions = resizeImage(imageInformation);
+
+      //then
+      assert.deepEqual(imageInformation, dimensions);
+    });
+
+    test('should return accurate result when MAX_HEIGHT option is provided', function (assert) {
+      // given
+      const imageInformation = { height: 50, width: 100 };
+      const options = {
+        MAX_HEIGHT: 100,
+      };
+
+      // when
+      const dimensions = resizeImage(imageInformation, options);
+
+      //then
+      assert.deepEqual(dimensions, { height: 100, width: 200 });
+    });
+
+    test('should return accurate result when MAX_WIDTH option is provided', function (assert) {
+      // given
+      const imageInformation = { height: 100, width: 50 };
+      const options = {
+        MAX_WIDTH: 100,
+      };
+
+      // when
+      const dimensions = resizeImage(imageInformation, options);
+
+      //then
+      assert.deepEqual(dimensions, { height: 200, width: 100 });
+    });
+  });
+
+  module('#resizeByHeight', function () {
+    test('should return the accurate result for a resize by height', function (assert) {
+      // given
+      const imageInformation = { width: 100, height: 50 };
+      const MAX_HEIGHT = 100;
+      // when
+      const dimensions = resizeByHeight(imageInformation, MAX_HEIGHT);
+
+      // then
+      assert.deepEqual(dimensions, { width: 200, height: 100 });
+    });
+  });
+
+  module('#resizeByWidth', function () {
+    test('should return the accurate result for a resize by width', function (assert) {
+      // given
+      const imageInformation = { width: 50, height: 100 };
+      const MAX_WIDTH = 100;
+      // when
+      const dimensions = resizeByWidth(imageInformation, MAX_WIDTH);
+
+      // then
+      assert.deepEqual(dimensions, { width: 100, height: 200 });
+    });
+  });
+
+  module('#validateOptions', function () {
+    test('should return false if options is undefined', function (assert) {
+      // given
+      const options = undefined;
+
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.false(validationStatus);
+    });
+    test('should return false if options has neither MAX_WIDTH nor MAX_HEIGHT', function (assert) {
+      // given
+      const options = {};
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.false(validationStatus);
+    });
+    test('should return true if options contains MAX_WIDTH', function (assert) {
+      // given
+      const options = { MAX_WIDTH: 20 };
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.true(validationStatus);
+    });
+    test('should return true if options contains MAX_HEIGHT', function (assert) {
+      // given
+      const options = { MAX_HEIGHT: 20 };
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.true(validationStatus);
+    });
+
+    test('should return false if provided MAX_WIDTH equals 0', function (assert) {
+      // given
+      const options = { MAX_WIDTH: 0 };
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.false(validationStatus);
+    });
+
+    test('should return false if provided MAX_HEIGHT equals 0', function (assert) {
+      // given
+      const options = { MAX_HEIGHT: 0 };
+      // when
+      const validationStatus = validateOptions(options);
+
+      // then
+      assert.false(validationStatus);
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Actuellement, on reçoit les métadonnées des images à afficher pour les modules. Dans le cadre de la feature du layout shift, on souhaite pouvoir redimensionner les images en fonction d'une hauteur ou d'une largeur maximale. Cela a déjà été mis en place dans[ cette PR](https://github.com/1024pix/pix/pull/13673) avec un produit en croix. Nous allons avoir besoin de le faire pour différents éléments de modules qui n'utilisent pas forcément le composant image, et il y aura besoin de redimensionner par largeur OU par hauteur maximale.

## 🌰 Proposition

Créer un utilitaire qui centralise la logique de redimensionnement, et qui soit utilisable dans les éléments qui ont besoin de gérer le layout shift.

## 🍁 Remarques
Quand cette PR sera mergée, il faudra refacto les élements suivants afin d'utiliser la fonction de redimensionnement : 
- [image](https://github.com/1024pix/pix/blob/dd96b5fee2a2429a1aede278a28cd18f91b0d92f/mon-pix/app/components/module/element/image.gjs#L33)
- qab ([PR en cours](https://github.com/1024pix/pix/pull/13830))

## 🪵 Pour tester
Les tests sont au 🟢
