### PR TITLE
[TECH] Remplir la colonne referenceId quand on insère et on met à jour des participations de type combined-course ou passages (PIX-20059)

### DIFF
--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -23,7 +23,6 @@ export class OrganizationLearnerParticipation {
     deletedBy,
     status,
     type,
-    attributes,
     referenceId,
   }) {
     this.id = id;
@@ -35,7 +34,6 @@ export class OrganizationLearnerParticipation {
     this.deletedBy = deletedBy;
     this.status = status;
     this.type = type;
-    this.attributes = attributes;
     this.referenceId = referenceId;
   }
 
@@ -69,7 +67,7 @@ export class OrganizationLearnerParticipation {
       deletedBy,
       status: participationStatus,
       type: OrganizationLearnerParticipationTypes.PASSAGE,
-      attributes: JSON.stringify({ id: moduleId }),
+      referenceId: moduleId,
     });
   }
 

--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -24,6 +24,7 @@ export class OrganizationLearnerParticipation {
     status,
     type,
     attributes,
+    referenceId,
   }) {
     this.id = id;
     this.organizationLearnerId = organizationLearnerId;
@@ -35,6 +36,7 @@ export class OrganizationLearnerParticipation {
     this.status = status;
     this.type = type;
     this.attributes = attributes;
+    this.referenceId = referenceId;
   }
 
   static buildFromPassage({
@@ -89,7 +91,7 @@ export class OrganizationLearnerParticipation {
       deletedBy: null,
       status,
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-      attributes: JSON.stringify({ id: combinedCourseId }),
+      referenceId: combinedCourseId?.toString(),
     });
   }
 }

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -22,7 +22,7 @@ export const save = async function ({ organizationLearnerId, questId, combinedCo
       organizationLearnerId,
       status: OrganizationLearnerParticipationStatuses.STARTED,
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
-      attributes: JSON.stringify({ id: combinedCourseId }),
+      referenceId: combinedCourseId,
     })
     .returning('id');
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -38,7 +38,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
           'combined_course_participations.questId as combinedCourseParticipationsQuestId',
           'combined_course_participations.createdAt as combinedCourseParticipationsCreatedAt',
           'combined_course_participations.updatedAt as combinedCourseParticipationsUpdatedAt',
-          'attributes',
+          'referenceId',
         )
         .join(
           'combined_course_participations',
@@ -66,7 +66,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(participation.organizationLearnerId).equal(organizationLearnerId);
       expect(participation.combinedCourseParticipationsOrganizationLearnerId).equal(organizationLearnerId);
 
-      expect(participation.attributes).to.deep.equal({ id: combinedCourseId });
+      expect(participation.referenceId).to.deep.equal(combinedCourseId.toString());
     });
 
     it('should left intact combined course participation for given organization learner and quest ids', async function () {

--- a/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/organization-learner-passage-participation-repository_test.js
@@ -66,7 +66,7 @@ describe('Quest | Integration | Infrastructure | repositories | organization lea
       expect(result[0].updatedAt).deep.equal(now);
       expect(result[0].createdAt).deep.equal(dayjs().subtract('30', 'days').toDate());
       expect(result[0].completedAt).equal(null);
-      expect(result[0].attributes).deep.equal({ id: 1234 });
+      expect(result[0].referenceId).deep.equal('1234');
     });
 
     it('should update passage when participation already exists', async function () {

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -88,7 +88,7 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
       expect(organizationLearnerParticipation.deletedAt).to.equal(null);
       expect(organizationLearnerParticipation.deletedBy).to.equal(null);
       expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.COMBINED_COURSE);
-      expect(organizationLearnerParticipation.attributes).deep.equal(JSON.stringify({ id: 1 }));
+      expect(organizationLearnerParticipation.referenceId).deep.equal('1');
     });
   });
   describe('when participation is completed', function () {

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -32,7 +32,7 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
       expect(organizationLearnerParticipation.deletedAt).deep.to.equal(new Date('2025-03-01'));
       expect(organizationLearnerParticipation.deletedBy).to.equal(13);
       expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.PASSAGE);
-      expect(organizationLearnerParticipation.attributes).deep.equal(JSON.stringify({ id: 'abcdef-42' }));
+      expect(organizationLearnerParticipation.referenceId).deep.equal('abcdef-42');
     });
 
     describe('status', function () {


### PR DESCRIPTION
## 🍂 Problème
On veut pouvoir remplir la colonne referenceId quand une participation à un passage ou à un parcours combiné est créée ou mise à jour.

## 🌰 Proposition
On remplit cette colonne lors du save du combinedCourseParticipation, du synchronize du organizationLearnerPassageParticipation et de l'update combinedCourseParticipation.

## 🪵 Pour tester
Passer un parcours combiné et vérifier que la colonne referenceId est bien mise à jour : 
sur l'organization_learner_participation du parcours combiné avec l'id du parcours
sur l'organization_learner_participation des passages avec le moduleId