### PR TITLE
[FEATURE] Créer une route pour détacher une orga fille de son parent (PIX-19983)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -11,12 +11,17 @@ import {
   OrganizationNotFound,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
+  UnableToDetachParentOrganizationFromChildOrganization,
 } from '../domain/errors.js';
 
 const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: UnableToAttachChildOrganizationToParentOrganizationError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: UnableToDetachParentOrganizationFromChildOrganization.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: OrganizationNotFound.name,

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -31,6 +31,14 @@ const attachChildOrganization = async function (request, h) {
   return h.response().code(204);
 };
 
+const detachParentOrganization = async function (request, h) {
+  const { childOrganizationId } = request.params;
+
+  await usecases.detachParentOrganizationFromOrganization({ childOrganizationId });
+
+  return h.response().code(204);
+};
+
 const getTemplateForAddOrganizationFeatureInBatch = async function (request, h) {
   const fields = ORGANIZATION_FEATURES_HEADER.columns.map(({ name }) => name);
   const csvTemplateFileContent = generateCSVTemplate(fields);
@@ -130,6 +138,7 @@ const organizationAdminController = {
   archiveOrganization,
   archiveInBatch,
   attachChildOrganization,
+  detachParentOrganization,
   getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,
   getOrganizationDetails,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -398,6 +398,29 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/organizations/{childOrganizationId}/detach-parent-organization',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            childOrganizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: (request, h) => organizationAdminController.detachParentOrganization(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de détacher une organization fille de son organization mère.',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -82,6 +82,18 @@ class FeatureParamsNotProcessable extends DomainError {
   }
 }
 
+class UnableToDetachParentOrganizationFromChildOrganization extends DomainError {
+  constructor({
+    code = 'UNABLE_TO_DETACH_PARENT_ORGANIZATION_FROM_CHILD_ORGANIZATION',
+    message = 'Unable to detach parent organization from child organization',
+    meta,
+  } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 export {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
@@ -93,4 +105,5 @@ export {
   OrganizationNotFound,
   TagNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
+  UnableToDetachParentOrganizationFromChildOrganization,
 };

--- a/api/src/organizational-entities/domain/usecases/detach-parent-organization-from-organization.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/detach-parent-organization-from-organization.usecase.js
@@ -1,0 +1,25 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { UnableToDetachParentOrganizationFromChildOrganization } from '../errors.js';
+
+const detachParentOrganizationFromOrganization = withTransaction(async function ({
+  childOrganizationId,
+  organizationForAdminRepository,
+}) {
+  const childOrganization = await organizationForAdminRepository.get({ organizationId: childOrganizationId });
+
+  _checkOrganizationHasParent(childOrganization);
+
+  childOrganization.updateParentOrganizationId(null);
+
+  await organizationForAdminRepository.update({ organization: childOrganization });
+});
+
+function _checkOrganizationHasParent(organization) {
+  if (!organization.parentOrganizationId) {
+    throw new UnableToDetachParentOrganizationFromChildOrganization({
+      message: 'Unable to detach parent organization from child because it has no parent.',
+      meta: { organizationId: Number(organization.id) },
+    });
+  }
+}
+export { detachParentOrganizationFromOrganization };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -73,6 +73,7 @@ import { createCertificationCenter } from './create-certification-center.usecase
 import { createOrganization } from './create-organization.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from './create-organizations-with-tags-and-target-profiles.usecase.js';
 import { createTag } from './create-tag.js';
+import { detachParentOrganizationFromOrganization } from './detach-parent-organization-from-organization.usecase.js';
 import { findAllAdministrationTeams } from './find-all-administration-teams.usecase.js';
 import { findAllTags } from './find-all-tags.usecase.js';
 import { findChildrenOrganizations } from './find-children-organizations.usecase.js';
@@ -100,6 +101,7 @@ const usecasesWithoutInjectedDependencies = {
   createOrganization,
   createOrganizationsWithTagsAndTargetProfiles,
   createTag,
+  detachParentOrganizationFromOrganization,
   findAllTags,
   findChildrenOrganizations,
   findOrganizationFeatures,
@@ -121,6 +123,7 @@ const usecasesWithoutInjectedDependencies = {
  * @property {attachChildOrganizationToOrganization} attachChildOrganizationToOrganization
  * @property {createCertificationCenter} createCertificationCenter
  * @property {createTag} createTag
+ * @property {detachParentOrganizationFromOrganization} detachParentOrganizationFromOrganization
  * @property {findPaginatedFilteredCertificationCenters} findPaginatedFilteredCertificationCenters
  * @property {getOrganizationDetails} getOrganizationDetails
  * @property {updateOrganizationsInBatch} updateOrganizationsInBatch

--- a/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/detach-parent-organization-from-organization.usecase.test.js
@@ -1,0 +1,57 @@
+import { UnableToDetachParentOrganizationFromChildOrganization } from '../../../../../src/organizational-entities/domain/errors.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import {
+  databaseBuilder,
+  expect,
+  insertMultipleSendingFeatureForNewOrganization,
+  knex,
+} from '../../../../test-helper.js';
+
+describe('Integration | UseCases | detach-parent-organization-from-organization', function () {
+  beforeEach(async function () {
+    await insertMultipleSendingFeatureForNewOrganization();
+  });
+  it('should detach parent organization from child organization', async function () {
+    // given
+    const parentOrganization = databaseBuilder.factory.buildOrganization();
+
+    const childOrganization = databaseBuilder.factory.buildOrganization({
+      parentOrganizationId: parentOrganization.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.detachParentOrganizationFromOrganization({ childOrganizationId: childOrganization.id });
+
+    // then
+    const updatedOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
+    expect(updatedOrganization.parentOrganizationId).to.be.null;
+  });
+
+  it('should throw a Not Found error when child organization does not exist', async function () {
+    // when
+    try {
+      await usecases.detachParentOrganizationFromOrganization({ childOrganizationId: 123 });
+    } catch (error) {
+      //then
+      expect(error).to.be.instanceOf(NotFoundError);
+    }
+  });
+
+  it('should throw a UnableToDetachParentOrganizationFromChildOrganization error when organization has no parent', async function () {
+    // given
+    const organization = databaseBuilder.factory.buildOrganization({ parentOrganizationId: null });
+    await databaseBuilder.commit();
+
+    // when
+    try {
+      await usecases.detachParentOrganizationFromOrganization({ childOrganizationId: organization.id });
+    } catch (error) {
+      // then
+      expect(error).to.be.instanceOf(UnableToDetachParentOrganizationFromChildOrganization);
+      expect(error.meta.organizationId).to.equal(organization.id);
+    }
+  });
+});

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -1,5 +1,8 @@
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../../../../src/organizational-entities/application/http-error-mapper-configuration.js';
-import { TagNotFoundError } from '../../../../src/organizational-entities/domain/errors.js';
+import {
+  TagNotFoundError,
+  UnableToDetachParentOrganizationFromChildOrganization,
+} from '../../../../src/organizational-entities/domain/errors.js';
 import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../../src/shared/application/models/domain-error-mapping-configuration.js';
 import { expect } from '../../../test-helper.js';
@@ -28,6 +31,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       //then
       expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
       expect(error.message).to.equal('Tag does not exist');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "UnableToDetachParentOrganizationFromChildOrganization"', function () {
+    it('should return a UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === UnableToDetachParentOrganizationFromChildOrganization.name,
+      );
+
+      const meta = { organizationId: 1234 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new UnableToDetachParentOrganizationFromChildOrganization({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+      expect(error.message).to.equal('Unable to detach parent organization from child organization');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/unit/application/organization/organization.admin.route.test.js
@@ -1,0 +1,58 @@
+import { organizationAdminController } from '../../../../../src/organizational-entities/application/organization/organization.admin.controller.js';
+import * as moduleUnderTest from '../../../../../src/organizational-entities/application/organization/organization.admin.route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Application | route | Admin | organization', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('POST /api/admin/organizations/{childOrganizationId}/detach-parent-organization', function () {
+    describe('error case', function () {
+      describe('when the authenticated user is not super admin', function () {
+        it('should return 403 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) =>
+            h
+              .response({ errors: new Error('forbidden') })
+              .code(403)
+              .takeover(),
+          );
+          sinon.stub(organizationAdminController, 'detachParentOrganization');
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/admin/organizations/123/detach-parent-organization',
+          );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+          sinon.assert.notCalled(organizationAdminController.detachParentOrganization);
+        });
+      });
+
+      describe('when childOrganizationId is not a number', function () {
+        it('should return 400 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').resolves(true);
+          sinon.stub(organizationAdminController, 'detachParentOrganization');
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/admin/organizations/mqlksdmdlk/detach-parent-organization',
+          );
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          sinon.assert.notCalled(organizationAdminController.detachParentOrganization);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de la simplification du processus de rattachement d'une organisation fille à une organisation mère, on veut dans un premier temps pouvoir facilement _détacher_ deux organisations.

## 🌰 Proposition

Créer un endpoint acceptant en paramètre un ID d'organisation fille, et permettant de la détacher de son parent.

## 🍁 Remarques

Cette route est restreinte au rôle `superadmin`.

## 🪵 Pour tester

- Noter un ID d'orga fille (par exemple **Child of "Collège House of The Dragon"**)
- pour tester les cas non passant, requêter l'API en POST sur le endpoint `/api/admin/organizations/{childOrganizationId}/detach-parent-organization` avec un token non `superadmin` (certif, metier ou support) et constater qu'on reçoit une erreur 403

```
TOKEN=$(curl --insecure 'https://admin-pr13931.review.pix.fr/api/token' --data-raw 'grant_type=password&username=certifadmin@example.net&password=pix123&scope=pix-admin'  -H 'x-forwarded-host: admin' -H 'x-forwarded-proto: HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr13931.review.pix.fr/api/admin/organizations/{childOrganizationId}/detach-parent-organization \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
```

- pour tester le cas passant, faire la même requête avec un token `superadmin`, constater qu'on reçoit une 204 et constater que l'orga fille n'est plus liée à son parent

```
TOKEN=$(curl --insecure 'https://admin-pr13931.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin'  -H 'x-forwarded-host: admin' -H 'x-forwarded-proto: HTTP'  -X POST | jq -r .access_token)
curl https://admin-pr13931.review.pix.fr/api/admin/organizations/{childOrganizationId}/detach-parent-organization \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
```
