### PR TITLE
[BUGFIX] Corriger le script toggles côté API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -197,7 +197,7 @@
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint",
     "test:api:git-modified": "git ls-files -m -- '*test.js' | xargs npm run test:api:path -- $1",
-    "toggles": "LOG_FOR_HUMANS_FORMAT=compact node src/shared/infrastructure/feature-toggles/feature-toggles-script.js",
+    "toggles": "LOG_FOR_HUMANS_FORMAT=compact node --env-file-if-exists=.env src/shared/infrastructure/feature-toggles/feature-toggles-script.js",
     "monitoring:arborescence": "node --env-file-if-exists=.env scripts/arborescence-monitoring/arborescence-monitoring.js",
     "monitoring:metrics": "node --env-file-if-exists=.env scripts/arborescence-monitoring/add-metrics-to-gist.js",
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/acceptance/module-instantiation_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/integration/repositories/module-repository_test.js'"


### PR DESCRIPTION
## 🍂 Problème

En utilisant la commande `npm run toggles -- --list` en local, les feature toggles ne s'affichent plus.

Cela semble être lié à cette [PR](https://github.com/1024pix/pix/pull/13818) qui ajoute, pour chaque exécution de `node`, l'option `--env-file-if-exists=.env`. Ce script semble avoir été oublié 😅 

## 🌰 Proposition

Ajouter l'option `--env-file-if-exists=.env` manquante.

## 🍁 Remarques
- Pas eu le temps d'identifier la vraie cause, mon hypothèse est que le logger a besoin du .env pour fonctionner.
- Les features toggles sont affichés par le logger avec un niveau `warn` (à peut être changer ?). Il faut que dans votre .env, il y ait la variable `LOG_LEVEL=warn` (ou debug par défaut)

## 🪵 Pour tester

- Lançer la commande `npm run toggles -- --list` en local
- Vérifier que les features toggles s'affichent bien 🎉 
