### PR TITLE
[FEATURE] Ajouter une colonne jsonb dans la table `organization_learner_participations` (PIX-19966).

### DIFF
--- a/api/db/migrations/20251009133517_add-jsonb-column-organization-learner-participations.js
+++ b/api/db/migrations/20251009133517_add-jsonb-column-organization-learner-participations.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table('organization_learner_participations', function (table) {
+    table
+      .jsonb('attributes')
+      .defaultTo(null)
+      .comment(
+        'column contains all extra informations related to the participation "type". at least the `id` of the related entity',
+      );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table('organization_learner_participations', function (table) {
+    table.dropColumn('attributes');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Avoir deux tables pour gérer des id de reference n'est finalement pas l'idéal. 

## 🌰 Proposition

Plutôt que de continuer dans cette voix. nous ajoutons une colonne jsonb qui contiendra tout le necessaire de la participations. 

## 🍁 Remarques

les tables `organization_learner_passage_participations` et `combined_course_participations` seront amener a disparaitre dans un futur proche

## 🪵 Pour tester

CI au vert