### PR TITLE
[FEATURE] Add column avatar in users table (PIX-20022)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -123,6 +123,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   rawPassword = DEFAULT_PASSWORD,
   shouldChangePassword = false,
   emailConfirmedAt = new Date('2021-04-28T02:42:00Z'),
+  avatarUrl,
 } = {}) {
   email = _generateEmailIfUndefined(email, id, lastName, firstName);
 
@@ -143,6 +144,7 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     createdAt,
     updatedAt,
     emailConfirmedAt,
+    avatarUrl,
   };
 
   const user = databaseBuffer.pushInsertable({

--- a/api/db/migrations/20251016141533_add_column_avatar_in_users.js
+++ b/api/db/migrations/20251016141533_add_column_avatar_in_users.js
@@ -1,0 +1,38 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'avatarUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null).comment('Url of the user avatar.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -78,6 +78,16 @@ function _buildUsers(databaseBuilder) {
     emailConfirmedAt: null,
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
+// user with avatar
+
+  const user = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Paul',
+    lastName: 'Emploi',
+    email: 'paul-emploi@example.net',
+    avatarUrl: 'https://thypix.com/fr/photos-de-profil-de-bob-leponge/'
+  });
+
+
 }
 
 export function buildUsers(databaseBuilder) {


### PR DESCRIPTION
## 🍂 Problème

Nous rencontrons plusieurs difficultés liées à l’identification des utilisateurs :

Du côté des centres de certification, ils souhaitent disposer d’une garantie supplémentaire pour vérifier que le compte Pix correspond bien à l’utilisateur. Cette vérification viendrait s’ajouter à l’identité déjà confirmée par le prénom et le nom.

Du côté des utilisateurs, notamment dans les SCO utilisant des ordinateurs partagés, le prénom et le nom ne suffisent pas toujours à éviter les confusions. L’ajout d’un élément d’identification complémentaire permettrait d’alerter l’utilisateur et de renforcer la sécurité.

## 🌰 Proposition

L’ajout d’un avatar sur le profil utilisateur pourrait être utilisé par différentes équipes et présenter plusieurs avantages :

Pour les centres de certification : combiner prénom, nom, pièce d’identité et avatar offre un niveau d’identification supplémentaire.

Pour les utilisateurs : placer l’avatar en haut à droite, à côté du prénom et du nom, permettrait d’attirer davantage l’attention de l’élève et de l’alerter s’il n’est pas sur la bonne session.
<img width="533" height="297" alt="image-20251014-193336" src="https://github.com/user-attachments/assets/11320233-5351-4940-a2e9-b2ecd2917269" />


## 🍁 Remarques

On exclue de donner la possibilité à l’utilisateur d’ajouter sa photo lui-même.
## 🪵 Pour tester
* 1
Se connecter à Mon pix avec user.avatar@example.net
Vérifier que la photo apparait dans Mon compte

* 2
Se connecter à Mon pix avec user.with.no.avatar@example.net
Vérifier qu'aucune photo n'apparait dans Mon compte

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
