### PR TITLE
[FEATURE] Ajouter un délai sur le bouton "Suivant" du stepper horizontal (2nd round) (PIX-20007)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -71,14 +71,13 @@
                   "elements": [
                     {
                       "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
-                      "type": "qcu",
+                      "type": "qcu-declarative",
                       "instruction": "<p>Pix est découpé en 6 domaines.</p>",
                       "proposals": [
                         {
                           "id": "1",
                           "content": "Vrai",
                           "feedback": {
-                            "state": "Incorrect.",
                             "diagnosis": "<p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
                           }
                         },
@@ -86,36 +85,92 @@
                           "id": "2",
                           "content": "Faux",
                           "feedback": {
-                            "state": "Correct&#8239;!",
                             "diagnosis": "<p> Bien vu !</p>"
                           }
                         }
-                      ],
-                      "solution": "2"
+                      ]
                     }
                   ]
                 },
                 {
                   "elements": [
                     {
-                      "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
-                      "type": "qcu",
-                      "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
+                      "id": "ef18ed04-9551-4cee-9648-9f14a28aab1b",
+                      "type": "qcm",
+                      "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
                       "proposals": [
                         {
                           "id": "1",
-                          "content": "Vrai",
+                          "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
+                        },
+                        {
+                          "id": "2",
+                          "content": "Développer son savoir-faire sur les jeux de type TPS"
+                        },
+                        {
+                          "id": "3",
+                          "content": "Développer ses compétences numériques"
+                        },
+                        {
+                          "id": "4",
+                          "content": "Certifier ses compétences Pix"
+                        },
+                        {
+                          "id": "5",
+                          "content": "Evaluer ses compétences de logique et compréhension mathématique"
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Correct&#8239;!",
+                          "diagnosis": "<p>Vous nous avez bien cernés&nbsp;:)</p>"
+                        },
+                        "invalid": {
+                          "state": "Et non&#8239;!",
+                          "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
+                        }
+                      },
+                      "solutions": ["1", "3", "4"]
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "7fb4c1c6-46f8-49a4-9547-f9febf545447",
+                      "type": "text",
+                      "content": "<p>Voici des photographies de chiens et de bagels.</p>"
+                    },
+                    {
+                      "id": "5c25213f-14ec-4107-a1cf-ab1b97271476",
+                      "type": "image",
+                      "url": "https://assets.pix.org/modules/bac-a-sable/des-chiens-et-des-bagels.jpg",
+                      "alt": "Une photo comportant des chiens et des bagels",
+                      "alternativeText": "",
+                      "legend": "",
+                      "licence": ""
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "b1ef75c8-714b-4b2d-8e88-e279c5737095",
+                      "type": "qcu-discovery",
+                      "instruction": "<p>Selon vous, combien y'a t-il de chiens dans la photo ?<br></p>",
+                      "proposals": [
+                        {
+                          "id": "1",
+                          "content": "<p>8</p>",
                           "feedback": {
-                            "state": "Correct&#8239;!",
-                            "diagnosis": "<p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>"
+                            "diagnosis": "<p>Bien joué !</p>"
                           }
                         },
                         {
                           "id": "2",
-                          "content": "Faux",
+                          "content": "<p>9</p>",
                           "feedback": {
-                            "state": "Incorrect.",
-                            "diagnosis": "<p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
+                            "diagnosis": "<p>Eh non ! Y'a un bagel dans votre calcul 🥯</p>"
                           }
                         }
                       ],

--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -18,6 +18,8 @@ import SeparatorElement from 'mon-pix/components/module/element/separator';
 import TextElement from 'mon-pix/components/module/element/text';
 import VideoElement from 'mon-pix/components/module/element/video';
 
+export const VERIFY_RESPONSE_DELAY = 500;
+
 export default class ModulixElement extends Component {
   @action
   getLastCorrectionForElement() {

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -10,9 +10,8 @@ import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
-
-export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcm extends ModuleElement {
   @service passageEvents;

--- a/mon-pix/app/components/module/element/qcu.gjs
+++ b/mon-pix/app/components/module/element/qcu.gjs
@@ -10,9 +10,8 @@ import { t } from 'ember-intl';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
-
-export const VERIFY_RESPONSE_DELAY = 500;
 
 export default class ModuleQcu extends ModuleElement {
   @tracked selectedAnswerId = null;

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -293,7 +293,7 @@ export default class ModuleGrain extends Component {
               <div class="grain-card-content__stepper">
                 <Stepper
                   @steps={{component.steps}}
-                  @onElementAnswer={{@onElementAnswer}}
+                  @onElementAnswer={{this.onElementAnswer}}
                   @onElementRetry={{@onElementRetry}}
                   @passage={{@passage}}
                   @getLastCorrectionForElement={{this.getLastCorrectionForElement}}

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -3,8 +3,8 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click, find, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
-import { VERIFY_RESPONSE_DELAY as QCM_VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcm';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import { NEXT_STEP_BUTTON_DELAY } from 'mon-pix/components/module/component/stepper';
 import ModuleGrain from 'mon-pix/components/module/grain/grain';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -623,7 +623,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
           await click(screen.getByLabelText('checkbox2'));
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
@@ -648,11 +648,11 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
-          await clock.tickAsync(Math.round(QCM_VERIFY_RESPONSE_DELAY / 2));
+          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).doesNotHaveAttribute('aria-disabled');
         });
@@ -925,7 +925,17 @@ module('Integration | Component | Module | Grain', function (hooks) {
       assert.ok(screen.getByText('element content'));
     });
 
-    module('When we verify an answerable element', function () {
+    module('When we verify an answerable element', function (hooks) {
+      let clock;
+
+      hooks.beforeEach(function () {
+        clock = sinon.useFakeTimers();
+      });
+
+      hooks.afterEach(function () {
+        clock.restore();
+      });
+
       test('should call the onElementAnswer action', async function (assert) {
         // given
         const steps = [
@@ -980,6 +990,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // then
         await clickByName('radio1');
         await clickByName(t('pages.modulix.buttons.activity.verify'));
+        await clock.tickAsync(NEXT_STEP_BUTTON_DELAY + 100);
         sinon.assert.calledOnce(onElementAnswerStub);
         assert.ok(true);
       });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -2,7 +2,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 import { click, findAll } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ApplicationAdapter from 'mon-pix/adapters/application';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModulePassage from 'mon-pix/components/module/passage';
 import { module, test } from 'qunit';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/module/qcm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcm_test.gjs
@@ -3,7 +3,8 @@ import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcm, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcm';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import ModulixQcm from 'mon-pix/components/module/element/qcm';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/mon-pix/tests/integration/components/module/qcu_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu_test.gjs
@@ -3,7 +3,8 @@ import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import ModulixQcu, { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
+import ModulixQcu from 'mon-pix/components/module/element/qcu';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -4,7 +4,7 @@ import Service from '@ember/service';
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixStepper from 'mon-pix/components/module/component/stepper';
-import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/element/qcu';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 


### PR DESCRIPTION
## 🍂 Problème

Pour améliorer l'expérience des modules, on souhaite avoir des affichages différés entre les feedbacks et les boutons.

## 🌰 Proposition

Pour le stepper horizontal, afficher le bouton "Suivant" après l'affichage du feedback.

## 🍁 Remarques
> [!IMPORTANT]
>  On nous a remonté le fait que le bouton suivant n'apparaît pas sur les stepper ayant des QCU Découverte.
Cette PR est donc une correction suite au revert de la première PR : https://github.com/1024pix/pix/pull/13833 / https://github.com/1024pix/pix/pull/13885

A voir pour ajouter une transition / animation pour rendre l'apparition du bouton suivant plus lisse.

## 🪵 Pour tester

### Nouveau contenu dans le stepper horizontal de bac-a-sable

- Aller sur le module https://app-pr13887.review.pix.fr/modules/bac-a-sable
- Constater que le stepper horizontal contient : 
  - un QCU
  - un QCU découverte
  - un QCM
  - un texte avec une image
  - un QCU déclaratif
- Après ce stepper horizontal se trouve un stepper vertical 


### Non régression

- Aller sur le module [tmp-ia-fonctionnement-debut](https://app-pr13887.review.pix.fr/modules/tmp-ia-fonctionnement-debut)
- Passer les grains jusqu'au stepper horizontal ayant un QCU découverte
- Vérifier que le bouton suivant apparaît bien maintenant.

Cas du stepper horizontal SANS question :

[app-pr13887.review.pix.fr/modules/tmp-ia-def-ind](https://app-pr13887.review.pix.fr/modules/tmp-ia-def-ind)

Cas du stepper horizontal AVEC questions :

[app-pr13887.review.pix.fr/modules/bac-a-sable](https://app-pr13887.review.pix.fr/modules/bac-a-sable)

Vérifier le comportement d'un stepper vertical :

[app-pr13887.review.pix.fr/modules/utiliser-souris-ordinateur-2](https://app-pr13887.review.pix.fr/modules/utiliser-souris-ordinateur-2/)
