### PR TITLE
[FEATURE] Ajout d'un paramètre versionId pour exécuter une simulation de Pix+ (PIX-19957).

### DIFF
--- a/api/src/certification/evaluation/application/scenario-simulator-controller.js
+++ b/api/src/certification/evaluation/application/scenario-simulator-controller.js
@@ -28,6 +28,7 @@ async function simulateFlashAssessmentScenario(
     locale,
     complementaryCertificationKey,
     stopAtChallenge,
+    versionId,
   } = request.payload;
 
   const pickAnswerStatus = dependencies.pickAnswerStatusService.pickAnswerStatusForCapacity(capacity);
@@ -48,6 +49,7 @@ async function simulateFlashAssessmentScenario(
           accessibilityAdjustmentNeeded,
           complementaryCertificationKey,
           stopAtChallenge,
+          versionId,
         },
         _.isUndefined,
       );

--- a/api/src/certification/evaluation/application/scenario-simulator-route.js
+++ b/api/src/certification/evaluation/application/scenario-simulator-route.js
@@ -34,6 +34,7 @@ const register = async (server) => {
                 .lowercase()
                 .required(),
               complementaryCertificationKey: Joi.string().valid(...Object.values(ComplementaryCertificationKeys)),
+              versionId: Joi.number().integer().min(0),
               stopAtChallenge: Joi.number().min(1).max(32).description('Limit the number of question in an iteration.'),
             })
             .required(),

--- a/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
+++ b/api/src/certification/evaluation/domain/usecases/simulate-flash-assessment-scenario.js
@@ -28,12 +28,14 @@ export async function simulateFlashAssessmentScenario({
   complementaryCertificationRepository,
   sharedChallengeRepository,
   accessibilityAdjustmentNeeded,
+  versionId,
   complementaryCertificationKey,
   stopAtChallenge,
 }) {
   if (complementaryCertificationKey) {
     return _simulateComplementaryCertificationScenario({
       complementaryCertificationKey,
+      versionId,
       challengeRepository: sharedChallengeRepository,
       complementaryCertificationRepository,
       flashAlgorithmService,
@@ -68,6 +70,7 @@ export async function simulateFlashAssessmentScenario({
 async function _simulateComplementaryCertificationScenario({
   locale,
   complementaryCertificationKey,
+  versionId,
   pickChallenge,
   pickAnswerStatus,
   initialCapacity,
@@ -83,6 +86,7 @@ async function _simulateComplementaryCertificationScenario({
     locale,
     challengeRepository,
     complementaryCertificationKey,
+    versionId,
     hasComplementaryReferential,
   });
 
@@ -146,12 +150,14 @@ function _getChallenges({
   locale,
   accessibilityAdjustmentNeeded,
   complementaryCertificationKey,
+  versionId,
   hasComplementaryReferential,
 }) {
   return challengeRepository.findActiveFlashCompatible({
     locale,
     accessibilityAdjustmentNeeded,
     complementaryCertificationKey,
+    versionId,
     hasComplementaryReferential,
   });
 }

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -126,9 +126,10 @@ export async function findActiveFlashCompatible({
   successProbabilityThreshold = config.features.successProbabilityThreshold,
   accessibilityAdjustmentNeeded = false,
   complementaryCertificationKey,
+  versionId,
 } = {}) {
   _assertLocaleIsDefined(locale);
-  const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })`;
+  const cacheKey = `findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded}, searchParameter: ${versionId ?? complementaryCertificationKey})`;
   let challengeDtos;
 
   if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
@@ -138,6 +139,7 @@ export async function findActiveFlashCompatible({
       complementaryCertificationKey,
       cacheKey,
       version,
+      versionId,
     });
   } else {
     challengeDtos = await _findChallengesForCoreCertification({ locale, accessibilityAdjustmentNeeded, cacheKey });
@@ -148,16 +150,23 @@ export async function findActiveFlashCompatible({
   );
 }
 
-async function _findValidChallengesForComplementaryCertification({ complementaryCertificationKey, cacheKey, version }) {
+async function _findValidChallengesForComplementaryCertification({
+  complementaryCertificationKey,
+  cacheKey,
+  version,
+  versionId,
+}) {
+  const whereClause = versionId ? { versionId } : { complementaryCertificationKey };
+
   const { closestVersion } = await knex('certification-frameworks-challenges')
-    .where({ complementaryCertificationKey })
+    .where(whereClause)
     .andWhere('version', '<=', version)
     .max('version as closestVersion')
     .first();
 
   const complementaryCertificationChallenges = await knex
     .from('certification-frameworks-challenges')
-    .where({ complementaryCertificationKey })
+    .where(whereClause)
     .whereNotNull('discriminant')
     .whereNotNull('difficulty')
     .andWhere('version', '=', closestVersion);

--- a/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/simulate-flash-assessment-scenario_test.js
@@ -28,32 +28,63 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
             locale,
             accessibilityAdjustmentNeeded: undefined,
             hasComplementaryReferential: false,
+            versionId: undefined,
           });
         });
       });
 
       describe('when the certification has a complementary referential', function () {
-        it('should fetch the complementary framework challenges', async function () {
-          // given
-          const locale = FRENCH_FRANCE;
-          const accessibilityAdjustmentNeeded = false;
-          const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
-          const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+        describe('when given a complementary certification key', function () {
+          it('should fetch the complementary framework challenges', async function () {
+            // given
+            const locale = FRENCH_FRANCE;
+            const accessibilityAdjustmentNeeded = false;
+            const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
+            const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
 
-          // when
-          await catchErr(simulateFlashAssessmentScenario)({
-            locale,
-            accessibilityAdjustmentNeeded,
-            complementaryCertificationKey,
-            sharedChallengeRepository: challengeRepositoryStub,
+            // when
+            await catchErr(simulateFlashAssessmentScenario)({
+              locale,
+              accessibilityAdjustmentNeeded,
+              complementaryCertificationKey,
+              sharedChallengeRepository: challengeRepositoryStub,
+            });
+
+            // then
+            expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+              complementaryCertificationKey,
+              locale,
+              accessibilityAdjustmentNeeded: undefined,
+              hasComplementaryReferential: true,
+              versionId: undefined,
+            });
           });
+        });
 
-          // then
-          expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
-            complementaryCertificationKey,
-            locale,
-            accessibilityAdjustmentNeeded: undefined,
-            hasComplementaryReferential: true,
+        describe('when given a versionId', function () {
+          it('should fetch the complementary framework challenges', async function () {
+            // given
+            const locale = FRENCH_FRANCE;
+            const accessibilityAdjustmentNeeded = false;
+            const versionId = 1;
+            const challengeRepositoryStub = { findActiveFlashCompatible: sinon.stub() };
+
+            // when
+            await catchErr(simulateFlashAssessmentScenario)({
+              locale,
+              accessibilityAdjustmentNeeded,
+              versionId,
+              sharedChallengeRepository: challengeRepositoryStub,
+            });
+
+            // then
+            expect(challengeRepositoryStub.findActiveFlashCompatible).to.have.been.calledOnceWithExactly({
+              complementaryCertificationKey: undefined,
+              locale,
+              accessibilityAdjustmentNeeded: undefined,
+              hasComplementaryReferential: true,
+              versionId,
+            });
           });
         });
       });
@@ -80,6 +111,7 @@ describe('Unit | Domain | Usecases | simulate-flash-assessment-scenario', functi
           accessibilityAdjustmentNeeded,
           complementaryCertificationKey: undefined,
           hasComplementaryReferential: undefined,
+          versionId: undefined,
         });
       });
     });

--- a/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/challenge-repository_test.js
@@ -2083,6 +2083,60 @@ describe('Integration | Repository | challenge-repository', function () {
         });
       });
     });
+
+    context('when version id is given', function () {
+      it('returns only valid calibrated flash compatible challenges that link to this version', async function () {
+        // given
+        const candidateReconciliationDate = new Date('2025-01-01');
+
+        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification.droit({});
+
+        challengesLC.push(
+          domainBuilder.buildChallenge({ id: 'challengeForComplementaryCertification', status: 'validé' }),
+        );
+        challengesLC.push(
+          domainBuilder.buildChallenge({
+            id: 'otherChallengeForComplementaryCertification',
+            status: 'validé',
+          }),
+        );
+
+        databaseBuilder.factory.learningContent.build({ skills: skillsLC, challenges: challengesLC });
+
+        const firstVersionId = 1;
+        const secondVersionId = 2;
+
+        const certificationFrameworksChallenge = databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: complementaryCertification.key,
+          challengeId: challengesLC[3].id,
+          version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
+          versionId: firstVersionId,
+        });
+
+        databaseBuilder.factory.buildCertificationFrameworksChallenge({
+          complementaryCertificationKey: complementaryCertification.key,
+          challengeId: challengesLC[0].id,
+          version: dayjs(candidateReconciliationDate).subtract(1, 'day').format('YYYYMMDDHHmmss'),
+          versionId: secondVersionId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const flashCompatibleChallenges = await challengeRepository.findActiveFlashCompatible({
+          date: candidateReconciliationDate,
+          locale: 'fr',
+          versionId: firstVersionId,
+          complementaryCertificationKey: complementaryCertification.key,
+        });
+
+        // then
+        expect(flashCompatibleChallenges).to.have.lengthOf(1);
+        expect(flashCompatibleChallenges[0].id).to.equal(challengesLC[3].id);
+        expect(flashCompatibleChallenges[0].difficulty).to.equal(certificationFrameworksChallenge.difficulty);
+        expect(flashCompatibleChallenges[0].discriminant).to.equal(certificationFrameworksChallenge.discriminant);
+      });
+    });
   });
 
   describe('#findValidatedBySkillId', function () {


### PR DESCRIPTION
## 🍂 Problème

Avec l'implémentation actuelle du simulateur de déroulé, nous ne pouvons avoir plus d'un référentiel pour un scope donné puisque, nous obligeant à mettre à jour ou recréer un référentiel chaque fois que l'équipe DATA veut effectuer une simulation avec une nouvelle (ou ancienne) calibration

## 🌰 Proposition

Afin de permettre à l'équipe DATA de pouvoir sélectionner le référentiel sur lequel effectuer une simulation, nous ajoutons un paramètre `versionId` qui leur permettra de choisir un référentiel donné puisqu'à un référentiel correspond une calibration

## 🍁 Remarques

Je modifie la cacheKey de recherche dans cette PR, sinon il n'est pas possible de faire plusieurs simulations: 
- Lors de la première simulation, on instancie le learning-content-repository qui met en cache les challenges correspondants
- Lors d'une seconde simulation (avec un autre calibrationId), vu que la cacheKey n'a pas changé, on vient chercher dans le cache les challenges de la première simulation, ne renvoyant ainsi aucun challenge

Nous gardons le paramètre `complementaryCertificationKey` que nous décommissionerons ultérieurement afin de nous permettre de continuer à garder le mécanisme de branches complémentaire/coeur actuellement en place.
Ce paramètre sera supprimé lorsque l'implémentation du choix des challenges du référentiel coeur sur la table `certification-frameworks-challenges` aura été implémenté.

## 🪵 Pour tester

- Créer un nouveau référentiel de façon à en avoir au minimum deux pour un scope (ex: DROIT, car un référentiel existe dans les SEEDS)

```bash
TOKEN=$(curl --insecure 'https://admin-pr13838.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr13838.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "capacity": 3, "complementaryCertificationKey": "DROIT", "calibrationId": <CALIBRATION_ID>, "locale": "fr-fr", "stopAtChallenge": 3 }' | jq '.'
```
