### PR TITLE
[BUGFIX] Ajouter le scope dans la cacheKey du référentiel (PIX-19990).

### DIFF
--- a/api/tests/shared/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/shared/unit/infrastructure/repositories/challenge-repository_test.js
@@ -1,0 +1,67 @@
+import { challengeRepository } from '../../../../../src/certification/session-management/infrastructure/repositories/index.js';
+import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { Frameworks } from '../../../../../src/certification/shared/domain/models/Frameworks.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Infrastructure | Repositories | challenge-repository', function () {
+  let findStub, dependencies;
+
+  beforeEach(function () {
+    findStub = sinon.stub();
+    dependencies = {
+      getInstance: () => {
+        return { find: findStub };
+      },
+    };
+  });
+
+  describe('findActiveFlashCompatible', function () {
+    context('when fetching a certification referential', function () {
+      context('when it is the CORE referential', function () {
+        it('should have a CORE cache key', async function () {
+          // given
+          findStub.resolves([]);
+
+          // when
+          await challengeRepository.findActiveFlashCompatible({
+            date: new Date(),
+            locale: 'fr',
+            successProbabilityThreshold: false,
+            accessibilityAdjustmentNeeded: false,
+            complementaryCertificationKey: undefined,
+            dependencies,
+          });
+
+          // then
+          expect(findStub).to.have.been.calledOnceWithExactly(
+            `findActiveFlashCompatible({ scope: ${Frameworks.CORE}, locale: fr, accessibilityAdjustmentNeeded: false})`,
+            sinon.match.func,
+          );
+        });
+      });
+
+      context('when it is a double certification', function () {
+        it('should have a CORE cache key', async function () {
+          // given
+          findStub.resolves([]);
+
+          // when
+          await challengeRepository.findActiveFlashCompatible({
+            date: new Date(),
+            locale: 'fr',
+            successProbabilityThreshold: false,
+            accessibilityAdjustmentNeeded: false,
+            complementaryCertificationKey: ComplementaryCertificationKeys.CLEA,
+            dependencies,
+          });
+
+          // then
+          expect(findStub).to.have.been.calledOnceWithExactly(
+            `findActiveFlashCompatible({ scope: ${Frameworks.CORE}, locale: fr, accessibilityAdjustmentNeeded: false})`,
+            sinon.match.func,
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

On a un soucis : il y a un seul cache dans le container pour tous les referentiels de certification. Sauf qu’ils ne contiennent pas les memes challenges, donc il faut des caches differents

Soit dans `findActiveFlashCompatible` =>  `const cacheKey = 'findActiveFlashCompatible({ locale: ${locale}, accessibilityAdjustmentNeeded: ${accessibilityAdjustmentNeeded} })';`  cela ne devrait pas etre le meme cache pour `_findChallengesForCoreCertification` que pour `_findValidChallengesForComplementaryCertification`
Et important : chaque `_findValidChallengesForComplementaryCertification` devrait avoir son cache a lui

## 🌰 Proposition

Ajouter le scope du référentiel dans la `cacheKey`.

## 🍁 Remarques

`findActiveFlashCompatible` est la source ultra importante mais on voit que il y a ce soucis autre part, genre dans `api/src/certification/evaluation/infrastructure/repositories/challenge-repository.js `

## 🪵 Pour tester

- Lancer une certif Pix+ en RA
- Lancer une certif PixCoeur en RA
- Si pas de page vide dans la 2ème certif, alors ✅   
