### PR TITLE
[FEATURE] Utiliser la table certification_versions pour la sélection des challenges (PIX-19930).

### DIFF
--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -1,0 +1,62 @@
+/**
+ * @typedef {import('../../../shared/domain/models/Frameworks.js').Frameworks} Frameworks
+ */
+
+import Joi from 'joi';
+
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
+
+export class Version {
+  static #schema = Joi.object({
+    id: Joi.number().required(),
+    scope: Joi.string()
+      .required()
+      .valid(...Object.values(Frameworks)),
+    startDate: Joi.date().required(),
+    expirationDate: Joi.date().allow(null).optional(),
+    assessmentDuration: Joi.number().required(),
+    globalScoringConfiguration: Joi.array().allow(null).optional(),
+    competencesScoringConfiguration: Joi.array().allow(null).optional(),
+    challengesConfiguration: Joi.object().required(),
+  });
+
+  /**
+   * @param {Object} params
+   * @param {number} params.id - version identifier
+   * @param {Frameworks} params.scope - Framework scope (CORE, DROIT, etc.)
+   * @param {Date} params.startDate - When this version becomes active
+   * @param {Date|null} [params.expirationDate] - When this version expires (null if current)
+   * @param {number} params.assessmentDuration - Assessment duration in minutes
+   * @param {Array<Object>} [params.globalScoringConfiguration] - Global scoring configuration
+   * @param {Array<Object>} [params.competencesScoringConfiguration] - Competences scoring configuration
+   * @param {Object} params.challengesConfiguration - Challenges configuration
+   */
+  constructor({
+    id,
+    scope,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    globalScoringConfiguration,
+    competencesScoringConfiguration,
+    challengesConfiguration,
+  }) {
+    this.id = id;
+    this.scope = scope;
+    this.startDate = startDate;
+    this.expirationDate = expirationDate;
+    this.assessmentDuration = assessmentDuration;
+    this.globalScoringConfiguration = globalScoringConfiguration;
+    this.competencesScoringConfiguration = competencesScoringConfiguration;
+    this.challengesConfiguration = challengesConfiguration;
+    this.#validate();
+  }
+
+  #validate() {
+    const { error } = Version.#schema.validate(this, { allowUnknown: false });
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  }
+}

--- a/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
@@ -1,0 +1,60 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { Version } from '../../domain/models/Version.js';
+
+/**
+ * @param {Object} params
+ * @param {import('../../../shared/domain/models/Frameworks.js').Frameworks} params.scope
+ * @param {Date} params.reconciliationDate
+ * @returns {Promise<Version>}
+ */
+export const getByScopeAndReconciliationDate = async ({ scope, reconciliationDate }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const versionData = await knexConn('certification_versions')
+    .select(
+      'id',
+      'scope',
+      'startDate',
+      'expirationDate',
+      'assessmentDuration',
+      'globalScoringConfiguration',
+      'competencesScoringConfiguration',
+      'challengesConfiguration',
+    )
+    .where({ scope })
+    .where('startDate', '<=', reconciliationDate)
+    .andWhere((queryBuilder) => {
+      queryBuilder.whereNull('expirationDate').orWhere('expirationDate', '>', reconciliationDate);
+    })
+    .orderBy('startDate', 'desc')
+    .first();
+
+  if (!versionData) {
+    throw new NotFoundError('No certification framework version found for the given scope and reconciliationDate');
+  }
+
+  return _toDomain(versionData);
+};
+
+const _toDomain = ({
+  id,
+  scope,
+  startDate,
+  expirationDate,
+  assessmentDuration,
+  globalScoringConfiguration,
+  competencesScoringConfiguration,
+  challengesConfiguration,
+}) => {
+  return new Version({
+    id,
+    scope,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    globalScoringConfiguration,
+    competencesScoringConfiguration,
+    challengesConfiguration,
+  });
+};

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -5,6 +5,7 @@ import * as assessmentRepository from '../../../../shared/infrastructure/reposit
 import * as assessmentResultRepository from '../../../../shared/infrastructure/repositories/assessment-result-repository.js';
 import * as sharedChallengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import * as versionsRepository from '../../../configuration/infrastructure/repositories/versions-repository.js';
 import * as verifyCertificateCodeService from '../../../evaluation/domain/services/verify-certificate-code-service.js';
 import * as certificationBadgesService from '../../../shared/domain/services/certification-badges-service.js';
 import * as certificationAssessmentRepository from '../../../shared/infrastructure/repositories/certification-assessment-repository.js';
@@ -27,6 +28,7 @@ import pickChallengeService from '../services/pick-challenge-service.js';
 
 /**
  * @typedef {certificationCompanionAlertRepository} CertificationCompanionAlertRepository
+ * @typedef {versionsRepository} VersionsRepository
  * @typedef {evaluationSessionRepository} EvaluationSessionRepository
  * @typedef {certificationChallengeRepository} CertificationChallengeRepository
  * @typedef {certificationAssessmentRepository} CertificationAssessmentRepository
@@ -70,6 +72,7 @@ const dependencies = {
   complementaryCertificationScoringCriteriaRepository,
   sharedFlashAlgorithmConfigurationRepository,
   certificationChallengeLiveAlertRepository,
+  versionsRepository,
   services,
 };
 

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -1,13 +1,13 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { config } from '../../../../../src/shared/config.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { ComplementaryCertificationCourse } from '../../../session-management/domain/models/ComplementaryCertificationCourse.js';
 import { CertificationCourse } from '../../domain/models/CertificationCourse.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
-import { getMostRecentBeforeDate } from './flash-algorithm-configuration-repository.js';
 
 async function save({ certificationCourse }) {
   const knexConn = DomainTransaction.getConnection();
@@ -65,9 +65,8 @@ async function get({ id }) {
 
   let accessibilityAdjustmentNeeded;
   if (certificationCourseDTO.version === 3) {
-    const configuration = await getMostRecentBeforeDate(certificationCourseDTO.createdAt);
-
-    certificationCourseDTO.numberOfChallenges = configuration.maximumAssessmentLength;
+    // TODO: get the number of challenge per course in a better way
+    certificationCourseDTO.numberOfChallenges = config.v3Certification.numberOfChallengesPerCourse;
 
     ({ accessibilityAdjustmentNeeded } = await knexConn('certification-candidates')
       .select('accessibilityAdjustmentNeeded')
@@ -144,9 +143,8 @@ async function findOneCertificationCourseByUserIdAndSessionId({ userId, sessionI
   const challengesDTO = await _findAllChallenges(certificationCourseDTO.id, knexConn);
 
   if (certificationCourseDTO.version === 3) {
-    const configuration = await getMostRecentBeforeDate(certificationCourseDTO.createdAt);
-
-    certificationCourseDTO.numberOfChallenges = configuration.maximumAssessmentLength;
+    // TODO: get the number of challenge per course in a better way
+    certificationCourseDTO.numberOfChallenges = config.v3Certification.numberOfChallengesPerCourse;
   }
 
   return _toDomain({

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
@@ -1,0 +1,211 @@
+import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import * as versionsRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/versions-repository.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Integration | Repository | Versions', function () {
+  describe('#getByScopeAndReconciliationDate', function () {
+    it('should return the most recent version before or equal to the reconciliation date', async function () {
+      // given
+      const reconciliationDate = new Date('2025-06-15');
+      const scope = Frameworks.CORE;
+
+      databaseBuilder.factory.buildCertificationVersion({
+        scope,
+        startDate: new Date('2025-01-01'),
+        expirationDate: new Date('2025-05-31'),
+        assessmentDuration: 90,
+        globalScoringConfiguration: [{ config: 'old' }],
+        competencesScoringConfiguration: [{ config: 'old' }],
+        challengesConfiguration: { config: 'old' },
+      }).id;
+
+      const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
+        scope,
+        startDate: new Date('2025-06-01'),
+        expirationDate: null,
+        assessmentDuration: 120,
+        globalScoringConfiguration: [{ config: 'current' }],
+        competencesScoringConfiguration: [{ config: 'current' }],
+        challengesConfiguration: { config: 'current' },
+      }).id;
+
+      databaseBuilder.factory.buildCertificationVersion({
+        scope,
+        startDate: new Date('2025-07-01'),
+        expirationDate: null,
+        assessmentDuration: 150,
+        globalScoringConfiguration: [{ config: 'future' }],
+        competencesScoringConfiguration: [{ config: 'future' }],
+        challengesConfiguration: { config: 'future' },
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await versionsRepository.getByScopeAndReconciliationDate({
+        scope,
+        reconciliationDate,
+      });
+
+      // then
+      expect(result).to.be.instanceOf(Version);
+      expect(result.id).to.equal(expectedVersionId);
+      expect(result.scope).to.equal(scope);
+      expect(result.startDate).to.deep.equal(new Date('2025-06-01'));
+      expect(result.expirationDate).to.be.null;
+      expect(result.assessmentDuration).to.equal(120);
+      expect(result.globalScoringConfiguration).to.deep.equal([{ config: 'current' }]);
+      expect(result.competencesScoringConfiguration).to.deep.equal([{ config: 'current' }]);
+      expect(result.challengesConfiguration).to.deep.equal({ config: 'current' });
+    });
+
+    it('should only consider versions of the specified scope', async function () {
+      // given
+      const reconciliationDate = new Date('2025-06-15');
+      const targetScope = Frameworks.PIX_PLUS_PRO_SANTE;
+      const otherScope = Frameworks.CORE;
+
+      const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
+        scope: targetScope,
+        startDate: new Date('2025-05-01'),
+        expirationDate: null,
+        assessmentDuration: 100,
+        globalScoringConfiguration: [{ target: 'scope' }],
+        competencesScoringConfiguration: null,
+        challengesConfiguration: { config: 'target' },
+      }).id;
+
+      databaseBuilder.factory.buildCertificationVersion({
+        scope: otherScope,
+        startDate: new Date('2025-06-10'),
+        expirationDate: null,
+        assessmentDuration: 150,
+        globalScoringConfiguration: [{ other: 'scope' }],
+        competencesScoringConfiguration: null,
+        challengesConfiguration: { config: 'other' },
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await versionsRepository.getByScopeAndReconciliationDate({
+        scope: targetScope,
+        reconciliationDate,
+      });
+
+      // then
+      expect(result).to.be.instanceOf(Version);
+      expect(result.id).to.equal(expectedVersionId);
+      expect(result.scope).to.equal(targetScope);
+      expect(result.globalScoringConfiguration).to.deep.equal([{ target: 'scope' }]);
+    });
+
+    context('when reconciliation date equals startDate', function () {
+      it('should return the exact version', async function () {
+        // given
+        const reconciliationDate = new Date('2025-06-01');
+        const scope = Frameworks.PIX_PLUS_DROIT;
+
+        const expectedVersionId = databaseBuilder.factory.buildCertificationVersion({
+          scope,
+          startDate: reconciliationDate,
+          expirationDate: null,
+          assessmentDuration: 100,
+          globalScoringConfiguration: null,
+          competencesScoringConfiguration: null,
+          challengesConfiguration: { minChallenges: 5 },
+        }).id;
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await versionsRepository.getByScopeAndReconciliationDate({
+          scope,
+          reconciliationDate,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(Version);
+        expect(result.id).to.equal(expectedVersionId);
+        expect(result.startDate).to.deep.equal(reconciliationDate);
+      });
+    });
+
+    context('when no version exists for the scope', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        const reconciliationDate = new Date('2025-06-15');
+        const scope = Frameworks.PIX_PLUS_EDU_1ER_DEGRE;
+
+        // Create a version for a different scope
+        databaseBuilder.factory.buildCertificationVersion({
+          scope: Frameworks.CORE,
+          startDate: new Date('2025-01-01'),
+          expirationDate: null,
+          assessmentDuration: 90,
+          globalScoringConfiguration: null,
+          competencesScoringConfiguration: null,
+          challengesConfiguration: { config: 'test' },
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(versionsRepository.getByScopeAndReconciliationDate)({
+          scope,
+          reconciliationDate,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal(
+          'No certification framework version found for the given scope and reconciliationDate',
+        );
+      });
+    });
+
+    context('when all versions are after the reconciliation date', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        const reconciliationDate = new Date('2024-12-31');
+        const scope = Frameworks.PIX_PLUS_EDU_2ND_DEGRE;
+
+        databaseBuilder.factory.buildCertificationVersion({
+          scope,
+          startDate: new Date('2025-01-01'),
+          expirationDate: null,
+          assessmentDuration: 90,
+          globalScoringConfiguration: null,
+          competencesScoringConfiguration: null,
+          challengesConfiguration: { config: 'test' },
+        });
+
+        databaseBuilder.factory.buildCertificationVersion({
+          scope,
+          startDate: new Date('2025-06-01'),
+          expirationDate: null,
+          assessmentDuration: 120,
+          globalScoringConfiguration: null,
+          competencesScoringConfiguration: null,
+          challengesConfiguration: { config: 'test' },
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(versionsRepository.getByScopeAndReconciliationDate)({
+          scope,
+          reconciliationDate,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal(
+          'No certification framework version found for the given scope and reconciliationDate',
+        );
+      });
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -1,0 +1,69 @@
+import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Configuration | Domain | Models | Version', function () {
+  it('should build a Version with all fields', function () {
+    // given
+    const versionData = {
+      id: 123,
+      scope: Frameworks.CORE,
+      startDate: new Date('2025-01-01'),
+      expirationDate: new Date('2025-12-31'),
+      assessmentDuration: 120,
+      globalScoringConfiguration: [{ capacity: 2.5 }],
+      competencesScoringConfiguration: [{ competence1: 'config' }],
+      challengesConfiguration: { minChallenges: 5, maxChallenges: 10 },
+    };
+
+    // when
+    const version = new Version(versionData);
+
+    // then
+    expect(version).to.be.instanceOf(Version);
+    expect(version).to.deep.equal(versionData);
+  });
+
+  it('should build a Version with optional fields as null', function () {
+    // given
+    const versionData = {
+      id: 456,
+      scope: Frameworks.PIX_PLUS_DROIT,
+      startDate: new Date('2025-06-01'),
+      expirationDate: null,
+      assessmentDuration: 90,
+      globalScoringConfiguration: null,
+      competencesScoringConfiguration: null,
+      challengesConfiguration: { minChallenges: 3 },
+    };
+
+    // when
+    const version = new Version(versionData);
+
+    // then
+    expect(version).to.be.instanceOf(Version);
+    expect(version.id).to.equal(456);
+    expect(version.scope).to.equal(Frameworks.PIX_PLUS_DROIT);
+    expect(version.expirationDate).to.be.null;
+    expect(version.globalScoringConfiguration).to.be.null;
+    expect(version.competencesScoringConfiguration).to.be.null;
+  });
+
+  it('should throw an EntityValidationError when trying to construct an invalid Version', function () {
+    // given
+    const invalidData = {
+      id: 123,
+      scope: Frameworks.CORE,
+      startDate: 'not-a-date',
+      assessmentDuration: 120,
+      challengesConfiguration: { config: 'test' },
+    };
+
+    // when
+    const error = catchErrSync(() => new Version(invalidData))();
+
+    // then
+    expect(error).to.be.instanceOf(EntityValidationError);
+  });
+});

--- a/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -328,7 +328,7 @@ describe('Acceptance | API | Certification Course', function () {
         it('should have created a v3 certification course without any challenges', async function () {
           // given
           const { options, userId, sessionId } = _createRequestOptions({ version: AlgorithmEngineVersion.V3 });
-          const { flashConfiguration } = _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
+          _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
           await databaseBuilder.commit();
 
           // when
@@ -338,7 +338,7 @@ describe('Acceptance | API | Certification Course', function () {
           const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
           expect(certificationCourse.version).to.equal(AlgorithmEngineVersion.V3);
           expect(response.result.data.attributes).to.include({
-            'nb-challenges': JSON.parse(flashConfiguration.challengesConfiguration).maximumAssessmentLength,
+            'nb-challenges': 32,
           });
         });
 
@@ -451,7 +451,6 @@ function _createRequestOptions(
 function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userId }) {
   const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
   databaseBuilder.factory.learningContent.build(learningContentObjects);
-  const flashConfiguration = databaseBuilder.factory.buildCertificationConfiguration();
   const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
     sessionId,
     userId,
@@ -475,10 +474,7 @@ function _createNonExistingCertifCourseSetup({ learningContent, sessionId, userI
     createdAt: new Date('2023-03-03'),
   });
 
-  return {
-    certificationCandidate,
-    flashConfiguration,
-  };
+  return { certificationCandidate };
 }
 
 function _createExistingCertifCourseSetup({ userId, sessionId, version = 2 }) {

--- a/api/tests/certification/evaluation/integration/application/api/select-next-certification-challenge-api_test.js
+++ b/api/tests/certification/evaluation/integration/application/api/select-next-certification-challenge-api_test.js
@@ -36,7 +36,7 @@ describe('Integration | Application | Certification | Evaluation | API', functio
         type: Assessment.types.CERTIFICATION,
       });
 
-      databaseBuilder.factory.buildCertificationConfiguration();
+      databaseBuilder.factory.buildCertificationVersion();
       await databaseBuilder.commit();
 
       // The usecase is called after the lock is placed by the api

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -16,16 +16,16 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
       sessionManagementCertificationChallengeRepository,
       pickChallengeService,
       flashAlgorithmService,
-      flashAlgorithmConfigurationRepository,
-      certificationCandidateRepository;
+      certificationCandidateRepository,
+      versionsRepository;
 
-    let flashAlgorithmConfiguration;
+    let challengesConfiguration;
     let certificationCandidateId;
     let assessment;
 
     beforeEach(function () {
-      flashAlgorithmConfigurationRepository = {
-        getMostRecentBeforeDate: sinon.stub(),
+      versionsRepository = {
+        getByScopeAndReconciliationDate: sinon.stub(),
       };
       answerRepository = {
         findByAssessmentExcludingChallengeIds: sinon.stub(),
@@ -66,7 +66,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
 
       certificationCandidateRepository.findByAssessmentId.withArgs({ assessmentId: assessment.id }).resolves(candidate);
 
-      flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
+      challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
     });
 
     context('when there are challenges left to answer', function () {
@@ -89,9 +89,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           },
         });
 
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourseWithComplementary.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
+        versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
@@ -153,7 +151,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
+          versionsRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -190,9 +188,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           const assessment = domainBuilder.buildAssessment();
           const locale = 'fr-FR';
 
-          flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-            .withArgs(v3CertificationCourse.getStartDate())
-            .resolves(flashAlgorithmConfiguration);
+          versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
           answerRepository.findByAssessmentExcludingChallengeIds
             .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
@@ -258,7 +254,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             certificationChallengeLiveAlertRepository,
             certificationCourseRepository,
             sharedChallengeRepository,
-            flashAlgorithmConfigurationRepository,
+            versionsRepository,
             flashAlgorithmService,
             locale,
             pickChallengeService,
@@ -314,7 +310,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             certificationChallengeLiveAlertRepository,
             certificationCourseRepository,
             sharedChallengeRepository,
-            flashAlgorithmConfigurationRepository,
+            versionsRepository,
             flashAlgorithmService,
             locale,
             pickChallengeService,
@@ -348,9 +344,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
         });
         const locale = 'fr-FR';
 
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
+        versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
         const answerStillValid = domainBuilder.buildAnswer({ challengeId: alreadyAnsweredChallenge.id });
         const answerWithOutdatedChallenge = domainBuilder.buildAnswer({ challengeId: outdatedChallenge.id });
@@ -419,7 +413,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
+          versionsRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -456,9 +450,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           id: nonAnsweredCertificationChallenge.challengeId,
         });
 
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
+        versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({
@@ -524,7 +516,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
+          versionsRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -567,9 +559,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           skill: firstSkill,
         });
 
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
+        versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({
@@ -625,7 +615,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
+          versionsRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -655,10 +645,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           getCapacityAndErrorRate: sinon.stub(),
         };
 
-        flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 1 });
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
+        challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 1 });
+        versionsRepository.getByScopeAndReconciliationDate.resolves({ challengesConfiguration });
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
@@ -697,7 +685,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
+          versionsRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -735,11 +723,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               version: AlgorithmEngineVersion.V3,
             });
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate.reset();
             const configuration = domainBuilder.buildFlashAlgorithmConfiguration(flashConfiguration);
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(v3CertificationCourse.getStartDate())
-              .resolves(configuration);
+            versionsRepository.getByScopeAndReconciliationDate.resolves({
+              challengesConfiguration: configuration,
+            });
 
             const assessment = domainBuilder.buildAssessment();
             const locale = 'fr-FR';
@@ -805,7 +792,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               certificationChallengeLiveAlertRepository,
               certificationCourseRepository,
               sharedChallengeRepository,
-              flashAlgorithmConfigurationRepository,
+              versionsRepository,
               flashAlgorithmService,
               locale,
               pickChallengeService,
@@ -829,11 +816,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationCourseId: v3CertificationCourse.getId(),
         });
         const locale = 'fr-FR';
-
-        flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 1 });
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
@@ -867,7 +849,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,
@@ -895,11 +876,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationCourseId: v3CertificationCourse.getId(),
         });
         const locale = 'fr-FR';
-
-        flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 1 });
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(v3CertificationCourse.getStartDate())
-          .resolves(flashAlgorithmConfiguration);
 
         answerRepository.findByAssessmentExcludingChallengeIds
           .withArgs({ assessmentId: assessment.id, excludedChallengeIds: [] })
@@ -933,7 +909,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           certificationChallengeLiveAlertRepository,
           certificationCourseRepository,
           sharedChallengeRepository,
-          flashAlgorithmConfigurationRepository,
           flashAlgorithmService,
           locale,
           pickChallengeService,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -14,8 +14,6 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ version: 3 }).id;
 
-      databaseBuilder.factory.buildCertificationConfiguration();
-
       databaseBuilder.factory.buildCertificationCandidate({ userId, sessionId });
       certificationCourse = domainBuilder.buildCertificationCourse.unpersisted({
         userId,
@@ -178,55 +176,6 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
           });
         });
       });
-
-      context('When the certification course is v3', function () {
-        it('should retrieve the number of challenges from the configuration', async function () {
-          const maximumAssessmentLength = 10;
-          const { expectedCertificationCourse, certificationCandidate } = _buildCertificationCourse({
-            description,
-            version: 3,
-            createdAt: new Date('2022-01-03'),
-          });
-
-          // Older configuration
-          databaseBuilder.factory.buildCertificationConfiguration({
-            startingDate: new Date('2022-01-01'),
-            expirationDate: new Date('2022-01-02'),
-            challengesConfiguration: {
-              maximumAssessmentLength: 5,
-            },
-          });
-
-          // Active configuration on the certification day
-          databaseBuilder.factory.buildCertificationConfiguration({
-            startingDate: new Date('2022-01-02'),
-            expirationDate: new Date('2022-01-04'),
-            challengesConfiguration: {
-              maximumAssessmentLength: maximumAssessmentLength,
-            },
-          });
-
-          // Newer configuration
-          databaseBuilder.factory.buildCertificationConfiguration({
-            startingDate: new Date('2022-01-04'),
-            challengesConfiguration: {
-              maximumAssessmentLength: 15,
-            },
-          });
-
-          await databaseBuilder.commit();
-          // when
-          const actualCertificationCourse = await certificationCourseRepository.get({
-            id: expectedCertificationCourse.id,
-          });
-
-          // then
-          expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(maximumAssessmentLength);
-          expect(actualCertificationCourse.isAdjustementNeeded()).to.equal(
-            certificationCandidate.accessibilityAdjustmentNeeded,
-          );
-        });
-      });
     });
 
     context('When the certification course does not exist', function () {
@@ -243,8 +192,6 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
   describe('#findOneCertificationCourseByUserIdAndSessionId', function () {
     const createdAt = new Date('2018-12-11T01:02:03Z');
     const createdAtLater = new Date('2018-12-12T01:02:03Z');
-    const v3ConfigurationCreationDate = new Date('2018-12-12T01:00:03Z');
-    const numberOfQuestionsForV3 = 10;
     let userId;
     let sessionId;
 
@@ -296,13 +243,6 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
         databaseBuilder.factory.buildCertificationCourse({ sessionId });
         databaseBuilder.factory.buildCertificationCourse({ userId });
 
-        databaseBuilder.factory.buildCertificationConfiguration({
-          startingDate: v3ConfigurationCreationDate,
-          challengesConfiguration: {
-            maximumAssessmentLength: numberOfQuestionsForV3,
-          },
-        });
-
         return databaseBuilder.commit();
       });
 
@@ -325,7 +265,7 @@ describe('Certification | Shared | Integration | Repository | Certification Cour
         });
 
         // then
-        expect(certificationCourse.toDTO().numberOfChallenges).to.equal(numberOfQuestionsForV3);
+        expect(certificationCourse.toDTO().numberOfChallenges).to.equal(32);
       });
     });
   });

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -1,6 +1,7 @@
 import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
 import { CertificationCompanionLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationCompanionLiveAlert.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
@@ -91,17 +92,22 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             certificationCenterId,
             version: AlgorithmEngineVersion.V3,
           }).id;
-          databaseBuilder.factory.buildCertificationConfiguration();
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             isPublished: false,
             version: AlgorithmEngineVersion.V3,
             userId,
             sessionId,
           }).id;
+
           const candidate = databaseBuilder.factory.buildCertificationCandidate({
             ...user,
             userId: user.id,
             sessionId,
+            reconciledAt: new Date('2020-01-15'),
+          });
+          databaseBuilder.factory.buildCertificationVersion({
+            scope: Frameworks.CORE,
+            startDate: candidate.reconciledAt,
           });
           databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
           databaseBuilder.factory.buildAssessment({
@@ -217,7 +223,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             certificationCenterId,
             version: AlgorithmEngineVersion.V3,
           }).id;
-          databaseBuilder.factory.buildCertificationConfiguration();
+          databaseBuilder.factory.buildCertificationVersion();
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             isPublished: false,
             version: AlgorithmEngineVersion.V3,

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -165,9 +165,13 @@ async function buildBaseDataForCertification() {
     INSEECode: '66136',
     isActualName: true,
   });
-  await knex('certification-configurations').insert({
-    startingDate: new Date('1980-01-01'),
+  await knex('certification_versions').insert({
+    scope: 'CORE',
+    startDate: new Date('2024-10-19'),
     expirationDate: null,
+    assessmentDuration: 120,
+    globalScoringConfiguration: null,
+    competencesScoringConfiguration: null,
     challengesConfiguration: JSON.stringify({
       maximumAssessmentLength: 32,
       challengesBetweenSameCompetence: null,


### PR DESCRIPTION
## 🍂 Problème

Nous ne souhaitons plus utiliser la table `certification-configurations` pour la sélection des épreuves d'une certification coeur.
À la place, c'est la table `certification_versions` qui viendra maintenant contenir les configurations souhaitées.

## 🌰 Proposition

Créer une méthode de repository `getByScopeAndReconciliationDate` dans un nouveau repo `certification-versions-repository`.

Cette nouvelle méthode de repo sera utilisée dans le fichier api/src/certification/evaluation/domain/usecases/get-next-challenge.js, ligne 106, à la place de : 

```js
const algorithmConfiguration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
  certificationCourse.getStartDate(),
);
```

Cette méthode de repo retournera un nouveau modèle Version dont voici l’implémentation : 

**Version** :
```js
 class Version {
  constructor({
    id,
    scope,
    startDate,
    expirationDate,
    assessmentDuration,
    globalScoringConfiguration,  // objet parsé depuis JSONB
    competencesScoringConfiguration, // objet parsé depuis JSONB
    challengesConfiguration,  // objet parsé depuis JSONB
  })
 }
```


## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Lancer une certif coeur en RA et vérifier que tout se passe toujours bien !
(Vérifier que le nombre d'épreuves à passer s'affiche)
