### PR TITLE
[TECH] Modifier l'url pour enregistrer le logo d'un contenu formatif sur Admin (PIX-20002).

### DIFF
--- a/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/list.gjs
@@ -125,7 +125,7 @@ export default class List extends Component {
                   <PixInput
                     @id="{{row.id}}-certificate-image"
                     name="certificate-image"
-                    placeholder="Ex : https://images.pix.fr/..."
+                    placeholder="Ex : https://assets.pix.org/..."
                     required="true"
                     aria-required="true"
                     @screenReaderOnly={{true}}
@@ -175,7 +175,7 @@ export default class List extends Component {
                   <PixInput
                     @id="{{row.id}}-certificate-sticker"
                     name="certificate-sticker"
-                    placeholder="Ex : https://images.pix.fr/..."
+                    placeholder="Ex : https://assets.pix.org/..."
                     required="true"
                     aria-required="true"
                     @screenReaderOnly={{true}}

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -80,7 +80,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
       editorName: this.form.editorName,
       isDisabled: this.form.isDisabled,
     };
-    training.editorLogoUrl = `https://images.pix.fr/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
+    training.editorLogoUrl = `https://assets.pix.org/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
 
     try {
       this.submitting = true;

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -139,7 +139,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       // then
       assert.ok(onSubmitStub.called);
       const submittedData = onSubmitStub.getCall(0).firstArg;
-      assert.strictEqual(submittedData.editorLogoUrl, 'https://images.pix.fr/contenu-formatif/editeur/new-logo.svg');
+      assert.strictEqual(submittedData.editorLogoUrl, 'https://assets.pix.org/contenu-formatif/editeur/new-logo.svg');
     });
 
     test('should toggle isDisabled field when checkbox is clicked', async function (assert) {


### PR DESCRIPTION
## 🍂 Problème

Dans une volonté de ne plus dépendre de images.pix.fr, plusieurs actions de modification sont à effectuer, pour le remplacer par asset.pix.org.
Coté contenu formatif, les logos ont été dupliqués pour être stockés dans pix assets, on veut désormais qu'ils soient enregistrés en BDD avec l'url assets.pix.org

## 🌰 Proposition

Modifier l'url pour que le logo soit enregistré avec asset lors de la création d'un contenu formatif

## 🍁 Remarques

Oubli de renommage des placeholders suite à la PR https://github.com/1024pix/pix/pull/13867

## 🪵 Pour tester

- Se connecter à Pix Admin
- https://admin-pr13876.review.pix.fr/trainings/new
- remplir le formulaire en y incluant un logo
- constater que le contenu formatif est créé en enregistrant un logo suivant l'url asset.pix.org
<img width="511" height="43" alt="Capture d’écran 2025-10-13 à 15 57 17" src="https://github.com/user-attachments/assets/4eb75b7b-82cb-4744-a63f-b4e419475bdd" />
- constater que le logo s'affiche bien en haut à droite de la page de détails d'un contenu formatif
<img width="1408" height="434" alt="Capture d’écran 2025-10-13 à 15 59 59" src="https://github.com/user-attachments/assets/0e10ad57-0f1d-4e85-bdb1-0319f0aaabda" />

