### PR TITLE
[FEATURE] Cacher les campagnes qui appartiennent à un parcours combinés (pix-19834)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -142,11 +142,12 @@ const findPaginatedFilteredByOrganizationId = async function ({
 
   const { results, pagination } = await fetchPage({ queryBuilder: query, paginationParams: page });
   const atLeastOneCampaign = await knex('campaigns')
-    .select('id')
+    .count('id')
     .where({ organizationId })
     .whereNull('deletedAt')
-    .first(1);
-  const hasCampaigns = Boolean(atLeastOneCampaign);
+    .whereNotIn('campaigns.id', campaignIdsToExclude)
+    .first();
+  const hasCampaigns = atLeastOneCampaign.count > 0;
 
   const campaignReports = results.map((attributes) => new CampaignReport(attributes));
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -1,14 +1,13 @@
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
-import * as injectedCombinedCourseRepo from '../../../../quest/infrastructure/repositories/combined-course-repository.js';
+import * as injectedCombinedCourseDetailRepository from '../../../../quest/infrastructure/repositories/combined-course-details-repository.js';
 import { CAMPAIGN_FEATURES } from '../../../../shared/domain/constants.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { filterByFullName } from '../../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
-import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { TargetProfileForSpecifier } from '../../../target-profile/domain/read-models/TargetProfileForSpecifier.js';
 import { CampaignReport } from '../../domain/read-models/CampaignReport.js';
@@ -108,8 +107,10 @@ const findPaginatedFilteredByOrganizationId = async function ({
   filter = {},
   page,
   userId,
-  combinedCourseRepo = injectedCombinedCourseRepo,
+  combinedCourseDetailsRepository = injectedCombinedCourseDetailRepository,
 }) {
+  const combinedCourses = await combinedCourseDetailsRepository.findByOrganizationId({ organizationId });
+  const campaignIdsToExclude = combinedCourses.flatMap((combinedCourse) => combinedCourse.campaignIds);
   const query = knex('campaigns')
     .distinct('campaigns.id')
     .select(
@@ -135,6 +136,7 @@ const findPaginatedFilteredByOrganizationId = async function ({
     .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where('campaigns.organizationId', organizationId)
     .whereNull('campaigns.deletedAt')
+    .whereNotIn('campaigns.id', campaignIdsToExclude)
     .modify(_setSearchFiltersForQueryBuilder, filter, userId)
     .orderBy('campaigns.createdAt', 'DESC');
 
@@ -146,12 +148,8 @@ const findPaginatedFilteredByOrganizationId = async function ({
     .first(1);
   const hasCampaigns = Boolean(atLeastOneCampaign);
 
-  const campaignReports = await PromiseUtils.mapSeries(results, async (attributes) => {
-    const campaignReport = new CampaignReport(attributes);
-    const combinedCourseInfo = await combinedCourseRepo.findByCampaignId({ campaignId: campaignReport.id });
-    campaignReport.setCombinedCourse(combinedCourseInfo[0]);
-    return campaignReport;
-  });
+  const campaignReports = results.map((attributes) => new CampaignReport(attributes));
+
   return { models: campaignReports, meta: { ...pagination, hasCampaigns } };
 };
 

--- a/api/src/quest/infrastructure/repositories/combined-course-details-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-details-repository.js
@@ -1,0 +1,25 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { CombinedCourseDetails } from '../../domain/models/CombinedCourse.js';
+import { Quest } from '../../domain/models/Quest.js';
+
+const findByOrganizationId = async ({ organizationId }) => {
+  const knexConn = DomainTransaction.getConnection();
+
+  const combinedCourses = await knexConn('combined_courses')
+    .select('combined_courses.*', 'quests.successRequirements', 'quests.rewardType', 'quests.rewardId')
+    .join('quests', 'combined_courses.questId', 'quests.id')
+    .where('combined_courses.organizationId', organizationId);
+
+  return combinedCourses.map((combinedCourse) => {
+    const quest = new Quest({
+      id: combinedCourse.questId,
+      successRequirements: combinedCourse.successRequirements,
+      eligibilityRequirements: [],
+      rewardId: combinedCourse.rewardId,
+      rewardType: combinedCourse.rewardType,
+    });
+    return new CombinedCourseDetails(combinedCourse, quest);
+  });
+};
+
+export { findByOrganizationId };

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -13,6 +13,7 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
+import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
 import * as combinedCourseRepository from './combined-course-repository.js';
@@ -38,6 +39,7 @@ const repositoriesWithoutInjectedDependencies = {
   questRepository,
   campaignRepository,
   combinedCourseRepository,
+  combinedCourseDetailsRepository,
   combinedCourseParticipantRepository,
   combinedCourseParticipationRepository,
   userRepository,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-details-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-details-repository_test.js
@@ -1,0 +1,95 @@
+import { CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
+import * as combinedCourseDetailsRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-details-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | combined-course-details', function () {
+  describe('#findByOrganizationId', function () {
+    it('should return all combined course details for a given organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+      const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+      const combinedCourse1 = databaseBuilder.factory.buildCombinedCourse({
+        code: 'COURSE1',
+        name: 'Parcours 1',
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: campaignId,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      const combinedCourse2 = databaseBuilder.factory.buildCombinedCourse({
+        code: 'COURSE2',
+        name: 'Parcours 2',
+        organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourses = await combinedCourseDetailsRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(combinedCourses).lengthOf(2);
+      expect(combinedCourses[0]).instanceof(CombinedCourseDetails);
+      expect(combinedCourses[1]).instanceof(CombinedCourseDetails);
+      expect(combinedCourses[0]).deep.equal(new CombinedCourseDetails(combinedCourse1));
+      expect(combinedCourses[1]).deep.equal(new CombinedCourseDetails(combinedCourse2));
+      expect(combinedCourses[0].campaignIds).deep.equal([campaignId]);
+      expect(combinedCourses[1].moduleIds).deep.equal([moduleId]);
+    });
+
+    it('should return an empty array when no combined courses exist for the organization', async function () {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const anotherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildCombinedCourse({
+        code: 'COURSE1',
+        name: 'Parcours 1',
+        organizationId: anotherOrganizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: 123,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const combinedCourses = await combinedCourseDetailsRepository.findByOrganizationId({ organizationId });
+
+      // then
+      expect(combinedCourses).lengthOf(0);
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

On ne veut pas remonter les campagnes d'un parcours combinés, car on ne souhaite pas que les utilisateurs y accède directement.

## 🌰 Proposition

Ne plus remonter les campagnes qui sont dans un parcours combinés

## 🍁 Remarques

On fait un petit refacto sur le booléen `hasCampaign` pour utiliser un count

## 🪵 Pour tester

- Aller dans pix orga
- afficher les campagnes de l'orga PRO_CLASSIC
- Ne pas voir la campagne du parcours COMBINIX2
