### PR TITLE
[FEATURE] Afficher le nom de l'orga mère sur le formulaire de création d'organisation (PIX-20048)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -39,6 +39,12 @@ export default class OrganizationCreationForm extends Component {
     return options;
   }
 
+  get submitButtonText() {
+    return this.args.parentOrganizationName
+      ? 'components.organizations.creation.actions.add-child-organization'
+      : 'common.actions.add';
+  }
+
   @action
   handleOrganizationTypeSelectionChange(value) {
     this.args.organization.type = value;
@@ -83,6 +89,14 @@ export default class OrganizationCreationForm extends Component {
     <form class="admin-form" {{on "submit" @onSubmit}}>
       <section class="admin-form__content admin-form__content--with-counters">
         <Card class="admin-form__card" @title="Information générique">
+          {{#if @parentOrganizationName}}
+            <h2 class="admin-form__content title">
+              {{t
+                "components.organizations.creation.parent-organization-name"
+                parentOrganizationName=@parentOrganizationName
+              }}
+            </h2>
+          {{/if}}
           <PixInput
             @id="organizationName"
             onchange={{this.handleOrganizationNameChange}}
@@ -148,7 +162,7 @@ export default class OrganizationCreationForm extends Component {
           {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @type="submit" @size="small" @variant="success">
-          {{t "common.actions.add"}}
+          {{t this.submitButtonText}}
         </PixButton>
       </section>
     </form>

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -112,6 +112,12 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: var(--pix-spacing-6x);
+
+    .title {
+      @extend %pix-title-xs;
+
+      color: var(--pix-neutral-900);
+    }
 }
 
 .admin-form__card {

--- a/admin/app/templates/authenticated/organizations/new.hbs
+++ b/admin/app/templates/authenticated/organizations/new.hbs
@@ -1,6 +1,10 @@
 {{page-title "Nouvelle orga"}}
 <header class="page-header">
-  <Organizations::Breadcrumb @currentPageLabel="Nouvelle organisation" />
+  {{#if this.parentOrganizationName}}
+    <Organizations::Breadcrumb @currentPageLabel="Nouvelle organisation fille" />
+  {{else}}
+    <Organizations::Breadcrumb @currentPageLabel="Nouvelle organisation" />
+  {{/if}}
 </header>
 
 <main class="main-admin-form">
@@ -8,5 +12,6 @@
     @organization={{@model}}
     @onSubmit={{this.addOrganization}}
     @onCancel={{this.goBackToOrganizationList}}
+    @parentOrganizationName={{this.parentOrganizationName}}
   />
 </main>

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -557,13 +557,17 @@
         "table-name": "List of children organisations"
       },
       "creation": {
+        "actions": {
+          "add-child-organization": "Add child organization"
+        },
         "administration-team": {
           "required-fields-error": "Please fill in all required fields.",
           "selector": {
             "label": "Choose an administration team",
             "placeholder": "Administration team"
           }
-        }
+        },
+        "parent-organization-name": "Parent organization: {parentOrganizationName}"
       },
       "editing": {
         "administration-team": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -558,13 +558,17 @@
         "table-name": "Liste des organisations filles"
       },
       "creation": {
+        "actions": {
+          "add-child-organization": "Ajouter une organisation fille"
+        },
         "administration-team": {
           "required-fields-error": "Veuillez remplir tous les champs obligatoires.",
           "selector": {
             "label": "Sélectionner une équipe en charge",
             "placeholder": "Équipe en charge"
           }
-        }
+        },
+        "parent-organization-name": "Organisation mère : {parentOrganizationName}"
       },
       "editing": {
         "administration-team": {


### PR DESCRIPTION
## 🍂 Problème

Dans le cas ou un queryParam est présent dans l’URL avec id/name de l’orga mère, alors on veut afficher dans le formulaire le nom de celle ci.

## 🌰 Proposition

- Afficher le nom de l'organisation mère dans le formulaire
- Afficher "Ajouter une organisation fille" dans le bouton

## 🍁 Remarques

~On utilise `runTask` dans la route côté front~

~`runTask` (de ember-lifeline) permet de planifier l’exécution du replaceWith dans le prochain tour de la boucle Ember — après que la transition actuelle soit stabilisée.~

~`runTask` décale la redirection pour ne pas perturber le cycle de vie du routeur Ember.~
~Cela garantit une transition stable, évite les erreurs internes (Cannot read properties of undefined),~
~et reste conforme aux bonnes pratiques Ember 5+ (pas d’accès direct au runloop).~

corrige l'erreur soulevée par @ThomasBazin https://github.com/1024pix/pix/pull/13956#issuecomment-3436050487

-> C'était le fait de re-rendre le même composant qui posait des soucis. Du coup on a fait le choix "simple" de rediriger vers la page d'accueil de PixAdmin en cas d'un des deux params manquant. 

## 🪵 Pour tester

- Sur pix-admin
- Se connecter avec un role METIER, SUPPORT ou ADMIN
- Aller sur https://admin-pr13956.review.pix.fr/organizations/new?parentOrganizationId=1&parentOrganizationName=Orga%20test%20mère
- Constater que le nom de l'organisation mère apparait
- Constater que le bouton de validation comporte le texte "Ajouter une organisation fille"

<img width="801" height="742" alt="image" src="https://github.com/user-attachments/assets/2bc8ba2b-4f91-4415-9d19-3e1447819034" />
<img width="608" height="171" alt="image" src="https://github.com/user-attachments/assets/6e66147d-058d-4147-bf50-93a0c6fe1a85" />


