### PR TITLE
[TECH] Activer par défaut certains feature toggles (PIX-20686).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -27,6 +27,7 @@ export default {
     type: 'boolean',
     description: 'Used to enable anonymization and deletion on prescriber context',
     defaultValue: false,
+    devDefaultValues: { test: true, reviewApp: true },
     tags: ['team-prescription', 'pix-api', 'backend'],
   },
   isFilteringRecommendedTrainingByOrganizationsEnabled: {
@@ -64,7 +65,8 @@ export default {
   isAutoShareEnabled: {
     type: 'boolean',
     description: 'Enable automatic campaign sharing.',
-    defaultValue: false,
+    defaultValue: true,
+    devDefaultValues: { test: true, reviewApp: true },
     tags: ['frontend', 'team-prescription', 'pix-app'],
   },
   isSurveyEnabledForCombinedCourses: {

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organization.usecase.test.js
@@ -8,7 +8,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
       // given
       const now = new Date('2022-02-22');
       const clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
-      const superAdminUser = databaseBuilder.factory.buildUser();
+      const superAdminUser = databaseBuilder.factory.buildUser.withRole();
       const organization = databaseBuilder.factory.buildOrganization();
       await databaseBuilder.commit();
 

--- a/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/archive-organizations-in-batch.usecase.test.js
@@ -46,7 +46,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         disabledAt: null,
       });
 
-      const user = databaseBuilder.factory.buildUser();
+      const user = databaseBuilder.factory.buildUser.withRole();
 
       const organizationIds = [organization1.id, organization2.id];
 
@@ -64,7 +64,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         archivedOrganizationId: organization1.id,
         updatedAt: now,
       });
-      await _assertCampaignAreArchived({ organizationId: organization1.id, archivedAt: now });
+      await _assertCampaignAreDeleted({ organizationId: organization1.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
 
       await _assertOrganizationIsArchived({ archivedOrganizationId: organization2.id, user, archivedAt: now });
@@ -72,7 +72,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         archivedOrganizationId: organization2.id,
         updatedAt: now,
       });
-      await _assertCampaignAreArchived({ organizationId: organization2.id, archivedAt: now });
+      await _assertCampaignAreDeleted({ organizationId: organization2.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization2.id, disabledAt: now });
     });
   });
@@ -95,7 +95,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         disabledAt: null,
       });
 
-      const user = databaseBuilder.factory.buildUser();
+      const user = databaseBuilder.factory.buildUser.withRole();
       await databaseBuilder.commit();
 
       const organizationIds = [organization1.id, nonExistingOrganizationId];
@@ -120,7 +120,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
         archivedOrganizationId: organization1.id,
         updatedAt: now,
       });
-      await _assertCampaignAreArchived({ organizationId: organization1.id, archivedAt: now });
+      await _assertCampaignAreDeleted({ organizationId: organization1.id, archivedAt: now });
       await _assertMembershipAreDisabled({ organizationId: organization1.id, disabledAt: now });
     });
   });
@@ -132,9 +132,9 @@ async function _assertMembershipAreDisabled({ organizationId, disabledAt }) {
   expect(archivedMembership1.disabledAt).to.deep.equal(disabledAt);
 }
 
-async function _assertCampaignAreArchived({ organizationId, archivedAt }) {
+async function _assertCampaignAreDeleted({ organizationId, archivedAt }) {
   const archivedCampaign1 = await knex('campaigns').where({ organizationId }).first();
-  expect(archivedCampaign1.archivedAt).to.deep.equal(archivedAt);
+  expect(archivedCampaign1.deletedAt).to.deep.equal(archivedAt);
 }
 
 async function _assertPendingInvitationsAreCanceled({ archivedOrganizationId, updatedAt }) {

--- a/api/tests/prescription/learner-management/integration/application/jobs/import-sup-organization-learners-job-controller_test.js
+++ b/api/tests/prescription/learner-management/integration/application/jobs/import-sup-organization-learners-job-controller_test.js
@@ -118,12 +118,9 @@ O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;${orenStudentId};Assassin
           },
         });
 
-        const deletedLearners = await knex('organization-learners')
-          .select('*')
-          .whereNotNull('deletedAt')
-          .orderBy('studentNumber');
+        const deletedLearners = await knex('organization-learners').select('*').whereNotNull('deletedAt');
         expect(deletedLearners).lengthOf(1);
-        expect(deletedLearners[0].studentNumber).equal(activeOrganizationLearner.studentNumber);
+        expect(deletedLearners[0].id).equal(activeOrganizationLearner.id);
       });
     });
   });

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
           attributes: {
             'dynamic-feature-toggle-system': false,
             'is-async-quest-rewarding-calculation-enabled': false,
-            'is-auto-share-enabled': false,
+            'is-auto-share-enabled': true,
             'is-filtering-recommended-training-by-organizations-enabled': false,
             'is-modulix-issue-report-displayed': false,
             'is-survey-enabled-for-combined-courses': true,

--- a/high-level-tests/e2e-playwright/pages/pix-app/CampaignResultsPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/CampaignResultsPage.ts
@@ -12,8 +12,4 @@ export class CampaignResultsPage {
     const masteryPercentageText = (await this.page.getByRole('row', { name: competenceTitle }).textContent()) as string;
     return masteryPercentageText.match(/(\d+)\s*%/)?.[1];
   }
-
-  async sendResults() {
-    await this.page.getByRole('button', { name: "J'envoie mes résultats" }).click();
-  }
 }

--- a/high-level-tests/e2e-playwright/tests/assessments/campaign-evaluation.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/assessments/campaign-evaluation.spec.ts
@@ -96,8 +96,9 @@ test(
           );
         }
 
-        await campaignResultsPage.sendResults();
-        await expect(pixAppPage.getByText('Vos résultats ont été envoyés')).toBeVisible();
+        await expect(
+          pixAppPage.getByRole('paragraph').filter({ hasText: 'Vos résultats ont été envoyés' }),
+        ).toBeVisible();
       });
     });
     await snapshotHandler.expectOrRecord('campaign-evaluation.json');

--- a/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
@@ -49,7 +49,6 @@ test('Combined courses', async ({ page }) => {
       await page.getByText('Oui.').click();
       await page.getByRole('button', { name: 'Je valide et je vais à la' }).click();
       await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
-      await page.getByRole('button', { name: "J'envoie mes résultats" }).click();
       await page.getByRole('link', { name: 'Continuer' }).click();
     });
 

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -1,0 +1,144 @@
+import { buildFreshPixAppUser, createOrganizationInDB, createTargetProfileInDB, knex } from '../../helpers/db.js';
+import { expect, test } from '../../helpers/fixtures.js';
+import { ReconciliationLoginPage } from '../../pages/pix-app/ReconciliationLoginPage.js';
+import { ReconciliationPage } from '../../pages/pix-app/ReconciliationPage.js';
+
+test('pass a combined course as sco user and see the final result', async ({ page }) => {
+  await createDataForCombinedCourse();
+
+  await page.goto('http://localhost:4200/parcours/COMBINIX1/');
+  await page.getByRole('button', { name: 'Se connecter' }).click();
+
+  const reconciliationLoginPage = new ReconciliationLoginPage(page);
+  await reconciliationLoginPage.login('alain.terieur@example.net', 'pix123');
+
+  const reconciliationPage = new ReconciliationPage(page);
+  await reconciliationPage.reconcile('Alain', 'Terieur', '10/07/2010');
+
+  await test.step('Start combined course', async function () {
+    await page.getByRole('button', { name: 'Commencer mon parcours' }).click();
+  });
+
+  await test.step('Run campaign', async function () {
+    await page.getByRole('button', { name: 'Je commence' }).click();
+    await page.getByRole('button', { name: 'Ignorer' }).click();
+    await page.getByRole('button', { name: 'Je passe et je vais à la' }).click();
+    await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
+    await page.getByRole('link', { name: 'Continuer' }).click();
+  });
+
+  await test.step('Resume combined course', async function () {
+    await page.getByRole('button', { name: 'Continuer mon parcours' }).click();
+  });
+
+  await test.step('Run module', async function () {
+    await page.getByRole('button', { name: 'Commencer le module' }).click();
+    await page.getByRole('button', { name: 'Terminer' }).click();
+    await page.getByRole('link', { name: 'Continuer' }).click();
+  });
+
+  await test.step('End of combined course', async function () {
+    await expect(page.getByRole('heading', { name: 'Félicitations ! Vous avez terminé !' })).toBeVisible();
+  });
+});
+
+/*
+Creates a simple combined course with a campaign and an always recommended module
+ */
+async function createDataForCombinedCourse() {
+  const TARGET_PROFILE_TUBES = [
+    {
+      id: 'recSqw34xWSLgEgt',
+      level: 1,
+    },
+  ];
+  const CAMPAIGN_SKILLS = ['rec1aqbvWEqtoMOLw'];
+  const email = 'alain.terieur@example.net';
+  const firstName = 'Alain';
+  const lastName = 'Terieur';
+  const birthdate = new Date('2010-07-10');
+  const userId = await buildFreshPixAppUser(firstName, lastName, email, 'pix123', false);
+  const organizationId = await createOrganizationInDB({ type: 'SCO', externalId: '123', isManagingStudents: true });
+  await knex('organization-learners').insert({ firstName, lastName, birthdate, organizationId });
+  const targetProfileId = await createTargetProfileInDB('targetProfile');
+  const [{ id: campaignId }] = await knex('campaigns')
+    .insert({
+      targetProfileId,
+      name: 'campagne diag',
+      code: 'ASSDIAG12',
+      organizationId,
+      creatorId: userId,
+      ownerId: userId,
+      type: 'ASSESSMENT',
+      customResultPageButtonText: 'Continuer',
+      customResultPageButtonUrl: 'http://localhost:4200/parcours/COMBINIX1',
+    })
+    .returning('id');
+  await knex('campaign_skills').insert({ campaignId, skillId: CAMPAIGN_SKILLS[0] });
+  await knex('target-profile_tubes').insert({
+    targetProfileId,
+    level: TARGET_PROFILE_TUBES[0].level,
+    tubeId: TARGET_PROFILE_TUBES[0].id,
+  });
+  const [{ id: trainingId }] = await knex('trainings')
+    .insert({
+      title: 'demo combinix 1',
+      link: '/modules/demo-combinix-1',
+      type: 'modulix',
+      duration: 1,
+      locale: 'fr',
+      editorName: 'demo',
+      editorLogoUrl: 'demo',
+    })
+    .returning('id');
+
+  const moduleId1 = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+  await knex('target-profile-trainings').insert({ targetProfileId, trainingId });
+  await knex('training-triggers').insert({ trainingId, threshold: 0, type: 'prerequisite' });
+  await knex('training-triggers').insert({ trainingId, threshold: 100, type: 'goal' });
+
+  const successRequirements = JSON.stringify([
+    {
+      requirement_type: 'campaignParticipations',
+      comparison: 'all',
+      data: {
+        campaignId: {
+          data: campaignId,
+          comparison: 'equal',
+        },
+        status: {
+          data: 'SHARED',
+          comparison: 'equal',
+        },
+      },
+    },
+    {
+      requirement_type: 'passages',
+      comparison: 'all',
+      data: {
+        moduleId: {
+          data: moduleId1,
+          comparison: 'equal',
+        },
+        isTerminated: {
+          data: true,
+          comparison: 'equal',
+        },
+      },
+    },
+  ]);
+  const eligibilityRequirements = JSON.stringify([]);
+  const [{ id: questId }] = await knex('quests')
+    .insert({
+      successRequirements,
+      eligibilityRequirements,
+    })
+    .returning('id');
+
+  await knex('combined_courses').insert({
+    name: 'Mon parcours combiné',
+    code: 'COMBINIX1',
+    organizationId,
+    questId,
+  });
+}

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -22,7 +22,7 @@ test('pass a combined course as sco user and see the final result', async ({ pag
   await test.step('Run campaign', async function () {
     await page.getByRole('button', { name: 'Je commence' }).click();
     await page.getByRole('button', { name: 'Ignorer' }).click();
-    await page.getByRole('button', { name: 'Je passe et je vais à la' }).click();
+    await page.getByRole('button', { name: 'Je passe et je vais à la prochaine question' }).click();
     await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
     await page.getByRole('link', { name: 'Continuer' }).click();
   });
@@ -34,7 +34,7 @@ test('pass a combined course as sco user and see the final result', async ({ pag
   await test.step('Run module', async function () {
     await page.getByRole('button', { name: 'Commencer le module' }).click();
     await page.getByRole('button', { name: 'Terminer' }).click();
-    await page.getByRole('link', { name: 'Continuer' }).click();
+    await page.getByRole('button', { name: 'Continuer' }).click();
   });
 
   await test.step('End of combined course', async function () {

--- a/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/assessment-campaign.test.ts
@@ -74,7 +74,6 @@ test('Assessment campaign', async ({ page }) => {
 
       const campaignResultsPage = new CampaignResultsPage(page);
       globalMasteryPercentage = await campaignResultsPage.getGlobalMasteryPercentage();
-      await campaignResultsPage.sendResults();
       await expect(page.getByRole('paragraph').filter({ hasText: 'Vos résultats ont été envoyés' })).toBeVisible();
     });
   });

--- a/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
+++ b/high-level-tests/e2e/cypress/fixtures/campaign-participations.json
@@ -52,7 +52,7 @@
   {
     "id": 7,
     "campaignId": 1,
-    "status": "TO_SHARE",
+    "status": "SHARED",
     "participantExternalId": "a11y vérif",
     "userId": 3,
     "organizationLearnerId": 8

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -24,8 +24,6 @@ Fonctionnalité: Campagne d'évaluation
     Et je clique sur "Voir mes résultats"
     Alors je vois 50% de réussite aux questions
     Alors je vois l'onglet de détails des résultats avec 2 compétences
-    Alors je vois la modale de contenus formatifs
-    Lorsque je clique sur "Fermer et revenir aux résultats"
     Alors je vois que j'ai envoyé les résultats
     Lorsque je clique sur "Voir les formations"
     Alors je vois la formation recommandée ayant le titre "Comment gagner des pièces d'or"

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -24,7 +24,6 @@ Fonctionnalité: Campagne d'évaluation
     Et je clique sur "Voir mes résultats"
     Alors je vois 50% de réussite aux questions
     Alors je vois l'onglet de détails des résultats avec 2 compétences
-    Lorsque je clique sur "J'envoie mes résultats"
     Alors je vois la modale de contenus formatifs
     Lorsque je clique sur "Fermer et revenir aux résultats"
     Alors je vois que j'ai envoyé les résultats


### PR DESCRIPTION
## 🍂 Problème

Sur les RA, le fonctionnement diffère de la prod pour les feature toggles `isAutoShareEnabled` et `isAnonymizationWithDeletionEnabled` ce qui est parfois embétant pour réproduire des bugs.

## 🌰 Proposition

On propose de passer les valeurs par défaut à true pour `isAutoShareEnabled` car il est en prod depuis plus d'un mois. Pour `isAnonymizationWithDeletionEnabled` on propose de seulement passer les valeurs pour test / Ra a true
car cela fait peu de temps que la feature est activée.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester
Passer une campagne et ne pas voir l'écran de partage des résultats
Supprimer un prescrit dans orga et voir qu'on ne remonte plus ses participations dans Admin
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
