### PR TITLE
[FEATURE] Ajouter un avatar au profil utilisateur (temporary PR).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -26,6 +26,7 @@ const { ROLES } = PIX_ADMIN;
  * @property {string} lastName
  * @property {string} email
  * @property {string} username
+ * @property {string} avatarUrl
  * @property {boolean} cgu
  * @property {string} lang
  * @property {string} locale
@@ -123,6 +124,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
   emailConfirmedAt = new Date('2021-04-28T02:42:00Z'),
+  avatarUrl = 'https://assets.pix.org/draft/flamingo.jpg',
 } = {}) {
   email = _generateEmailIfUndefined(email, id, lastName, firstName);
 
@@ -143,6 +145,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     createdAt,
     updatedAt,
     emailConfirmedAt,
+    avatarUrl,
   };
 
   const user = databaseBuffer.pushInsertable({

--- a/api/db/migrations/20251007133438_add-avatar-url-to-user.js
+++ b/api/db/migrations/20251007133438_add-avatar-url-to-user.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'avatarUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).nullable().comment('URL of the user avatar image');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -78,6 +78,16 @@ function _buildUsers(databaseBuilder) {
     emailConfirmedAt: null,
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
+
+  //user with a avatar url
+  const userWithAvatarUrl = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'User',
+    lastName: 'Withavatar',
+    email: 'user.withavatar@example.net',
+    emailConfirmedAt: null,
+    avatarUrl: 'https://www.cnil.fr/sites/cnil/files/thumbnails/image/b_marteau.png',
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithAvatarUrl.id, lastLoggedAt: null });
 }
 
 export function buildUsers(databaseBuilder) {

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -78,6 +78,7 @@ export const userRoutes = [
               'has-seen-other-challenges-tooltip': Joi.boolean().allow(null),
               'should-see-data-protection-policy-information-banner': Joi.boolean().allow(null),
               'pix-orga-terms-of-service-status': Joi.boolean().allow(null), // sent by Pix Orga when creating a user upon invitation
+              'avatar-url': Joi.string().uri().allow(null),
             }).required(),
             relationships: Joi.object(),
           }).required(),

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -40,6 +40,7 @@ class User {
       authenticationMethods = [],
       hasBeenAnonymised,
       hasBeenAnonymisedBy,
+      avatarUrl,
     } = {},
     dependencies = { localeService },
   ) {
@@ -73,6 +74,7 @@ class User {
     this.authenticationMethods = authenticationMethods;
     this.hasBeenAnonymised = hasBeenAnonymised;
     this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
+    this.avatarUrl = avatarUrl;
   }
 
   get isActive() {

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
@@ -29,6 +29,7 @@ const serialize = function (users, meta) {
       'codeForLastProfileToShare',
       'trainings',
       'shouldSeeDataProtectionPolicyInformationBanner',
+      'avatarUrl',
     ],
     profile: {
       ref: 'id',

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -23,6 +23,7 @@ export default class User extends Model {
   @attr('boolean') shouldSeeDataProtectionPolicyInformationBanner;
   @attr('boolean') emailConfirmed;
   @attr() lastDataProtectionPolicySeenAt;
+  @attr('string') avatarUrl;
 
   // includes
   @belongsTo('is-certifiable', { async: true, inverse: null }) isCertifiable;

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -36,4 +36,8 @@ export default class User extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
+
+  get trigram() {
+    return this.firstName?.charAt(0).toUpperCase() + this.lastName?.slice(0, 2).toUpperCase();
+  }
 }

--- a/mon-pix/app/styles/pages/_personal-information.scss
+++ b/mon-pix/app/styles/pages/_personal-information.scss
@@ -15,6 +15,11 @@
     border-bottom: none;
   }
 
+  &__avatar {
+    width: 90px;
+    height: 90px;
+  }
+
   &__label {
     display: flex;
     align-items: center;

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -14,5 +14,12 @@ import t from 'ember-intl/helpers/t';
       </p>
       <p class="personal-information-item__value" data-test-lastName>{{@model.lastName}}</p>
     </div>
+
+    <div class="personal-information-item">
+      <p class="form-textfield__label personal-information-item__label">
+        {{t "pages.user-account.personal-information.trigram"}}
+      </p>
+      <p class="personal-information-item__value" data-test-lastName>{{@model.lastName}}</p>
+    </div>
   </div>
 </template>

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -21,5 +21,17 @@ import t from 'ember-intl/helpers/t';
       </p>
       <p class="personal-information-item__value" data-test-lastName>{{@model.trigram}}</p>
     </div>
+
+    <div class="personal-information-item">
+      <p class="form-textfield__label personal-information-item__label">
+        {{t "pages.user-account.personal-information.avatar"}}
+      </p>
+      <img
+        class="form-textfield__label personal-information-item__avatar"
+        src="{{@model.avatarUrl}}"
+        alt="User's avatar"
+        role="none"
+      />
+    </div>
   </div>
 </template>

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -22,16 +22,18 @@ import t from 'ember-intl/helpers/t';
       <p class="personal-information-item__value" data-test-lastName>{{@model.trigram}}</p>
     </div>
 
-    <div class="personal-information-item">
-      <p class="form-textfield__label personal-information-item__label">
-        {{t "pages.user-account.personal-information.avatar"}}
-      </p>
-      <img
-        class="form-textfield__label personal-information-item__avatar"
-        src="{{@model.avatarUrl}}"
-        alt="User's avatar"
-        role="none"
-      />
-    </div>
+    {{#if @model.avatarUrl}}
+      <div class="personal-information-item">
+        <p class="form-textfield__label personal-information-item__label">
+          {{t "pages.user-account.personal-information.avatar"}}
+        </p>
+        <img
+          class="form-textfield__label personal-information-item__avatar"
+          src="{{@model.avatarUrl}}"
+          alt="User's avatar"
+          role="none"
+        />
+      </div>
+    {{/if}}
   </div>
 </template>

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -19,7 +19,7 @@ import t from 'ember-intl/helpers/t';
       <p class="form-textfield__label personal-information-item__label">
         {{t "pages.user-account.personal-information.trigram"}}
       </p>
-      <p class="personal-information-item__value" data-test-lastName>{{@model.lastName}}</p>
+      <p class="personal-information-item__value" data-test-lastName>{{@model.trigram}}</p>
     </div>
   </div>
 </template>

--- a/mon-pix/tests/acceptance/personal-information-test.js
+++ b/mon-pix/tests/acceptance/personal-information-test.js
@@ -29,6 +29,7 @@ module('Acceptance | personal-information', function (hooks) {
       const userNames = screen.getAllByText(user.firstName).length;
       assert.strictEqual(userNames, 2);
       assert.ok(screen.getByText(user.lastName));
+      assert.ok(screen.getByText('JDO'));
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2301,6 +2301,7 @@
         "update-successful": "Your language has been updated!"
       },
       "personal-information": {
+        "avatar": "Avatar",
         "first-name": "First name",
         "last-name": "Last name",
         "menu-link-title": "Personal information",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2303,7 +2303,8 @@
       "personal-information": {
         "first-name": "First name",
         "last-name": "Last name",
-        "menu-link-title": "Personal information"
+        "menu-link-title": "Personal information",
+        "trigram": "My trigram"
       },
       "title": "My account"
     },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -2286,7 +2286,8 @@
       "personal-information": {
         "first-name": "Nombre",
         "last-name": "Apellidos",
-        "menu-link-title": "Mis datos personales"
+        "menu-link-title": "Mis datos personales",
+        "trigram": "Trigrama"
       },
       "title": "Mi cuenta"
     },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -2284,6 +2284,7 @@
         "update-successful": "El idioma ha sido cambiado."
       },
       "personal-information": {
+        "avatar": "Avatar",
         "first-name": "Nombre",
         "last-name": "Apellidos",
         "menu-link-title": "Mis datos personales",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2290,7 +2290,8 @@
       "personal-information": {
         "first-name": "Nombre",
         "last-name": "Apellidos",
-        "menu-link-title": "Mis datos personales"
+        "menu-link-title": "Mis datos personales",
+        "trigram": "Trigrama"
       },
       "title": "Mi cuenta"
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2288,6 +2288,7 @@
         "update-successful": "El idioma ha sido cambiado."
       },
       "personal-information": {
+        "avatar": "Avatar",
         "first-name": "Nombre",
         "last-name": "Apellidos",
         "menu-link-title": "Mis datos personales",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2311,7 +2311,8 @@
       "personal-information": {
         "first-name": "Prénom",
         "last-name": "Nom",
-        "menu-link-title": "Mes informations personnelles"
+        "menu-link-title": "Mes informations personnelles",
+        "trigram": "Mon trigramme"
       },
       "title": "Mon compte"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2309,6 +2309,7 @@
         "update-successful": "Votre langue a été changée !"
       },
       "personal-information": {
+        "avatar": "Avatar",
         "first-name": "Prénom",
         "last-name": "Nom",
         "menu-link-title": "Mes informations personnelles",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2292,6 +2292,7 @@
         "update-successful": "Je taal is veranderd!"
       },
       "personal-information": {
+        "avatar": "Avatar",
         "first-name": "Voornaam",
         "last-name": "Achternaam",
         "menu-link-title": "Mijn persoonlijke gegevens",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2294,7 +2294,8 @@
       "personal-information": {
         "first-name": "Voornaam",
         "last-name": "Achternaam",
-        "menu-link-title": "Mijn persoonlijke gegevens"
+        "menu-link-title": "Mijn persoonlijke gegevens",
+        "trigram": "Triegram"
       },
       "title": "Mijn account"
     },


### PR DESCRIPTION
## 🍂 Problème
Lors du séminaire du 16 octobre se tiendra un atelier de découverte du développement d'une feature chez Pix. A cette occasion on veut proposer une PR fullstack d'exemple à reproduire lors de l'atelier.

## 🌰 Proposition
Dans cet exercice, on a cherché à ajouter au profil de l'utilisateur un avatar. Cette PR contient la modification du back et du front, ainsi que l'alteration de la base de données et l'ajout d'une donnée d'exemple sur un builder.

## 🍁 Remarques
Cette PR est l'une des manières de réaliser le besoin exprimé et non la seule. 

## 🪵 Pour tester
- Lancer Pix App et se connecter avec le compte "user.withavatar@example.net" 
- Aller dans Mon Compte
- Constater la présence d'un avatar
- (Bonus : Se créer un compte, vérifier que sur un nouveau compte le champ Avatar ne s'affiche pas)
