### PR TITLE
[TECH] Mettre à jour la stack Scalingo utilisée en review app

### DIFF
--- a/admin/scalingo.json
+++ b/admin/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -49,5 +49,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }

--- a/audit-logger/scalingo.json
+++ b/audit-logger/scalingo.json
@@ -43,5 +43,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }

--- a/certif/scalingo.json
+++ b/certif/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/junior/scalingo.json
+++ b/junior/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/mon-pix/scalingo.json
+++ b/mon-pix/scalingo.json
@@ -12,7 +12,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/orga/scalingo.json
+++ b/orga/scalingo.json
@@ -16,7 +16,7 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22",
+  "stack": "scalingo-24",
   "addons": [
     {
       "plan": "postgresql:postgresql-sandbox"

--- a/scalingo.json
+++ b/scalingo.json
@@ -35,5 +35,5 @@
       "size": "S"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }


### PR DESCRIPTION
## 🍂 Problème
Une nouvelle stack Scalingo, basée sur Ubuntu 24, est disponible.  

## 🌰 Proposition
Utiliser la stack scalingo-24 sur les RA afin de vérifier qu'il n'y a pas de problème avant de généraliser son utilisation.

## 🪵 Pour tester
Déployer quelques RA