### PR TITLE
[FEATURE] Autoriser le nouveau type de grain `short-lesson` sur Pix App (PIX-20066) 

### DIFF
--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -42,7 +42,15 @@ export default class ModuleGrain extends Component {
     'text',
     'video',
   ];
-  static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity', 'discovery', 'challenge', 'summary', 'transition'];
+  static AVAILABLE_GRAIN_TYPES = [
+    'short-lesson',
+    'lesson',
+    'activity',
+    'discovery',
+    'challenge',
+    'summary',
+    'transition',
+  ];
 
   static LOCALLY_ANSWERABLE_ELEMENTS = ['qab', 'qcu-declarative', 'qcu-discovery', 'flashcards'];
 

--- a/mon-pix/tests/unit/components/module/grain-test.gjs
+++ b/mon-pix/tests/unit/components/module/grain-test.gjs
@@ -179,4 +179,25 @@ module('Unit | Component | Module | Grain', function (hooks) {
       });
     });
   });
+
+  module('#grainType', function () {
+    module('when the grain type is short-lesson', function () {
+      test('should return the short-lesson type', function (assert) {
+        // given
+        const qcu = { id: 'qcu-id-1', type: 'qcu' };
+        const grain = {
+          type: 'short-lesson',
+          components: [{ type: 'element', element: qcu }],
+        };
+
+        const component = createGlimmerComponent('module/grain/grain', { grain });
+
+        // when
+        const grainType = component.grainType;
+
+        // then
+        assert.strictEqual(grainType, 'short-lesson');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🍂 Problème
Un nouveau de type de grain a été créé pour les modules

## 🌰 Proposition
L'utiliser dans le front 

## 🍁 Remarques

Il faudra d'abord merger https://github.com/1024pix/pix/pull/13934 avant de merger celle-ci.
## 🪵 Pour tester

- Ouvrir le bac-a-sable
- Constater que le grain de type short-lesson a le format attendu (pas de titre et pas de fond violet)
