### PR TITLE
[FEATURE] Ajouter un lien vers la page personnelle sur le profil utilisateur (temporary PR - Do Not Merge).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -29,6 +29,7 @@ const { ROLES } = PIX_ADMIN;
  * @property {boolean} cgu
  * @property {string} lang
  * @property {string} locale
+ * @property {string} personalPageUrl
  * @property {Date} lastTermsOfServiceValidatedAt
  * @property {Date} lastPixCertifTermsOfServiceValidatedAt
  * @property {boolean} mustValidateTermsOfService
@@ -54,6 +55,7 @@ const buildUser = function buildUser({
   cgu = true,
   lang = 'fr',
   locale = null,
+  personalPageUrl = null,
   lastTermsOfServiceValidatedAt = null,
   lastPixCertifTermsOfServiceValidatedAt = null,
   mustValidateTermsOfService = false,
@@ -81,6 +83,7 @@ const buildUser = function buildUser({
     cgu,
     lang,
     locale,
+    personalPageUrl,
     lastTermsOfServiceValidatedAt,
     lastPixCertifTermsOfServiceValidatedAt,
     mustValidateTermsOfService,
@@ -113,6 +116,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   cgu = true,
   lang = 'fr',
   locale,
+  personalPageUrl,
   lastTermsOfServiceValidatedAt = new Date('2019-04-28T02:42:00Z'),
   lastPixCertifTermsOfServiceValidatedAt = null,
   mustValidateTermsOfService = false,
@@ -135,6 +139,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     cgu,
     lang,
     locale,
+    personalPageUrl,
     lastTermsOfServiceValidatedAt,
     lastPixCertifTermsOfServiceValidatedAt,
     mustValidateTermsOfService,

--- a/api/db/migrations/20251015100543_add-personal-page-url-to-user.js
+++ b/api/db/migrations/20251015100543_add-personal-page-url-to-user.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'personalPageUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).nullable().comment('URL of the personal page');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -78,6 +78,16 @@ function _buildUsers(databaseBuilder) {
     emailConfirmedAt: null,
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
+
+  // user with a personal page URL
+  const userWithPersonalPageUrl = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Quentin',
+    lastName: 'Libouk',
+    email: 'quentin@example.net',
+    personalPageUrl: 'https://github.com/Libouk',
+    emailConfirmedAt: null,
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithPersonalPageUrl.id, lastLoggedAt: null });
 }
 
 export function buildUsers(databaseBuilder) {

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -40,6 +40,7 @@ class User {
       authenticationMethods = [],
       hasBeenAnonymised,
       hasBeenAnonymisedBy,
+      personalPageUrl,
     } = {},
     dependencies = { localeService },
   ) {
@@ -73,6 +74,7 @@ class User {
     this.authenticationMethods = authenticationMethods;
     this.hasBeenAnonymised = hasBeenAnonymised;
     this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
+    this.personalPageUrl = personalPageUrl;
   }
 
   get isActive() {

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-with-activity.serializer.js
@@ -29,6 +29,7 @@ const serialize = function (users, meta) {
       'codeForLastProfileToShare',
       'trainings',
       'shouldSeeDataProtectionPolicyInformationBanner',
+      'personalPageUrl',
     ],
     profile: {
       ref: 'id',

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -23,6 +23,7 @@ export default class User extends Model {
   @attr('boolean') shouldSeeDataProtectionPolicyInformationBanner;
   @attr('boolean') emailConfirmed;
   @attr() lastDataProtectionPolicySeenAt;
+  @attr('string') personalPageUrl;
 
   // includes
   @belongsTo('is-certifiable', { async: true, inverse: null }) isCertifiable;

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -15,17 +15,19 @@ import t from 'ember-intl/helpers/t';
       <p class="personal-information-item__value" data-test-lastName>{{@model.lastName}}</p>
     </div>
 
-    <div class="personal-information-item">
-      <p class="form-textfield__label personal-information-item__label">
-        {{t "pages.user-account.personal-information.personal-page-url"}}
-      </p>
-      <a
-        href="{{@model.personalPageUrl}}"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="personal-information-item__value"
-        data-test-lastName
-      >{{@model.personalPageUrl}}</a>
-    </div>
+    {{#if @model.personalPageUrl}}
+      <div class="personal-information-item">
+        <p class="form-textfield__label personal-information-item__label">
+          {{t "pages.user-account.personal-information.personal-page-url"}}
+        </p>
+        <a
+          href="{{@model.personalPageUrl}}"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="personal-information-item__value"
+          data-test-lastName
+        >{{@model.personalPageUrl}}</a>
+      </div>
+    {{/if}}
   </div>
 </template>

--- a/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
+++ b/mon-pix/app/templates/authenticated/user-account/personal-information.gjs
@@ -14,5 +14,18 @@ import t from 'ember-intl/helpers/t';
       </p>
       <p class="personal-information-item__value" data-test-lastName>{{@model.lastName}}</p>
     </div>
+
+    <div class="personal-information-item">
+      <p class="form-textfield__label personal-information-item__label">
+        {{t "pages.user-account.personal-information.personal-page-url"}}
+      </p>
+      <a
+        href="{{@model.personalPageUrl}}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="personal-information-item__value"
+        data-test-lastName
+      >{{@model.personalPageUrl}}</a>
+    </div>
   </div>
 </template>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2303,7 +2303,8 @@
       "personal-information": {
         "first-name": "First name",
         "last-name": "Last name",
-        "menu-link-title": "Personal information"
+        "menu-link-title": "Personal information",
+        "personal-page-url": "Personal page URL"
       },
       "title": "My account"
     },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -2286,7 +2286,8 @@
       "personal-information": {
         "first-name": "Nombre",
         "last-name": "Apellidos",
-        "menu-link-title": "Mis datos personales"
+        "menu-link-title": "Mis datos personales",
+        "personal-page-url": "URL de la página personal"
       },
       "title": "Mi cuenta"
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2290,7 +2290,8 @@
       "personal-information": {
         "first-name": "Nombre",
         "last-name": "Apellidos",
-        "menu-link-title": "Mis datos personales"
+        "menu-link-title": "Mis datos personales",
+        "personal-page-url": "URL de la página personal"
       },
       "title": "Mi cuenta"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2311,7 +2311,8 @@
       "personal-information": {
         "first-name": "Prénom",
         "last-name": "Nom",
-        "menu-link-title": "Mes informations personnelles"
+        "menu-link-title": "Mes informations personnelles",
+        "personal-page-url": "URL de ma page personnelle"
       },
       "title": "Mon compte"
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2294,7 +2294,8 @@
       "personal-information": {
         "first-name": "Voornaam",
         "last-name": "Achternaam",
-        "menu-link-title": "Mijn persoonlijke gegevens"
+        "menu-link-title": "Mijn persoonlijke gegevens",
+        "personal-page-url": "persoonlijke pagina-url"
       },
       "title": "Mijn account"
     },


### PR DESCRIPTION
## 🍂 Problème
Dans le cadre de l'Epix d'enrichissement de l'espace Mon Compte de l'ensemble des utilisateurs, on souhaite permettre aux utilisateurs de visualiser un lien vers leur page personnelle d'un site tierce. Ce lien devra ouvrir un nouvel onglet.

## 🌰 Proposition
Ajouter sur la page Mon Compte dans Informations Personnelles un nouvel élément qui sera un lien vers la page personnelle de l'utilisateur. Cette information sera sauvegardée en base de données.

## 🍁 Remarques
La feature d'ajout de cet URL au profil sera réalisée ultérieurement.

## 🪵 Pour tester
- Lancer Mon Pix avec le compte quentin@example.net
- Aller dans Mon Compte puis Informations Personnelles
- Constater la présence d'un lien vers la page personnelle
- Ce lien doit ouvrir un nouvel onglet
- Se connecter avec un autre compte pour vérifier qu'en l'absence de lien vers la page personnelle, l'élement n'apparait pas

## 🔍  Pour les curieux
A toutes fins utiles, voici les étapes nécessaires à la réalisation de cette feature : 
Backend (API) : 
1. Création d'une migration pour ajouter une colonne sur la table User `npm run db:new-migration add-personal-page-url-to-user `
2. Ajout de la nouvelle propriété dans le builder `buildUserWithRawPassword`
3. Création d'un nouvel userWithRawPassword dans les seeds avec la nouvelle propriété renseignée
4. Application de la nouvelle migration et alimentation de la BDD avec la nouvelle seed avec la commande `npm run db:reset`
5. Ajout de la nouvelle propriété dans le modèle User de l'API
6. Ajout de la nouvelle propriété dans le serializer User With Activity
7. Vérification depuis Pix App que la nouvelle propriété est bien transmise dans l'appel de la route /users/me
 
Frontend (Pix App) : 
1. Création des traductions de l'intitulé de la nouvelle propriété
2. Ajout de la nouvelle propriété dans le modèle mon-pix User
3. Affichage de la nouvelle propriété dans le composant personal-information
4. Mise en place d'une condition sur l'affichage de la nouvelle propriété
