### PR TITLE
[BUGFIX] Corriger une clé de traduction erronée (PIX-20018).

### DIFF
--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -588,7 +588,7 @@
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
-        "legal-with-autoshare": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -588,7 +588,7 @@
           "title": "Medir tus competencias digitales con retos lúdicos y de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
         },
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
-        "legal-with-autoshare": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
+        "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
         "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
       },


### PR DESCRIPTION
## 🍂 Problème
Sur Pix App en espagnol, on constate sur la page d'accès à une campagne une traduction en anglais et non en espagnol. Le problème vient d'une clé de traduction erronée. 

## 🌰 Proposition
Corriger la clé de traduction

## 🪵 Pour tester
- Lancer app.pix.org et choisir la langue espagnol (?locale=es ou ?locale=es-419)
- Lancer une campagne avec le code EVAL12345
- Vérifier que la chaine "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador." apparait bien
