### PR TITLE
[BUGFIX] Réparer l'import fwb / import générique (PIX-20075)

### DIFF
--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -30,10 +30,10 @@ const importOrganizationLearnerFromFeature = async function (request, h) {
 
 const reconcileCommonOrganizationLearner = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;
-  const { campaignCode, reconciliationInfos } = request.deserializedPayload;
+  const { code, reconciliationInfos } = request.deserializedPayload;
 
   await usecases.reconcileCommonOrganizationLearner({
-    campaignCode,
+    code,
     userId: authenticatedUserId,
     reconciliationInfos,
   });

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -127,7 +127,7 @@ const register = async (server) => {
           payload: Joi.object({
             data: {
               attributes: {
-                'campaign-code': Joi.string().required(),
+                code: Joi.string().required(),
                 'reconciliation-infos': Joi.object().required(),
               },
               type: Joi.string().required(),

--- a/api/src/prescription/learner-management/domain/usecases/reconcile-common-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/reconcile-common-organization-learner.js
@@ -8,14 +8,14 @@ import { ReconcileCommonOrganizationLearnerError } from '../errors.js';
 
  * @name reconcileCommonOrganizationLearner
  * @param {Object} params
- * @param {string} params.campaignCode
+ * @param {string} params.code
  * @param {number} params.userId
  * @param {Object} params.reconciliationInfos
  *
  * @returns {Promise<void>}
  */
 const reconcileCommonOrganizationLearner = async function ({
-  campaignCode,
+  code,
   userId,
   reconciliationInfos,
   campaignRepository,
@@ -24,7 +24,7 @@ const reconcileCommonOrganizationLearner = async function ({
   organizationLearnerRepository,
   userReconciliationService,
 }) {
-  const campaign = await campaignRepository.getByCode(campaignCode);
+  const campaign = await campaignRepository.getByCode(code);
   if (!campaign) {
     throw new ReconcileCommonOrganizationLearnerError('CAMPAIGN_NOT_FOUND');
   }
@@ -35,6 +35,7 @@ const reconcileCommonOrganizationLearner = async function ({
   }
 
   const importFormat = await organizationLearnerImportFormatRepository.get(campaign.organizationId);
+
   if (!importFormat) {
     throw new ReconcileCommonOrganizationLearnerError('IMPORT_FORMAT_NOT_FOUND');
   }

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organizations-to-join-serializer.js
@@ -22,9 +22,6 @@ const serialize = function (organizations) {
       'isReconciliationRequired',
       'hasReconciliationFields',
     ],
-    reconciliationFields: {
-      attributes: ['name', 'fieldId', 'position', 'type'],
-    },
   }).serialize(organizations);
 };
 

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -206,7 +206,7 @@ describe('Acceptance | Prescription | learner management | Application | organiz
         payload: {
           data: {
             attributes: {
-              'campaign-code': campaign.code,
+              code: campaign.code,
               'reconciliation-infos': {
                 reconcileField1: 'Aheurfix',
                 reconcileField2: 'Edgar',

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
@@ -40,12 +40,12 @@ describe('Unit | Prescription | Learner Management | Application | organization-
 
     it('called usecases with correct parameters', async function () {
       const userId = Symbol('userId');
-      const campaignCode = Symbol('campaignCode');
+      const code = Symbol('campaignCode');
       const reconciliationInfos = Symbol('reconciliationInfos');
       const request = {
         auth: { credentials: { userId } },
         deserializedPayload: {
-          campaignCode,
+          code,
           reconciliationInfos,
         },
       };
@@ -53,7 +53,7 @@ describe('Unit | Prescription | Learner Management | Application | organization-
       const response = await organizationLearnersController.reconcileCommonOrganizationLearner(request, hFake);
 
       expect(
-        reconcileCommonOrganizationLearnerStub.calledWithExactly({ userId, campaignCode, reconciliationInfos }),
+        reconcileCommonOrganizationLearnerStub.calledWithExactly({ userId, code, reconciliationInfos }),
         'reconcileCommonOrganizationLearner',
       ).to.be.true;
       expect(response.statusCode).to.be.equal(204);

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
@@ -99,7 +99,7 @@ describe('Unit | Prescription | learner management | Application | Router | orga
     describe('error cases', function () {
       it('should throw an error when payload reconciliationInfos is not an object', async function () {
         // given
-        const payload = { data: { attributes: { 'campaign-code': 'myCode', 'reconciliation-infos': null } } };
+        const payload = { data: { attributes: { code: 'myCode', 'reconciliation-infos': null } } };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -111,7 +111,7 @@ describe('Unit | Prescription | learner management | Application | Router | orga
 
       it('should not called controller when payload campaignCode is not a string', async function () {
         // given
-        const payload = { data: { attributes: { 'campaign-code': null, 'reconciliation-infos': {} } } };
+        const payload = { data: { attributes: { code: null, 'reconciliation-infos': {} } } };
 
         // when
         const response = await httpTestServer.request(method, url, payload, null, headers);
@@ -125,7 +125,7 @@ describe('Unit | Prescription | learner management | Application | Router | orga
     it('should called the controller when everything is ok', async function () {
       // given
       const payload = {
-        data: { attributes: { 'campaign-code': 'myCode', 'reconciliation-infos': {} }, type: 'organization-learner' },
+        data: { attributes: { code: 'myCode', 'reconciliation-infos': {} }, type: 'organization-learner' },
       };
 
       // when

--- a/api/tests/prescription/learner-management/unit/domain/usecases/reconcile-common-organization-learner_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/reconcile-common-organization-learner_test.js
@@ -4,7 +4,7 @@ import { reconcileCommonOrganizationLearner } from '../../../../../../src/prescr
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | reconcile-common-organization-learner', function () {
-  let campaignCode,
+  let code,
     organizationId,
     importFormat,
     userId,
@@ -17,7 +17,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
     userReconciliationService;
 
   beforeEach(function () {
-    campaignCode = 'PIX123456';
+    code = 'PIX123456';
     organizationId = 'organization id';
     userId = Symbol('userId');
     reconcileInfos = Symbol('reconcile infos');
@@ -51,7 +51,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
 
       // when
       const error = await catchErr(reconcileCommonOrganizationLearner)({
-        campaignCode,
+        code,
         userId,
         reconcileInfos,
         campaignRepository,
@@ -69,14 +69,14 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
   context('when there is no import feature on organization', function () {
     it('should throw a ReconcileCommonOrganizationLearnerError', async function () {
       // given
-      campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
+      campaignRepository.getByCode.withArgs(code).resolves({ organizationId });
       organizationFeatureApi.getAllFeaturesFromOrganization
         .withArgs(organizationId)
         .resolves({ hasLearnersImportFeature: false });
 
       //when
       const error = await catchErr(reconcileCommonOrganizationLearner)({
-        campaignCode,
+        code,
         userId,
         reconcileInfos,
         campaignRepository,
@@ -94,7 +94,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
   context('when there is no import format for organization', function () {
     it('should throw a ReconcileCommonOrganizationLearnerError', async function () {
       // given
-      campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
+      campaignRepository.getByCode.withArgs(code).resolves({ organizationId });
       organizationFeatureApi.getAllFeaturesFromOrganization
         .withArgs(organizationId)
         .resolves({ hasLearnersImportFeature: true });
@@ -102,7 +102,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
 
       //when
       const error = await catchErr(reconcileCommonOrganizationLearner)({
-        campaignCode,
+        code,
         userId,
         reconcileInfos,
         campaignRepository,
@@ -120,7 +120,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
   context('Reconciliation', function () {
     beforeEach(function () {
       // given
-      campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
+      campaignRepository.getByCode.withArgs(code).resolves({ organizationId });
       organizationFeatureApi.getAllFeaturesFromOrganization
         .withArgs(organizationId)
         .resolves({ hasLearnersImportFeature: true });
@@ -139,7 +139,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
 
         //when
         const error = await catchErr(reconcileCommonOrganizationLearner)({
-          campaignCode,
+          code,
           userId,
           reconcileInfos,
           campaignRepository,
@@ -173,7 +173,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
           .returns(null);
         //when
         const error = await catchErr(reconcileCommonOrganizationLearner)({
-          campaignCode,
+          code,
           userId,
           reconcileInfos,
           campaignRepository,
@@ -216,7 +216,7 @@ describe('Unit | UseCase | reconcile-common-organization-learner', function () {
 
         //when
         const result = await reconcileCommonOrganizationLearner({
-          campaignCode,
+          code,
           userId,
           reconcileInfos,
           campaignRepository,

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-to-join-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-to-join-serializer_test.js
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | organization-to-join-serializer', functi
             'reconciliation-fields': [
               {
                 name: 'COMMON_FIRSTNAME',
-                'field-id': 'reconcileField2',
+                fieldId: 'reconcileField2',
                 position: 2,
                 type: 'string',
               },

--- a/mon-pix/app/components/pages/organizations/invited/reconciliation.gjs
+++ b/mon-pix/app/components/pages/organizations/invited/reconciliation.gjs
@@ -24,17 +24,17 @@ export default class InvitedWrapper extends Component {
   async registerLearner(reconciliationInfos) {
     this.isLoading = true;
     this.errorMessage = null;
+    const verifiedCode = await this.store.findRecord('verified-code', this.args.model.verifiedCode.id);
     const organizationLearner = this.store.createRecord('organization-learner', {
       organizationId: this.args.model.organizationToJoin.id,
       reconciliationInfos,
+      code: verifiedCode.id,
     });
 
     try {
       await organizationLearner.save();
 
       this.accessStorage.setAssociationDone(this.args.model.organizationToJoin.id);
-      const verifiedCode = await this.store.findRecord('verified-code', this.args.model.campaign.code);
-
       if (verifiedCode.type === 'campaign') {
         this.router.transitionTo('campaigns.fill-in-participant-external-id', verifiedCode.id);
       } else {
@@ -61,6 +61,7 @@ export default class InvitedWrapper extends Component {
       }
     });
   }
+
   get reconciliationFieldNames() {
     return this.args.model.organizationToJoin.reconciliationFields.map(({ name }) => {
       const translationKey = this.FIELD_KEY[name];

--- a/mon-pix/app/models/organization-learner.js
+++ b/mon-pix/app/models/organization-learner.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class OrganizationLearner extends Model {
-  @attr('string') campaignCode;
+  @attr('string') code;
   @attr() reconciliationInfos;
 }

--- a/mon-pix/tests/unit/components/pages/organizations/invited/reconciliation-test.js
+++ b/mon-pix/tests/unit/components/pages/organizations/invited/reconciliation-test.js
@@ -6,17 +6,17 @@ import createGlimmerComponent from '../../../../../helpers/create-glimmer-compon
 
 module('Unit | Component | Pages | Organizations | Invited | Reconciliation', function (hooks) {
   setupTest(hooks);
-  let createRecordStub, component, model, campaignCode, organizationId;
+  let createRecordStub, component, model, code, organizationId;
   hooks.beforeEach(function () {
-    campaignCode = Symbol('code');
+    code = Symbol('code');
     organizationId = Symbol(1);
     createRecordStub = {
       unloadRecord: sinon.stub(),
       save: sinon.stub(),
     };
     model = {
-      campaign: {
-        code: campaignCode,
+      verifiedCode: {
+        id: code,
       },
       organizationToJoin: {
         id: organizationId,
@@ -46,11 +46,11 @@ module('Unit | Component | Pages | Organizations | Invited | Reconciliation', fu
       .withArgs('organization-learner', {
         organizationId,
         reconciliationInfos,
+        code,
       })
       .returns(createRecordStub);
 
-    component.store.findRecord.withArgs('verified-code', campaignCode).returns({ id: campaignCode, type: 'campaign' });
-
+    component.store.findRecord.withArgs('verified-code', code).returns({ id: code, type: 'campaign' });
     // when
     await component.registerLearner(reconciliationInfos);
 
@@ -59,7 +59,7 @@ module('Unit | Component | Pages | Organizations | Invited | Reconciliation', fu
     assert.true(createRecordStub.unloadRecord.called, 'called unloadRecord');
     assert.true(component.accessStorage.setAssociationDone.calledWithExactly(organizationId), 'called accessStorage');
     assert.true(
-      component.router.transitionTo.calledWithExactly('campaigns.fill-in-participant-external-id', campaignCode),
+      component.router.transitionTo.calledWithExactly('campaigns.fill-in-participant-external-id', code),
       'called transitionTo',
     );
   });
@@ -71,10 +71,14 @@ module('Unit | Component | Pages | Organizations | Invited | Reconciliation', fu
       .withArgs('organization-learner', {
         organizationId,
         reconciliationInfos,
+        code,
       })
       .returns(createRecordStub);
     createRecordStub.save.rejects({ errors: [{ status: 400, detail: 'oh no !' }] });
     // when
+
+    component.store.findRecord.withArgs('verified-code', code).returns({ id: code, type: 'campaign' });
+
     await component.registerLearner(reconciliationInfos);
 
     // then
@@ -91,10 +95,14 @@ module('Unit | Component | Pages | Organizations | Invited | Reconciliation', fu
       .withArgs('organization-learner', {
         organizationId,
         reconciliationInfos,
+        code,
       })
       .returns(createRecordStub);
     createRecordStub.save.rejects({ errors: [{ status: 400, title: ' title error ', detail: 'Une erreur !' }] });
+
     // when
+    component.store.findRecord.withArgs('verified-code', code).returns({ id: code, type: 'campaign' });
+
     await component.registerLearner(reconciliationInfos);
 
     // then


### PR DESCRIPTION
## 🍂 Problème
La réconciliation est cassée pour les organisations avec un import générique à cause d'un attribut manquant dans la requête.

## 🌰 Proposition
On remplace l'attribut "campaignCode" par "code" (qui est attendu dans la requête).
Et on répare le mapping des reconciliationFields (les champs de réconciliation n'étaient pas pris en compte à cause d'un problème de récupération de fieldId)

## 🪵 Pour tester
PixOrga
Se mettre sur PRO_NOT_MANAGING
Faire un import avec un generic_import.csv

PixApp
Se connecter avec l'un des élèves de la liste
Puis "J'ai un code" -> PROGENCOL
Se réconcilier et vérifier que ça fonctionne 