### PR TITLE
[FEATURE] Supprimer le tag Découverte dans les modules (PIX-19958).

### DIFF
--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -221,8 +221,8 @@ export default class ModuleGrain extends Component {
     return this.args.grain.type === 'lesson' || this.args.grain.type === 'summary';
   }
 
-  get isGrainTypeWithTag() {
-    return this.args.grain.type === 'activity' || this.args.grain.type === 'discovery';
+  get isGrainTypeActivity() {
+    return this.args.grain.type === 'activity';
   }
 
   get grainTitle() {
@@ -234,10 +234,6 @@ export default class ModuleGrain extends Component {
       default:
         return '';
     }
-  }
-
-  get tagText() {
-    return this.intl.t(`pages.modulix.grain.tag.${this.args.grain.type}`);
   }
 
   get skipButtonLabel() {
@@ -266,9 +262,9 @@ export default class ModuleGrain extends Component {
           total=@totalSteps
         }}</h3>
       <div class="grain__card grain-card--{{this.grainType}}">
-        {{#if this.isGrainTypeWithTag}}
+        {{#if this.isGrainTypeActivity}}
           <PixTag class="grain-card-tag" @color="grey">
-            {{this.tagText}}
+            {{t "pages.modulix.grain.tag.activity"}}
           </PixTag>
         {{/if}}
         {{#if this.isGrainTypeWithTitle}}

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -1850,31 +1850,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when grain has type ‘Discovery‘', function () {
-    test('should display the corresponding tag', async function (assert) {
-      // given
-      const textElement = {
-        content: 'element content',
-        type: 'text',
-        isAnswerable: false,
-      };
-      const grain = {
-        id: '12345-abcdef',
-        type: 'discovery',
-        components: [{ type: 'element', element: textElement }],
-      };
-
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain::Grain @grain={{this.grain}} />`);
-
-      // then
-      assert.dom(screen.getByText('Découverte')).exists();
-    });
-  });
-
   module('when grain has type ‘Activity‘', function () {
     test('should display the corresponding tag', async function (assert) {
       // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1646,11 +1646,7 @@
       },
       "grain": {
         "tag": {
-          "activity": "Activity",
-          "challenge": "Challenge",
-          "discovery": "Discovery",
-          "lesson": "Lesson",
-          "summary": "Summary"
+          "activity": "Activity"
         },
         "title": {
           "lesson": "Lesson",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1746,11 +1746,7 @@
       },
       "grain": {
         "tag": {
-          "activity": "Actividad",
-          "challenge": "Desafío",
-          "discovery": "Descubrimiento",
-          "lesson": "Lección",
-          "summary": "Recapitular"
+          "activity": "Actividad"
         },
         "title": {
           "lesson": "Lección",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1749,11 +1749,7 @@
       },
       "grain": {
         "tag": {
-          "activity": "Actividad",
-          "challenge": "Desafío",
-          "discovery": "Descubrimiento",
-          "lesson": "Lección",
-          "summary": "Recapitular"
+          "activity": "Actividad"
         },
         "title": {
           "lesson": "Lección",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1654,11 +1654,7 @@
       },
       "grain": {
         "tag": {
-          "activity": "Activité",
-          "challenge": "Défi",
-          "discovery": "Découverte",
-          "lesson": "Leçon",
-          "summary": "Récap'"
+          "activity": "Activité"
         },
         "title": {
           "lesson": "Leçon",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1753,11 +1753,7 @@
       },
       "grain": {
         "tag": {
-          "activity": "Activiteit",
-          "challenge": "Uitdaging",
-          "discovery": "Ontdekking",
-          "lesson": "Les",
-          "summary": "Recap"
+          "activity": "Activiteit"
         },
         "title": {
           "lesson": "Les",


### PR DESCRIPTION
## 🍂 Problème

L'équipe contenu a demandé une modalité Découverte avec un feedback neutre. On a donc créé cette modalité avec le tag pour amener une différence avec les autres activité pour l'utilisateur comprenne qu'il peut se "rater" sur cette épreuve.

Finalement dans le pattern, nous avons 7-8 épreuve découverte a la suite et donc le tag et trop présent, jamais lu et donc inutile

## 🌰 Proposition

Supprimer le tag Découverte.

## 🍁 Remarques

J'ai supprimé les clés de trad inutilisés.

## 🪵 Pour tester

Aller sur https://app.integration.pix.fr/modules/preview/bac-a-sable/ et voir le tag Découverte

<img width="435" height="189" alt="Capture d’écran 2025-10-10 à 10 07 46" src="https://github.com/user-attachments/assets/60c40759-3fce-4d8e-a607-ce858dcbc7b0" />


Aller sur https://app-pr13853.review.pix.fr/modules/preview/bac-a-sable/ et voir qu'il n'y est plus