### PR TITLE
[FEATURE] Afficher le nombre d'organisations filles rattachées à l'orga parente (PIX-18893)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -27,16 +27,19 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
       await this.model.organization.hasMany('children').reload();
     } catch (responseError) {
       const error = get(responseError, 'errors[0]');
+      const { childOrganizationId } = error.meta;
       let message;
       switch (error?.code) {
         case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF':
           message = this.intl.t(
             'pages.organization-children.notifications.error.unable-to-attach-child-organization-to-itself',
+            { childOrganizationId },
           );
           break;
         case 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION':
           message = this.intl.t(
             'pages.organization-children.notifications.error.unable-to-attach-already-attached-child-organization',
+            { childOrganizationId },
           );
           break;
         case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION':
@@ -47,6 +50,7 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
         case 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION':
           message = this.intl.t(
             'pages.organization-children.notifications.error.unable-to-attach-parent-organization-as-child-organization',
+            { childOrganizationId },
           );
           break;
         default:

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -16,8 +16,12 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
 
     try {
       await organizationAdapter.attachChildOrganization({ childOrganizationIds, parentOrganizationId });
+
+      const count = childOrganizationIds.split(',').length;
       this.pixToast.sendSuccessNotification({
-        message: this.intl.t('pages.organization-children.notifications.success.attach-child-organization'),
+        message: this.intl.t('pages.organization-children.notifications.success.attach-child-organization', {
+          count,
+        }),
       });
 
       await this.model.organization.hasMany('children').reload();

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children-test.js
@@ -16,12 +16,14 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
     controller = this.owner.lookup('controller:authenticated/organizations/get/children');
     notifications = this.owner.lookup('service:pixToast');
     store = this.owner.lookup('service:store');
+
+    this.intl = this.owner.lookup('service:intl');
   });
 
   module('#handleFormSubmitted', function () {
     test('attaches child organization to parent organization and displays success notification', async function (assert) {
       // given
-      const childOrganizationId = '1234';
+      const childOrganizationIds = '1234, 5678';
       const organizationAdapter = { attachChildOrganization: sinon.stub().resolves() };
 
       sinon.stub(store, 'adapterFor').returns(organizationAdapter);
@@ -36,19 +38,21 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
       });
 
       // when
-      await controller.handleFormSubmitted(childOrganizationId);
+      await controller.handleFormSubmitted(childOrganizationIds);
 
       // then
       assert.true(store.adapterFor.calledWithExactly('organization'));
       assert.true(
         organizationAdapter.attachChildOrganization.calledWithExactly({
-          childOrganizationIds: '1234',
+          childOrganizationIds: '1234, 5678',
           parentOrganizationId: '12',
         }),
       );
       assert.true(
         notifications.sendSuccessNotification.calledWithExactly({
-          message: `L'organisation fille a bien été liée à l'organisation mère`,
+          message: this.intl.t('pages.organization-children.notifications.success.attach-child-organization', {
+            count: 2,
+          }),
         }),
       );
       assert.true(reloadStub.calledOnce);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1066,7 +1066,7 @@
           "unable-to-attach-parent-organization-as-child-organization": "Unable to attach a parent organization as child organization"
         },
         "success": {
-          "attach-child-organization": "The child organization has been linked to the parent organization"
+          "attach-child-organization": "{count, plural, =1 {The child organization has been linked to the parent organization} other {The {count} child organizations have been linked to the parent organization}}"
         }
       },
       "title": "Children organisations"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1060,10 +1060,10 @@
       "empty-table": "No child organisation",
       "notifications": {
         "error": {
-          "unable-to-attach-already-attached-child-organization": "Child organization already linked",
-          "unable-to-attach-child-organization-to-another-child-organization": "Unable to attach a child organization to another child organization",
-          "unable-to-attach-child-organization-to-itself": "Unable to attach organization to itself",
-          "unable-to-attach-parent-organization-as-child-organization": "Unable to attach a parent organization as child organization"
+          "unable-to-attach-already-attached-child-organization": "Child organization {childOrganizationId} already linked",
+          "unable-to-attach-child-organization-to-another-child-organization": "Unable to attach the child organization to another child organization",
+          "unable-to-attach-child-organization-to-itself": "Unable to attach organization {childOrganizationId} to itself",
+          "unable-to-attach-parent-organization-as-child-organization": "Unable to attach the parent organization {childOrganizationId} as child organization"
         },
         "success": {
           "attach-child-organization": "{count, plural, =1 {The child organization has been linked to the parent organization} other {The {count} child organizations have been linked to the parent organization}}"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1067,7 +1067,7 @@
           "unable-to-attach-parent-organization-as-child-organization": "Impossible d'attacher une organisation mère en tant qu'organisation fille."
         },
         "success": {
-          "attach-child-organization": "L'organisation fille a bien été liée à l'organisation mère"
+          "attach-child-organization": "{count, plural, =1 {L'organisation fille a bien été liée à l'organisation mère} other {Les {count} organisations filles ont bien été liées à l'organisation mère}}"
         }
       },
       "title": "Organisations filles"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1061,10 +1061,10 @@
       "empty-table": "Aucune organisation fille",
       "notifications": {
         "error": {
-          "unable-to-attach-already-attached-child-organization": "L'organisation fille est déjà liée.",
-          "unable-to-attach-child-organization-to-another-child-organization": "Impossible d'attacher une organisation fille à une autre organisation fille.",
-          "unable-to-attach-child-organization-to-itself": "Impossible d'attacher l'organisation à elle-même",
-          "unable-to-attach-parent-organization-as-child-organization": "Impossible d'attacher une organisation mère en tant qu'organisation fille."
+          "unable-to-attach-already-attached-child-organization": "L'organisation fille {childOrganizationId} est déjà liée.",
+          "unable-to-attach-child-organization-to-another-child-organization": "Impossible d'attacher l'organisation fille à une autre organisation fille.",
+          "unable-to-attach-child-organization-to-itself": "Impossible d'attacher l'organisation {childOrganizationId} à elle-même",
+          "unable-to-attach-parent-organization-as-child-organization": "Impossible d'attacher l'organisation mère {childOrganizationId} en tant qu'organisation fille."
         },
         "success": {
           "attach-child-organization": "{count, plural, =1 {L'organisation fille a bien été liée à l'organisation mère} other {Les {count} organisations filles ont bien été liées à l'organisation mère}}"


### PR DESCRIPTION
## 🍂 Problème
Dans PixAdmin, lorsque l'on rattache x organisations filles à une organisation mère, une notification générique est affichée.
On aimerait avoir deux choses : 
- Un message différent si une seule ou plusieurs orgas ont été rattachées
- Si plusieurs orgas, alors afficher le nombre total rattachée

## 🌰 Proposition
Ajouter une variable count dans la clé de traduction, qui provient du nombre d'organisations rattachée. Et afficher un texte pluralisé dans le cas ou N organisations ont été rattachée

## 🍁 Remarques
J'ai fait le choix de prendre le nombre d'organisations directement présente dans l'input qu'on utilise pour attacher N organisations, car il n'y a pas de possibilités que cette fonctionnalité marche partiellement. Soit TOUTES les orgas dans la liste peuvent être rattachés et du coup on valide via la notif. Soit si au moins une seule est en erreur, peut importe le cas, on en enregistre aucune. C'est toute ou rien.
Peut être que plus tard on voudrait pouvoir en enregistrer quelques unes même si le reste est en erreur, mais ce n'est pas la demande pour l'instant

## 🪵 Pour tester

- Se connecter à PixAdmin en tant que SUPER_ADMIN
- Aller sur une page d'organisation
- Tenter de rattacher UNE SEULE organisation -> Voir le message au singulier
- Tenter d'en rattacher au moins 2 -> Voir le message pluriel avec la variable affichée
- Tenter d'en rattacher plusieurs, mais avec une déjà rattachée par exemple -> La notif d'erreur est toujours la même
- 🐈‍⬛ 
