### PR TITLE
[BUGFIX] : La barre de navigation d'un Module n'est plus sticky en haut (PIX-19967)

### DIFF
--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -12,7 +12,7 @@
 
   flex-grow: 1;
   min-height: 100vh;
-  overflow-x: hidden;
+  overflow-x: clip;
   color: var(--pix-neutral-900);
   background: var(--pix-neutral-0);
 }


### PR DESCRIPTION
## 🍂 Problème
Actuellement, la progress bar d'un module n'est plus sticky quand on scroll dans la page 

## 🌰 Proposition
Remplacer `overflow-x:hidden` par `overflow-x:clip`

## 🍁 Remarques
On est chanceux car ça fait deux mois qu'on peut l'utiliser

## 🪵 Pour tester
- Aller sur le [module ](https://app-pr13843.review.pix.fr/modules/bac-a-sable)
- Faire du modulix
- Dès qu'on peut scroller, vérifier que la barre reste affichée sur l'écran.
