### PR TITLE
[BUGFIX] Afficher les boutons d'accès aux campagnes associé à un parcours combiné (PIX-20118)

### DIFF
--- a/orga/app/components/combined-course/header.gjs
+++ b/orga/app/components/combined-course/header.gjs
@@ -43,15 +43,11 @@ export default class CombinedCourseHeader extends Component {
       <:subtitle>
         <div class="combined-course-page__header">
           <p class="combined-course-page__header-body">{{t "pages.combined-course.introduction"}}</p>
-          {{#if @model.campaignIds.length}}
+          {{#if @campaignIds.length}}
             <div class="combined-course-page__campaigns">
-              {{#each @model.campaignIds as |campaignId index|}}
+              {{#each @campaignIds as |campaignId index|}}
                 <PixButtonLink @route="authenticated.campaigns.campaign" @model={{campaignId}} @variant="primary">
-                  {{t
-                    "pages.combined-course.campaigns"
-                    count=@model.campaignIds.length
-                    index=(this.getCampaignIndex index)
-                  }}
+                  {{t "pages.combined-course.campaigns" count=@campaignIds.length index=(this.getCampaignIndex index)}}
                 </PixButtonLink>
               {{/each}}
             </div>

--- a/orga/app/templates/authenticated/combined-course.gjs
+++ b/orga/app/templates/authenticated/combined-course.gjs
@@ -4,6 +4,7 @@ import CombinedCourseHeader from 'pix-orga/components/combined-course/header';
   <CombinedCourseHeader
     @code={{@model.code}}
     @name={{@model.name}}
+    @campaignIds={{@model.campaignIds}}
     @participationsCount={{@model.combinedCourseStatistics.participationsCount}}
     @completedParticipationsCount={{@model.combinedCourseStatistics.completedParticipationsCount}}
   />

--- a/orga/tests/acceptance/combined-course-test.js
+++ b/orga/tests/acceptance/combined-course-test.js
@@ -34,6 +34,8 @@ module('Acceptance | Combined course page', function (hooks) {
 
     // then
     assert.ok(await screen.getByRole('heading', { name: new RegExp(combinedCourse.name) }));
+    assert.ok(screen.getByText(combinedCourse.code));
+    assert.ok(await screen.getByRole('link', { name: t('pages.combined-course.campaigns', { count: 1, index: 1 }) }));
   });
 
   test('it should display combined course statistics', async function (assert) {

--- a/orga/tests/integration/components/combined-course/header-test.gjs
+++ b/orga/tests/integration/components/combined-course/header-test.gjs
@@ -49,7 +49,9 @@ module('Integration | Component | CombinedCourse | Header', function (hooks) {
       });
 
       // when
-      const screen = await render(<template><CombinedCourseHeader @model={{combinedCourse}} /></template>);
+      const screen = await render(
+        <template><CombinedCourseHeader @campaignIds={{combinedCourse.campaignIds}} /></template>,
+      );
 
       // then
       const link1 = screen.getByRole('link', { name: t('pages.combined-course.campaigns', { count: 2, index: 1 }) });
@@ -69,7 +71,9 @@ module('Integration | Component | CombinedCourse | Header', function (hooks) {
       });
 
       // when
-      const screen = await render(<template><CombinedCourseHeader @model={{combinedCourse}} /></template>);
+      const screen = await render(
+        <template><CombinedCourseHeader @campaignIds={{combinedCourse.campaignIds}} /></template>,
+      );
 
       // then
       assert.notOk(screen.queryByRole('link', { name: t('pages.combined-course.campaigns', { count: 0, index: 0 }) }));


### PR DESCRIPTION
## 🍂 Problème

Sur la page de détail d’un parcours combiné, on souhaite avoir un accès aux pages des campagnes associées. Or les boutons mis en place ne s’affichent plus actuellement. 

Lors de l’ajout de la pagination, le header du détails du parcours combiné a été mis dans un autre composant, modifiant l’accès à ses variables (on ne passe plus de `@model` entier au nouveau composant). Mais dans celui-ci le tableaux de campagnes associé se base toujours sur `@model`, ce qui nous donne un `undefined`.

## 🌰 Proposition

Ajouter le tableau de `campaignIds` en propriété du nouveau composant header de combined course.

## 🪵 Pour tester

Aller dans Pix Orga
Aller sur la page de détail du parcours COMBINIX2
Voir qu’un bouton d’accès à la campagne s’affiche
