### PR TITLE
[TECH] Utiliser le helper de redimensionnement d'image dans le composant qab-card et dans le composant image (PIX-19993)

### DIFF
--- a/mon-pix/app/components/module/element/image.gjs
+++ b/mon-pix/app/components/module/element/image.gjs
@@ -6,6 +6,8 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
 
+import { resizeImage } from '../../../utils/resize-image';
+
 export default class ModulixImageElement extends Component {
   @tracked modalIsOpen = false;
 
@@ -30,22 +32,8 @@ export default class ModulixImageElement extends Component {
     return this.args.image.legend?.length > 0 || this.args.image.licence?.length > 0;
   }
 
-  get width() {
-    if (this.args.image.infos && this.hasDimensions) {
-      return ModulixImageElement.MAX_WIDTH;
-    }
-    return null;
-  }
-
-  get height() {
-    if (this.args.image.infos && this.hasDimensions) {
-      return Math.round((ModulixImageElement.MAX_WIDTH * this.args.image.infos.height) / this.args.image.infos.width);
-    }
-    return null;
-  }
-
-  get hasDimensions() {
-    return this.args.image.infos.width > 0 && this.args.image.infos.height > 0;
+  get dimensions() {
+    return resizeImage(this.args.image.infos, { MAX_WIDTH: ModulixImageElement.MAX_WIDTH });
   }
 
   <template>
@@ -55,8 +43,8 @@ export default class ModulixImageElement extends Component {
           class="element-image-container__image"
           alt={{@image.alt}}
           src={{@image.url}}
-          width={{this.width}}
-          height={{this.height}}
+          width={{this.dimensions.width}}
+          height={{this.dimensions.height}}
         />
         {{#if this.hasCaption}}
           <figcaption class="element-image-container__caption">{{@image.legend}}<span

--- a/mon-pix/app/components/module/element/qab/qab-card.gjs
+++ b/mon-pix/app/components/module/element/qab/qab-card.gjs
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
+import { resizeImage } from '../../../../utils/resize-image';
+
 export default class QabCard extends Component {
   static MAX_HEIGHT = 190;
 
@@ -12,10 +14,6 @@ export default class QabCard extends Component {
     return this.args.status === 'success';
   }
 
-  get hasDimensions() {
-    return this.args.card.image.information.width > 0 && this.args.card.image.information.height > 0;
-  }
-
   get hasImage() {
     return this.args.card.image?.url?.length > 0;
   }
@@ -25,20 +23,8 @@ export default class QabCard extends Component {
     return userPrefersReducedMotion.matches;
   }
 
-  get height() {
-    if (this.args.card.image.information && this.hasDimensions) {
-      return QabCard.MAX_HEIGHT;
-    }
-    return null;
-  }
-
-  get width() {
-    if (this.args.card.image.information && this.hasDimensions) {
-      return Math.round(
-        (QabCard.MAX_HEIGHT * this.args.card.image.information.width) / this.args.card.image.information.height,
-      );
-    }
-    return null;
+  get dimensions() {
+    return resizeImage(this.args.card.image.information, { MAX_HEIGHT: QabCard.MAX_HEIGHT });
   }
 
   <template>
@@ -62,8 +48,8 @@ export default class QabCard extends Component {
               class="qab-card-container-content__image"
               src={{@card.image.url}}
               alt={{@card.image.altText}}
-              height={{this.height}}
-              width={{this.width}}
+              height={{this.dimensions.height}}
+              width={{this.dimensions.width}}
             />
           {{/if}}
           <p class="qab-card-container-content__text">{{@card.text}}</p>


### PR DESCRIPTION
## 🍂 Problème
On a créé un [utilitaire](https://github.com/1024pix/pix/pull/13836) pour redimensionner les images. Il faut maintenant l'utiliser car il y a de la duplication de code.

## 🌰 Proposition
Refacto le code existant pour utiliser la fonction de redimensionnement des images.

## 🍁 Remarques
Pas de tests spécifiques à écrire, tout était déjà testé 🙆🏻 

## 🪵 Pour tester
### Elément QAB
- [ ] Faire un tour sur le qab dans [le bac a sable](https://app-pr13872.review.pix.fr/modules/bac-a-sable/details)
- [ ] Couper la connexion
- [ ] Vérifier qu'il y a la zone prévue pour l'image
- [ ] Se régaler d'un code refactorisé ☕️

### Elément Image
- [ ] Faire un tour sur 1er stepper horizontal dans [distinguer le vrai du faux](https://app.recette.pix.fr/modules/distinguer-vrai-faux-sur-internet)
- [ ] Couper la connexion
- [ ] Vérifier qu'il y a la zone prévue pour l'image
- [ ] Se régaler d'un code refactorisé 🍵 
