### PR TITLE
[FEATURE] Ajouter des étapes aux parcours combinés (PIX-19798)

### DIFF
--- a/mon-pix/app/components/routes/combined-courses.gjs
+++ b/mon-pix/app/components/routes/combined-courses.gjs
@@ -66,6 +66,11 @@ const Header = <template>
   </header>
 </template>;
 
+const Step = <template>
+  <h2 class="combined-course__step-title">{{t "pages.combined-courses.content.step" stepNumber=(@stepNumber)}}
+  </h2>
+</template>;
+
 export default class CombinedCourses extends Component {
   <template>
     <section class="combined-course">
@@ -85,7 +90,12 @@ export default class CombinedCourses extends Component {
       {{#if this.shouldDisplayRetryModulesText}}
         <p class="combined-course__retry-text">{{t "pages.combined-courses.completed.retry-text"}}</p>
       {{/if}}
-      {{#each @combinedCourse.items as |item|}}
+      {{#each @combinedCourse.items as |item index|}}
+        {{#unless @combinedCourse.areItemsOfTheSameType}}
+          {{#if (@combinedCourse.isPreviousItemDifferent index)}}
+            <Step @stepNumber={{this.getCurrentStep}} />
+          {{/if}}
+        {{/unless}}
         <CombinedCourseItem
           @item={{item}}
           @isLocked={{item.isLocked}}
@@ -103,6 +113,8 @@ export default class CombinedCourses extends Component {
   @service intl;
   @service store;
   @service router;
+
+  step = 1;
 
   @action
   async startQuestParticipation(e) {
@@ -131,6 +143,11 @@ export default class CombinedCourses extends Component {
       this.args.combinedCourse.hasItemOfTypeModule &&
       this.args.combinedCourse.status === CombinedCourseStatuses.COMPLETED
     );
+  }
+
+  @action
+  getCurrentStep() {
+    return this.step++;
   }
 }
 

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -31,5 +31,10 @@ export default class CombinedCourseItem extends Model {
     return this.image;
   }
 
+  get typeForStepDisplay() {
+    if (this.type === CombinedCourseItemTypes.FORMATION) return CombinedCourseItemTypes.MODULE;
+    return this.type;
+  }
+
   @belongsTo('combined-course', { async: false, inverse: 'items' }) combinedCourse;
 }

--- a/mon-pix/app/models/combined-course.js
+++ b/mon-pix/app/models/combined-course.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Model, { attr, hasMany } from '@ember-data/model';
 import { CombinedCourseItemTypes } from 'mon-pix/models/combined-course-item';
 
@@ -21,6 +22,25 @@ export default class CombinedCourse extends Model {
     return this.hasMany('items')
       .value()
       .find((item) => !item.isCompleted);
+  }
+
+  @action
+  isPreviousItemDifferent(index) {
+    if (index === 0) {
+      return true;
+    }
+    const item = this.hasMany('items').value();
+    if (item[index].typeForStepDisplay !== item[index - 1].typeForStepDisplay) {
+      return true;
+    }
+  }
+
+  get areItemsOfTheSameType() {
+    const items = this.hasMany('items').value();
+    return (
+      items.every((item) => item.type === CombinedCourseItemTypes.MODULE) ||
+      items.every((item) => item.type === CombinedCourseItemTypes.CAMPAIGN)
+    );
   }
 
   get hasItemOfTypeModule() {

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -31,6 +31,15 @@
     text-align: right;
   }
 
+  &__step-title {
+    @extend %pix-title-xs;
+
+    margin: var(--pix-spacing-10x) 0 var(--pix-spacing-4x);
+
+    &:first-of-type {
+      margin-top : 0
+    }
+  }
 }
 
 .combined-course-header {

--- a/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses-test.gjs
@@ -559,4 +559,83 @@ module('Integration | Component | combined course', function (hooks) {
       );
     });
   });
+  module('when items are of different types', function () {
+    test('should display steps', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.STARTED,
+        code: 'COMBINIX9',
+      });
+
+      const campaignCombinedCourseItem = store.createRecord('combined-course-item', {
+        id: 1,
+        title: 'ma campagne',
+        reference: 'ABCDIAG1',
+        type: 'CAMPAIGN',
+        isCompleted: true,
+      });
+
+      const moduleCombinedCourseItem = store.createRecord('combined-course-item', {
+        id: 2,
+        title: 'mon module',
+        reference: 'mon-module',
+        type: 'MODULE',
+        redirection: 'une+url+chiffree',
+        isCompleted: false,
+      });
+
+      combinedCourse.items.push(campaignCombinedCourseItem, moduleCombinedCourseItem);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+      // then
+      assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.content.step', { stepNumber: 1 }) }));
+      assert.ok(screen.getByRole('heading', { name: t('pages.combined-courses.content.step', { stepNumber: 2 }) }));
+    });
+  });
+  module('when items are of same types', function () {
+    test('should not display steps', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourse = store.createRecord('combined-course', {
+        id: 1,
+        status: CombinedCourseStatuses.STARTED,
+        code: 'COMBINIX9',
+      });
+
+      const campaignCombinedCourseItem = store.createRecord('combined-course-item', {
+        id: 3,
+        title: 'ma campagne',
+        reference: 'ABCDIAG1',
+        type: 'CAMPAIGN',
+        isCompleted: true,
+      });
+
+      const campaignCombinedCourse2Item = store.createRecord('combined-course-item', {
+        id: 4,
+        title: 'ma campagne',
+        reference: 'ABCDIAG1',
+        type: 'CAMPAIGN',
+        isCompleted: true,
+      });
+
+      combinedCourse.items.push(campaignCombinedCourseItem, campaignCombinedCourse2Item);
+
+      this.setProperties({ combinedCourse });
+
+      // when
+      const screen = await render(hbs`
+        <Routes::CombinedCourses @combinedCourse={{this.combinedCourse}}  />`);
+
+      // then
+      assert.notOk(screen.queryByRole('heading', { name: 'étape 1' }));
+    });
+  });
 });

--- a/mon-pix/tests/unit/models/combined-course-item-test.js
+++ b/mon-pix/tests/unit/models/combined-course-item-test.js
@@ -52,5 +52,12 @@ module('Unit | Model | Combined Course Item', function (hooks) {
       });
       assert.strictEqual(combinedCourseItem.iconUrl, CombinedCourseAssets.FORMATION_ICON);
     });
+    test('should return module when typeForStepDisplay getter is called', function (assert) {
+      const combinedCourseItem = store.createRecord('combined-course-item', {
+        type: CombinedCourseItemTypes.FORMATION,
+        image: 'my-module-url',
+      });
+      assert.strictEqual(combinedCourseItem.typeForStepDisplay, CombinedCourseItemTypes.MODULE);
+    });
   });
 });

--- a/mon-pix/tests/unit/models/combined-course-test.js
+++ b/mon-pix/tests/unit/models/combined-course-test.js
@@ -64,4 +64,38 @@ module('Unit | Model | Combined Course', function (hooks) {
       assert.false(combinedCourse.hasItemOfTypeModule);
     });
   });
+  module('#areItemsOfTheSameType', function () {
+    test('returns false when items are of different types', function (assert) {
+      const combinedCourseItem1 = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        type: 'CAMPAIGN',
+      });
+      const combinedCourseItem2 = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        type: 'FORMATION',
+      });
+      const combinedCourseItem3 = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        type: 'MODULE',
+        redirection: '/modules/demo-combinix-2',
+      });
+
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [combinedCourseItem1, combinedCourseItem2, combinedCourseItem3];
+      assert.false(combinedCourse.areItemsOfTheSameType);
+    });
+    test('returns true when items are of different types', function (assert) {
+      const combinedCourseItem1 = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        type: 'CAMPAIGN',
+      });
+      const combinedCourseItem2 = store.createRecord('combined-course-item', {
+        isCompleted: false,
+        type: 'CAMPAIGN',
+      });
+      const combinedCourse = store.createRecord('combined-course');
+      combinedCourse.items = [combinedCourseItem1, combinedCourseItem2];
+      assert.true(combinedCourse.areItemsOfTheSameType);
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1209,7 +1209,8 @@
       },
       "content": {
         "resume-button": "Resume course",
-        "start-button": "Start course"
+        "start-button": "Start course",
+        "step": "Step {stepNumber}"
       },
       "items": {
         "approximatelySymbol": "≈",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1198,7 +1198,8 @@
     "combined-courses": {
       "content": {
         "start-button": "Iniciar el curso",
-        "resume-course": "Reanudar mi curso"
+        "resume-course": "Reanudar mi curso",
+        "step": "Paso {stepNumber}"
       },
       "completed": {
         "title": "¡Enhorabuena! ¡Ya ha terminado!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1210,7 +1210,8 @@
       },
       "content": {
         "resume-button": "Continuer mon parcours",
-        "start-button": "Commencer mon parcours"
+        "start-button": "Commencer mon parcours",
+        "step": "Étape {stepNumber}"
       },
       "items": {
         "approximatelySymbol": "≈",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1202,7 +1202,8 @@
     "combined-courses": {
       "content": {
         "start-button": "Cursus starten",
-        "resume-button": "Cursus hervatten"
+        "resume-button": "Cursus hervatten",
+        "step": "Stap {stepNumber}"
       },
       "completed": {
         "title": "Gefeliciteerd! Je bent klaar!",


### PR DESCRIPTION
## 🍂 Problème
On veut pouvoir afficher des étapes qui différencient campagnes et modules.

## 🌰 Proposition
A chaque changement de type de module (formation / module ou campagne), on veut afficher un titre "Etape" et incrémenter son numéro.

## 🪵 Pour tester
Tirer la branche en local et aller modifier temporairement les seeds pour avoir un parcours combiné avec un seul type d'item.
Puis tester en RA avec le code COMBINIX1 pour vérifier le changement d'étape entre la campagne de diagnostic et le bloc formation / les modules.