### PR TITLE
[TECH] Créer le feature toogle pour la nouvelle nav modulix (PIX-20101)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -74,4 +74,11 @@ export default {
     devDefaultValues: { test: false, reviewApp: false },
     tags: ['frontend', 'team-acces', 'pix-orga'],
   },
+  isModulixNavEnabled: {
+    type: 'boolean',
+    description: 'Enables navigation for modules',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: false },
+    tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,6 +29,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
             'use-pix-orga-new-auth-design': false,
+            'is-modulix-nav-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,4 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isAutoShareEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
+  @attr('boolean') isModulixNavEnabled;
 }


### PR DESCRIPTION
## 🍂 Problème
On souhaite  créeer une navbar pour modulix, sans impacter l'expérience utilisateur existante avant la fin du dev.

## 🌰 Proposition
Créer un feature toggle

## 🍁 Remarques


## 🪵 Pour tester
- Aller sur [Pix App](https://app-pr13961.review.pix.fr/)
- Inspecter le réseau et regarder les feature toggles renvoyés
- faire un `scalingo --region osc-fr1 -a pix-api-review-pr13961 run bash`
- lancer la commande `npm run toggles -- --key=isModulixNavEnabled --value=true`
- retourner sur la page d'accueil de pix app
- constater que la valeur du feature toggle est passée à true


