### PR TITLE
[TECH] :truck: Déplace le modèle `AdminMember` dans le contest `src/team`

### DIFF
--- a/api/src/shared/infrastructure/repositories/admin-member.repository.js
+++ b/api/src/shared/infrastructure/repositories/admin-member.repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { AdminMemberError } from '../../../authorization/domain/errors.js';
-import { AdminMember } from '../../domain/models/AdminMember.js';
+import { AdminMember } from '../../../team/domain/models/AdminMember.js';
 
 const TABLE_NAME = 'pix-admin-roles';
 

--- a/api/src/team/domain/models/AdminMember.js
+++ b/api/src/team/domain/models/AdminMember.js
@@ -4,7 +4,7 @@ const Joi = BaseJoi.extend(JoiDate);
 import lodash from 'lodash';
 
 import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
 
 const { isNil } = lodash;
 

--- a/api/src/team/domain/usecases/save-admin-member.usecase.js
+++ b/api/src/team/domain/usecases/save-admin-member.usecase.js
@@ -1,5 +1,5 @@
-import { AdminMember } from '../../../shared/domain/models/AdminMember.js';
 import { AlreadyExistingAdminMemberError } from '../errors.js';
+import { AdminMember } from '../models/AdminMember.js';
 
 const saveAdminMember = async function ({ email, role, userRepository, adminMemberRepository }) {
   const { id: userId, firstName, lastName } = await userRepository.getByEmail(email);

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -3,8 +3,8 @@ import { AuthenticationMethod } from '../../../../../src/identity-access-managem
 import { authenticateOidcUser } from '../../../../../src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
-import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { AuthenticationSessionContent } from '../../../../../src/shared/domain/models/AuthenticationSessionContent.js';
+import { AdminMember } from '../../../../../src/team/domain/models/AdminMember.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oidc-user', function () {

--- a/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/admin-member.repository.test.js
@@ -1,7 +1,7 @@
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { AdminMemberError } from '../../../../../src/authorization/domain/errors.js';
-import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { adminMemberRepository } from '../../../../../src/shared/infrastructure/repositories/admin-member.repository.js';
+import { AdminMember } from '../../../../../src/team/domain/models/AdminMember.js';
 import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 const { ROLES } = PIX_ADMIN;

--- a/api/tests/team/unit/domain/models/AdminMember_test.js
+++ b/api/tests/team/unit/domain/models/AdminMember_test.js
@@ -4,7 +4,7 @@ import { expect } from '../../../../test-helper.js';
 const { ROLES } = PIX_ADMIN;
 
 import { ObjectValidationError } from '../../../../../src/shared/domain/errors.js';
-import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
+import { AdminMember } from '../../../../../src/team/domain/models/AdminMember.js';
 
 describe('Unit | Shared | Domain | Models | AdminMember', function () {
   describe('constructor', function () {

--- a/api/tests/team/unit/domain/usecases/save-admin-member.usecase.test.js
+++ b/api/tests/team/unit/domain/usecases/save-admin-member.usecase.test.js
@@ -1,7 +1,7 @@
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { UserNotFoundError } from '../../../../../src/shared/domain/errors.js';
-import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { AlreadyExistingAdminMemberError } from '../../../../../src/team/domain/errors.js';
+import { AdminMember } from '../../../../../src/team/domain/models/AdminMember.js';
 import { saveAdminMember } from '../../../../../src/team/domain/usecases/save-admin-member.usecase.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/tooling/domain-builder/factory/build-admin-member.js
+++ b/api/tests/tooling/domain-builder/factory/build-admin-member.js
@@ -1,5 +1,5 @@
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import { AdminMember } from '../../../../src/shared/domain/models/AdminMember.js';
+import { AdminMember } from '../../../../src/team/domain/models/AdminMember.js';
 
 const { ROLES } = PIX_ADMIN;
 


### PR DESCRIPTION
## 🍂 Problème

Le modèle `AdminMember` est dans le contexte partagé, mais n'est utilisé que dans le contexte `team`.

## 🌰 Proposition

Déplacer le modèle `AdminMember` dans le contexte `team`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Je  suppose qu'un petit tour dans pixAdmin pour s'assurer des accès possible ou pas permet de vérifier que ce déplacement n'a rien cassé ?
