### PR TITLE
[TECH] Ajouter une colonne `referenceId` dans la table `organization_learner_participations` (PIX-20058).

### DIFF
--- a/api/db/migrations/20251020133841_add-referenceId-column-organization-learner-participation.js
+++ b/api/db/migrations/20251020133841_add-referenceId-column-organization-learner-participation.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'organization_learner_participations';
+const COLUMN_NAME = 'referenceId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string(COLUMN_NAME)
+      .defaultTo(null)
+      .comment('Reference of participation typology campaign / combined course / modules');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

l'ajout de l'id dans la colonne attributes comporte des risques dans la vérification, la mise à jour du json. et peut amener à la suppression de cette id. 

## 🌰 Proposition

Ajouter une colonne referenceId afin de pouvoir gérer une contrainte polymorphique sur la table organization_learner_participations

## 🍁 Remarques

Ajout des contraintes une fois que le legacy sera rattrappé. 

## 🪵 Pour tester

Vérifier que la colonne est présente. 