### PR TITLE
[TECH] Utiliser le helper de redimensionnement d'image dans le composant flashcards-card (PIX-19922)

### DIFF
--- a/mon-pix/app/components/module/element/flashcards/flashcards-card.gjs
+++ b/mon-pix/app/components/module/element/flashcards/flashcards-card.gjs
@@ -4,10 +4,18 @@ import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 
+import { resizeImage } from '../../../../utils/resize-image';
+
 export default class ModulixFlashcardsCard extends Component {
+  static MAX_HEIGHT = 170;
+
   get currentSide() {
     const side = this.args.displayedSideName;
     return this.args.card[side];
+  }
+
+  get dimensions() {
+    return resizeImage(this.currentSide.image.information, { MAX_HEIGHT: ModulixFlashcardsCard.MAX_HEIGHT });
   }
 
   <template>
@@ -20,8 +28,8 @@ export default class ModulixFlashcardsCard extends Component {
           <div class="element-flashcards-card__image">
             <img
               src={{this.currentSide.image.url}}
-              width={{this.currentSide.image.information.width}}
-              height={{this.currentSide.image.information.height}}
+              width={{this.dimensions.width}}
+              height={{this.dimensions.height}}
               alt=""
             />
           </div>

--- a/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
@@ -81,14 +81,18 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
           },
         };
 
+        const expectedWidth = Math.round(
+          (ModulixFlashcardsCard.MAX_HEIGHT * card.recto.image.information.width) / card.recto.image.information.height,
+        );
+
         // when
         const screen = await render(
           <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="recto" /></template>,
         );
 
         // then
-        assert.dom(screen.getByRole('presentation')).hasAttribute('width', '300');
-        assert.dom(screen.getByRole('presentation')).hasAttribute('height', '400');
+        assert.dom(screen.getByRole('presentation')).hasAttribute('height', `${ModulixFlashcardsCard.MAX_HEIGHT}`);
+        assert.dom(screen.getByRole('presentation')).hasAttribute('width', `${expectedWidth}`);
       });
     });
   });
@@ -165,14 +169,18 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
           },
         };
 
+        const expectedWidth = Math.round(
+          (ModulixFlashcardsCard.MAX_HEIGHT * card.verso.image.information.width) / card.verso.image.information.height,
+        );
+
         // when
         const screen = await render(
           <template><ModulixFlashcardsCard @card={{card}} @displayedSideName="verso" /></template>,
         );
 
         // then
-        assert.dom(screen.getByRole('presentation')).hasAttribute('width', '300');
-        assert.dom(screen.getByRole('presentation')).hasAttribute('height', '400');
+        assert.dom(screen.getByRole('presentation')).hasAttribute('height', `${ModulixFlashcardsCard.MAX_HEIGHT}`);
+        assert.dom(screen.getByRole('presentation')).hasAttribute('width', `${expectedWidth}`);
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème
Même combat que pour la [PR](https://github.com/1024pix/pix/pull/13872) 

## 🌰 Proposition
utiliser l'utilitaire de redimensionnement d'image pour se prémunir du layout shift

## 🍁 Remarques
J'ai mis une MAX_HEIGHT, mais je ne suis pas sûr que ce soit la meilleure solution. A voir

## 🪵 Pour tester
- [ ] Faire un tour sur une flashcard dans [le bac a sable](https://app-pr13888.review.pix.fr/modules/bac-a-sable/details)
- [ ] Couper la connexion
- [ ] Vérifier qu'il y a la zone prévue pour l'image sur le recto (verso des flashcards 1, 2 et 3)
- [ ] Vérifier qu'il y a la zone prévue pour l'image sur le verso (recto de la 3eme flashcard)
