### PR TITLE
[TECH] Récupérer Ember Inspector sur Pix Admin.

### DIFF
--- a/admin/app/app.js
+++ b/admin/app/app.js
@@ -1,30 +1,16 @@
-import { RSVP } from '@ember/-internals/runtime';
 import Application from '@ember/application';
-import * as runtime from '@glimmer/runtime';
-import * as tracking from '@glimmer/tracking';
-import * as validator from '@glimmer/validator';
-import Ember from 'ember';
+import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';
 import loadInitializers from 'ember-load-initializers';
 import config from 'pix-admin/config/environment';
 
 import Resolver from './resolver';
 
-class App extends Application {
+export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
+
+  inspector = setupInspector(this);
 }
 
-// This is a temporary solution, see https://github.com/emberjs/ember-inspector/issues/2612
-window.define('@glimmer/tracking', () => tracking);
-window.define('@glimmer/runtime', () => runtime);
-window.define('@glimmer/validator', () => validator);
-window.define('rsvp', () => RSVP);
-window.define('ember', () => ({ default: Ember }));
-window.define('<my-app>/config/environment', () => ({
-  default: config,
-}));
-
 loadInitializers(App, config.modulePrefix);
-
-export default App;

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -19,6 +19,7 @@
         "@ember/test-helpers": "^5.2.2",
         "@embroider/compat": "^3.9.1",
         "@embroider/core": "^3.5.7",
+        "@embroider/legacy-inspector-support": "^0.1.3",
         "@embroider/webpack": "^4.1.1",
         "@glimmer/component": "^2.0.0",
         "@glimmer/tracking": "^1.1.2",
@@ -1099,7 +1100,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2864,7 +2864,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2888,7 +2887,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2988,7 +2986,6 @@
       "integrity": "sha512-Zn4mAGUSKEKFw23SE63VgdP9w+UBw1lUTTp2AId4cblR/+ZJlxAodZKy0zI9dk4QHSn4zsT9BHMyK7V6U+ZmhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.16.12",
@@ -3027,7 +3024,6 @@
       "integrity": "sha512-bRT6NllMT59+25BwwnQDPnSa8FrlNUAFTX7pHr2eZMhnEwAa2VIttQyiZD4ZspDKESf2kkIooU+OECA7Kt/btA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/core": "5.6.0",
@@ -3072,7 +3068,6 @@
       "integrity": "sha512-lobHpRNIONefVjDpZrtCs9vBUB+oZTcDXpfh1Kx+pvoTk0IkZKFUnEKuSwmWSh3R13+20yrdW0Gl7lbWxQMtAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/core": "5.6.0"
@@ -3097,7 +3092,6 @@
       "deprecated": "Use @warp-drive/ember",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/core": "5.6.0"
@@ -3137,7 +3131,6 @@
       "integrity": "sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.8.7",
@@ -3153,7 +3146,6 @@
       "integrity": "sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -3950,7 +3942,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4221,7 +4212,6 @@
       "integrity": "sha512-0oytko2+iaYS31TG9Axj7Py0e0FAccUhu9J1h7ldEnQegK+Eu5+OINU0dYQgt0ijp6f2yF4+o3J7u9CJCLZ1gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -4302,6 +4292,16 @@
       "peerDependencies": {
         "@embroider/core": "^3.5.7",
         "webpack": "^5"
+      }
+    },
+    "node_modules/@embroider/legacy-inspector-support": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@embroider/legacy-inspector-support/-/legacy-inspector-support-0.1.3.tgz",
+      "integrity": "sha512-0VzD1xExkT78a1CUiW8wZ5VZDL4bVyMSc3t8E/RiAW1X6TlyKIA/m6zoQgsQtQIiiTPPxH0/1Tdd0F7b5//etw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.10.0"
       }
     },
     "node_modules/@embroider/macros": {
@@ -6355,7 +6355,8 @@
       "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
       "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -7248,7 +7249,6 @@
       "integrity": "sha512-pUt2QEWzhMkBD3tzjpDmycNsVQsvUBXfQpIrIQ8K55BS1b5fXNKXc/srOi6XoSy+elh7V7sgjdEZLOWP3ttcRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.6.0"
@@ -7260,7 +7260,6 @@
       "integrity": "sha512-ePYhowffjOtIuD27JnX2/+PXe2WyDqLzNOArgOYbo1xtZeDWg5V+Mmja6Zd3MlxptcHDiUsmfYei8XUgWGQ4Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/core": "5.6.0"
@@ -7321,7 +7320,6 @@
       "integrity": "sha512-97hUDe2tYU+eOcLlrdCs4Q0z8AjvFvkAWDhJo+5FAgQFNSlbHJzCYuv3jtAcvQUBoYqxTng+P8nFv4L0DiaPAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12"
       },
@@ -7541,7 +7539,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7591,7 +7588,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10084,7 +10080,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -15913,7 +15908,6 @@
       "integrity": "sha512-nFFHhAD06C6DM2iD/UQFe+XKPEh27ALudZVZ6CipCAn598i8gfnm5k09ZZiW/YYpU0+4DAqtf91LwZN2e+O3vw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember-data/adapter": "5.6.0",
         "@ember-data/debug": "5.6.0",
@@ -16101,7 +16095,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -18000,7 +17993,6 @@
       "integrity": "sha512-pPYBAGyczX0hedGWQFQOEiL9s45KS9efKxJxUQkMLjQyh+1Uef1mcmAGsdw2KmvNupITkE/nXxmVO1kZ9tt3ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -18043,7 +18035,6 @@
       "integrity": "sha512-t+FD5/EWAR3WvGVj1etblFJJ6CaJqddDxusNcYYFZmW7zrQpCnQ9ziwpXM5/sw1sWabkhJZgYPXCn8bDRRhOfg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.9.0",
         "@embroider/macros": "^1.16.12",
@@ -19575,7 +19566,6 @@
       "integrity": "sha512-se8UFNu9n017VmKry124jc+Mh1ybZ8sAf9IthYYGpdPYH4PRLxBbxa+YEUdtu1vWoKZG2lVthtOUbCmIAjNrpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
@@ -21598,7 +21588,6 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -21689,7 +21678,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -22634,7 +22622,8 @@
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
       "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -24633,7 +24622,8 @@
       "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
       "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/inflection": {
       "version": "2.0.1",
@@ -26804,7 +26794,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -28214,7 +28203,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -28504,7 +28492,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -28940,7 +28927,6 @@
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -28968,6 +28954,7 @@
       "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fake-xml-http-request": "^2.1.2",
         "route-recognizer": "^0.3.3"
@@ -28979,7 +28966,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -29281,7 +29267,6 @@
       "integrity": "sha512-Eu0k/5JDjx0QnqxsE1WavnDNDgL1zgMZKsMw/AoAxnsl9p4RgyLODyo2N7abZY7CEAnvl5YUqFZdkImzbgXzSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
@@ -30095,8 +30080,7 @@
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
       "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/router_js": {
       "version": "8.0.6",
@@ -30128,7 +30112,6 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -31838,7 +31821,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -32249,7 +32231,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -32681,7 +32662,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -34328,7 +34308,6 @@
       "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -34388,7 +34367,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -51,6 +51,7 @@
     "@ember/test-helpers": "^5.2.2",
     "@embroider/compat": "^3.9.1",
     "@embroider/core": "^3.5.7",
+    "@embroider/legacy-inspector-support": "^0.1.3",
     "@embroider/webpack": "^4.1.1",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
## 🍂 Problème

[En juillet 2025, on avait déjà fait le constat que l'addon Ember Inspector ne fonctionnait plus](https://github.com/1024pix/pix/pull/12737) depuis la montée de version d'`ember-source`.
Avec cette issue : https://github.com/emberjs/ember-inspector/issues/2612, on avait pu appliquer un fix temporaire.

Mais Ember Inspector est de nouveaux dans les choux.

<img width="409" height="317" alt="Capture d’écran 2025-10-21 à 15 13 11" src="https://github.com/user-attachments/assets/edda217b-970d-48fe-9c09-04c1af0e4b1c" />

## 🌰 Proposition

Toujours en suivant cette issue, https://github.com/emberjs/ember-inspector/issues/2612, redonner vie à Ember Inspector sur Admin.

- Installer `legacy-inspector-support` => https://github.com/embroider-build/embroider/tree/main/packages/legacy-inspector-support
- Appeler la fonction `setupInspector` coté `app.js` d'Admin.

> [!NOTE]
> Si c'est merge, j'appliquerais la solution pour les autres apps. 

## 🪵 Pour tester

Constater que l'on accède de nouveau à Ember Inspector sur Admin

Ouvrir Admin, ouvrir son navigateur puis aller sur le ember Inspector

<img width="876" height="804" alt="Capture d’écran 2025-10-21 à 15 41 10" src="https://github.com/user-attachments/assets/a19c1bf0-1545-49f8-9110-9adb81f9ebfb" />

