### PR TITLE
[TECH] Migration de la table Organizations pour que le nouveau champ soit obligatoire (PIX-19606)

### DIFF
--- a/api/db/migrations/20251014091818_add-not-nullable-constraint-on-administrationTeamId-in-organizations-table.js
+++ b/api/db/migrations/20251014091818_add-not-nullable-constraint-on-administrationTeamId-in-organizations-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'administrationTeamId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+export { down, up };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -17,11 +17,12 @@ import {
 } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Infrastructure | Repository | organization-for-admin', function () {
-  let clock, byDefaultFeatureId;
+  let clock, byDefaultFeatureId, administrationTeam;
   const now = new Date('2022-02-02');
 
   beforeEach(async function () {
     clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    administrationTeam = databaseBuilder.factory.buildAdministrationTeam({ name: 'ma team' });
     await databaseBuilder.commit();
   });
 
@@ -33,7 +34,6 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     context('when there are Organizations in the database', function () {
       it('should return an Array of Organizations with informations', async function () {
         // given
-        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam({ name: 'ma team' });
         const expectedOrganization = databaseBuilder.factory.buildOrganization({
           id: 123,
           name: 'mon orga',
@@ -672,7 +672,6 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
   describe('#get', function () {
     it('returns an organization for admin by provided id', async function () {
       // given
-      const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
       const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
       const parentOrganization = databaseBuilder.factory.buildOrganization({
         type: 'SCO',
@@ -789,7 +788,6 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       it('should return an organization with import feature with empty params', async function () {
         // given
         const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
-        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization of the dark side',
@@ -875,7 +873,6 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       it('should return if its enable and the additional params', async function () {
         // given
         const superAdminUser = databaseBuilder.factory.buildUser({ firstName: 'Cécile', lastName: 'Encieux' });
-        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
         const organization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
           name: 'Organization of the dark side',
@@ -1015,7 +1012,6 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         const superAdminUser = databaseBuilder.factory.buildUser();
         const archivist = databaseBuilder.factory.buildUser();
         const archivedAt = new Date('2022-02-02');
-        const administrationTeam = databaseBuilder.factory.buildAdministrationTeam();
 
         const insertedOrganization = databaseBuilder.factory.buildOrganization({
           type: 'SCO',
@@ -1097,6 +1093,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         name: 'Organization SCO',
         type: 'SCO',
         createdBy: superAdminUserId,
+        administrationTeamId: administrationTeam.id,
       });
 
       // when
@@ -1130,6 +1127,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           name: "École de l'avenir",
           type: 'SCO-1D',
           createdBy: superAdminUserId,
+          administrationTeamId: administrationTeam.id,
         });
 
         const savedOrganization = await repositories.organizationForAdminRepository.save({ organization });

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -249,6 +249,15 @@ export async function createOrganizationInDB({
   isManagingStudents: boolean;
 }) {
   const someDate = new Date();
+  const administrationTeamId = await knex('administration_teams')
+    .insert({
+      name: `Team for ${externalId}`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning('id')
+    .then((rows) => rows[0].id);
+
   const [{ id }] = await knex('organizations')
     .insert({
       type,
@@ -270,6 +279,7 @@ export async function createOrganizationInDB({
       archivedAt: null,
       identityProviderForCampaigns: null,
       parentOrganizationId: null,
+      administrationTeamId,
     })
     .returning('id');
   return id;

--- a/high-level-tests/e2e/cypress/fixtures/administration_teams.json
+++ b/high-level-tests/e2e/cypress/fixtures/administration_teams.json
@@ -1,0 +1,10 @@
+[
+  {
+  "id": 1,
+  "name": "Team Alpha"
+  },
+  {
+  "id": 2,
+  "name": "Team Rocket"
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -2,18 +2,21 @@
   {
     "id": 1,
     "type": "PRO",
-    "name": "Dragon & Co"
+    "name": "Dragon & Co",
+    "administrationTeamId": 1
   },
   {
     "id": 2,
     "type": "SCO",
     "name": "The Night Watch",
-    "isManagingStudents": true
+    "isManagingStudents": true,
+    "administrationTeamId": 2
   },
   {
     "id": 3,
     "type": "SUP",
     "name": "The Order of Maesters",
-    "isManagingStudents": true
+    "isManagingStudents": true,
+    "administrationTeamId": 1
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-1.test.js
@@ -7,6 +7,7 @@ describe("a11y", () => {
   beforeEach(() => {
     cy.task("db:fixture", "users");
     cy.task("db:fixture", "authentication-methods");
+    cy.task("db:fixture", "administration_teams");
     cy.task("db:fixture", "organizations");
     cy.task("db:fixture", "memberships");
     cy.task("db:fixture", "organization-invitations");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-authenticated-2.test.js
@@ -7,6 +7,7 @@ describe("a11y", () => {
   beforeEach(() => {
     cy.task("db:fixture", "users");
     cy.task("db:fixture", "authentication-methods");
+    cy.task("db:fixture", "administration_teams");
     cy.task("db:fixture", "organizations");
     cy.task("db:fixture", "memberships");
     cy.task("db:fixture", "organization-invitations");

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
@@ -1,44 +1,45 @@
-describe('a11y', () => {
+describe("a11y", () => {
   beforeEach(() => {
-    cy.task('db:fixture', 'users');
-    cy.task('db:fixture', 'authentication-methods');
-    cy.task('db:fixture', 'organizations');
-    cy.task('db:fixture', 'memberships');
-    cy.task('db:fixture', 'organization-invitations');
-    cy.task('db:fixture', 'user-orga-settings');
-    cy.task('db:fixture', 'target-profiles');
-    cy.task('db:fixture', 'target-profile_tubes');
-    cy.task('db:fixture', 'campaigns');
-    cy.task('db:fixture', 'campaign_skills');
-    cy.task('db:fixture', 'organization-learners');
-    cy.task('db:fixture', 'campaign-participations');
-    cy.task('db:fixture', 'assessments');
-    cy.task('db:fixture', 'answers');
-    cy.task('db:fixture', 'knowledge-elements');
-    cy.task('db:fixture', 'legal-document-versions');
-    cy.task('db:fixture', 'legal-document-version-user-acceptances');
+    cy.task("db:fixture", "users");
+    cy.task("db:fixture", "authentication-methods");
+    cy.task("db:fixture", "administration_teams");
+    cy.task("db:fixture", "organizations");
+    cy.task("db:fixture", "memberships");
+    cy.task("db:fixture", "organization-invitations");
+    cy.task("db:fixture", "user-orga-settings");
+    cy.task("db:fixture", "target-profiles");
+    cy.task("db:fixture", "target-profile_tubes");
+    cy.task("db:fixture", "campaigns");
+    cy.task("db:fixture", "campaign_skills");
+    cy.task("db:fixture", "organization-learners");
+    cy.task("db:fixture", "campaign-participations");
+    cy.task("db:fixture", "assessments");
+    cy.task("db:fixture", "answers");
+    cy.task("db:fixture", "knowledge-elements");
+    cy.task("db:fixture", "legal-document-versions");
+    cy.task("db:fixture", "legal-document-version-user-acceptances");
   });
 
-  describe('Not authenticated pages', () => {
+  describe("Not authenticated pages", () => {
     const notAuthenticatedPages = [
-      { url: '/campagnes' },
-      { url: '/campagnes/WALL/presentation' },
-      { url: '/changer-de-mot-passe' },
-      { url: '/connexion' },
-      { url: '/inscription' },
-      { url: '/mot-de-passe-oublie' },
-      { url: '/nonconnecte' },
-      { url: '/recuperer-mon-compte', skipFailures: true },
-      { url: '/verification-certificat' },
-      { url: '/modules/bac-a-sable/details' },
-      { url: '/modules/bac-a-sable/passage' },
+      { url: "/campagnes" },
+      { url: "/campagnes/WALL/presentation" },
+      { url: "/changer-de-mot-passe" },
+      { url: "/connexion" },
+      { url: "/inscription" },
+      { url: "/mot-de-passe-oublie" },
+      { url: "/nonconnecte" },
+      { url: "/recuperer-mon-compte", skipFailures: true },
+      { url: "/verification-certificat" },
+      { url: "/modules/bac-a-sable/details" },
+      { url: "/modules/bac-a-sable/passage" },
     ];
 
     notAuthenticatedPages.forEach(({ url, skipFailures = false }) => {
       it(`${url} should be accessible`, () => {
         // when
         cy.visitMonPix(url);
-        cy.get('.app-loader').should('not.exist');
+        cy.get(".app-loader").should("not.exist");
         cy.injectAxe();
 
         // then

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -7,6 +7,7 @@ const {
 Given("les données de test sont chargées", () => {
   cy.task("db:fixture", "users");
   cy.task("db:fixture", "authentication-methods");
+  cy.task("db:fixture", "administration_teams");
   cy.task("db:fixture", "organizations");
   cy.task("db:fixture", "memberships");
   cy.task("db:fixture", "organization-invitations");


### PR DESCRIPTION
## 🍂 Problème

Toutes les organisations ont désormais une équipe en charge rattachée. La colonne `administrationTeamId` peut maintenant être `notNullable`

## 🌰 Proposition

Ajouter une migration avec une contrainte "notNullable" sur la table `organizations`


## 🪵 Pour tester

- Non regression création et modification d'organisations dans pix-admin
- Les tests passent au vert