### PR TITLE
[FEATURE] Bloquer l'accès au portail surveillant pour les centres SCO pendant leur fermeture annuelle (PIX-19390)

### DIFF
--- a/api/src/certification/session-management/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/src/certification/session-management/domain/read-models/AllowedCertificationCenterAccess.js
@@ -1,4 +1,29 @@
 /**
  * @class AllowedCertificationCenterAccess
  */
-export class AllowedCertificationCenterAccess {}
+export class AllowedCertificationCenterAccess {
+  /**
+   * @param {Object} params
+   * @param {boolean} params.isAccessBlockedCollege
+   * @param {boolean} params.isAccessBlockedLycee
+   * @param {boolean} params.isAccessBlockedAEFE
+   * @param {boolean} params.isAccessBlockedAgri
+   * @param {string|null} params.pixCertifScoBlockedAccessDateCollege
+   * @param {string|null} params.pixCertifScoBlockedAccessDateLycee
+   */
+  constructor({
+    isAccessBlockedCollege = false,
+    isAccessBlockedLycee = false,
+    isAccessBlockedAEFE = false,
+    isAccessBlockedAgri = false,
+    pixCertifScoBlockedAccessDateCollege = null,
+    pixCertifScoBlockedAccessDateLycee = null,
+  } = {}) {
+    this.isAccessBlockedCollege = isAccessBlockedCollege;
+    this.isAccessBlockedLycee = isAccessBlockedLycee;
+    this.isAccessBlockedAEFE = isAccessBlockedAEFE;
+    this.isAccessBlockedAgri = isAccessBlockedAgri;
+    this.pixCertifScoBlockedAccessDateCollege = pixCertifScoBlockedAccessDateCollege;
+    this.pixCertifScoBlockedAccessDateLycee = pixCertifScoBlockedAccessDateLycee;
+  }
+}

--- a/api/src/identity-access-management/application/api/certification-center-access-api.js
+++ b/api/src/identity-access-management/application/api/certification-center-access-api.js
@@ -17,9 +17,17 @@ export const getCertificationCenterAccess = async ({
   certificationCenterId,
   dependencies = { certificationPointOfContactRepository },
 }) => {
-  await dependencies.certificationPointOfContactRepository.getCertificationCenterAccess({
-    certificationCenterId,
-  });
+  const allowedCertificationCenterAccess =
+    await dependencies.certificationPointOfContactRepository.getCertificationCenterAccess({
+      certificationCenterId,
+    });
 
-  return new AllowedCertificationCenterAccessDTO({});
+  return new AllowedCertificationCenterAccessDTO({
+    isAccessBlockedCollege: allowedCertificationCenterAccess.isAccessBlockedCollege(),
+    isAccessBlockedLycee: allowedCertificationCenterAccess.isAccessBlockedLycee(),
+    isAccessBlockedAEFE: allowedCertificationCenterAccess.isAccessBlockedAEFE(),
+    isAccessBlockedAgri: allowedCertificationCenterAccess.isAccessBlockedAgri(),
+    pixCertifScoBlockedAccessDateCollege: allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateCollege,
+    pixCertifScoBlockedAccessDateLycee: allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateLycee,
+  });
 };

--- a/api/src/identity-access-management/application/api/models/AllowedCertificationCenterAccessDTO.js
+++ b/api/src/identity-access-management/application/api/models/AllowedCertificationCenterAccessDTO.js
@@ -3,9 +3,27 @@
  */
 export class AllowedCertificationCenterAccessDTO {
   /**
-   * @param {Object} params - DTO properties
+   * @param {Object} params
+   * @param {boolean} params.isAccessBlockedCollege
+   * @param {boolean} params.isAccessBlockedLycee
+   * @param {boolean} params.isAccessBlockedAEFE
+   * @param {boolean} params.isAccessBlockedAgri
+   * @param {string|null} params.pixCertifScoBlockedAccessDateCollege
+   * @param {string|null} params.pixCertifScoBlockedAccessDateLycee
    */
-  constructor(params = {}) {
-    Object.assign(this, params);
+  constructor({
+    isAccessBlockedCollege = false,
+    isAccessBlockedLycee = false,
+    isAccessBlockedAEFE = false,
+    isAccessBlockedAgri = false,
+    pixCertifScoBlockedAccessDateCollege = null,
+    pixCertifScoBlockedAccessDateLycee = null,
+  } = {}) {
+    this.isAccessBlockedCollege = !!isAccessBlockedCollege;
+    this.isAccessBlockedLycee = !!isAccessBlockedLycee;
+    this.isAccessBlockedAEFE = !!isAccessBlockedAEFE;
+    this.isAccessBlockedAgri = !!isAccessBlockedAgri;
+    this.pixCertifScoBlockedAccessDateCollege = pixCertifScoBlockedAccessDateCollege;
+    this.pixCertifScoBlockedAccessDateLycee = pixCertifScoBlockedAccessDateLycee;
   }
 }

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/certification-center-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/certification-center-access-repository_test.js
@@ -13,7 +13,14 @@ describe('Session Management | Integration | Infrastructure | Repository | certi
           certificationCenterId: certificationCenter.id,
         });
 
-      expect(certificationCenterAccess).to.deep.equal({});
+      expect(certificationCenterAccess).to.deep.equal({
+        isAccessBlockedCollege: false,
+        isAccessBlockedLycee: false,
+        isAccessBlockedAEFE: false,
+        isAccessBlockedAgri: false,
+        pixCertifScoBlockedAccessDateCollege: null,
+        pixCertifScoBlockedAccessDateLycee: null,
+      });
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -203,6 +203,7 @@ import { buildAssessmentResult as buildCertificationScoringAssessmentResult } fr
 import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
 import { buildCertificationChallengeCapacity } from './certification/scoring/build-certification-challenge-capacity.js';
 import { buildChallengeCalibration } from './certification/scoring/build-challenge-calibration.js';
+import { buildAllowedCertificationCenterAccess as buildSessionManagementAllowedCertificationCenterAccess } from './certification/session-management/build-allowed-certification-center-access.js';
 import { buildCertificationCandidate as buildSessionManagementCandidate } from './certification/session-management/build-certification-candidate.js';
 import { buildCertificationDetails } from './certification/session-management/build-certification-details.js';
 import { buildCertificationSessionComplementaryCertification } from './certification/session-management/build-certification-session-complementary-certification.js';
@@ -278,6 +279,7 @@ const certification = {
     buildPixPlusCertificationCourse,
   },
   sessionManagement: {
+    buildAllowedCertificationCenterAccess: buildSessionManagementAllowedCertificationCenterAccess,
     buildCertificationSessionComplementaryCertification,
     buildSession: buildSessionManagement,
     buildCertificationCandidate: buildSessionManagementCandidate,

--- a/certif/app/components/login-session-supervisor/form.gjs
+++ b/certif/app/components/login-session-supervisor/form.gjs
@@ -41,9 +41,15 @@ export default class LoginSessionSupervisor extends Component {
         supervisorPassword: this.supervisorPasswordValue,
       });
     } catch ({ errors }) {
-      switch (errors[0].code) {
+      const error = errors[0];
+      switch (error.code) {
         case 'CERTIFICATION_CENTER_IS_ARCHIVED':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.certification-center-archived');
+          break;
+        case 'SESSION_NOT_ACCESSIBLE':
+          this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-accessible', {
+            date: error.meta?.blockedAccessDate,
+          });
           break;
         default:
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.incorrect-data');

--- a/certif/tests/integration/components/login-session-supervisor/form-test.gjs
+++ b/certif/tests/integration/components/login-session-supervisor/form-test.gjs
@@ -91,6 +91,41 @@ module('Integration | Component | Login session supervisor | Form', function (ho
       });
     });
 
+    module('when the session is not accessible', function () {
+      test('it should display an error with the blocked access date', async function (assert) {
+        // given
+        const blockedAccessDate = '2025-09-01';
+        const authenticateSupervisor = sinon
+          .stub()
+          .rejects({ errors: [{ code: 'SESSION_NOT_ACCESSIBLE', meta: { blockedAccessDate } }] });
+
+        // when
+        const screen = await render(
+          <template><LoginSessionSupervisorForm @authenticateSupervisor={{authenticateSupervisor}} /></template>,
+        );
+
+        await fillIn(
+          screen.getByLabelText(t('pages.session-supervising.login.form.session-number'), { exact: false }),
+          222,
+        );
+        await fillIn(
+          screen.getByLabelText(t('pages.session-supervising.login.form.session-password.label'), { exact: false }),
+          222,
+        );
+        await click(screen.getByRole('button', { name: t('pages.session-supervising.login.form.actions.invigilate') }));
+
+        // then
+        assert.ok(authenticateSupervisor.called);
+        assert
+          .dom(
+            within(screen.getByRole('alert')).getByText(
+              t('pages.session-supervising.login.form.errors.session-not-accessible', { date: blockedAccessDate }),
+            ),
+          )
+          .exists();
+      });
+    });
+
     module('on success', function () {
       test('it should not display an error', async function (assert) {
         // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -568,7 +568,8 @@
           "errors": {
             "certification-center-archived": "“You cannot access the certification centre because it is disabled.”",
             "incorrect-data": "The session number and/or the session password entered are incorrect.",
-            "mandatory-fields": "The fields “Session number” and “Session password” are required."
+            "mandatory-fields": "The fields “Session number” and “Session password” are required.",
+            "session-not-accessible": "Opening of your PixCertif space on {date} (00:00, Metropolitan France time)."
           },
           "session-number": "Session number",
           "session-password": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -568,7 +568,8 @@
           "errors": {
             "certification-center-archived": "“Vous ne pouvez pas accéder au centre de certification car ce dernier est désactivé.”",
             "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects.",
-            "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires."
+            "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires.",
+            "session-not-accessible": "Ouverture de votre espace PixCertif le {date} (00h00, heure France métropolitaine)."
           },
           "session-number": "Numéro de la session",
           "session-password": {


### PR DESCRIPTION
🍂 Problème
-----------
Les centres SCO doivent être bloqués pendant leur fermeture annuelle basée sur le calendrier ministériel (College, Lycée, AEFE, Agri). Actuellement, un surveillant peut accéder directement au portail en utilisant un lien favori.

🌰 Proposition
--------------
Ajout d'une vérification côté backend dans le use case `supervise-session` qui :
- Vérifie le type de centre (SCO) et ses tags (COLLEGE, LYCEE, AEFE, AGRICULTURE)
- Compare la date actuelle avec les dates de blocage configurées
- Lance une erreur `SessionNotAccessible` avec la date de déblocage si l'accès est bloqué

Affichage d'un message d'erreur côté frontend similaire à celui de Pix Certif.

🍁 Remarques
------------
Cette PR est bloquée par https://github.com/1024pix/pix/pull/13850 -> désormais mergée

🪵 Pour tester
--------------
1. Modifier les variables d'environnement` :  :
   ```
   PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE=2030-12-31
   PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE=2030-12-31
   ```
3. Identifier une session d'un centre SCO et récupérer le code surveillant 
4. Accéder à `https://certif-pr13891.review.pix.fr/connexion-espace-surveillant`
5. Tenter de se connecter avec le numéro de session et mot de passe
6. Vérifier le message d'erreur : "Ouverture de votre espace surveillant le 2030-12-31 (00h00, heure France métropolitaine)."