### PR TITLE
[BUGFIX] Intercepter la contrainte d'unicité sur la création de participations lié à un même learner (PIX-20047).

### DIFF
--- a/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
@@ -27,7 +26,8 @@ const save = async function ({ competenceEvaluation }) {
 };
 
 const updateStatusByUserIdAndCompetenceId = async function ({ userId, competenceId, status }) {
-  const [competenceEvaluation] = await knex('competence-evaluations')
+  const knexConn = DomainTransaction.getConnection();
+  const [competenceEvaluation] = await knexConn('competence-evaluations')
     .where({ userId, competenceId })
     .update({ status })
     .returning('*');
@@ -46,12 +46,13 @@ const updateAssessmentId = async function ({ currentAssessmentId, newAssessmentI
 };
 
 const getByAssessmentId = async function (assessmentId) {
-  const competenceEvaluation = await knex('competence-evaluations').where({ assessmentId }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const competenceEvaluation = await knexConn('competence-evaluations').where({ assessmentId }).first();
   if (!competenceEvaluation) {
     throw new NotFoundError();
   }
 
-  const assessment = await knex('assessments').where({ id: competenceEvaluation.assessmentId }).first();
+  const assessment = await knexConn('assessments').where({ id: competenceEvaluation.assessmentId }).first();
 
   return _toDomain({ competenceEvaluation, assessment });
 };
@@ -76,8 +77,9 @@ const getByCompetenceIdAndUserId = async function ({
 };
 
 const findByUserId = async function (userId) {
-  const competenceEvaluations = await knex('competence-evaluations').where({ userId }).orderBy('createdAt', 'asc');
-  const assessments = await knex('assessments').whereIn(
+  const knexConn = DomainTransaction.getConnection();
+  const competenceEvaluations = await knexConn('competence-evaluations').where({ userId }).orderBy('createdAt', 'asc');
+  const assessments = await knexConn('assessments').whereIn(
     'id',
     competenceEvaluations.map((competenceEvaluation) => competenceEvaluation.assessmentId),
   );
@@ -93,7 +95,8 @@ const findByUserId = async function (userId) {
 };
 
 const findByAssessmentId = async function (assessmentId) {
-  const competenceEvaluations = await knex('competence-evaluations')
+  const knexConn = DomainTransaction.getConnection();
+  const competenceEvaluations = await knexConn('competence-evaluations')
     .where({ assessmentId })
     .orderBy('createdAt', 'asc');
 

--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -10,8 +10,9 @@ const save = async function (request, h, dependencies = { campaignParticipationS
   const userId = request.auth.credentials.userId;
   const campaignParticipation = await dependencies.campaignParticipationSerializer.deserialize(request.payload);
 
-  const { campaignParticipation: campaignParticipationCreated } = await DomainTransaction.execute(() => {
-    return usecases.startCampaignParticipation({ campaignParticipation, userId });
+  const { campaignParticipation: campaignParticipationCreated } = await usecases.startCampaignParticipation({
+    campaignParticipation,
+    userId,
   });
 
   return h.response(dependencies.campaignParticipationSerializer.serialize(campaignParticipationCreated)).created();

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participant-repository.js
@@ -129,6 +129,12 @@ async function _createNewCampaignParticipation(campaignParticipation) {
         `User ${campaignParticipation.userId} has already a campaign participation with campaign ${campaignParticipation.campaignId}`,
       );
     }
+
+    if (error.constraint === 'one_active_participation_by_learner') {
+      throw new AlreadyExistingCampaignParticipationError(
+        `learner ${campaignParticipation.organizationLearnerId} has already a campaign participation with campaign ${campaignParticipation.campaignId}`,
+      );
+    }
     throw error;
   }
 }

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -149,9 +149,6 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
       usecases.startCampaignParticipation.resolves({});
       const deserializedCampaignParticipation = Symbol('campaignParticipation');
       dependencies.campaignParticipationSerializer.deserialize.resolves(deserializedCampaignParticipation);
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
-      });
 
       // when
       await learnerParticipationController.save(request, hFake, dependencies);
@@ -172,9 +169,6 @@ describe('Unit | Application | Controller | Learner-Participation', function () 
       const campaignParticipation = domainBuilder.buildCampaignParticipation();
       usecases.startCampaignParticipation.resolves({
         campaignParticipation,
-      });
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback();
       });
 
       const serializedCampaignParticipation = { id: 88, assessmentId: 12 };

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/start-campaign-participation_test.js
@@ -1,6 +1,7 @@
 import { CampaignParticipant } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipant.js';
 import { ParticipationStartedJob } from '../../../../../../src/prescription/campaign-participation/domain/models/ParticipationStartedJob.js';
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { KnowledgeElement } from '../../../../../../src/shared/domain/models/KnowledgeElement.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -12,6 +13,9 @@ describe('Unit | UseCase | start-campaign-participation', function () {
   let participationStartedJobRepository;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((callback) => callback());
+
     campaignRepository = {
       findAllSkills: sinon.stub(),
       areKnowledgeElementsResettable: sinon.stub(),


### PR DESCRIPTION
## 🍂 Problème

On avait une contrainte que nous laissions filer. ce qui entraine un crash du conteneur

## 🌰 Proposition

Intercepter cette contrainte et retourner une erreur du domain

## 🍁 Remarques

Cela ne resoudra pas le souci de l'utilisateur. Nous devons voir ce que nous faisons dans le cas de la dissociation

## 🪵 Pour tester

Dissocier dans PixAdmin un learner sur SCO_SCIECLE
Aller sur PixApp et s'associer avec un autre compte
Tenter de faire la même participation et se faire refuser l'entrée par le videur