### PR TITLE
[FEATURE] Ajouter le script pour lister les modules et leur id dans l'API (PIX-19881)

### DIFF
--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -1,0 +1,19 @@
+import moduleDatasource from '../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
+
+/**
+ * List all modules for DB replication with id, slug and title
+ * @returns {Promise<void>}
+ */
+async function listModulesForDBReplication() {
+  const imports = await moduleDatasource.list();
+  const moduleInformation = imports.map((module) => {
+    return { id: module.id, slug: module.slug, title: module.title };
+  });
+  console.log(JSON.stringify(moduleInformation, null, 2).replace(/"([^"]+)": "([^"]+)"/g, "$1: '$2'"));
+}
+
+async function main() {
+  await listModulesForDBReplication();
+}
+
+await main();


### PR DESCRIPTION
## 🍂 Problème

Quand des modules sont créés, il faut régulièrement mettre à jour le tableau des informations de module présents dans le projet [pix-db-replication](https://github.com/1024pix/pix-db-replication/blob/dev/src/steps/modulix-learning-content/lcms-client.js), afin d'avoir ces infos dans metabase. 

## 🌰 Proposition

Créer un script pour automatiser le console.log de la liste des modules avec leurs infos. 

## 🍁 Remarques

RAS

## 🪵 Pour tester

- Se mettre sur la branche localement
- Aller dans le dossier /scripts
- Lancer avec node le script `list-modules-for-db-replication.js`
- Vérifier le rendu dans la console
