### PR TITLE
[BUGFIX] Recuperer a nouveau la cle de complementaire dans le get-next-challenge (PIX-19982).

### DIFF
--- a/api/src/certification/evaluation/domain/models/Candidate.js
+++ b/api/src/certification/evaluation/domain/models/Candidate.js
@@ -1,21 +1,27 @@
 import Joi from 'joi';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
+import { Frameworks } from '../../../shared/domain/models/Frameworks.js';
 
 export class Candidate {
   static #schema = Joi.object({
     accessibilityAdjustmentNeeded: Joi.boolean().optional(),
     reconciledAt: Joi.date().required(),
+    subscriptionScope: Joi.string()
+      .valid(...Object.values(Frameworks))
+      .required(),
   });
 
   /**
    * @param {Object} params
    * @param {Date} params.reconciledAt
    * @param {boolean} [params.accessibilityAdjustmentNeeded]
+   * @param {Frameworks} params.subscriptionScope
    */
-  constructor({ accessibilityAdjustmentNeeded, reconciledAt } = {}) {
+  constructor({ accessibilityAdjustmentNeeded, reconciledAt, subscriptionScope } = {}) {
     this.accessibilityAdjustmentNeeded = !!accessibilityAdjustmentNeeded;
     this.reconciledAt = reconciledAt;
+    this.subscriptionScope = subscriptionScope;
 
     this.#validate();
   }

--- a/api/src/certification/evaluation/domain/models/factories/CandidateFactory.js
+++ b/api/src/certification/evaluation/domain/models/factories/CandidateFactory.js
@@ -1,0 +1,29 @@
+import { SUBSCRIPTION_TYPES } from '../../../../shared/domain/constants.js';
+import { ComplementaryCertificationKeys } from '../../../../shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../shared/domain/models/Frameworks.js';
+import { Candidate } from '../Candidate.js';
+
+export class CandidateFactory {
+  static fromSubscription({
+    accessibilityAdjustmentNeeded,
+    reconciledAt,
+    subscriptionType,
+    complementaryCertificationKey,
+  } = {}) {
+    let subscriptionScope;
+    if (
+      subscriptionType === SUBSCRIPTION_TYPES.CORE ||
+      complementaryCertificationKey === ComplementaryCertificationKeys.CLEA
+    ) {
+      subscriptionScope = Frameworks.CORE;
+    } else {
+      subscriptionScope = complementaryCertificationKey;
+    }
+
+    return new Candidate({
+      accessibilityAdjustmentNeeded,
+      reconciledAt,
+      subscriptionScope,
+    });
+  }
+}

--- a/api/src/certification/evaluation/domain/usecases/index.js
+++ b/api/src/certification/evaluation/domain/usecases/index.js
@@ -36,6 +36,13 @@ import pickChallengeService from '../services/pick-challenge-service.js';
  * @typedef {sharedFlashAlgorithmConfigurationRepository} SharedFlashAlgorithmConfigurationRepository
  * @typedef {sharedChallengeRepository} SharedChallengeRepository
  * @typedef {certificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
+ * @typedef {flashAlgorithmService} FlashAlgorithmService
+ * @typedef {certificationCandidateRepository} CertificationCandidateRepository
+ * @typedef {certificationChallengeLiveAlertRepository} CertificationChallengeLiveAlertRepository
+ * @typedef {answerRepository} AnswerRepository
+ * @typedef {sharedChallengeRepository} SharedChallengeRepository
+ * @typedef {flashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
+ * @typedef {sessionManagementCertificationChallengeRepository} SessionManagementCertificationChallengeRepository
  * @typedef {services} Services
  */
 const dependencies = {

--- a/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/evaluation/infrastructure/repositories/certification-candidate-repository.js
@@ -1,10 +1,15 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationCandidateNotFoundError } from '../../../../shared/domain/errors.js';
-import { Candidate } from '../../domain/models/Candidate.js';
+import { CandidateFactory } from '../../domain/models/factories/CandidateFactory.js';
 
 export const findByAssessmentId = async function ({ assessmentId }) {
   const result = await knex('certification-candidates')
-    .select('certification-candidates.accessibilityAdjustmentNeeded', 'certification-candidates.reconciledAt')
+    .select(
+      'certification-candidates.accessibilityAdjustmentNeeded',
+      'certification-candidates.reconciledAt',
+      { subscriptionType: 'certification-subscriptions.type' },
+      { complementaryCertificationKey: 'complementary-certifications.key' },
+    )
     .join('certification-courses', function () {
       this.on('certification-courses.userId', '=', 'certification-candidates.userId').andOn(
         'certification-courses.sessionId',
@@ -13,6 +18,16 @@ export const findByAssessmentId = async function ({ assessmentId }) {
       );
     })
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+    .join(
+      'certification-subscriptions',
+      'certification-subscriptions.certificationCandidateId',
+      'certification-candidates.id',
+    )
+    .leftJoin(
+      'complementary-certifications',
+      'certification-subscriptions.complementaryCertificationId',
+      'complementary-certifications.id',
+    )
     .where('assessments.id', assessmentId)
     .first();
 
@@ -23,6 +38,16 @@ export const findByAssessmentId = async function ({ assessmentId }) {
   return _toDomain(result);
 };
 
-const _toDomain = ({ accessibilityAdjustmentNeeded, reconciledAt }) => {
-  return new Candidate({ accessibilityAdjustmentNeeded, reconciledAt });
+const _toDomain = ({
+  accessibilityAdjustmentNeeded,
+  reconciledAt,
+  subscriptionType,
+  complementaryCertificationKey,
+}) => {
+  return CandidateFactory.fromSubscription({
+    accessibilityAdjustmentNeeded,
+    reconciledAt,
+    subscriptionType,
+    complementaryCertificationKey,
+  });
 };

--- a/api/tests/certification/evaluation/acceptance/answer-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/answer-route_test.js
@@ -64,11 +64,12 @@ async function _setupTestData(databaseBuilder, { competenceId, doesCandidateNeed
 
   const session = databaseBuilder.factory.buildSession({});
 
-  databaseBuilder.factory.buildCertificationCandidate({
+  const candidate = databaseBuilder.factory.buildCertificationCandidate({
     sessionId: session.id,
     userId,
     accessibilityAdjustmentNeeded: doesCandidateNeedAccessibilityAdjustment,
   });
+  databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
 
   const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
     userId,

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -86,10 +86,12 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           version: AlgorithmEngineVersion.V3,
         }).id;
 
-        databaseBuilder.factory.buildCertificationCandidate({
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
           sessionId,
           userId: candidate.id,
         });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId,
           userId: candidate.id,
@@ -221,10 +223,12 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           version: AlgorithmEngineVersion.V3,
         }).id;
 
-        databaseBuilder.factory.buildCertificationCandidate({
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
           sessionId,
           userId: candidate.id,
         });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId,
           userId: candidate.id,

--- a/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
+++ b/api/tests/certification/evaluation/unit/domain/models/Candidate_test.js
@@ -1,4 +1,5 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
@@ -6,12 +7,17 @@ describe('Certification | Evaluation | Unit | Domain | Models | Candidate', func
   it('should build an evaluated candidate', function () {
     // given
     // when
-    const candidate = new Candidate({ accessibilityAdjustmentNeeded: true, reconciledAt: new Date('2024-10-18') });
+    const candidate = new Candidate({
+      accessibilityAdjustmentNeeded: true,
+      reconciledAt: new Date('2024-10-18'),
+      subscriptionScope: Frameworks.CORE,
+    });
 
     // then
     expect(candidate).to.deep.equal({
       accessibilityAdjustmentNeeded: true,
       reconciledAt: new Date('2024-10-18'),
+      subscriptionScope: Frameworks.CORE,
     });
   });
 

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -72,11 +72,12 @@ describe('Certification | Session-management | Acceptance | Application | Routes
           version: AlgorithmEngineVersion.V2,
           sessionId: session.id,
         });
-        databaseBuilder.factory.buildCertificationCandidate({
+        const candidate = databaseBuilder.factory.buildCertificationCandidate({
           userId: certificationCourse.userId,
           reconciledAt: new Date('2024-01-15'),
           sessionId: session.id,
         });
+        databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
         const assessment = databaseBuilder.factory.buildAssessment({
           id: 456,
           type: Assessment.types.CERTIFICATION,

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -100,11 +100,13 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             userId,
             sessionId: session.id,
           }).id;
-          databaseBuilder.factory.buildCertificationCandidate({
+          const candidate = databaseBuilder.factory.buildCertificationCandidate({
             sessionId: session.id,
             userId,
             reconciledAt: new Date('2020-01-01'),
           });
+          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
+
           databaseBuilder.factory.buildCertificationCenterMembership({
             userId,
             certificationCenterId: session.certificationCenterId,
@@ -204,11 +206,12 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             sessionId: session.id,
             completedAt: new Date(),
           }).id;
-          databaseBuilder.factory.buildCertificationCandidate({
+          const candidate = databaseBuilder.factory.buildCertificationCandidate({
             sessionId: session.id,
             userId,
             reconciledAt: new Date('2020-01-01'),
           });
+          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
           databaseBuilder.factory.buildCertificationCenterMembership({
             userId,
             certificationCenterId: session.certificationCenterId,
@@ -290,11 +293,12 @@ describe('Certification | Session Management | Acceptance | Application | Route 
             userId,
             createdAt: new Date(),
           }).id;
-          databaseBuilder.factory.buildCertificationCandidate({
+          const candidate = databaseBuilder.factory.buildCertificationCandidate({
             sessionId: session.id,
             userId,
             reconciledAt: new Date('2020-01-01'),
           });
+          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
           databaseBuilder.factory.buildCertificationCenterMembership({
             userId,
             certificationCenterId: session.certificationCenterId,
@@ -780,10 +784,11 @@ const _createSession = async ({ version = 2 } = {}) => {
   const session = databaseBuilder.factory.buildSession({ version });
   const certificationCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, version });
   const certificationCourseId = certificationCourse.id;
-  databaseBuilder.factory.buildCertificationCandidate({
+  const candidate = databaseBuilder.factory.buildCertificationCandidate({
     userId: certificationCourse.userId,
     sessionId: certificationCourse.sessionId,
   });
+  databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
   const report1 = databaseBuilder.factory.buildCertificationReport({
     sessionId: session.id,
     certificationCourseId,

--- a/api/tests/certification/shared/fixtures/certification-course.js
+++ b/api/tests/certification/shared/fixtures/certification-course.js
@@ -130,7 +130,12 @@ const buildKnowledgeElementsFromAnswers = ({ answers, challenges, userId }) => {
 export const createSuccessfulCertificationCourse = async ({ sessionId, userId, certificationCourse }) => {
   const { challenges } = createLearningContent();
 
-  databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId, reconciledAt: new Date('2020-01-01') });
+  const candidate = databaseBuilder.factory.buildCertificationCandidate({
+    sessionId,
+    userId,
+    reconciledAt: new Date('2020-01-01'),
+  });
+  databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
 
   const assessment = databaseBuilder.factory.buildAssessment({
     userId,

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -98,7 +98,12 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             userId,
             sessionId,
           }).id;
-          databaseBuilder.factory.buildCertificationCandidate({ ...user, userId: user.id, sessionId });
+          const candidate = databaseBuilder.factory.buildCertificationCandidate({
+            ...user,
+            userId: user.id,
+            sessionId,
+          });
+          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
           databaseBuilder.factory.buildAssessment({
             id: assessmentId,
             type: Assessment.types.CERTIFICATION,
@@ -219,7 +224,12 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             userId,
             sessionId,
           }).id;
-          databaseBuilder.factory.buildCertificationCandidate({ ...user, userId: user.id, sessionId });
+          const candidate = databaseBuilder.factory.buildCertificationCandidate({
+            ...user,
+            userId: user.id,
+            sessionId,
+          });
+          databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
           const assessment = databaseBuilder.factory.buildAssessment({
             id: assessmentId,
             type: Assessment.types.CERTIFICATION,

--- a/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/certification/evaluation/build-candidate.js
@@ -1,13 +1,14 @@
 import { Candidate } from '../../../../../../src/certification/evaluation/domain/models/Candidate.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
 
-const buildEvaluationCandidate = function ({
+export const buildEvaluationCandidate = function ({
   accessibilityAdjustmentNeeded,
   reconciledAt = new Date('2024-10-18'),
+  subscriptionScope = Frameworks.CORE,
 } = {}) {
   return new Candidate({
     accessibilityAdjustmentNeeded,
     reconciledAt,
+    subscriptionScope,
   });
 };
-
-export { buildEvaluationCandidate };


### PR DESCRIPTION
## 🍂 Problème

Dans une precedente PR : https://github.com/1024pix/pix/pull/13742 il y a eu un loupe sur l'injection de dependances.
Dans `api/src/certification/evaluation/domain/usecases/get-next-challenge.js` sur ce bout de code ci

```js
let complementaryCertificationKey; <--------- le on ne passe jamais dans le if ci-dessous
  if (certificationCourse.complementaryCertificationCourse?.complementaryCertificationId) {
    const complementaryCertification = await complementaryCertificationRepository.get({ <--- et heureusement car cette dependance etait a `undefined`, on aurait eu une 500
      id: certificationCourse.complementaryCertificationCourse.complementaryCertificationId,
    });
    complementaryCertificationKey = complementaryCertification.key;
  }
```

Effet kiss cool, par defaut le code n'explosait pas en vol car on allait chercher la CORE si pas de complementaire (il fallait etre capable de voir que les challenges en certif etait pas les bons, donc bien connaitre le contenu, ce qui est encore moins facile a voir dans les environnements de tests)

## 🌰 Proposition

* Fixer le bout de code responsable
* Nous avons choisi de paser par la souscription puisque c'est le "ticket" auquel le candidat est inscrit en session

## 🍁 Remarques

* Va beneficier d'une MER d'urgence

## 🪵 Pour tester

* Test de non reg sur une certif
  * CORE
  * CLEA
  * Complementaire (qu'importe laquelle)

Il faudra malheureusement attendre pour l'instant la recette pour verifier que on prend bien, en complementaire, des challenges du ref de certification complementaire (et pas de la coeur) 
