### PR TITLE
[FEATURE] Prendre en compte les retours à la ligne à l'affichage d'une "bonne réponse à afficher" (PIX-19931)

### DIFF
--- a/mon-pix/app/components/solution-panel/formatted-solution.gjs
+++ b/mon-pix/app/components/solution-panel/formatted-solution.gjs
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+
+export default class FormattedSolution extends Component {
+  get displayedSolution() {
+    return this.args.solutionToDisplay?.replaceAll('\n', ' <br>');
+  }
+
+  <template><MarkdownToHtml ...attributes @markdown={{this.displayedSolution}} /></template>
+}

--- a/mon-pix/app/components/solution-panel/qcm-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qcm-solution-panel.gjs
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import isEmpty from 'lodash/isEmpty';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+import FormattedSolution from 'mon-pix/components/solution-panel/formatted-solution';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import { pshuffle } from 'mon-pix/utils/pshuffle';
@@ -37,12 +38,13 @@ export default class QcmSolutionPanel extends Component {
         {{#if @solutionToDisplay}}
           <div class="comparison-window-solution comparison-window-solution--with-margin">
             <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-            <div class="comparison-window-solution__text">{{@solutionToDisplay}}</div>
+            <FormattedSolution class="comparison-window-solution__text" @solutionToDisplay={{@solutionToDisplay}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
   </template>
+
   get solutionArray() {
     const solution = this.args.solution;
     const solutionArray = !isEmpty(solution) ? valueAsArrayOfBoolean(solution, this._proposalsArray.length) : [];

--- a/mon-pix/app/components/solution-panel/qcu-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qcu-solution-panel.gjs
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import isEmpty from 'lodash/isEmpty';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+import FormattedSolution from 'mon-pix/components/solution-panel/formatted-solution';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import { pshuffle } from 'mon-pix/utils/pshuffle';
@@ -60,13 +61,17 @@ export default class QcuSolutionPanel extends Component {
           </p>
         </div>
       {{else}}
-        <MarkdownToHtml
+        <FormattedSolution
           class="qcu-solution-answer-feedback__expected-answer"
-          @markdown="{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}} {{this.solutionAsText}}"
+          @solutionToDisplay="{{t
+            'pages.comparison-window.results.feedback.wrong'
+            htmlSafe=true
+          }} {{this.solutionAsText}}"
         />
       {{/if}}
     </div>
   </template>
+
   get solutionArray() {
     const solution = this.args.solution;
     return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];

--- a/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qroc-solution-panel.gjs
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
+import FormattedSolution from 'mon-pix/components/solution-panel/formatted-solution';
 
 import inc from '../../helpers/inc';
 
@@ -118,7 +119,10 @@ export default class QrocSolutionPanel extends Component {
           {{#if this.understandableSolution}}
             <p class="comparison-window-solution">
               <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-              <span class="comparison-window-solution__text">{{this.understandableSolution}}</span>
+              <FormattedSolution
+                class="comparison-window-solution__text"
+                @solutionToDisplay={{this.understandableSolution}}
+              />
             </p>
           {{/if}}
         {{/if}}

--- a/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qrocm-dep-solution-panel.gjs
@@ -7,6 +7,7 @@ import t from 'ember-intl/helpers/t';
 import eq from 'ember-truth-helpers/helpers/eq';
 import jsyaml from 'js-yaml';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+import FormattedSolution from 'mon-pix/components/solution-panel/formatted-solution';
 import inc from 'mon-pix/helpers/inc';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
@@ -42,7 +43,7 @@ export default class QrocmDepSolutionPanel extends Component {
                 {{#if block.solution}}
                   <p class="correction-qrocm__solution">
                     <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                    <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                    <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                   </p>
                 {{/if}}
               </div>
@@ -58,7 +59,7 @@ export default class QrocmDepSolutionPanel extends Component {
                 {{#if block.solution}}
                   <p class="correction-qrocm__solution">
                     <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                    <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                    <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                   </p>
                 {{/if}}
               </div>
@@ -77,7 +78,7 @@ export default class QrocmDepSolutionPanel extends Component {
                 {{#if block.solution}}
                   <p class="correction-qrocm__solution">
                     <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                    <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                    <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                   </p>
                 {{/if}}
               </div>
@@ -92,7 +93,10 @@ export default class QrocmDepSolutionPanel extends Component {
           {{#unless this.shouldDisplayAnswersUnderInputs}}
             <p class="comparison-window-solution">
               <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-              <span class="correction-qrocm__solution-text">{{this.formattedSolution}}</span>
+              <FormattedSolution
+                class="correction-qrocm__solution-text"
+                @solutionToDisplay={{this.formattedSolution}}
+              />
             </p>
           {{/unless}}
         {{/unless}}

--- a/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.gjs
+++ b/mon-pix/app/components/solution-panel/qrocm-ind-solution-panel.gjs
@@ -7,6 +7,7 @@ import t from 'ember-intl/helpers/t';
 import eq from 'ember-truth-helpers/helpers/eq';
 import keys from 'lodash/keys';
 import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
+import FormattedSolution from 'mon-pix/components/solution-panel/formatted-solution';
 import getQrocInputSize from 'mon-pix/helpers/get-qroc-input-size';
 import inc from 'mon-pix/helpers/inc';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
@@ -49,7 +50,7 @@ export default class QrocmIndSolutionPanel extends Component {
               {{#if block.emptyOrWrongAnswer}}
                 <p class="correction-qrocm__solution">
                   <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                  <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                  <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                 </p>
               {{/if}}
             {{else if (eq @challenge.format "phrase")}}
@@ -66,7 +67,7 @@ export default class QrocmIndSolutionPanel extends Component {
               {{#if block.emptyOrWrongAnswer}}
                 <p class="correction-qrocm__solution">
                   <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                  <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                  <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                 </p>
               {{/if}}
             {{else}}
@@ -84,7 +85,7 @@ export default class QrocmIndSolutionPanel extends Component {
                 {{#if block.emptyOrWrongAnswer}}
                   <p class="correction-qrocm__solution">
                     <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-                    <span class="correction-qrocm__solution-text">{{block.solution}}</span>
+                    <FormattedSolution class="correction-qrocm__solution-text" @solutionToDisplay={{block.solution}} />
                   </p>
                 {{/if}}
               </div>
@@ -102,7 +103,7 @@ export default class QrocmIndSolutionPanel extends Component {
         {{#if @solutionToDisplay}}
           <div class="comparison-window-solution comparison-window-solution--with-margin">
             <span class="sr-only">{{t "pages.comparison-window.results.a11y.the-answer-was"}}</span>
-            <div class="comparison-window-solution__text">{{@solutionToDisplay}}</div>
+            <FormattedSolution class="comparison-window-solution__text" @solutionToDisplay={{@solutionToDisplay}} />
           </div>
         {{/if}}
       {{/if}}

--- a/mon-pix/tests/integration/components/solution-panel/formatted-solution-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/formatted-solution-test.js
@@ -1,0 +1,44 @@
+import { render } from '@1024pix/ember-testing-library';
+// eslint-disable-next-line no-restricted-imports
+import { find } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | formatted-solution.js', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let solutionToDisplay;
+
+  test('should display the provided solution', async function (assert) {
+    // Given
+    solutionToDisplay = 'patate';
+    this.set('solutionToDisplay', solutionToDisplay);
+
+    // When
+    await render(
+      hbs`<SolutionPanel::FormattedSolution class='solution' @solutionToDisplay={{this.solutionToDisplay}} />`,
+    );
+
+    // Then
+    assert.dom('.solution').hasText(solutionToDisplay);
+  });
+
+  module('when solution has a new line', function () {
+    test('should display the new line', async function (assert) {
+      // Given
+      solutionToDisplay = 'patate\nau\nfromage';
+      this.set('solutionToDisplay', solutionToDisplay);
+
+      // When
+      await render(
+        hbs`<SolutionPanel::FormattedSolution class='solution' @solutionToDisplay={{this.solutionToDisplay}} />`,
+      );
+
+      // Then
+      const solution = find('.solution');
+      assert.dom(solution).hasText(solutionToDisplay);
+      assert.dom(solution).containsHtml('<br>');
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Sur la page d'affichage des résultats (checkpoint), les retours à la ligne de `solutionToDisplay` ne sont pas pris en compte.

## 🌰 Proposition

Traiter le contenu de ce champ comme du markdown, et remplacer les retours à la ligne par des balises `<br>`.

## 🍁 Remarques

- Le `replaceAll('\n', ' <br>')` est nécessaire (au moins temporairement) car l'éditeur du champ concerné sur Pix Editor n'est pas un WYSIWYG.
- Le nom du nouveau composant est négociable, n'hésitez pas à mettre un commentaire si vous avec une meilleur idée.

## 🪵 Pour tester

> J'ai testé manuellement la non-régression visuelle pour tous les types d'épreuve, ça me semble OK.

- Ouvrir [la review app](https://app-pr13925.review.pix.fr/accueil)
- Répondre faux à des questions
- Arriver jusqu'à la page d'affichage des résultats
- Ouvrir la modale des réponses & tutos
- Constater que "solution à la ligne" s'affiche avec des retours à la ligne
<img width="379" height="420" alt="exemple du résultat attendu" src="https://github.com/user-attachments/assets/405227b7-3a77-463d-80bc-532d3f32ef74" />
