### PR TITLE
[FEATURE] Masquer es et es-419 dans le locale switcher (PIX-20087)

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -40,8 +40,8 @@ module.exports = function (environment) {
       DEFAULT_LOCALE: process.env.DEFAULT_LOCALE || 'en',
       SUPPORTED_LOCALES: [
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
-        { value: 'es', nativeName: 'Español', displayedInSwitcher: true },
-        { value: 'es-419', nativeName: 'Español (Latinoamérica)', displayedInSwitcher: true },
+        { value: 'es', nativeName: 'Español', displayedInSwitcher: false },
+        { value: 'es-419', nativeName: 'Español (Latinoamérica)', displayedInSwitcher: false },
         { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
         { value: 'fr-FR', nativeName: 'Français (France)', displayedInSwitcher: false },
         { value: 'fr-BE', nativeName: 'Français (Belgique)', displayedInSwitcher: true },

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -315,7 +315,7 @@ module('Unit | Services | locale', function (hooks) {
   });
 
   module('switcherDisplayedLocales', function () {
-    test('returns all the pixLocales that should be displayed in the switcher with french first', function (assert) {
+    test('returns all the pixLocales that should be displayed in the switcher', function (assert) {
       // when
       const switcherDisplayedLocales = localeService.switcherDisplayedLocales;
 
@@ -324,14 +324,6 @@ module('Unit | Services | locale', function (hooks) {
         {
           label: 'English',
           value: 'en',
-        },
-        {
-          label: 'Español',
-          value: 'es',
-        },
-        {
-          label: 'Español (Latinoamérica)',
-          value: 'es-419',
         },
         {
           label: 'Français',


### PR DESCRIPTION
## 🍂 Problème

L'espagnol ne doit pas (pour le moment) être disponible depuis le locale switcher sur Pix App.

## 🌰 Proposition

Cacher les locales `es` et `es-419` du locale switcher.

## 🪵 Pour tester

1. Aller sur https://app-pr13953.review.pix.org/
2. Voir que `es` et `es-419` ne sont plus afficher dans locale switcher
3. Voir qu'il est quand même possible de changer le locale via query params: https://app-pr13953.review.pix.org?locale=es