### PR TITLE
[FEATURE] Enregistrer l'id de l'orga parente, lors de la création d'une orga fille (PIX-20023)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -1,11 +1,17 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class NewController extends Controller {
   @service pixToast;
   @service router;
   @service intl;
+
+  queryParams = ['parentOrganizationId', 'parentOrganizationName'];
+
+  @tracked parentOrganizationId = null;
+  @tracked parentOrganizationName = null;
 
   @action
   goBackToOrganizationList() {
@@ -21,6 +27,12 @@ export default class NewController extends Controller {
         message: this.intl.t('components.organizations.creation.administration-team.required-fields-error'),
       });
       return;
+    }
+
+    if (this.parentOrganizationId) {
+      this.model.setProperties({
+        parentOrganizationId: this.parentOrganizationId,
+      });
     }
 
     try {

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -5,11 +5,23 @@ export default class NewRoute extends Route {
   @service store;
   @service accessControl;
 
+  queryParams = {
+    parentOrganizationId: { refreshModel: true },
+    parentOrganizationName: { refreshModel: true },
+  };
+
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
   }
 
   model() {
     return this.store.createRecord('organization');
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.parentOrganizationId = null;
+      controller.parentOrganizationName = null;
+    }
   }
 }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -213,6 +213,7 @@ const save = async function ({ organization }) {
     'createdBy',
     'documentationUrl',
     'administrationTeamId',
+    'parentOrganizationId',
   ]);
   const [organizationCreated] = await knexConn(ORGANIZATIONS_TABLE_NAME).returning('*').insert(data);
   const savedOrganization = _toDomain(organizationCreated);

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -117,6 +117,7 @@ const deserialize = function (json) {
     dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
     dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
     administrationTeamId: parseInt(attributes['administration-team-id']),
+    parentOrganizationId: attributes['parent-organization-id'] ? parseInt(attributes['parent-organization-id']) : null,
     features: attributes.features,
     tagIds,
   });

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -215,6 +215,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         dataProtectionOfficerLastName: organizationAttributes.dataProtectionOfficerLastName,
         dataProtectionOfficerEmail: organizationAttributes.dataProtectionOfficerEmail,
         administrationTeamId: parseInt(organizationAttributes.administrationTeamId),
+        parentOrganizationId: null,
         features: {
           [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: {
             active: organizationAttributes.features.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.active,
@@ -274,6 +275,28 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
       // then
       expect(organization.tags).to.be.empty;
       expect(organization.tagIds).to.deep.members([4, 2]);
+    });
+
+    it('should deserialize parentOrganizationId if present', function () {
+      // when
+      const organization = organizationForAdminSerializer.deserialize({
+        data: {
+          type: 'organizations',
+          id: '7',
+          attributes: {
+            name: 'Lycée St Cricq',
+            type: Organization.types.SCO,
+            'external-id': 'ABCD123',
+            'province-code': '64',
+            'created-by': '10',
+            'administration-team-id': '1',
+            'parent-organization-id': '5',
+          },
+        },
+      });
+
+      // then
+      expect(organization.parentOrganizationId).to.equal(5);
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

On veut pouvoir créer une organisation fille depuis le formulaire de création d'organisation 

## 🌰 Proposition

- Récupérer depuis un queryParam, l’id de l’organisation mère. 
- Ajouter cette info dans le payload de création d’une orga.


## 🪵 Pour tester

- Sur pix-admin
- Se connecter avec un role METIER, SUPPORT ou ADMIN
- Aller sur https://admin-pr13952.review.pix.fr/organizations/new?parentOrganizationId=1
- Créer une organisation fille
- Constater que l'organisation crée est bien la fille de l'organisation 1 