### PR TITLE
[FEATURE] Intégrer le formulaire de connexion dans le nouveau layout (PIX-19801)

### DIFF
--- a/mon-pix/app/components/authentication/login-form.gjs
+++ b/mon-pix/app/components/authentication/login-form.gjs
@@ -98,7 +98,7 @@ export default class LoginForm extends Component {
   <template>
     <form {{on "submit" this.signin}} class="authentication-login-form">
       {{#if this.globalError}}
-        <PixNotificationAlert @type="error" @withIcon={{true}} role="alert">
+        <PixNotificationAlert @type="error" role="alert">
           {{this.globalError}}
         </PixNotificationAlert>
       {{/if}}

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -94,6 +94,12 @@ class NewLoginForm extends Component {
     }
   }
 
+  get pixAppForgottenPasswordUrlWithEmail() {
+    const url = new URL(this.url.pixAppForgottenPasswordUrl);
+    if (this.login) url.searchParams.set('email', this.login);
+    return url.toString();
+  }
+
   @action
   updatePassword(event) {
     this.password = event.target.value?.trim();
@@ -222,7 +228,7 @@ class NewLoginForm extends Component {
         </PixInputPassword>
         <a
           class="link link--grey link--underlined pix-body-s"
-          href="{{this.url.pixAppForgottenPasswordUrl}}"
+          href="{{this.pixAppForgottenPasswordUrlWithEmail}}"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -203,7 +203,6 @@ class NewLoginForm extends Component {
         name="login"
         {{on "input" this.updateLogin}}
         @value={{this.login}}
-        type="email"
         placeholder={{t "pages.login-form.email.placeholder"}}
         @validationStatus={{this.validation.login.status}}
         @errorMessage={{t this.validation.login.error}}

--- a/orga/app/components/auth/login-form.gjs
+++ b/orga/app/components/auth/login-form.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -9,10 +10,248 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import ENV from 'pix-orga/config/environment';
+import { FormValidation } from 'pix-orga/utils/form-validation';
 
 import isEmailValid from '../../utils/email-validator';
 
-export default class LoginForm extends Component {
+const VALIDATION_ERRORS = {
+  login: 'pages.login-form.errors.empty-email',
+  password: 'pages.login-form.errors.empty-password',
+};
+
+class NewLoginForm extends Component {
+  @service currentDomain;
+  @service url;
+  @service intl;
+  @service locale;
+  @service session;
+  @service store;
+
+  @tracked globalError = null;
+  @tracked isLoading = false;
+  @tracked password = '';
+  @tracked login = '';
+
+  validation = new FormValidation({
+    login: {
+      validate: (value) => Boolean(value),
+      error: VALIDATION_ERRORS.login,
+    },
+    password: {
+      validate: (value) => Boolean(value),
+      error: VALIDATION_ERRORS.password,
+    },
+  });
+
+  get displayRecoveryLink() {
+    if (!this.currentDomain.isFranceDomain) return false;
+    return !this.args.isWithInvitation;
+  }
+
+  @action
+  async authenticate(event) {
+    if (event) event.preventDefault();
+
+    try {
+      this.globalError = null;
+      this.isLoading = true;
+
+      const formValues = { login: this.login, password: this.password };
+      const isValid = this.validation.validateAll(formValues);
+      if (!isValid) return;
+
+      const login = this.login.trim();
+
+      if (this.args.isWithInvitation) {
+        try {
+          await this._acceptOrganizationInvitation(
+            this.args.organizationInvitationId,
+            this.args.organizationInvitationCode,
+            login,
+          );
+        } catch (err) {
+          const error = err.errors[0];
+          const isInvitationAlreadyAcceptedByAnotherUser = error.status === '409';
+          if (isInvitationAlreadyAcceptedByAnotherUser) {
+            this.globalError = this.intl.t('pages.login-form.errors.status.409');
+            this.isLoading = false;
+            return;
+          }
+          const isUserAlreadyOrganizationMember = error.status === '412';
+          if (!isUserAlreadyOrganizationMember) {
+            this.globalError = this.intl.t(this._getI18nKeyByStatus(+error.status));
+            this.isLoading = false;
+            return;
+          }
+        }
+      }
+
+      await this.session.authenticate('authenticator:oauth2', login, this.password);
+    } catch (responseError) {
+      this._handleApiError(responseError);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  @action
+  updatePassword(event) {
+    this.password = event.target.value?.trim();
+    this.validation.password.validate(this.password);
+  }
+
+  @action
+  updateLogin(event) {
+    this.login = event.target.value?.trim();
+    this.validation.login.validate(this.login);
+  }
+
+  async _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, email) {
+    const type = 'organization-invitation-response';
+    const id = `${organizationInvitationId}_${organizationInvitationCode}`;
+    const organizationInvitationRecord = this.store.peekRecord(type, id);
+
+    if (!organizationInvitationRecord) {
+      let record;
+      try {
+        record = this.store.createRecord(type, { id, code: organizationInvitationCode, email });
+        await record.save({ adapterOptions: { organizationInvitationId } });
+      } catch (error) {
+        record.deleteRecord();
+        throw error;
+      }
+    }
+  }
+
+  _handleApiError(responseError) {
+    const errors = responseError?.responseJSON?.errors;
+    const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+    switch (error?.code) {
+      case 'SHOULD_CHANGE_PASSWORD':
+        this.globalError = this.intl.t(ENV.APP.API_ERROR_MESSAGES.SHOULD_CHANGE_PASSWORD.I18N_KEY, {
+          url: this.url.pixAppForgottenPasswordUrl,
+          htmlSafe: true,
+        });
+        break;
+      case 'USER_IS_TEMPORARY_BLOCKED':
+        this.globalError = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
+          url: this.url.pixAppForgottenPasswordUrl,
+          htmlSafe: true,
+        });
+        break;
+      case 'USER_IS_BLOCKED':
+        this.globalError = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.I18N_KEY, {
+          url: 'https://support.pix.org/support/tickets/new',
+          htmlSafe: true,
+        });
+        break;
+      default:
+        this.globalError = this.intl.t(this._getI18nKeyByStatus(responseError.status));
+    }
+  }
+
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case 400:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 401:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY;
+      // TODO: This case should be handled with a specific error code like USER_IS_TEMPORARY_BLOCKED or USER_IS_BLOCKED
+      case 403:
+        return ENV.APP.API_ERROR_MESSAGES.NOT_LINKED_ORGANIZATION.I18N_KEY;
+      case 422:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 504:
+        return ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
+    }
+  }
+
+  <template>
+    <form class="authentication-login-form" {{on "submit" this.authenticate}}>
+      {{#if @hasInvitationAlreadyBeenAccepted}}
+        <PixNotificationAlert @type="error" role="alert">
+          {{t "pages.login-form.invitation-already-accepted"}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      {{#if @isInvitationCancelled}}
+        <PixNotificationAlert @type="error" role="alert">
+          {{t "pages.login-form.invitation-was-cancelled"}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      {{#if this.globalError}}
+        <PixNotificationAlert @type="error" role="alert">
+          {{this.globalError}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      <p class="authentication-login-form__mandatory-fields-message">
+        {{t "common.form.mandatory-all-fields"}}
+      </p>
+
+      <PixInput
+        @id="login-email"
+        name="login"
+        {{on "input" this.updateLogin}}
+        @value={{this.login}}
+        type="email"
+        placeholder={{t "pages.login-form.email.placeholder"}}
+        @validationStatus={{this.validation.login.status}}
+        @errorMessage={{t this.validation.login.error}}
+        autocomplete="email"
+        aria-required="true"
+      >
+        <:label>{{t "pages.login-form.email.label"}}</:label>
+      </PixInput>
+
+      <div class="authentication-login-form__password">
+        <PixInputPassword
+          @id="login-password"
+          name="password"
+          {{on "input" this.updatePassword}}
+          @value={{this.password}}
+          @validationStatus={{this.validation.password.status}}
+          @errorMessage={{t this.validation.password.error}}
+          autocomplete="current-password"
+          aria-required={{true}}
+        >
+          <:label>{{t "pages.login-form.password"}}</:label>
+        </PixInputPassword>
+        <a
+          class="link link--grey link--underlined pix-body-s"
+          href="{{this.url.pixAppForgottenPasswordUrl}}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{t "pages.login-form.forgot-password"}}
+        </a>
+      </div>
+
+      <PixButton @type="submit" @isLoading={{this.isLoading}}>
+        {{t "pages.login-form.login"}}
+      </PixButton>
+
+      {{#if this.displayRecoveryLink}}
+        <div class="authentication-login-form__recover-access">
+          <p class="authentication-login-form__recover-access__question">
+            {{t "pages.login-form.admin-role-question"}}
+          </p>
+          <LinkTo class="link link--black link--underlined" @route="join-request">
+            {{t "pages.login-form.active-or-retrieve"}}
+          </LinkTo>
+          <div class="authentication-login-form__recover-access__message">
+            ({{t "pages.login-form.only-for-admin"}})
+          </div>
+        </div>
+      {{/if}}
+    </form>
+  </template>
+}
+
+class LegacyLoginForm extends Component {
   @service currentDomain;
   @service url;
   @service intl;
@@ -180,28 +419,28 @@ export default class LoginForm extends Component {
   }
 
   <template>
-    <div class="login-form">
+    <div class="login-form-legacy-design">
 
       {{#unless @isWithInvitation}}
-        <p class="login-form__information">{{t "pages.login-form.is-only-accessible"}}</p>
+        <p class="login-form-legacy-design__information">{{t "pages.login-form.is-only-accessible"}}</p>
       {{/unless}}
 
       {{#if @hasInvitationAlreadyBeenAccepted}}
-        <p class="login-form__invitation-error">{{t "pages.login-form.invitation-already-accepted"}}</p>
+        <p class="login-form-legacy-design__invitation-error">{{t "pages.login-form.invitation-already-accepted"}}</p>
       {{/if}}
 
       {{#if @isInvitationCancelled}}
-        <p class="login-form__invitation-error">{{t "pages.login-form.invitation-was-cancelled"}}</p>
+        <p class="login-form-legacy-design__invitation-error">{{t "pages.login-form.invitation-was-cancelled"}}</p>
       {{/if}}
 
       {{#if this.errorMessage}}
-        <p id="login-form-error-message" class="login-form__error-message" role="alert">
+        <p id="login-form-error-message" class="login-form-legacy-design__error-message" role="alert">
           {{this.errorMessage}}
         </p>
       {{/if}}
 
-      <form class="login-form__input-container" {{on "submit" this.authenticate}}>
-        <p class="login-form__mandatory-information">{{t "common.form.mandatory-all-fields"}}</p>
+      <form class="login-form-legacy-design__input-container" {{on "submit" this.authenticate}}>
+        <p class="login-form-legacy-design__mandatory-information">{{t "common.form.mandatory-all-fields"}}</p>
 
         <PixInput
           @id="login-email"
@@ -215,7 +454,7 @@ export default class LoginForm extends Component {
           aria-required="true"
           autocomplete="email"
         >
-          <:label>{{t "pages.login-form.email"}}</:label>
+          <:label>{{t "pages.login-form.email.label"}}</:label>
         </PixInput>
 
         <PixInputPassword
@@ -236,7 +475,7 @@ export default class LoginForm extends Component {
           {{t "pages.login-form.login"}}
         </PixButton>
 
-        <div class="login-form__forgotten-password">
+        <div class="login-form-legacy-design__forgotten-password">
           <a href="{{this.url.pixAppForgottenPasswordUrl}}" target="_blank" rel="noopener noreferrer">
             {{t "pages.login-form.forgot-password"}}
           </a>
@@ -244,14 +483,46 @@ export default class LoginForm extends Component {
 
         {{#if this.displayRecoveryLink}}
           <div>
-            <div class="login-form__recover-access-link help-text">
-              <LinkTo @route="join-request" class="link">{{t "pages.login-form.active-or-retrieve"}}</LinkTo>
+            <div class="login-form-legacy-design__recover-access-link help-text">
+              <LinkTo @route="join-request" class="link">
+                {{t "pages.login-form.admin-role-question"}}
+                {{t "pages.login-form.active-or-retrieve"}}</LinkTo>
             </div>
-            <div class="login-form__recover-access-message help-text">({{t "pages.login-form.only-for-admin"}})</div>
+            <div class="login-form-legacy-design__recover-access-message help-text">({{t
+                "pages.login-form.only-for-admin"
+              }})</div>
           </div>
         {{/if}}
 
       </form>
     </div>
+  </template>
+}
+
+export default class LoginForm extends Component {
+  @service featureToggles;
+
+  get isNewAuthDesignEnabled() {
+    return this.featureToggles.featureToggles.usePixOrgaNewAuthDesign;
+  }
+
+  <template>
+    {{#if this.isNewAuthDesignEnabled}}
+      <NewLoginForm
+        @isWithInvitation={{@isWithInvitation}}
+        @organizationInvitationId={{@organizationInvitationId}}
+        @organizationInvitationCode={{@organizationInvitationCode}}
+        @hasInvitationAlreadyBeenAccepted={{@hasInvitationAlreadyBeenAccepted}}
+        @isInvitationCancelled={{@isInvitationCancelled}}
+      />
+    {{else}}
+      <LegacyLoginForm
+        @isWithInvitation={{@isWithInvitation}}
+        @organizationInvitationId={{@organizationInvitationId}}
+        @organizationInvitationCode={{@organizationInvitationCode}}
+        @hasInvitationAlreadyBeenAccepted={{@hasInvitationAlreadyBeenAccepted}}
+        @isInvitationCancelled={{@isInvitationCancelled}}
+      />
+    {{/if}}
   </template>
 }

--- a/orga/app/components/authentication-layout/footer.gjs
+++ b/orga/app/components/authentication-layout/footer.gjs
@@ -12,7 +12,7 @@ export default class Footer extends Component {
       {{#if this.currentDomain.isInternationalDomain}}
         <LocaleSwitcher />
       {{/if}}
-      <FooterLinks />
+      <FooterLinks @size="extra-small" />
     </footer>
   </template>
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -60,6 +60,7 @@
 // pages
 
 @use 'pages/login' as *;
+@use 'pages/sign-form' as *;
 @use 'pages/join' as *;
 @use 'pages/join-request' as *;
 @use 'pages/authenticated' as *;

--- a/orga/app/styles/components/authentication-layout/index.scss
+++ b/orga/app/styles/components/authentication-layout/index.scss
@@ -13,6 +13,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    padding: var(--pix-spacing-4x);
   }
 }
 
@@ -66,13 +67,13 @@
   justify-content: space-between;
 
   .authentication-layout-header__pix-logo {
-    width: 9rem;
+    height: 3.75rem;
   }
 }
 
 .authentication-layout-footer {
   width: 100%;
-  margin-top: auto;
+  margin-top: var(--pix-spacing-12x);
 
   .locale-switcher {
     margin-bottom: var(--pix-spacing-4x);

--- a/orga/app/styles/components/footer-links.scss
+++ b/orga/app/styles/components/footer-links.scss
@@ -8,10 +8,6 @@
 
   &--extra-small {
     @extend %pix-body-xs;
-
-    a {
-      text-decoration: underline;
-    }
   }
 
   li {
@@ -21,6 +17,9 @@
   }
 
   a {
+    color: var(--pix-neutral-800);
+    text-decoration: underline;
+
     &:hover,
     &:focus {
       color: var(--pix-primary-500);

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -1,6 +1,6 @@
 @use 'pix-design-tokens/typography';
 
-.login-form {
+.login-form-legacy-design {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -70,6 +70,53 @@
 
     button[type="submit"] {
       width: 100%;
+    }
+  }
+}
+
+.authentication-login-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+
+  input {
+    width: 100%;
+    padding: var(--pix-spacing-3x);
+  }
+
+  a {
+    text-decoration: underline;
+  }
+
+  &__mandatory-fields-message {
+    @extend %pix-body-xs;
+
+    color: var(--pix-neutral-500);
+  }
+
+  &__password {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    align-items: end;
+
+    .pix-input-password {
+      width: 100%;
+    }
+  }
+
+  &__recover-access {
+    @extend %pix-body-s;
+
+    padding-top: var(--pix-spacing-8x);
+    text-align: left;
+
+    &__question {
+      font-weight: var(--pix-font-bold);
+    }
+
+    &__message {
+      color: var(--pix-neutral-500);
     }
   }
 }

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -86,6 +86,14 @@
     text-decoration: underline;
   }
 
+  &--black {
+    color: var(--pix-neutral-900);
+  }
+
+  &--grey {
+    color: var(--pix-neutral-500);
+  }
+
   &--white {
     color: var(--pix-neutral-0);
 

--- a/orga/app/styles/pages/sign-form.scss
+++ b/orga/app/styles/pages/sign-form.scss
@@ -1,0 +1,6 @@
+.signin-page-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+  padding-top: var(--pix-spacing-6x);
+}

--- a/orga/app/templates/login.gjs
+++ b/orga/app/templates/login.gjs
@@ -9,22 +9,24 @@ import PageTitle from 'pix-orga/components/ui/page-title';
 <template>
   {{pageTitle (t "pages.login.title")}}
   {{#if @controller.isNewAuthDesignEnabled}}
+    <AuthenticationLayout class="signin-page-layout">
+      <:header>
+      </:header>
 
-    <main class="authentication">
-      <AuthenticationLayout>
-        <:header>
-        </:header>
-
-        <:content>
+      <:content>
+        <div>
           <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>
-          <LoginForm
-            @isWithInvitation={{false}}
-            @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
-            @isInvitationCancelled={{@controller.isInvitationCancelled}}
-          />
-        </:content>
-      </AuthenticationLayout>
-    </main>
+          <h3 class="pix-body-l">{{t "pages.login.with-pix-account"}}</h3>
+        </div>
+
+        <LoginForm
+          @isWithInvitation={{false}}
+          @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
+          @isInvitationCancelled={{@controller.isInvitationCancelled}}
+        />
+      </:content>
+    </AuthenticationLayout>
+
   {{else}}
     <main class="login-page">
       <div>

--- a/orga/app/utils/form-validation.js
+++ b/orga/app/utils/form-validation.js
@@ -1,0 +1,103 @@
+import { tracked } from '@glimmer/tracking';
+import camelCase from 'lodash/camelCase.js';
+
+const COMMON_API_ERROR = 'common.error';
+
+/**
+ * Manages form validation with configurable validation rules for each form field.
+ */
+export class FormValidation {
+  /**
+   * @param {Record<string, Object>} validations - A map of form field names to validation options.
+   * @example new FormValidation({ email: { validate: (value) => isValidEmail(value), error: 'Bad email' } })
+   */
+  constructor(validations = {}) {
+    this.validations = validations;
+
+    Object.entries(validations).forEach(([name, options]) => {
+      this[name] = new Validation(options);
+    });
+  }
+
+  /**
+   * Validates all fields in the form based on the configured validation rules.
+   * @param {Record<string, any>} - The current values of form fields to validate.
+   * @returns {boolean} - Returns true if all fields pass validation.
+   */
+  validateAll(values = {}) {
+    const validatedFields = Object.keys(this.validations).map((name) => this[name]?.validate(values[name]));
+    return validatedFields.every((isValid) => isValid === true);
+  }
+
+  /**
+   * Updates validation status for fields based on API error responses.
+   * @param {Array<{attribute: string, message: string}>} errors - List of errors from API response.
+   */
+  setErrorsFromApi(errors) {
+    if (!errors || errors?.length === 0) return;
+
+    errors.forEach(({ attribute, message }) => {
+      const name = camelCase(attribute);
+      if (!this[name]) return;
+
+      this[name].status = 'error';
+
+      const { apiErrors } = this[name].options;
+      if (apiErrors && apiErrors[message]) {
+        this[name].apiError = apiErrors[message];
+      } else {
+        this[name].apiError = COMMON_API_ERROR;
+      }
+    });
+  }
+}
+
+/**
+ * Represents validation status and rules for a single form field.
+ */
+class Validation {
+  @tracked status = 'default';
+  @tracked apiError = null;
+
+  /**
+   * @param {Object} options - Validation options for the field.
+   * @param {Function} options.validate - Function to validate the field's value.
+   * @param {string} options.error - Error message if validation fails.
+   */
+  constructor(options) {
+    this.options = options;
+  }
+
+  /**
+   * Checks if the field's current status is valid.
+   * @returns {boolean} - True if the field is valid.
+   */
+  get isValid() {
+    return this.status !== 'error';
+  }
+
+  /**
+   * Retrieves the error message if the field is invalid.
+   * @returns {string|null} - The error message or null if the field is valid.
+   */
+  get error() {
+    if (this.isValid) return null;
+    if (this.apiError) return this.apiError;
+    return this.options.error;
+  }
+
+  /**
+   * Validates the field's value based on the provided validate function in options.
+   * @param {any} value - The field value to validate.
+   * @returns {boolean} - True if the field is valid after validation.
+   */
+  validate(value) {
+    if (!this.options.validate) return;
+
+    const isValidInput = this.options.validate(value);
+    this.status = isValidInput ? 'success' : 'error';
+    this.apiError = null;
+
+    return this.isValid;
+  }
+}

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -108,8 +108,8 @@ module('Acceptance | join', function (hooks) {
         // then
         assert.strictEqual(currentURL(), '/connexion');
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
-        assert.ok('.login-form__invitation-error');
-        assert.dom('.login-form__invitation-error').hasText(expectedErrorMessage);
+        assert.ok('.login-form-legacy-design__invitation-error');
+        assert.dom('.login-form-legacy-design__invitation-error').hasText(expectedErrorMessage);
       });
     });
     module('when organization-invitation has been cancelled', function () {
@@ -141,7 +141,7 @@ module('Acceptance | join', function (hooks) {
     let loginButton;
 
     hooks.beforeEach(function () {
-      emailInputLabel = t('pages.login-form.email');
+      emailInputLabel = t('pages.login-form.email.label');
       passwordInputLabel = t('pages.login-form.password');
       loginButton = t('pages.login-form.login');
     });

--- a/orga/tests/acceptance/login-test.js
+++ b/orga/tests/acceptance/login-test.js
@@ -79,7 +79,7 @@ module('Acceptance | Login', function (hooks) {
       const screen = await visit('/connexion');
 
       // when
-      await fillByLabel(t('pages.login-form.email'), user.email);
+      await fillByLabel(t('pages.login-form.email.label'), user.email);
       await fillByLabel(t('pages.login-form.password'), 'secret');
       await clickByName(t('pages.login-form.login'));
 
@@ -152,7 +152,7 @@ module('Acceptance | Login', function (hooks) {
       const screen = await visit('/connexion');
 
       // when
-      await fillByLabel(t('pages.login-form.email'), user.email);
+      await fillByLabel(t('pages.login-form.email.label'), user.email);
       await fillByLabel(t('pages.login-form.password'), 'secret');
       await clickByName(t('pages.login-form.login'));
 

--- a/orga/tests/integration/components/auth/login-form-test.js
+++ b/orga/tests/integration/components/auth/login-form-test.js
@@ -17,313 +17,490 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
   let emailInputLabel;
   let passwordInputLabel;
   let loginLabel;
+  let featureToggles;
 
   hooks.beforeEach(function () {
     sessionService = this.owner.lookup('service:session');
+    featureToggles = this.owner.lookup('service:featureToggles');
     storeService = this.owner.lookup('service:store');
 
-    emailInputLabel = t('pages.login-form.email');
+    emailInputLabel = t('pages.login-form.email.label');
     loginLabel = t('pages.login-form.login');
     passwordInputLabel = t('pages.login-form.password');
   });
 
-  test('it should ask for email and password', async function (assert) {
-    // when
-    await renderScreen(hbs`<Auth::LoginForm />`);
-
-    // then
-    assert.dom('#login-email').exists();
-    assert.dom('#login-password').exists();
-  });
-
-  test('[a11y] it should display a message that all inputs are required', async function (assert) {
-    // when
-    const screen = await renderScreen(hbs`<Auth::LoginForm />`);
-
-    // then
-    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
-  });
-
-  test('it should not display error message', async function (assert) {
-    // when
-    await renderScreen(hbs`<Auth::LoginForm />`);
-
-    // then
-    assert.dom('#login-form-error-message').doesNotExist();
-  });
-
-  module('When there are spaces in email', function (hooks) {
+  module('When feature toggle usePixOrgaNewAuthDesign is not enabled', function (hooks) {
     hooks.beforeEach(function () {
-      sinon.stub(sessionService, 'authenticate');
-      sessionService.authenticate.resolves();
+      sinon.stub(featureToggles, 'featureToggles').value({ usePixOrgaNewAuthDesign: false });
     });
+    module('When the login form is displayed', function () {
+      test('it asks for email and password', async function (assert) {
+        // given & when
+        await renderScreen(hbs`<Auth::LoginForm />`);
 
-    test('it should should get rid of spaces', async function (assert) {
-      // given
-      await renderScreen(hbs`<Auth::LoginForm @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`);
-      await fillByLabel(emailInputLabel, ' pix@example.net ');
-      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
-
-      // when
-      await clickByName(loginLabel);
-
-      // then
-      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
-    });
-  });
-
-  module('When there is no invitation', function (hooks) {
-    hooks.beforeEach(function () {
-      sinon.stub(sessionService, 'authenticate');
-      sessionService.authenticate.resolves();
-    });
-
-    test('it should call authentication service with appropriate parameters', async function (assert) {
-      // given
-      await renderScreen(hbs`<Auth::LoginForm @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`);
-      await fillByLabel(emailInputLabel, 'pix@example.net');
-      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
-
-      // when
-      await clickByName(loginLabel);
-
-      // then
-      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
-    });
-
-    test('should not call authenticate session when form is invalid', async function (assert) {
-      // given
-      await renderScreen(hbs`<Auth::LoginForm @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`);
-      await fillByLabel(emailInputLabel, '');
-      await fillByLabel(passwordInputLabel, 'pix123');
-
-      // when
-      await clickByName(loginLabel);
-
-      // then
-      assert.ok(sessionService.authenticate.notCalled);
-    });
-  });
-
-  module('When there is an invitation', function (hooks) {
-    let saveStub;
-    hooks.beforeEach(function () {
-      sinon.stub(storeService, 'peekRecord');
-      storeService.peekRecord.returns(null);
-      const createRecordStub = sinon.stub(storeService, 'createRecord');
-      saveStub = sinon.stub().resolves();
-      createRecordStub.returns({
-        save: saveStub,
+        // then
+        assert.dom('#login-email').exists();
+        assert.dom('#login-password').exists();
       });
-      sinon.stub(sessionService, 'authenticate');
-      sessionService.authenticate.resolves();
-    });
 
-    test('it should be ok and call authentication service with appropriate parameters', async function (assert) {
-      // given
-      await renderScreen(
-        hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
-      );
-      await fillByLabel(emailInputLabel, 'pix@example.net');
-      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+      test('[a11y] it displays a message that all inputs are required', async function (assert) {
+        // given & when
+        const screen = await renderScreen(hbs`<Auth::LoginForm />`);
 
-      //  when
-      await clickByName(loginLabel);
+        // then
+        assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
+      });
 
-      // then
-      assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
-    });
+      test('it displays no error message', async function (assert) {
+        // given & when
+        await renderScreen(hbs`<Auth::LoginForm />`);
 
-    test('should accept organization invitation when form is valid', async function (assert) {
-      // given
-      await renderScreen(
-        hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
-      );
-      await fillByLabel(emailInputLabel, 'pix@example.net');
-      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
-
-      //  when
-      await clickByName(loginLabel);
-
-      // then
-      assert.ok(saveStub.calledWithMatch({ adapterOptions: { organizationInvitationId: '1' } }));
-    });
-
-    test('should not accept organization invitation when form is invalid', async function (assert) {
-      // given
-      await renderScreen(
-        hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
-      );
-      await fillByLabel(emailInputLabel, '');
-      await fillByLabel(passwordInputLabel, 'pix123');
-
-      //  when
-      await clickByName(loginLabel);
-
-      // then
-      assert.ok(saveStub.notCalled);
-    });
-  });
-
-  test('it should display an invalid credentials message when authentication fails', async function (assert) {
-    // given
-    const errorResponse = {
-      status: 401,
-      responseJSON: {
-        errors: [{ status: '401' }],
-      },
-    };
-
-    sinon.stub(sessionService, 'authenticate');
-    sessionService.authenticate.rejects(errorResponse);
-
-    const screen = await renderScreen(hbs`<Auth::LoginForm />`);
-    await fillByLabel(emailInputLabel, 'pix@example.net');
-    await fillByLabel(passwordInputLabel, 'Mauvais mot de passe');
-
-    //  when
-    await clickByName(loginLabel);
-
-    // then
-    assert.dom(screen.getByText(t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
-  });
-
-  test('it displays a should change password message', async function (assert) {
-    // given
-    const errorResponse = {
-      responseJSON: {
-        errors: [{ status: '401', code: 'SHOULD_CHANGE_PASSWORD' }],
-      },
-    };
-    const currentDomainService = this.owner.lookup('service:current-domain');
-    sinon.stub(currentDomainService, 'getExtension').returns('fr');
-    sinon.stub(sessionService, 'authenticate');
-    sessionService.authenticate.rejects(errorResponse);
-
-    const screen = await renderScreen(hbs`<Auth::LoginForm />`);
-    await fillByLabel(emailInputLabel, 'pix@example.net');
-    await fillByLabel(passwordInputLabel, 'Mauvais mot de passe');
-
-    //  when
-    await clickByName(loginLabel);
-
-    // then
-    const expectedErrorMessage = t('pages.login-form.errors.should-change-password', {
-      url: 'https://app.pix.fr/mot-de-passe-oublie',
-      htmlSafe: true,
-    });
-    assert
-      .dom(
-        screen.getByText((content, node) => {
-          const hasText = (node) => node.innerHTML.trim() === expectedErrorMessage.__string;
-          const nodeHasText = hasText(node);
-          const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
-          return nodeHasText && childrenDontHaveText;
-        }),
-      )
-      .exists();
-  });
-
-  test('it should display an not linked organisation message when authentication fails', async function (assert) {
-    // given
-    const errorResponse = {
-      status: Number(ApiErrorMessages.NOT_LINKED_ORGANIZATION.CODE),
-      responseJSON: {
-        errors: [{ status: '403' }],
-      },
-    };
-
-    sinon.stub(sessionService, 'authenticate');
-    sessionService.authenticate.rejects(errorResponse);
-
-    const screen = await renderScreen(hbs`<Auth::LoginForm />`);
-    await fillByLabel(emailInputLabel, 'pix@example.net');
-    await fillByLabel(passwordInputLabel, 'pix123');
-
-    //  when
-    await clickByName(loginLabel);
-
-    // then
-    assert.dom(screen.getByText(t(ApiErrorMessages.NOT_LINKED_ORGANIZATION.I18N_KEY))).exists();
-  });
-
-  test('it should not display context message', async function (assert) {
-    assert.dom('login-form__information').doesNotExist();
-  });
-
-  module('When the user fills the login form with an invalid email or password', function (hooks) {
-    hooks.beforeEach(function () {
-      const createRecordStub = sinon.stub(storeService, 'createRecord');
-      createRecordStub.returns({
-        save: sinon.stub().rejects({ errors: [{ status: '404' }] }),
-        deleteRecord: sinon.stub(),
+        // then
+        assert.dom('#login-form-error-message').doesNotExist();
       });
     });
 
-    test('displays the correct error message', async function (assert) {
-      // given
-      const screen = await renderScreen(
-        hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
-      );
-      await fillByLabel(emailInputLabel, 'pix@example.net');
-      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+    module('When there are spaces in email', function () {
+      test('it gets rid of spaces', async function (assert) {
+        // given
+        sinon.stub(sessionService, 'authenticate');
+        sessionService.authenticate.resolves();
+        await renderScreen(hbs`<Auth::LoginForm @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`);
+        await fillByLabel(emailInputLabel, ' pix@example.net ');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
 
-      //  when
-      await clickByName(loginLabel);
+        // when
+        await clickByName(loginLabel);
 
-      // then
-      assert.dom(screen.getByText("L'adresse e-mail et/ou le mot de passe saisis sont incorrects.")).exists();
+        // then
+        assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
+      });
+    });
+
+    module('Error cases', function () {
+      module('when inputs have invalid formats', function () {
+        test('it displays an invalid email error message when focus-out', async function (assert) {
+          // given
+          const invalidEmail = 'invalidEmail';
+          const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+
+          // when
+          await fillByLabel(emailInputLabel, invalidEmail);
+          await triggerEvent('#login-email', 'focusout');
+
+          // then
+          assert.dom(screen.getByText(t('pages.login-form.errors.invalid-email'))).exists();
+        });
+
+        test('it displays an empty password error message when focus-out', async function (assert) {
+          // given
+          const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+
+          // when
+          await fillByLabel(passwordInputLabel, '');
+          await triggerEvent('#login-password', 'focusout');
+
+          // then
+          assert.dom(screen.getByText(t('pages.login-form.errors.empty-password'))).exists();
+        });
+      });
+
+      module('When the user has a temporary password', function () {
+        test('it displays a should change password message', async function (assert) {
+          // given
+          const errorResponse = {
+            responseJSON: {
+              errors: [{ status: '401', code: 'SHOULD_CHANGE_PASSWORD' }],
+            },
+          };
+          const currentDomainService = this.owner.lookup('service:current-domain');
+          sinon.stub(currentDomainService, 'getExtension').returns('fr');
+          sinon.stub(sessionService, 'authenticate');
+          sessionService.authenticate.rejects(errorResponse);
+
+          const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+          await fillByLabel(emailInputLabel, 'pix@example.net');
+          await fillByLabel(passwordInputLabel, 'Mauvais mot de passe');
+
+          //  when
+          await clickByName(loginLabel);
+
+          // then
+          const expectedErrorMessage = t('pages.login-form.errors.should-change-password', {
+            url: 'https://app.pix.fr/mot-de-passe-oublie',
+            htmlSafe: true,
+          });
+          assert
+            .dom(
+              screen.getByText((content, node) => {
+                const hasText = (node) => node.innerHTML.trim() === expectedErrorMessage.__string;
+                const nodeHasText = hasText(node);
+                const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
+                return nodeHasText && childrenDontHaveText;
+              }),
+            )
+            .exists();
+        });
+      });
+
+      module('When credentials do not match any user', function () {
+        test('it displays an invalid credentials message', async function (assert) {
+          // given
+          const errorResponse = {
+            status: 401,
+            responseJSON: {
+              errors: [{ status: '401' }],
+            },
+          };
+
+          sinon.stub(sessionService, 'authenticate');
+          sessionService.authenticate.rejects(errorResponse);
+
+          const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+          await fillByLabel(emailInputLabel, 'pix@example.net');
+          await fillByLabel(passwordInputLabel, 'Mauvais mot de passe');
+
+          //  when
+          await clickByName(loginLabel);
+
+          // then
+          assert.dom(screen.getByText(t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
+        });
+      });
+
+      module('When the user is not an organization member', function () {
+        test('it displays an not linked organisation message', async function (assert) {
+          // given
+          const errorResponse = {
+            status: Number(ApiErrorMessages.NOT_LINKED_ORGANIZATION.CODE),
+            responseJSON: {
+              errors: [{ status: '403' }],
+            },
+          };
+
+          sinon.stub(sessionService, 'authenticate');
+          sessionService.authenticate.rejects(errorResponse);
+
+          const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+          await fillByLabel(emailInputLabel, 'pix@example.net');
+          await fillByLabel(passwordInputLabel, 'pix123');
+
+          //  when
+          await clickByName(loginLabel);
+
+          // then
+          assert.dom(screen.getByText(t(ApiErrorMessages.NOT_LINKED_ORGANIZATION.I18N_KEY))).exists();
+        });
+      });
+    });
+
+    module('When there is no invitation', function (hooks) {
+      hooks.beforeEach(function () {
+        sinon.stub(sessionService, 'authenticate');
+        sessionService.authenticate.resolves();
+      });
+      test('it displays context message', async function (assert) {
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        assert.dom('.login-form-legacy-design__information').exists();
+      });
+
+      test('it calls authentication service with appropriate parameters', async function (assert) {
+        // given
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        // when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
+      });
+
+      test('does not call authenticate session when form is invalid', async function (assert) {
+        // given
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        await fillByLabel(emailInputLabel, '');
+        await fillByLabel(passwordInputLabel, 'pix123');
+
+        // when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.notCalled);
+      });
+    });
+
+    module('When there is an invitation', function (hooks) {
+      let saveStub;
+      hooks.beforeEach(function () {
+        sinon.stub(storeService, 'peekRecord');
+        storeService.peekRecord.returns(null);
+        const createRecordStub = sinon.stub(storeService, 'createRecord');
+        saveStub = sinon.stub().resolves();
+        createRecordStub.returns({
+          save: saveStub,
+        });
+        sinon.stub(sessionService, 'authenticate');
+        sessionService.authenticate.resolves();
+      });
+
+      test('it displays no context message', async function (assert) {
+        // given & when
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+
+        // then
+        assert.dom('.login-form-legacy-design__information').doesNotExist();
+      });
+
+      test('it calls authentication service with appropriate parameters', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
+      });
+
+      test('accepts organization invitation when form is valid', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(saveStub.calledWithMatch({ adapterOptions: { organizationInvitationId: '1' } }));
+      });
+
+      test('does not accept organization invitation when form is invalid', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, '');
+        await fillByLabel(passwordInputLabel, 'pix123');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(saveStub.notCalled);
+      });
+    });
+
+    module('when domain is pix.org', function () {
+      test('does not display recovery link', async function (assert) {
+        // given
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('org');
+
+        // when
+        await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom('.login-form-legacy-design__recover-access-link').doesNotExist();
+        assert.dom('.login-form-legacy-design__recover-access-message').doesNotExist();
+      });
+    });
+
+    module('when domain is pix.fr', function () {
+      test('displays recovery link', async function (assert) {
+        // given
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+
+        // when
+        await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom('.login-form-legacy-design__recover-access-link').exists();
+        assert.dom('.login-form-legacy-design__recover-access-message').exists();
+      });
     });
   });
 
-  module('when domain is pix.org', function () {
-    test('should not display recovery link', async function (assert) {
-      // when
-      await renderScreen(hbs`<Auth::LoginForm />`);
-
-      // then
-      assert.dom('.login-form__recover-access-link').doesNotExist();
-    });
-  });
-
-  module('when domain is pix.fr', function () {
-    test('should display recovery link', async function (assert) {
-      // given
-      const domainService = this.owner.lookup('service:currentDomain');
-      sinon.stub(domainService, 'getExtension').returns('fr');
-
-      // when
-      await renderScreen(hbs`<Auth::LoginForm />`);
-
-      // then
-      assert.dom('.login-form__recover-access-link').exists();
-    });
-  });
-
-  module('when the user fills inputs with errors', function () {
-    test('should display an invalid email error message when focus-out', async function (assert) {
-      //given
-      const invalidEmail = 'invalidEmail';
-      const screen = await renderScreen(hbs`<Auth::LoginForm />`);
-
-      // when
-      await fillByLabel(emailInputLabel, invalidEmail);
-      await triggerEvent('#login-email', 'focusout');
-
-      // then
-      assert.dom(screen.getByText(t('pages.login-form.errors.invalid-email'))).exists();
+  module('When feature toggle usePixOrgaNewAuthDesign is enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      sinon.stub(featureToggles, 'featureToggles').value({ usePixOrgaNewAuthDesign: true });
     });
 
-    test('should display an empty password error message when focus-out', async function (assert) {
-      //given
-      const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+    module('When the login form is displayed', function () {
+      test('it asks for email and password', async function (assert) {
+        // given & when
+        await renderScreen(hbs`<Auth::LoginForm />`);
 
-      // when
-      await fillByLabel(passwordInputLabel, '');
-      await triggerEvent('#login-password', 'focusout');
+        // then
+        assert.dom('#login-email').exists();
+        assert.dom('#login-password').exists();
+      });
 
-      // then
-      assert.dom(screen.getByText(t('pages.login-form.errors.empty-password'))).exists();
+      test('[a11y] it displays a message that all inputs are required', async function (assert) {
+        // given & when
+        const screen = await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
+      });
+
+      test('it displays no error message', async function (assert) {
+        // given & when
+        await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom('#login-form-error-message').doesNotExist();
+      });
+    });
+
+    module('When there is no invitation', function (hooks) {
+      hooks.beforeEach(function () {
+        sinon.stub(sessionService, 'authenticate');
+        sessionService.authenticate.resolves();
+      });
+      test('it displays no context message', async function (assert) {
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        assert.dom('.login-form-legacy-design__information').doesNotExist();
+      });
+
+      test('it calls authentication service with appropriate parameters', async function (assert) {
+        // given
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        // when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
+      });
+
+      test('does not call authenticate session when form is invalid', async function (assert) {
+        // given
+        await renderScreen(hbs`<Auth::LoginForm />`);
+        await fillByLabel(emailInputLabel, '');
+        await fillByLabel(passwordInputLabel, 'pix123');
+
+        // when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.notCalled);
+      });
+    });
+
+    module('When there is an invitation', function (hooks) {
+      let saveStub;
+      hooks.beforeEach(function () {
+        sinon.stub(storeService, 'peekRecord');
+        storeService.peekRecord.returns(null);
+        const createRecordStub = sinon.stub(storeService, 'createRecord');
+        saveStub = sinon.stub().resolves();
+        createRecordStub.returns({
+          save: saveStub,
+        });
+        sinon.stub(sessionService, 'authenticate');
+        sessionService.authenticate.resolves();
+      });
+
+      test('it displays no context message', async function (assert) {
+        // given & when
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+
+        // then
+        assert.dom('.login-form-legacy-design__information').doesNotExist();
+      });
+
+      test('it calls authentication service with appropriate parameters', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(sessionService.authenticate.calledWith('authenticator:oauth2', 'pix@example.net', 'JeMeLoggue1024'));
+      });
+
+      test('accepts organization invitation when form is valid', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, 'pix@example.net');
+        await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(saveStub.calledWithMatch({ adapterOptions: { organizationInvitationId: '1' } }));
+      });
+
+      test('does not accept organization invitation when form is invalid', async function (assert) {
+        // given
+        await renderScreen(
+          hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`,
+        );
+        await fillByLabel(emailInputLabel, '');
+        await fillByLabel(passwordInputLabel, 'pix123');
+
+        //  when
+        await clickByName(loginLabel);
+
+        // then
+        assert.ok(saveStub.notCalled);
+      });
+    });
+
+    module('when domain is pix.org', function () {
+      test('does not display recovery link', async function (assert) {
+        // given
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('org');
+
+        // when
+        await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom('.authentication-login-form__recover-access__question').doesNotExist();
+        assert.dom('.authentication-login-form__recover-access .link--underlined').doesNotExist();
+        assert.dom('.authentication-login-form__recover-access__message').doesNotExist();
+      });
+    });
+
+    module('when domain is pix.fr', function () {
+      test('displays recovery link', async function (assert) {
+        // given
+        const domainService = this.owner.lookup('service:currentDomain');
+        sinon.stub(domainService, 'getExtension').returns('fr');
+
+        // when
+        await renderScreen(hbs`<Auth::LoginForm />`);
+
+        // then
+        assert.dom('.authentication-login-form__recover-access__question').exists();
+        assert.dom('.authentication-login-form__recover-access .link--underlined').exists();
+        assert.dom('.authentication-login-form__recover-access__message').exists();
+      });
     });
   });
 });

--- a/orga/tests/integration/components/auth/login-or-register-test.js
+++ b/orga/tests/integration/components/auth/login-or-register-test.js
@@ -13,8 +13,11 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   let loginButton;
 
   hooks.beforeEach(function () {
+    const featureToggles = this.owner.lookup('service:featureToggles');
+    sinon.stub(featureToggles, 'featureToggles').value({ usePixOrgaNewAuthDesign: false });
     loginButton = t('pages.login-or-register.login-form.button');
   });
+
   test('displays the organization name the user is invited to', async function (assert) {
     // when
     const invitationMessage = t('pages.login-or-register.title', { organizationName: 'Organization Aztec' });
@@ -41,7 +44,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     await clickByName(loginButton);
 
     // then
-    assert.dom('.login-form').exists();
+    assert.dom('.login-form-legacy-design').exists();
   });
 
   test('toggles the register form on click on register button', async function (assert) {
@@ -61,6 +64,9 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   module('when domain is not .fr', function () {
     test('displays the locale switcher and translate to selected locale', async function (assert) {
       // given
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
       const routerService = this.owner.lookup('service:router');
       sinon.stub(routerService, 'replaceWith').returns(false);
 
@@ -74,8 +80,11 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
       assert.dom(screen.getByText('You have been invited to join the organisation Organization Aztec')).exists();
     });
 
-    test('saves selected locale and remove lang from query params', async function (assert) {
+    test('saves selected locale and removes lang from query params', async function (assert) {
       // given
+      const domainService = this.owner.lookup('service:currentDomain');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
       const routerService = this.owner.lookup('service:router');
       const localeService = this.owner.lookup('service:locale');
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1070,13 +1070,19 @@
       "organization-code": "UAI/RNE de l'établissement"
     },
     "login": {
-      "title": "Log in"
+      "title": "Log in",
+      "with-pix-account": "with your Pix Account"
     },
     "login-form": {
-      "active-or-retrieve": "Are you a headteacher? Activate or become the administrator of your school's Pix Orga space",
-      "email": "Email address",
+      "active-or-retrieve": "Activate or become the administrator of your school's Pix Orga space",
+      "admin-role-question": "Are you a headteacher?",
+      "email": {
+        "label": "Email address",
+        "placeholder": "e.g. john.smith@email.com"
+      },
       "errors": {
-        "empty-password": "Your password can't be empty.",
+        "empty-email": "You have not entered your e-mail address.",
+        "empty-password": "You have not entered your password.",
         "invalid-email": "Your email address is invalid.",
         "should-change-password": "You currently have a temporary password. '<'a href=\"{url}\"'>'Reset your password here'</a>'.",
         "status": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1058,13 +1058,19 @@
       "organization-code": "UAI/RNE de l'établissement"
     },
     "login": {
-      "title": "Connectez-vous"
+      "title": "Connectez-vous",
+      "with-pix-account": "avec votre compte Pix"
     },
     "login-form": {
-      "active-or-retrieve": "Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
-      "email": "Adresse e-mail",
+      "active-or-retrieve": "Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire",
+      "admin-role-question": "Vous êtes personnel de direction ou directeur d'école ?",
+      "email": {
+        "label": "Adresse e-mail",
+        "placeholder": "ex: jean.dupont@email.com"
+      },
       "errors": {
-        "empty-password": "Le champ mot de passe est obligatoire.",
+        "empty-email": "Votre adresse e-mail n’est pas renseignée.",
+        "empty-password": "Votre mot de passe n’est pas renseigné.",
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser.",
         "status": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1058,13 +1058,19 @@
       "organization-code": "UAI/RNE van de instelling"
     },
     "login": {
-      "title": "Inloggen"
+      "title": "Inloggen",
+      "with-pix-account": "met uw Pix-account"
     },
     "login-form": {
-      "active-or-retrieve": "Are you a headteacher? Activate or become the administrator of your school's Pix Orga space",
-      "email": "E-mailadres",
+      "active-or-retrieve": "Activeer of word beheerder van de Pix Orga-ruimte van uw school.",
+      "admin-role-question": "Bent u een schoolhoofd?",
+      "email": {
+        "label": "E-mailadres",
+        "placeholder": "b.v. jan.jansen@email.com"
+      },
       "errors": {
-        "empty-password": "Het veld wachtwoord is verplicht.",
+        "empty-email": "Uw e-mailadres is niet ingevuld.",
+        "empty-password": "Uw wachtwoord is niet ingevoerd.",
         "invalid-email": "Je e-mailadres is ongeldig.",
         "should-change-password": "Je hebt momenteel een tijdelijk wachtwoord. Klik op '<'a href=\"{url}\"'>'wachtwoord vergeten'</a>' om het opnieuw in te stellen.",
         "status": {


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre du nouveau design des pages d'authentification de Pix Orga, nous modifions le design du formulaire de login.

## 🌰 Proposition

Suivre cette maquette 

https://www.figma.com/design/wDdAJwtswAllBk0ZtMLu4Y/Acc%C3%A8s?node-id=2651-86197

<img width="6536" height="2955" alt="image" src="https://github.com/user-attachments/assets/b1023453-df4b-4b22-b11f-07be52333170" />


MAJ : Nouvelles specs (voir 1er commentaire du ticket JIRA pour les explications) 
a) Petit changement de plan en cours de route : on va masquer la phrase tout en haut. “L’accès à Pix Orga est limité aux membres invités …. de votre organisation pour qu’il vous invite” + ne pas laisser le grand espace blanc, c’est une bidouille pour masquer car la maquette n’est pas MAJ

b) Le message d’erreur (voir dans la partie Pourquoi) doit s’afficher également sur la mire sous “Connectez-vous”

## 🍁 Remarques

Explication des différences entre le rendu et la maquette : 
1. Il ne faut pas de locale switcher en .fr
2. La mention "email ou identifiant" n'a pas été reprise car elle correspond aux fonctionnalités de connexion de Pix App et non Pix Orga
3. [Voir la MAJ dans la description] Sur les deux phrases “L’accès à Pix Orga est limité aux membres invités …. de votre organisation pour qu’il vous invite” , qui apparaissent actuellement quand l'utilisateur n'arrive pas sur cette page avec une invitation : il ne faut plus les faire figurer sur la page quel que soit le cas (utilisateur avec ou sans invitation), car la même explication est donnée par le message d'erreur si l'utilisateur qui se connecte a un compte mais pas l'autorisation de se connecter à Pix Orga. 
4. Les liens du footer du rendu de cette PR correspondent réellement à ceux de Pix Orga tels que précisés dans `https://github.com/1024pix/pix/pull/13834` 
5. La phrase '(Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.)' n'apparaît pas dans la maquette mais elle est bien présente dans la page de connexion de Pix Orga (ancien design), elle a donc été reprise ici en .fr, comme dans l'ancien design.
6. Le composant SSO n'apparaît pas encore en bas du formulaire car il doit faire l'objet d'une prochaine PR

## 🪵 Pour tester

note : commande pour passer le FT à true en RA : 
```shell
scalingo -a pix-api-review-pr13893 run "npm run toggles -- --key=usePixOrgaNewAuthDesign --value=true"
```

**[Sur la version pix.fr]** 
      - la phrase  “L’accès à Pix Orga est limité aux membres invités …. de votre organisation pour qu’il vous invite” n'apparaît plus,
     -  le message destiné aux chefs d'établissements doit être affiché ("Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire (https://orga.dev.pix.fr/demande-administration-sco) (Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.)"
     -  vérifier que le reste est conforme à la maquette 
     - Tester une connexion "classique" : allorga@example.net : 
                           -- Les champs doivent être obligatoires.
                           -- L'utilisateur est redirigé sur pix orga une fois connecté.
                           -- Vérifier les liens
     - Tester un cas de connexion d'utilisateur connu mais non membre d'une organisation (par exemple hermione@school.net), et vérifiez le message d'erreur "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite."

**[Sur la version pix.org]** 
        - la phrase  “L’accès à Pix Orga est limité aux membres invités …. de votre organisation pour qu’il vous invite” n'apparaît plus,
        - Le changement de langue : le texte de la page doit changer en fonction de la langue choisie
        - le message destiné aux chefs d'établissements en bas de page ne doit pas être affiché  ("Vous êtes personnel de direction ou directeur d'école ? Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire (https://orga.dev.pix.fr/demande-administration-sco) (Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.)"
         -  vérifier que le reste est conforme à la maquette 
         - Tester une connexion "classique" : allorga@example.net : 
                           -- Les champs doivent être obligatoires.
                           -- L'utilisateur est redirigé sur pix orga une fois connecté.
                           -- Vérifier les liens

**[NON REGRESSION]** 
Vérifiez que la connexion sur le formulaire actuel est toujours fonctionnelle