### PR TITLE
[TECH] Remplace l'utilisation de `hasComplementaryReferential` par la clef de complémentaire dans le service de score v2 (Pix-19964)

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-course.js
+++ b/api/db/database-builder/factory/build-complementary-certification-course.js
@@ -8,10 +8,11 @@ const buildComplementaryCertificationCourse = function ({
   certificationCourseId,
   createdAt = new Date('2020-01-01'),
   complementaryCertificationBadgeId,
+  complementaryCertificationKey,
 } = {}) {
   complementaryCertificationId = complementaryCertificationId
     ? complementaryCertificationId
-    : buildComplementaryCertification().id;
+    : buildComplementaryCertification({ complementaryCertificationKey }).id;
   complementaryCertificationBadgeId = complementaryCertificationBadgeId
     ? complementaryCertificationBadgeId
     : buildComplementaryCertificationBadge({ complementaryCertificationId, badgeId: null }).id;

--- a/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
+++ b/api/src/certification/evaluation/domain/services/scoring/score-complementary-certification-v2.js
@@ -46,7 +46,7 @@ export async function scoreComplementaryCertificationV2({
 
   let complementaryCertificationKey;
   if (certificationCourse.complementaryCertificationCourse?.complementaryCertificationId) {
-    const complementaryCertification = await complementaryCertificationRepository.get({
+    const complementaryCertification = await complementaryCertificationRepository.getById({
       id: certificationCourse.complementaryCertificationCourse.complementaryCertificationId,
     });
     complementaryCertificationKey = complementaryCertification?.key;
@@ -173,7 +173,7 @@ async function _buildComplementaryCertificationScoring({
   certificationCourse,
   minimumEarnedPix,
 }) {
-  if (complementaryCertificationKey && complementaryCertificationKey.key !== ComplementaryCertificationKeys.CLEA) {
+  if (complementaryCertificationKey && complementaryCertificationKey !== ComplementaryCertificationKeys.CLEA) {
     const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId({
       certificationCourseId,
     });

--- a/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/complementary-certification-scoring-criteria-repository.js
@@ -10,7 +10,6 @@ export const findByCertificationCourseId = async function ({ certificationCourse
       minimumReproducibilityRate: 'complementary-certifications.minimumReproducibilityRate',
       minimumReproducibilityRateLowerLevel: 'complementary-certifications.minimumReproducibilityRateLowerLevel',
       complementaryCertificationBadgeKey: 'badges.key',
-      complementaryCertificationKey: 'complementary-certifications.key',
       minimumEarnedPix: 'complementary-certification-badges.minimumEarnedPix',
     })
     .join(

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
@@ -103,7 +103,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
       complementaryCertificationRepository.get
         .withArgs({ id: complementaryCertificationId })
-        .resolves({ key: 'PIX_PLUS_TEST' });
+        .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
       complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.resolves([
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({ id: 888 }),
@@ -426,7 +426,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: 'PIX_PLUS_TEST' });
+              .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
             // when
             await scoreComplementaryCertificationV2({
@@ -505,7 +505,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
           complementaryCertificationRepository.get
             .withArgs({ id: complementaryCertificationId })
-            .resolves({ key: 'PIX_PLUS_TEST' });
+            .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
           complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.resolves([
             domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({ id: 888 }),
@@ -582,7 +582,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: 'PIX_PLUS_TEST' });
+              .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
             const complementaryCertificationScoringCriteria =
               domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria({
@@ -688,7 +688,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
             complementaryCertificationRepository.get
               .withArgs({ id: complementaryCertificationId })
-              .resolves({ key: 'PIX_PLUS_TEST' });
+              .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
             certificationAssessmentRepository.getByCertificationCourseId
               .withArgs({ certificationCourseId })
@@ -792,7 +792,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
                 complementaryCertificationRepository.get
                   .withArgs({ id: complementaryCertificationId })
-                  .resolves({ key: 'PIX_PLUS_TEST' });
+                  .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -901,7 +901,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
                 complementaryCertificationRepository.get
                   .withArgs({ id: complementaryCertificationId })
-                  .resolves({ key: 'PIX_PLUS_TEST' });
+                  .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -1016,7 +1016,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
       complementaryCertificationRepository.get
         .withArgs({ id: complementaryCertificationId })
-        .resolves({ key: 'PIX_PLUS_TEST' });
+        .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
       // when
       await scoreComplementaryCertificationV2({
@@ -1103,7 +1103,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: 'PIX_PLUS_TEST' });
+          .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1193,7 +1193,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: 'PIX_PLUS_TEST' });
+          .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1283,7 +1283,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: 'PIX_PLUS_TEST' });
+          .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1373,7 +1373,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
 
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: 'PIX_PLUS_TEST' });
+          .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1462,7 +1462,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
         );
         complementaryCertificationRepository.get
           .withArgs({ id: complementaryCertificationId })
-          .resolves({ key: 'PIX_PLUS_TEST' });
+          .resolves({ key: Frameworks.PIX_PLUS_DROIT });
 
         // when
         await scoreComplementaryCertificationV2({

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/score-complementary-certification-v2_test.js
@@ -12,6 +12,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
   const complementaryCertificationScoringCriteriaRepository = {};
   const certificationCourseRepository = {};
   const complementaryCertificationBadgesRepository = {};
+  const complementaryCertificationRepository = {};
 
   const dependencies = {
     certificationAssessmentRepository,
@@ -20,6 +21,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
     complementaryCertificationScoringCriteriaRepository,
     certificationCourseRepository,
     complementaryCertificationBadgesRepository,
+    complementaryCertificationRepository,
   };
 
   beforeEach(function () {
@@ -30,12 +32,14 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
     complementaryCertificationScoringCriteriaRepository.findByCertificationCourseId = sinon.stub();
     certificationCourseRepository.get = sinon.stub();
     complementaryCertificationBadgesRepository.getAllWithSameTargetProfile = sinon.stub();
+    complementaryCertificationRepository.get = sinon.stub();
   });
 
   context('when there is a complementary referential', function () {
     it('should score the complementary certification', async function () {
       // given
       const certificationCourseId = 123;
+      const complementaryCertificationId = 456;
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
         certificationCourseId,
         userId: 456,
@@ -72,9 +76,22 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
         .withArgs({ certificationCourseId })
         .resolves(domainBuilder.buildAssessmentResult());
 
-      certificationCourseRepository.get
-        .withArgs({ id: certificationCourseId })
-        .resolves(domainBuilder.buildCertificationCourse());
+      const complementaryCertificationCourse = {
+        id: 999,
+        complementaryCertificationId,
+        certificationCourseId,
+        complementaryCertificationBadgeId: 888,
+      };
+
+      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+        domainBuilder.buildCertificationCourse({
+          complementaryCertificationCourse,
+        }),
+      );
+
+      complementaryCertificationRepository.get
+        .withArgs({ id: complementaryCertificationId })
+        .resolves({ key: 'PIX_PLUS_TEST' });
 
       complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.resolves([
         domainBuilder.certification.enrolment.buildComplementaryCertificationBadge({ id: 888 }),
@@ -374,9 +391,23 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
               .withArgs({ certificationCourseId })
               .resolves(assessmentResult);
 
-            certificationCourseRepository.get
-              .withArgs({ id: certificationCourseId })
-              .resolves(domainBuilder.buildCertificationCourse());
+            const complementaryCertificationId = 456;
+            const complementaryCertificationCourse = {
+              id: 999,
+              complementaryCertificationId,
+              certificationCourseId,
+              complementaryCertificationBadgeId: 888,
+            };
+
+            certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+              domainBuilder.buildCertificationCourse({
+                complementaryCertificationCourse,
+              }),
+            );
+
+            complementaryCertificationRepository.get
+              .withArgs({ id: complementaryCertificationId })
+              .resolves({ key: 'PIX_PLUS_TEST' });
 
             // when
             await scoreComplementaryCertificationV2({
@@ -428,9 +459,25 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
           assessmentResultRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
             .resolves(domainBuilder.buildAssessmentResult.rejected());
-          certificationCourseRepository.get
-            .withArgs({ id: certificationCourseId })
-            .resolves(domainBuilder.buildCertificationCourse());
+
+          const complementaryCertificationId = 456;
+          const complementaryCertificationCourse = {
+            id: 999,
+            complementaryCertificationId,
+            certificationCourseId,
+            complementaryCertificationBadgeId: 888,
+          };
+
+          certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+            domainBuilder.buildCertificationCourse({
+              complementaryCertificationCourse,
+            }),
+          );
+
+          complementaryCertificationRepository.get
+            .withArgs({ id: complementaryCertificationId })
+            .resolves({ key: 'PIX_PLUS_TEST' });
+
           const complementaryCertificationScoringCriteria =
             domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria({
               complementaryCertificationCourseId: 999,
@@ -487,9 +534,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
               certificationChallenges: [certificationChallenge1, certificationChallenge2],
               certificationAnswersByDate: [certificationAnswer1, certificationAnswer2],
             });
-            certificationCourseRepository.get
-              .withArgs({ id: certificationCourseId })
-              .resolves(domainBuilder.buildCertificationCourse());
+
+            const complementaryCertificationId = 456;
+            const complementaryCertificationCourse = {
+              id: 999,
+              complementaryCertificationId,
+              certificationCourseId,
+              complementaryCertificationBadgeId: 888,
+            };
+
+            certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+              domainBuilder.buildCertificationCourse({
+                complementaryCertificationCourse,
+              }),
+            );
+
+            complementaryCertificationRepository.get
+              .withArgs({ id: complementaryCertificationId })
+              .resolves({ key: 'PIX_PLUS_TEST' });
 
             const complementaryCertificationScoringCriteria =
               domainBuilder.certification.evaluation.buildComplementaryCertificationScoringCriteria({
@@ -569,9 +631,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
                 certificationCourseId,
               })
               .resolves([complementaryCertificationScoringCriteria]);
-            certificationCourseRepository.get
-              .withArgs({ id: certificationCourseId })
-              .resolves(domainBuilder.buildCertificationCourse());
+
+            const complementaryCertificationId = 456;
+            const complementaryCertificationCourse = {
+              id: 999,
+              complementaryCertificationId,
+              certificationCourseId,
+              complementaryCertificationBadgeId: 888,
+            };
+
+            certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+              domainBuilder.buildCertificationCourse({
+                complementaryCertificationCourse,
+              }),
+            );
+
+            complementaryCertificationRepository.get
+              .withArgs({ id: complementaryCertificationId })
+              .resolves({ key: 'PIX_PLUS_TEST' });
 
             certificationAssessmentRepository.getByCertificationCourseId
               .withArgs({ certificationCourseId })
@@ -648,9 +725,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
                     certificationCourseId,
                   })
                   .resolves([complementaryCertificationScoringCriteria]);
-                certificationCourseRepository.get
-                  .withArgs({ id: certificationCourseId })
-                  .resolves(domainBuilder.buildCertificationCourse());
+
+                const complementaryCertificationId = 456;
+                const complementaryCertificationCourse = {
+                  id: 999,
+                  complementaryCertificationId,
+                  certificationCourseId,
+                  complementaryCertificationBadgeId: 888,
+                };
+
+                certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+                  domainBuilder.buildCertificationCourse({
+                    complementaryCertificationCourse,
+                  }),
+                );
+
+                complementaryCertificationRepository.get
+                  .withArgs({ id: complementaryCertificationId })
+                  .resolves({ key: 'PIX_PLUS_TEST' });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -733,9 +825,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
                     certificationCourseId,
                   })
                   .resolves([complementaryCertificationScoringCriteria]);
-                certificationCourseRepository.get
-                  .withArgs({ id: certificationCourseId })
-                  .resolves(domainBuilder.buildCertificationCourse());
+
+                const complementaryCertificationId = 456;
+                const complementaryCertificationCourse = {
+                  id: 999,
+                  complementaryCertificationId,
+                  certificationCourseId,
+                  complementaryCertificationBadgeId: 888,
+                };
+
+                certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+                  domainBuilder.buildCertificationCourse({
+                    complementaryCertificationCourse,
+                  }),
+                );
+
+                complementaryCertificationRepository.get
+                  .withArgs({ id: complementaryCertificationId })
+                  .resolves({ key: 'PIX_PLUS_TEST' });
 
                 complementaryCertificationBadgesRepository.getAllWithSameTargetProfile.withArgs(888).resolves([
                   domainBuilder.certification.complementaryCertification.buildComplementaryCertificationBadge({
@@ -815,9 +922,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
       assessmentResultRepository.getByCertificationCourseId
         .withArgs({ certificationCourseId })
         .resolves(domainBuilder.buildAssessmentResult({ pixScore: 128, reproducibilityRate: 100 }));
-      certificationCourseRepository.get
-        .withArgs({ id: certificationCourseId })
-        .resolves(domainBuilder.buildCertificationCourse());
+
+      const complementaryCertificationId = 456;
+      const complementaryCertificationCourse = {
+        id: 999,
+        complementaryCertificationId,
+        certificationCourseId,
+        complementaryCertificationBadgeId: 888,
+      };
+
+      certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+        domainBuilder.buildCertificationCourse({
+          complementaryCertificationCourse,
+        }),
+      );
+
+      complementaryCertificationRepository.get
+        .withArgs({ id: complementaryCertificationId })
+        .resolves({ key: 'PIX_PLUS_TEST' });
 
       // when
       await scoreComplementaryCertificationV2({
@@ -877,9 +999,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             certificationCourseId,
           })
           .resolves([complementaryCertificationScoringCriteria]);
-        certificationCourseRepository.get
-          .withArgs({ id: certificationCourseId })
-          .resolves(domainBuilder.buildCertificationCourse());
+
+        const complementaryCertificationId = 456;
+        const complementaryCertificationCourse = {
+          id: 999,
+          complementaryCertificationId,
+          certificationCourseId,
+          complementaryCertificationBadgeId: 888,
+        };
+
+        certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+          domainBuilder.buildCertificationCourse({
+            complementaryCertificationCourse,
+          }),
+        );
+
+        complementaryCertificationRepository.get
+          .withArgs({ id: complementaryCertificationId })
+          .resolves({ key: 'PIX_PLUS_TEST' });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -943,9 +1080,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             reproducibilityRate: 70,
           }),
         );
-        certificationCourseRepository.get
-          .withArgs({ id: certificationCourseId })
-          .resolves(domainBuilder.buildCertificationCourse());
+
+        const complementaryCertificationId = 456;
+        const complementaryCertificationCourse = {
+          id: 999,
+          complementaryCertificationId,
+          certificationCourseId,
+          complementaryCertificationBadgeId: 888,
+        };
+
+        certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+          domainBuilder.buildCertificationCourse({
+            complementaryCertificationCourse,
+          }),
+        );
+
+        complementaryCertificationRepository.get
+          .withArgs({ id: complementaryCertificationId })
+          .resolves({ key: 'PIX_PLUS_TEST' });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1009,9 +1161,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             reproducibilityRate: 75,
           }),
         );
-        certificationCourseRepository.get
-          .withArgs({ id: certificationCourseId })
-          .resolves(domainBuilder.buildCertificationCourse());
+
+        const complementaryCertificationId = 456;
+        const complementaryCertificationCourse = {
+          id: 999,
+          complementaryCertificationId,
+          certificationCourseId,
+          complementaryCertificationBadgeId: 888,
+        };
+
+        certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+          domainBuilder.buildCertificationCourse({
+            complementaryCertificationCourse,
+          }),
+        );
+
+        complementaryCertificationRepository.get
+          .withArgs({ id: complementaryCertificationId })
+          .resolves({ key: 'PIX_PLUS_TEST' });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1075,9 +1242,24 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             reproducibilityRate: 75,
           }),
         );
-        certificationCourseRepository.get
-          .withArgs({ id: certificationCourseId })
-          .resolves(domainBuilder.buildCertificationCourse());
+
+        const complementaryCertificationId = 456;
+        const complementaryCertificationCourse = {
+          id: 999,
+          complementaryCertificationId,
+          certificationCourseId,
+          complementaryCertificationBadgeId: 888,
+        };
+
+        certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+          domainBuilder.buildCertificationCourse({
+            complementaryCertificationCourse,
+          }),
+        );
+
+        complementaryCertificationRepository.get
+          .withArgs({ id: complementaryCertificationId })
+          .resolves({ key: 'PIX_PLUS_TEST' });
 
         // when
         await scoreComplementaryCertificationV2({
@@ -1141,9 +1323,22 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring Comple
             reproducibilityRate: 75,
           }),
         );
-        certificationCourseRepository.get
-          .withArgs({ id: certificationCourseId })
-          .resolves(domainBuilder.buildCertificationCourse({ isRejectedForFraud: true }));
+        const complementaryCertificationId = 456;
+        const complementaryCertificationCourse = {
+          id: 999,
+          complementaryCertificationId,
+          certificationCourseId,
+          complementaryCertificationBadgeId: 888,
+        };
+        certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(
+          domainBuilder.buildCertificationCourse({
+            complementaryCertificationCourse,
+            isRejectedForFraud: true,
+          }),
+        );
+        complementaryCertificationRepository.get
+          .withArgs({ id: complementaryCertificationId })
+          .resolves({ key: 'PIX_PLUS_TEST' });
 
         // when
         await scoreComplementaryCertificationV2({


### PR DESCRIPTION
## 🍂 Problème

Nous utilisons encore `hasComplementaryReferential` dans le service de score v2.

## 🌰 Proposition

Remplacer l'utilisation de `hasComplementaryReferential` par la clef de complémentaire, issue du `CertificationCourse`.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

scorer une certification v2 et s'assurer que ça fonctionne comme ça devrait
