### PR TITLE
[FEATURE] Cache le bouton "Quitter" sur la page de récap d'un module si une url de redirection est passée (PIX-20109)

### DIFF
--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -9,17 +9,19 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
   {{/if}}
 
   <main class="module-recap">
-    <div class="module-recap__header">
-      <PixButtonLink
-        @size="large"
-        @route="authenticated.user-dashboard"
-        @variant="tertiary"
-        @iconAfter="doorOpen"
-        class="module-recap-header__icon"
-      >
-        {{t "pages.modulix.recap.backToModuleDetails"}}
-      </PixButtonLink>
-    </div>
+    {{#unless @module.redirectionUrl}}
+      <div class="module-recap__header">
+        <PixButtonLink
+          @size="large"
+          @route="authenticated.user-dashboard"
+          @variant="tertiary"
+          @iconAfter="doorOpen"
+          class="module-recap-header__icon"
+        >
+          {{t "pages.modulix.recap.backToModuleDetails"}}
+        </PixButtonLink>
+      </div>
+    {{/unless}}
 
     <img class="module-recap__illustration" src="/images/modulix/recap-success.svg" alt="" width="228" height="200" />
 

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -85,4 +85,39 @@ module('Integration | Component | Module | Recap', function (hooks) {
     // then
     assert.dom(screen.getByRole('link', { name: 'Continuer' })).exists();
   });
+
+  module('when a redirection url is set', function () {
+    test('should display link to a custom url', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const module = store.createRecord('module', {
+        id: 'mon-slug',
+        title: 'Module title',
+        isBeta: true,
+        redirectionUrl: 'https//some-url.fr',
+      });
+      // when
+      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+
+      // then
+      const button = screen.getByRole('link', { name: 'Continuer' });
+      assert.strictEqual(button.getAttribute('href'), module.redirectionUrl);
+    });
+
+    test('should not display quit link', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const module = store.createRecord('module', {
+        id: 'mon-slug',
+        title: 'Module title',
+        isBeta: true,
+        redirectionUrl: 'https//some-url.fr',
+      });
+      // when
+      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+
+      // then
+      assert.strictEqual(screen.queryByRole('link', { name: 'Quitter' }), null);
+    });
+  });
 });


### PR DESCRIPTION
## 🍂 Problème

Actuellement il y a un bouton quitter en haut à droite sur la page de récap d'un module. Cependant, de nombreux élèves clique dessus par erreur au lieu du bouton continuer et se retrouve donc sur la page d'accueil de Pix au lieu du parcours combiné qu'ils étaient en train de faire.

## 🌰 Proposition

Lorsqu'une url de rédirection est passée on cache le bouton quitter comme c'est le cas pour cette même fonctionnalité au niveau des campagnes.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Se connecter sur PixApp avec attestation-blank
- Entrer le code COMBINIX1 
- Faire la campagne de diagnostic puis le premier module
- Constater que sur la page de récap le bouton quitter est absent ✅ 
- Passer un autre module en dehors du cadre du parcours combiné
- Sur la page de récap constater la présence du bouton quitter  ✅
