### PR TITLE
[TECH] Modifier les logger.error en logger.warn lorsqu'une erreur se produit pendant le stream

### DIFF
--- a/api/src/llm/infrastructure/streaming/to-event-stream.js
+++ b/api/src/llm/infrastructure/streaming/to-event-stream.js
@@ -52,7 +52,7 @@ export async function fromLLMResponse({
 }) {
   const writableStream = new PassThrough();
   writableStream.on('error', (err) => {
-    logger.error({ err, prompt }, 'error while streaming response');
+    logger.warn({ err, prompt }, 'error while streaming response');
   });
   if (attachmentMessageType !== ATTACHMENT_MESSAGE_TYPES.NONE) {
     writableStream.write(events.getAttachmentMessage(attachmentMessageType === ATTACHMENT_MESSAGE_TYPES.IS_VALID));
@@ -75,7 +75,7 @@ export async function fromLLMResponse({
     writableStream,
     async (err) => {
       if (err || !streamCapture.done || streamCapture.errorOccurredDuringStream) {
-        logger.error({ err, prompt }, 'error in stream');
+        logger.warn({ err: err ?? streamCapture.errorOccurredDuringStream, prompt }, 'error in stream');
       }
       await onStreamDone(streamCapture, !err);
     },


### PR DESCRIPTION
## 🍂 Problème

Logger.error c'est un peu fort et alarmant + pas de détail d'erreur lorsque l'erreur a été streamée depuis chatpix

## 🌰 Proposition

Transformer les logger.error en logger.warning
Si une erreur s'est produite côté ChatPix, en principe le message de l'erreur est streamée, on peut donc le remettre dans le log

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
