### PR TITLE
[BUGFIX] Gérer le usecase handle-badge-acquisition quand le campaign Id n'existe pas (PIX-20053)

### DIFF
--- a/api/src/devcomp/domain/usecases/handle-training-recommendation.js
+++ b/api/src/devcomp/domain/usecases/handle-training-recommendation.js
@@ -6,7 +6,7 @@ const handleTrainingRecommendation = async function ({
   trainingRepository,
   userRecommendedTrainingRepository,
 }) {
-  if (!assessment.isForCampaign()) {
+  if (!assessment.isCampaignParticipationAvailable()) {
     return;
   }
   const { campaignParticipationId } = assessment;

--- a/api/src/evaluation/domain/usecases/handle-badge-acquisition.js
+++ b/api/src/evaluation/domain/usecases/handle-badge-acquisition.js
@@ -6,7 +6,7 @@ const handleBadgeAcquisition = async function ({
   badgeAcquisitionRepository,
   knowledgeElementRepository,
 }) {
-  if (assessment.isForCampaign()) {
+  if (assessment.isCampaignParticipationAvailable()) {
     const campaignParticipationId = assessment.campaignParticipationId;
     const associatedBadges = await _fetchPossibleCampaignAssociatedBadges(
       campaignParticipationId,

--- a/api/src/evaluation/domain/usecases/handle-stage-acquisition.js
+++ b/api/src/evaluation/domain/usecases/handle-stage-acquisition.js
@@ -25,7 +25,7 @@ const handleStageAcquisition = async function ({
   getMasteryPercentageService,
   convertLevelStagesIntoThresholdsService,
 }) {
-  if (!assessment.isForCampaign()) return;
+  if (!assessment.isCampaignParticipationAvailable()) return;
 
   const campaignParticipation = await campaignParticipationRepository.get(assessment.campaignParticipationId);
 

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -137,6 +137,10 @@ class Assessment {
     return this.type === types.CAMPAIGN;
   }
 
+  isCampaignParticipationAvailable() {
+    return this.isForCampaign() && Boolean(this.campaignParticipationId);
+  }
+
   isCertification() {
     return this.type === types.CERTIFICATION;
   }

--- a/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-user-module-statuses_test.js
@@ -4,10 +4,15 @@ import { getUserModuleStatuses } from '../../../../../src/devcomp/domain/usecase
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | UseCases | get-user-module-statuses', function () {
-  let now;
+  const now = new Date('2025-07-02T14:00:00Z');
+  let clock;
 
   beforeEach(function () {
-    now = new Date('2025-07-02T14:00:00Z');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
   });
 
   it('should return a list of UserModuleStatuses', async function () {

--- a/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/handle-training-recommendation_test.js
@@ -106,6 +106,26 @@ describe('Unit | Devcomp | Domain | UseCases | handle-training-recommendation', 
     });
   });
 
+  describe('when campaign participation is not available', function () {
+    it('should do nothing', async function () {
+      // given
+      const locale = Symbol('locale');
+      const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId: null });
+
+      findWithTriggersByCampaignParticipationIdAndLocaleStub.throws();
+
+      // when & then
+      await expect(
+        handleTrainingRecommendation({
+          locale,
+          assessment,
+          trainingRepository,
+          userRecommendedTrainingRepository,
+        }),
+      ).to.fulfilled;
+    });
+  });
+
   describe('when assessment is not for campaign', function () {
     it('should do nothing', async function () {
       // given

--- a/api/tests/evaluation/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -188,4 +188,23 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
       });
     });
   });
+
+  context('when assessment is not linked to a campaign', function () {
+    it('should not throw', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      const assessmentDB = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: null,
+        type: Assessment.types.CAMPAIGN,
+      });
+
+      await databaseBuilder.commit();
+
+      const assessment = domainBuilder.buildAssessment(assessmentDB);
+      const result = evaluationUsecases.handleBadgeAcquisition({ assessment });
+
+      await expect(result).to.fulfilled;
+    });
+  });
 });

--- a/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/handle-stage-acquisition_test.js
@@ -104,7 +104,24 @@ describe('Evaluation | Integration | Usecase | Handle Stage Acquisition', functi
 
         await mockLearningContent(learningContentBuilder(learningContent));
       });
+      context('When campaignParticipation is not available', function () {
+        it('should not throw', async function () {
+          // given
+          assessment = new Assessment({
+            userId,
+            campaignParticipationId: null,
+            type: Assessment.types.CAMPAIGN,
+          });
+          stages = [databaseBuilder.factory.buildStage({ targetProfileId, threshold: 0 })];
 
+          // when & then
+          await expect(
+            evaluationUsecases.handleStageAcquisition({
+              assessment,
+            }),
+          ).fulfilled;
+        });
+      });
       context('when some KEs are acquired', function () {
         beforeEach(async function () {
           databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });

--- a/api/tests/evaluation/unit/application/answers/answer-controller_test.js
+++ b/api/tests/evaluation/unit/application/answers/answer-controller_test.js
@@ -146,7 +146,10 @@ describe('Unit | Controller | answer-controller', function () {
 
       it('should call appropriate usecase when assessment is of type CAMPAIGN', async function () {
         // given
-        const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CAMPAIGN });
+        const assessment = domainBuilder.buildAssessment({
+          type: Assessment.types.CAMPAIGN,
+          campaignParticipationId: 1234,
+        });
         assessmentRepository.getWithAnswers.withArgs(assessmentId).resolves(assessment);
 
         // when

--- a/api/tests/evaluation/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-correction-for-answer_test.js
@@ -57,6 +57,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
         const assessment = domainBuilder.buildAssessment({
           state: 'started',
           type: Assessment.types.CAMPAIGN,
+          campaignParticipationId: 1234,
         });
         assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -190,9 +190,27 @@ describe('Unit | Domain | Models | Assessment', function () {
   });
 
   describe('#isForCampaign', function () {
-    it('should return true when the assessment is for a CAMPAIGN', function () {
+    it('should return true when the assessment is for a CAMPAIGN and not linked to a participation', function () {
       // given
-      const assessment = new Assessment({ type: 'CAMPAIGN', campaign: domainBuilder.buildCampaign() });
+      const assessment = new Assessment({
+        type: 'CAMPAIGN',
+        campaign: domainBuilder.buildCampaign(),
+        campaignParticipationId: null,
+      });
+
+      // when
+      const isForCampaign = assessment.isForCampaign();
+
+      // then
+      expect(isForCampaign).to.be.true;
+    });
+    it('should return true when the assessment is for a CAMPAIGN and linked to a participation', function () {
+      // given
+      const assessment = new Assessment({
+        type: 'CAMPAIGN',
+        campaign: domainBuilder.buildCampaign(),
+        campaignParticipationId: Symbol('campaignParticipationId'),
+      });
 
       // when
       const isForCampaign = assessment.isForCampaign();

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -224,6 +224,62 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
+  describe('#isCampaignParticipationAvailable', function () {
+    it('should return false when the assessment is for a CAMPAIGN and not linked to a participation', function () {
+      // given
+      const assessment = new Assessment({
+        type: 'CAMPAIGN',
+        campaign: domainBuilder.buildCampaign(),
+        campaignParticipationId: null,
+      });
+
+      // when
+      const isCampaignParticipationAvailable = assessment.isCampaignParticipationAvailable();
+
+      // then
+      expect(isCampaignParticipationAvailable).to.be.false;
+    });
+    it('should return true when the assessment is for a CAMPAIGN and linked to a participation', function () {
+      // given
+      const assessment = new Assessment({
+        type: 'CAMPAIGN',
+        campaign: domainBuilder.buildCampaign(),
+        campaignParticipationId: Symbol('campaignParticipationId'),
+      });
+
+      // when
+      const isCampaignParticipationAvailable = assessment.isCampaignParticipationAvailable();
+
+      // then
+      expect(isCampaignParticipationAvailable).to.be.true;
+    });
+
+    it('should return false when the assessment is not a CAMPAIGN type', function () {
+      // given
+      const assessment = new Assessment({
+        type: 'PLACEMENT',
+        campaignParticipationId: Symbol('campaignParticipationId'),
+      });
+
+      // when
+      const isCampaignParticipationAvailable = assessment.isCampaignParticipationAvailable();
+
+      // then
+      expect(isCampaignParticipationAvailable).to.be.false;
+    });
+
+    it('should return false when the assessment has no type and has campaignParticipationId', function () {
+      // given
+      const assessment = new Assessment({ campaignParticipationId: Symbol('campaignParticipationId') });
+
+      // when
+      const isCampaignParticipationAvailable = assessment.isCampaignParticipationAvailable();
+
+      // then
+      expect(isCampaignParticipationAvailable).to.be.false;
+    });
+  });
+
   describe('#isCertification', function () {
     it('should return true when the assessment is a CERTIFICATION', function () {
       // given


### PR DESCRIPTION
## 🍂 Problème
Quand un id de campagne n'existe pas, les requêtes sur l'acquisition de badge cassent.

## 🌰 Proposition
On propose de ne pas entrer dans le usecase quand l'id de campagne n'existe pas.

## 🍁 Remarques
On en profite pour fixer un flaky sur getUserModuleStatus (voir deuxième commit).

## 🪵 Pour tester
- Faire un parcours `PROASSMUL`  et s'arrêter avant de voir les résultats 
- Supprimer la participation dans PixOrga
- Cliquer sur "Voir les résultats"
- ne pas avoir d'erreurs (et pas de loader de l'infini et au delà)
