### PR TITLE
[BUGFIX] Empêcher l'erreur sur la recherche par ID de centre de certification (PIX-19394)

### DIFF
--- a/admin/app/components/certification-centers/list-items.gjs
+++ b/admin/app/components/certification-centers/list-items.gjs
@@ -17,7 +17,7 @@ export default class CertificationCenterListItems extends Component {
   <template>
     <div class="certification-centers-list">
       <PixFilterBanner @title={{t "common.filters.title"}}>
-        <PixInput value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}}>
+        <PixInput value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}} type="number">
           <:label>Identifiant</:label>
         </PixInput>
         <PixInput value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}}>

--- a/admin/app/routes/authenticated/certification-centers/list.js
+++ b/admin/app/routes/authenticated/certification-centers/list.js
@@ -13,19 +13,27 @@ export default class ListRoute extends Route {
     externalId: { refreshModel: true },
   };
 
-  model(params) {
-    return this.store.query('certification-center', {
-      filter: {
-        id: params.id ? params.id.trim() : '',
-        name: params.name ? params.name.trim() : '',
-        type: params.type ? params.type.trim() : '',
-        externalId: params.externalId ? params.externalId.trim() : '',
-      },
-      page: {
-        number: params.pageNumber,
-        size: params.pageSize,
-      },
-    });
+  async model(params) {
+    let model;
+
+    try {
+      model = await this.store.query('certification-center', {
+        filter: {
+          id: params.id ? params.id.replace(/ /g, '') : '',
+          name: params.name ? params.name.trim() : '',
+          type: params.type ? params.type.trim() : '',
+          externalId: params.externalId ? params.externalId.trim() : '',
+        },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      });
+    } catch {
+      model = [];
+    }
+
+    return model;
   }
 
   resetController(controller, isExiting) {

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.gjs
@@ -55,7 +55,7 @@ module('Integration | Component | routes/authenticated/certification-centers | l
 
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Type' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).exists();
+    assert.dom(screen.getByRole('spinbutton', { name: 'Identifiant' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'ID externe' })).exists();
   });

--- a/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
@@ -44,12 +44,12 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
     module('when queryParams filters are  truthy', function () {
       test('it should call store.query with filters containing trimmed values', async function (assert) {
         // given
-        params.id = 'someId';
+        params.id = ' 12 3 456 ';
         params.name = ' someName';
         params.type = 'someType ';
-        params.externalId = 'someExternalId';
+        params.externalId = ' someExternalId ';
         expectedQueryArgs.filter = {
-          id: 'someId',
+          id: '123456',
           name: 'someName',
           type: 'someType',
           externalId: 'someExternalId',
@@ -61,6 +61,21 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         // then
         sinon.assert.calledWith(route.store.query, 'certification-center', expectedQueryArgs);
         assert.ok(true);
+      });
+    });
+
+    module('when route is in error', function () {
+      test('it should return an empty model', async function (assert) {
+        // given
+        params.id = { id: 'Non number ID' };
+
+        route.store.query = sinon.stub().rejects();
+
+        // when
+        const certificationCenters = await route.model(params);
+
+        // then
+        assert.deepEqual(certificationCenters, []);
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Actuellement sur Pix Admin dans la liste des centres de certification, lorsqu'on recherche un centre par son Identifiant en utilisant des lettres et non des chiffres, on a une erreur Ember.
Comme on envoie une `string` pour le filtre alors que l'ID attend un `number`, l'API renvoie une erreur 400.

## 🌰 Proposition

- Changer le type de l'input ID en number pour empêcher de mettre du texte dans ce champ
- Si cette sécu est contournée, catcher l'erreur de l'API et renvoyer un tableau vide pour pouvoir indiquer Aucun résultat.


## 🪵 Pour tester

Sur Pix Admin:
- aller sur la page des Centres de Certification
- constater qu'il est impossible de rechercher un centre par son champ Identifiant en tapant des lettres et non des chiffres
- dans l'inspecteur, supprimer l'attribut `type="number"` sur ce champ, taper des lettres et constater qu'on affiche **Aucun résultat** et non une erreur
<img width="1195" height="465" alt="Capture d’écran 2025-10-17 à 13 54 07" src="https://github.com/user-attachments/assets/a1089aaa-7f00-46e8-a482-62d6257240c0" />
