### PR TITLE
[TECH] :wastebasket: Supprime des utilisation de `hasComplementaryReferential` devenu inutile (PIX-20074)

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-repository.js
@@ -6,13 +6,10 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
-import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 
 function _toDomain(row) {
-  const hasComplementaryReferential = row.key !== ComplementaryCertificationKeys.CLEA;
   return new ComplementaryCertification({
     ...row,
-    hasComplementaryReferential,
   });
 }
 


### PR DESCRIPTION
## 🍂 Problème

Les derniers remaniements de code ont laissé des références à `hasCompementaryReferential` inutile.

## 🌰 Proposition

Supprimer les références à `hasComplementaryReferential` devenu inutile.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Passer faire un tour sur la page qui liste les certifications complémentaires
