### PR TITLE
[FEATURE] Afficher le nom de l'équipe en charge sur la liste des organisations (PIX-19768)

### DIFF
--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -120,6 +120,14 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
               {{organization.type}}
             </:cell>
           </PixTableColumn>
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{t "components.organizations.list-items.table.header.administration-team-name"}}
+            </:header>
+            <:cell>
+              {{organization.administrationTeamName}}
+            </:cell>
+          </PixTableColumn>
           <PixTableColumn @context={{context}} class="break-word">
             <:header>
               Identifiant externe

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   const triggerFiltering = function () {};
 
-  test('it should display header with id, name, type and externalId', async function (assert) {
+  test('it should display header with id, name, type, team and externalId', async function (assert) {
     // given
     const externalId = '1234567A';
     const organizations = [
@@ -37,6 +37,13 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     assert.dom(within(table).getByRole('columnheader', { name: 'ID' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Nom' })).exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Type' })).exists();
+    assert
+      .dom(
+        within(table).getByRole('columnheader', {
+          name: t('components.organizations.list-items.table.header.administration-team-name'),
+        }),
+      )
+      .exists();
     assert.dom(within(table).getByRole('columnheader', { name: 'Identifiant externe' })).exists();
   });
 
@@ -55,9 +62,9 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     // given
     const externalId = '1234567A';
     const organizations = [
-      { id: 1, name: 'École ACME', type: 'SCO', externalId: '1234567A' },
-      { id: 2, name: 'Université BROS', type: 'SUP', externalId: '1234567B' },
-      { id: 3, name: 'Entreprise KSSOS', type: 'PRO', externalId: '1234567C' },
+      { id: 1, name: 'École ACME', type: 'SCO', externalId: '1234567A', administrationTeamName: 'Team A' },
+      { id: 2, name: 'Université BROS', type: 'SUP', externalId: '1234567B', administrationTeamName: 'Team B' },
+      { id: 3, name: 'Entreprise KSSOS', type: 'PRO', externalId: '1234567C', administrationTeamName: 'Team C' },
     ];
     organizations.meta = {
       rowCount: 3,
@@ -74,6 +81,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     assert.dom(within(table).getByRole('cell', { name: '1' })).exists();
     assert.dom(within(table).getByRole('cell', { name: 'École ACME' })).exists();
     assert.dom(within(table).getByRole('cell', { name: 'SCO' })).exists();
+    assert.dom(within(table).getByRole('cell', { name: 'Team A' })).exists();
     assert.dom(within(table).getByRole('cell', { name: externalId })).exists();
     assert.strictEqual(rows.length, 4);
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -625,7 +625,10 @@
       },
       "list-items": {
         "table": {
-          "caption": "Liste des organisations. Contient l'identifiant, le nom, de type et l'identifiant externe de l'organisation."
+          "caption": "List of organizations. Contains the ID, name, type, team in charge, and external ID of the organization.",
+          "header": {
+            "administration-team-name": "Team"
+          }
         }
       },
       "member-items": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -626,7 +626,10 @@
       },
       "list-items": {
         "table": {
-          "caption": "Liste des organisations. Contient l'identifiant, le nom, de type et l'identifiant externe de l'organisation."
+          "caption": "Liste des organisations. Contient l'identifiant, le nom, le type, l'équipe en charge et l'identifiant externe de l'organisation.",
+          "header": {
+            "administration-team-name": "Équipe"
+          }
         }
       },
       "member-items": {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -268,8 +268,18 @@ const update = async function ({ organization }) {
 const findPaginatedFiltered = async function ({ filter, page }) {
   const knexConn = DomainTransaction.getConnection();
   const query = knexConn(ORGANIZATIONS_TABLE_NAME)
+    .select({
+      id: 'organizations.id',
+      name: 'organizations.name',
+      type: 'organizations.type',
+      externalId: 'organizations.externalId',
+      archivedAt: 'organizations.archivedAt',
+      administrationTeamId: 'organizations.administrationTeamId',
+      administrationTeamName: 'administration_teams.name',
+    })
+    .leftJoin('administration_teams', 'administration_teams.id', 'organizations.administrationTeamId')
     .modify(_setSearchFiltersForQueryBuilder, filter)
-    .orderBy('name', 'ASC');
+    .orderBy('organizations.name', 'ASC');
 
   const { results, pagination } = await fetchPage({
     queryBuilder: query,
@@ -369,7 +379,7 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
     qb.where('organizations.id', id);
   }
   if (name) {
-    qb.whereILike('name', `%${name}%`);
+    qb.whereILike('organizations.name', `%${name}%`);
   }
   if (type) {
     qb.where('type', type);

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -24,6 +24,7 @@ const serialize = function (organizations, meta) {
       'showNPS',
       'formNPSUrl',
       'showSkills',
+      'administrationTeamName',
     ],
     memberships: {
       ref: 'id',

--- a/api/tests/organizational-entities/integration/domain/usecases/find-paginated-filtered-organizations.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/find-paginated-filtered-organizations.usecase.test.js
@@ -2,11 +2,18 @@ import { OrganizationForAdmin } from '../../../../../src/organizational-entities
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
-describe('Integration | Organizational Entities | Domain | UseCase | archive-organization', function () {
+describe('Integration | Organizational Entities | Domain | UseCase | find-paginated-filtered-organizations', function () {
   it('should result organizations with filtering and pagination', async function () {
     // given
-    const orga1 = databaseBuilder.factory.buildOrganization({ name: 'Dragon 1' });
-    const orga2 = databaseBuilder.factory.buildOrganization({ name: 'Dragon 2' });
+    const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
+    databaseBuilder.factory.buildOrganization({
+      name: 'Dragon 1',
+      administrationTeamId: administrationTeam.id,
+    });
+    databaseBuilder.factory.buildOrganization({
+      name: 'Dragon 2',
+      administrationTeamId: administrationTeam.id,
+    });
     databaseBuilder.factory.buildOrganization({ name: 'Licorne' });
     await databaseBuilder.commit();
 
@@ -19,7 +26,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | archive-org
     const response = await usecases.findPaginatedFilteredOrganizations({ filter, page });
 
     // then
-    expect(response.models).to.deep.include.members([new OrganizationForAdmin(orga1), new OrganizationForAdmin(orga2)]);
+    expect(response.models[0]).to.be.an.instanceOf(OrganizationForAdmin);
+    expect(response.models[1]).to.be.an.instanceOf(OrganizationForAdmin);
     expect(response.pagination.page).to.equal(resolvedPagination.page);
     expect(response.pagination.pageSize).to.equal(resolvedPagination.pageSize);
     expect(response.pagination.rowCount).to.equal(resolvedPagination.rowCount);

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -11,11 +11,14 @@ describe('Unit | Serializer | organization-serializer', function () {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
-      const organization = domainBuilder.buildOrganization({
+      const administrationTeam = domainBuilder.buildAdministrationTeam({ name: 'pouet' });
+      const organization = domainBuilder.buildOrganizationForAdmin({
         email: 'sco.generic.account@example.net',
         tags,
         createdBy: 10,
         documentationUrl: 'https://pix.fr/',
+        administrationTeamId: administrationTeam.id,
+        administrationTeamName: administrationTeam.name,
       });
       const meta = { some: 'meta' };
 
@@ -41,6 +44,7 @@ describe('Unit | Serializer | organization-serializer', function () {
             'show-nps': organization.showNPS,
             'form-nps-url': organization.formNPSUrl,
             'show-skills': organization.showSkills,
+            'administration-team-name': organization.administrationTeamName,
           },
           relationships: {
             memberships: {


### PR DESCRIPTION
## 🍂 Problème
Nous avons ajoutés les informations concernant l'équipe en charge au grain d'une organisation, cependant on aimerait que cette info s'affiche également sur la page "organisations".

## 🌰 Proposition
Dur la liste des organisations dans Pix Admin, ajouter une nouvelle colonne “Equipe”, et y afficher le nom complet de l'équipe
À positionner entre les 2 colonnes existantes: “Type” et “Identifiant”

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Se connecter a PixAdmin
- Aller sur la page "Organisations" 
- Vérifier que le noms des équipes en charge des orgas s'affiche bien
- Egalement vérifier sur la page d'un profil cible, onglet "organisation" que l'information s'affiche bien aussi
- 🐈‍⬛ 
