### PR TITLE
[TECH] Supprimer les dernières traces du FT useLocale

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -60,13 +60,6 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'team-prescription', 'pix-app'],
   },
-  useLocale: {
-    type: 'boolean',
-    description: 'Enable usage of cookie locale in Frontend apps keeping retro-compatibility with the backend.',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['frontend', 'team-acces'],
-  },
   isSurveyEnabledForCombinedCourses: {
     type: 'boolean',
     description: 'Enables survey button at the end of the combined courses',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -28,7 +28,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
-            'use-locale': false,
             'use-pix-orga-new-auth-design': false,
           },
         },


### PR DESCRIPTION
## 🍂 Problème

Il reste encore du code correspondant au FT `useLocale` qui n’a pas été supprimé.

## 🌰 Proposition

Supprimer les occurrences de `useLocale` et `use-locale`.

## 🍁 Remarques

RAS

## 🪵 Pour tester

Vérifier que la CI passe.
