### PR TITLE
[TECH] Ajouter un domain-builder pour le modèle Version (PIX-20024).

### DIFF
--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -66,7 +66,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
 
       certificationCandidateRepository.findByAssessmentId.withArgs({ assessmentId: assessment.id }).resolves(candidate);
 
-      challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
+      challengesConfiguration = domainBuilder.certification.configuration.buildVersion().challengesConfiguration;
     });
 
     context('when there are challenges left to answer', function () {

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
@@ -1,0 +1,24 @@
+import { Version } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import { Frameworks } from '../../../../../../src/certification/shared/domain/models/Frameworks.js';
+
+export const buildVersion = ({
+  id = 1,
+  scope = Frameworks.CORE,
+  startDate = new Date(),
+  expirationDate,
+  assessmentDuration = 105,
+  globalScoringConfiguration,
+  competencesScoringConfiguration,
+  challengesConfiguration = {},
+} = {}) => {
+  return new Version({
+    id,
+    scope,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    globalScoringConfiguration,
+    competencesScoringConfiguration,
+    challengesConfiguration,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -172,6 +172,7 @@ import { buildActiveCalibratedChallenge } from './certification/configuration/bu
 import { buildCenter as buildConfigurationCenter } from './certification/configuration/build-center.js';
 import { buildCertificationFrameworksChallenge } from './certification/configuration/build-certification-frameworks-challenge.js';
 import { buildConsolidatedFramework } from './certification/configuration/build-consolidated-framework.js';
+import { buildVersion } from './certification/configuration/build-version.js';
 import { buildCandidate } from './certification/enrolment/build-candidate.js';
 import { buildCertificationEligibility } from './certification/enrolment/build-certification-eligibility.js';
 import { buildComplementaryCertificationBadgeWithOffsetVersion as buildComplementaryCertificationBadgeForEnrolment } from './certification/enrolment/build-complementary-certification-badge.js';
@@ -234,10 +235,11 @@ const banner = {
 
 const certification = {
   configuration: {
-    buildCenter: buildConfigurationCenter,
-    buildConsolidatedFramework,
-    buildCertificationFrameworksChallenge,
     buildActiveCalibratedChallenge,
+    buildCenter: buildConfigurationCenter,
+    buildCertificationFrameworksChallenge,
+    buildConsolidatedFramework,
+    buildVersion,
   },
   complementaryCertification: {
     buildComplementaryCertificationBadge: buildComplementaryCertificationBadge,


### PR DESCRIPTION
## 🍂 Problème

Un modèle Version a été ajouté pour garder un historique de configuration de certification, or aucun domain builder dédié n'existait.

## 🌰 Proposition

Ajouter un domain builder pour le modèle Version et l'utiliser dans le test unitaire du usecase `get-next-challenge`.

## 🪵 Pour tester

Tests verts ✅ 
