### PR TITLE
[FEATURE] API - Ajouter le type de grain "leçon courte"(PIX-20065)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -17,21 +17,6 @@
       "type": "question-yourself",
       "grains": [
         {
-          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-                "type": "text",
-                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
-              }
-            }
-          ]
-        },
-        {
           "id": "533c69b8-a836-41be-8ffc-8d4636e31224",
           "type": "activity",
           "title": "Voici un vrai-faux",
@@ -395,6 +380,42 @@
                     }
                   }
                 ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "1d2e3c80-0b23-40c6-bb56-4fa957207ac6",
+      "type": "blank",
+      "grains": [
+        {
+          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
+          "type": "transition",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
+                "type": "text",
+                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
+              }
+            }
+          ]
+        },
+        {
+          "id": "8bbfb1ef-3d35-48ce-bb3f-b63a8df9a8ac",
+          "type": "short-lesson",
+          "title": "",
+          "components": [
+            {
+              "type": "element",
+              "element": {
+                "id": "60b9e09b-dbb8-4de8-83fd-665873ca2f03",
+                "type": "text",
+                "content": "<p>Ceci est un grain de type leçon courte, dédié au bon vieux pattern</p>"
               }
             }
           ]

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -75,7 +75,9 @@ const componentStepperSchema = Joi.object({
 
 const grainSchema = Joi.object({
   id: uuidSchema,
-  type: Joi.string().valid('lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition').required(),
+  type: Joi.string()
+    .valid('lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition', 'short-lesson')
+    .required(),
   title: htmlNotAllowedSchema.required().allow(''),
   components: Joi.array()
     .items(


### PR DESCRIPTION
## 🌰 Proposition

Ajouter le type de grain "short-lesson" pour afficher différemment les leçons contenus dans les modules qui suivent l'ancien pattern.

## 🍁 Remarques

- Un grain avec ce type a été ajouté dans le bac-a-sable

## 🪵 Pour tester

- Aller sur le [bac-a-sable](https://app-pr13934.review.pix.fr//modules/bac-a-sable) et le commencer
- Afficher la première section. Celle-ci n'a pas de titre
- Vérifier qu'une leçon apparaît, précisant que c'est une leçon pour le vieux pattern
- Vérifier dans la console dév que la réponse API du module comporte bien un grain "short-lesson"

<img width="634" height="271" alt="image" src="https://github.com/user-attachments/assets/102f00f1-3f68-4343-bee3-56063d9c5d7b" />