### PR TITLE
[BUGFIX] Modifier le lien d'accès aux badges sur Pix Admin (PIX-19984).

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -32,7 +32,7 @@ export default class Badge extends Component {
     });
   }
 
-  IMAGE_BASE_URL = 'https://images.pix.fr/badges/';
+  IMAGE_BASE_URL = 'https://assets.pix.org/badges/';
 
   get isCertifiableText() {
     return this.args.badge.isCertifiable ? 'Certifiable' : 'Non certifiable';

--- a/admin/app/components/target-profiles/badge-form.gjs
+++ b/admin/app/components/target-profiles/badge-form.gjs
@@ -18,7 +18,7 @@ export default class BadgeForm extends Component {
   @service store;
   @service router;
 
-  BASE_URL = 'https://images.pix.fr/badges/';
+  BASE_URL = 'https://assets.pix.org/badges/';
 
   badge = {
     key: '',
@@ -113,7 +113,7 @@ export default class BadgeForm extends Component {
             <p class="badge-form__information">
               <a
                 class="badge-form__information--link"
-                href="https://1024pix.github.io/pix-images-list/viewer.html?directory=badges"
+                href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/badges"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/admin/mirage/factories/badge.js
+++ b/admin/mirage/factories/badge.js
@@ -14,7 +14,7 @@ export default Factory.extend({
   },
 
   imageUrl() {
-    return 'https://images.pix.fr/badges/mon_badge_qui_nexiste_probablement_pas.png';
+    return 'https://assets.pix.org/badges/mon_badge_qui_nexiste_probablement_pas.png';
   },
 
   altMessage() {
@@ -41,7 +41,7 @@ export default Factory.extend({
       });
       badge.update({
         criteria: [criteriaCampaign],
-        imageUrl: `https://images.pix.fr/badges/${badge.imageUrl}`,
+        imageUrl: `https://assets.pix.org/badges/${badge.imageUrl}`,
       });
     }
   },


### PR DESCRIPTION
## 🍂 Problème

Sur Pix Admin, l'url actuel pour accéder à la liste des badges (dispo dans la page de création d'un badge (clé de lecture)) n'est plus pertinente. Les badges ne s'affichent plus.

## 🌰 Proposition

Modifier l'url pour que le métier puisse avoir de nouveau accès aux images.

## 🍁 Remarques

=> on a le même soucis pour lui https://1024pix.github.io/pix-images-list/viewer.html?directory=contenu-formatif/editeur/

## 🪵 Pour tester

- Aller sur https://admin-pr13867.review.pix.fr/
- aller sur les profil cibles depuis le menu et en choisir un
- créer une clé de lecture de type Badge depuis ce profil cible
- un lien pour afficher les images est présent, cliquer dessus
- constater qu'on est redirigé vers Pix Assets avec les badges
