### PR TITLE
[BUGFIX] Faire en sorte que la hauteur d'une step s'adapte à son contenu (PIX-19897)

### DIFF
--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -85,14 +85,13 @@
 
     &__position {
       display: inline-block;
-
-      @extend %pix-body-m;
-
       margin: var(--pix-spacing-1x) 0 var(--pix-spacing-4x) 0;
       padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
       color: var(--pix-neutral-800);
       background: var(--pix-neutral-20);
       border-radius: var(--modulix-radius-l);
+
+      @extend %pix-body-m;
     }
   }
 }
@@ -107,6 +106,7 @@
 
     flex: 0 0 100%;
     align-items: center;
+    height:fit-content;
     margin-right: var(--stepper-gap-between-steps);
     padding: var(--pix-spacing-4x);
     border: 1px solid var(--pix-neutral-100);


### PR DESCRIPTION
## 🍂 Problème
Actuellement, les steps des steppers horizontaux ont une hauteur qui devient de plus en plus importante, au fur et à mesure qu'on passe des steps.
Exemple : 
<img width="817" height="969" alt="image" src="https://github.com/user-attachments/assets/9d91b21a-d63b-4c0b-8c17-7e72c0013dda" />


## 🌰 Proposition
Ajouter une propriété css afin d'adapter la hauteur d'une step à son contenu.

## 🍁 Remarques
Le bouton "Passer l'activité" apparaît souvent plus bas que la bordure de la Step, quand celle-ci n'est pas la plus grande du Stepper horizontal.
Exemple : dans le module [deepfakes](http://localhost:4200/modules/tmp-ia-deepfakes-alt/) 
<img width="871" height="671" alt="image" src="https://github.com/user-attachments/assets/dd9a9857-322a-41d0-bf57-342a6215c3de" />


## 🪵 Pour tester
- Aller sur le grain de l'ail des ours sur [ce module](https://app-pr13902.review.pix.fr/modules/tmp-ia-def-ind)
- Enchainer les steps
- Vérifier que la hauteur du stepper est liée aux éléments contenus

