### PR TITLE
[FEATURE] Déplace le bouton de fin de campagne personnalisé (PIX-19976)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/custom-organization-block.gjs
@@ -47,8 +47,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
     <div class="evaluation-results-hero__organization-block">
       {{#if @campaign.customResultPageText}}
         <MarkdownToHtml
-          class="evaluation-results-hero-organization-block__message"
-          @isInline={{true}}
+          @class="evaluation-results-hero-organization-block__message"
           @markdown={{@campaign.customResultPageText}}
         />
       {{/if}}
@@ -58,6 +57,7 @@ export default class EvaluationResultsCustomOrganizationBlock extends Component 
           class="evaluation-results-hero-organization-block__link"
           @href={{this.customButtonUrl}}
           @variant="primary"
+          @size="large"
           onclick={{this.handleCustomButtonClick}}
         >
           {{@campaign.customResultPageButtonText}}

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -316,14 +316,14 @@ export default class EvaluationResultsHero extends Component {
         {{#if @campaignParticipationResult.acquiredBadges.length}}
           <AcquiredBadges @acquiredBadges={{@campaignParticipationResult.acquiredBadges}} />
         {{/if}}
-      </div>
 
-      {{#if this.showCustomOrganizationBlock}}
-        <CustomOrganizationBlock
-          @campaign={{@campaign}}
-          @campaignParticipationResult={{@campaignParticipationResult}}
-        />
-      {{/if}}
+        {{#if this.showCustomOrganizationBlock}}
+          <CustomOrganizationBlock
+            @campaign={{@campaign}}
+            @campaignParticipationResult={{@campaignParticipationResult}}
+          />
+        {{/if}}
+      </div>
 
       {{#if (or @campaignParticipationResult.canRetry @campaignParticipationResult.canReset)}}
         <RetryOrResetBlock @campaign={{@campaign}} @campaignParticipationResult={{@campaignParticipationResult}} />

--- a/mon-pix/app/styles/pages/_evaluation-results.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results.scss
@@ -216,9 +216,14 @@
   border-top: 1px solid var(--pix-neutral-100);
 }
 
-.evaluation-results-hero-organization-block__link {
-  width: fit-content;
-  margin: 0 auto var(--pix-spacing-4x);
+.evaluation-results-hero-organization-block {
+  &__link {
+    width: fit-content;
+  }
+
+  &__message {
+    margin-bottom: var(--pix-spacing-4x);
+  }
 }
 
 // Retry or reset block


### PR DESCRIPTION
## 🍂 Problème

Le bouton personnalisé de fin de campagne qui permet de retourner au parcours combiné n'est pas très visible.

## 🌰 Proposition

Faire les changement présents sur la maquette.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Se connecter avec MonPix avec attestation-blank
- Entrer le code COMBINIX1
- Aller sur la page de résultats de la campagne de diagnostic
- Constater que le bouton a été déplacé et grossit