### PR TITLE
[FEATURE] Migrer les leçons `lesson` des modules multi sections en leçons courte `short-lesson` (PIX-20068)(PIX-20042).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -184,7 +184,7 @@
         },
         {
           "id": "7c150706-4752-4949-a5b8-63b6b440781b",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #1",
           "components": [
             {
@@ -261,7 +261,7 @@
         },
         {
           "id": "f2411f2b-a946-4ddf-a114-99221ac876b2",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #2",
           "components": [
             {
@@ -510,7 +510,7 @@
         },
         {
           "id": "1aebd2f0-1072-478c-a356-717c1f72ec17",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #3",
           "components": [
             {
@@ -586,7 +586,7 @@
         },
         {
           "id": "944222dd-f5ae-4ffd-a226-1eeac38efea0",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #4",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -286,7 +286,7 @@
         },
         {
           "id": "3fd6303e-499d-4ace-a5a6-8882a118726d",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson n°1 : données étiquetées",
           "components": [
             {
@@ -406,7 +406,7 @@
         },
         {
           "id": "b0076163-02ae-4805-af3e-dd82781347ba",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 2 : décomposition en valeurs numériques",
           "components": [
             {
@@ -471,7 +471,7 @@
         },
         {
           "id": "bdc51924-26ee-4f22-b302-fe4dec080387",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 3 : Ajustement des paramètres",
           "components": [
             {
@@ -556,7 +556,7 @@
         },
         {
           "id": "08c2f199-5026-487b-9c27-9f16d4ab481f",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 4 : Généralisation",
           "components": [
             {
@@ -721,7 +721,7 @@
         },
         {
           "id": "3f86b7a5-8df1-48a0-94ef-2a28c8c0c010",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #5 : D’autres cas d’usages, dont le texte",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -215,7 +215,7 @@
         },
         {
           "id": "bd0e1d7a-2538-439e-ab8c-006393e03efb",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 1 : Que peut faire un ordinateur ? ",
           "components": [
             {
@@ -373,7 +373,7 @@
         },
         {
           "id": "16244191-1e74-4396-b9bd-d27ace391181",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 2 : Où trouver des utilisations de l'IA",
           "components": [
             {
@@ -447,7 +447,7 @@
         },
         {
           "id": "fdf3c015-b354-4f35-a463-76cfc0de4b03",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 3 : IA et secteurs d'activité",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -234,7 +234,7 @@
         },
         {
           "id": "5c345832-9595-4be9-91cc-d792d6ef7bbe",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Des biais sont présents dans les données du Web",
           "components": [
             {
@@ -317,7 +317,7 @@
         },
         {
           "id": "050a3f37-3b40-415e-ba36-d64a398025dc",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "L’IA reproduit les biais qu’elle trouve dans les contenus",
           "components": [
             {
@@ -535,7 +535,7 @@
         },
         {
           "id": "e3eb29db-3138-466a-8a34-4258779a1b82",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Le biais de confirmation",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -377,7 +377,7 @@
         },
         {
           "id": "be1e7402-03dc-41d4-b688-f14631793661",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 1 ",
           "components": [
             {
@@ -483,7 +483,7 @@
         },
         {
           "id": "c3e770fb-f410-4b3a-9be6-465e0bba410a",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 2",
           "components": [
             {
@@ -596,7 +596,7 @@
         },
         {
           "id": "6ad583ab-11b2-4530-a663-75544292108a",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 3",
           "components": [
             {
@@ -758,7 +758,7 @@
         },
         {
           "id": "25aa32f6-954f-4032-98db-6659ac47a66e",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 4",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -234,7 +234,7 @@
         },
         {
           "id": "3a24ab4a-8868-4ebe-91b6-77dd9da41366",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Des biais sont présents dans les données du Web",
           "components": [
             {
@@ -317,7 +317,7 @@
         },
         {
           "id": "8fbcf927-c430-41ae-b9e9-27f5d2a78cb0",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "L’IA reproduit les biais qu’elle trouve dans les contenus",
           "components": [
             {
@@ -535,7 +535,7 @@
         },
         {
           "id": "5698bfa3-1026-489c-9c5a-bd450e463137",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Le biais de confirmation",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -139,7 +139,7 @@
         },
         {
           "id": "62cf44b8-1c7e-41f6-b647-eeaa35f5ab26",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson #1 : Vos discussions avec l’IA sont conservées",
           "components": [
             {
@@ -220,7 +220,7 @@
         },
         {
           "id": "177c84a2-8744-42ac-a603-4c3d6fc9c5b7",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #2 : Ce qu’il vaut mieux éviter de partager ",
           "components": [
             {
@@ -324,7 +324,7 @@
         },
         {
           "id": "3fbddcb3-8286-495b-91fd-9b8bff036f96",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon #3 : Ce que vous écrivez à l’IA peut réapparaître ailleurs",
           "components": [
             {
@@ -401,7 +401,7 @@
         },
         {
           "id": "a8274031-5c1c-494b-9737-90d972fd5f5b",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 4",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -181,7 +181,7 @@
         },
         {
           "id": "20a54ce5-2e41-42f5-8848-474a139c68fb",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Dec 1 Lesson 1",
           "components": [
             {
@@ -383,7 +383,7 @@
         },
         {
           "id": "633e8926-63a6-4301-9d7f-8c89dbb9c403",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Dec 2 Lesson 2",
           "components": [
             {
@@ -479,7 +479,7 @@
         },
         {
           "id": "c7fc8a64-3a00-4f72-9cf8-75c821223102",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Dec 3 Lesson 3",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -132,7 +132,7 @@
         },
         {
           "id": "1fce9705-da34-49c7-a7f2-c65db62018a6",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 1",
           "components": [
             {
@@ -363,7 +363,7 @@
         },
         {
           "id": "6a0ff61b-362d-41c4-8dd6-420eb60bf743",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 2 - avec stepper",
           "components": [
             {
@@ -474,7 +474,7 @@
         },
         {
           "id": "06a185df-1a0f-4709-abe7-953211e75a4f",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Lesson 3 - avec stepper",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -297,7 +297,7 @@
         },
         {
           "id": "24f08127-eeea-44a5-a5b3-21c7f333b760",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Un long voyage",
           "components": [
             {
@@ -494,7 +494,7 @@
         },
         {
           "id": "67ffb9ff-0a27-4ef4-aefe-ea406e053988",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "L’IA, ça calcule, ça chauffe, ça consomme.",
           "components": [
             {
@@ -738,7 +738,7 @@
         },
         {
           "id": "c388aeb1-74d6-49cf-924c-87fa8a015bb7",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon conso énergie supercalculateur",
           "components": [
             {
@@ -923,7 +923,7 @@
         },
         {
           "id": "a17d541a-c8dd-427a-a685-4842f7e8f164",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - Agir pour réduire l‘impact",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -141,7 +141,7 @@
         },
         {
           "id": "417ba69e-c96c-445a-b4dc-1107fd18c4cd",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Le contexte du prompt",
           "components": [
             {
@@ -238,7 +238,7 @@
         },
         {
           "id": "ac059738-54bc-4682-bc96-af014c8f6705",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Le ton dans un prompt",
           "components": [
             {
@@ -313,7 +313,7 @@
         },
         {
           "id": "a280f603-3c78-4b98-a858-c2e0119a19af",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "L’importance du format et de l’itération dans les prompts",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -175,7 +175,7 @@
         },
         {
           "id": "63c077cf-0a98-4526-b946-8ee3c28afeec",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 1",
           "components": [
             {
@@ -283,7 +283,7 @@
         },
         {
           "id": "2f0b42f0-02a3-4133-8401-ec270f2ca315",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 2",
           "components": [
             {
@@ -391,7 +391,7 @@
         },
         {
           "id": "8d975832-e974-4253-bb75-3a3d3636f52c",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 3",
           "components": [
             {
@@ -466,7 +466,7 @@
         },
         {
           "id": "7f3868a0-f259-4394-9bbb-d04b34c55366",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 4",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -154,7 +154,7 @@
         },
         {
           "id": "3be25655-da30-4575-ad97-63c7d28a37c4",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 1",
           "components": [
             {
@@ -215,7 +215,7 @@
         },
         {
           "id": "53ce4351-7009-4a25-b7f8-cc134dcacc10",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 2",
           "components": [
             {
@@ -385,7 +385,7 @@
         },
         {
           "id": "e3bfe080-6bb2-4f37-9920-2c328cee9755",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 3",
           "components": [
             {
@@ -488,7 +488,7 @@
         },
         {
           "id": "862d0165-40a7-4106-a191-94e3182eb156",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 4",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -407,7 +407,7 @@
         },
         {
           "id": "8bbfb1ef-3d35-48ce-bb3f-b63a8df9a8ac",
-          "type": "short-lesson",
+          "type": "lesson",
           "title": "",
           "components": [
             {
@@ -415,7 +415,7 @@
               "element": {
                 "id": "60b9e09b-dbb8-4de8-83fd-665873ca2f03",
                 "type": "text",
-                "content": "<p>Ceci est un grain de type leçon courte, dédié au bon vieux pattern</p>"
+                "content": "<p>Ceci est un grain de type leçon, dédié au bon vieux pattern</p>"
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -240,7 +240,7 @@
         },
         {
           "id": "fab2ec90-8350-4f51-8700-336bcd3acade",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 1 - Vidéo",
           "components": [
             {
@@ -355,7 +355,7 @@
         },
         {
           "id": "6e9c3dbf-34de-4652-b119-aa2a02772fdd",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon 2 - infographie",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -124,7 +124,7 @@
         },
         {
           "id": "f2c81b8b-1574-4304-bd69-8ed05f579794",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 1 ",
           "components": [
             {
@@ -203,7 +203,7 @@
         },
         {
           "id": "f97811eb-2349-48e3-95a2-8c378724909a",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 2 ",
           "components": [
             {
@@ -420,7 +420,7 @@
         },
         {
           "id": "6c2e4b2c-bc41-4fd3-a8e3-d904fcede740",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 3 : Les différents types de comptes de l'ENT",
           "components": [
             {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -222,7 +222,7 @@
         },
         {
           "id": "935c4c4c-4705-4e2e-8c8f-a8db2a285bde",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 1 ",
           "components": [
             {
@@ -310,7 +310,7 @@
         },
         {
           "id": "b30b20c6-ba19-4992-8efb-20a6bf932c01",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 2",
           "components": [
             {
@@ -381,7 +381,7 @@
         },
         {
           "id": "75794098-82f6-4f6e-b768-5315ea55ae6b",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 3",
           "components": [
             {
@@ -467,7 +467,7 @@
         },
         {
           "id": "d09b483b-c182-44be-9c55-8c570e7b70d2",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 4",
           "components": [
             {
@@ -563,7 +563,7 @@
         },
         {
           "id": "779de80b-ba18-4e95-ab6d-bbc5ce8edd5a",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Leçon - 5 : Les interactions entre joueurs",
           "components": [
             {


### PR DESCRIPTION
## 🍂 Problème

Le métier souhaite distinguer visuellement les leçons longues des courtes. Aujourd'hui certaines leçons ne dépassent pas 4 lignes.
Les modules "nouveaux patterns" sont des modules ayant systématiques plusieurs sections (non flag blank).
Les `short-lesson` seront attribués  à ce pattern.

## 🌰 Proposition

Migrer les modules multi section possédant des `lesson` : les `lesson`deviennent alors des `short-lesson`

## 🍁 Remarques

> [!IMPORTANT]
> Cette PR sera à merge après : 
-  https://github.com/1024pix/pix/pull/13934 
- https://github.com/1024pix/pix/pull/13935

## 🪵 Pour tester

-  Vérifier que tous les modules multi section possédant des `lesson` sont passé en `short-lesson`
- Exemple: module [cyber-message-arnaque](https://app-pr13951.review.pix.fr/modules/cyber-message-arnaque)