### PR TITLE
[FEATURE] Adapter les scripts extract CSV pour prendre en compte ce nouveau type de grain (PIX-20117)

### DIFF
--- a/api/scripts/modulix/get-modules-csv.js
+++ b/api/scripts/modulix/get-modules-csv.js
@@ -20,7 +20,8 @@ export async function getModulesListAsCsv(modules) {
       },
       {
         label: 'ModuleTotalLessons',
-        value: (row) => getGrains(row).filter((grain) => grain.type === 'lesson').length,
+        value: (row) =>
+          getGrains(row).filter((grain) => grain.type === 'lesson' || grain.type === 'short-lesson').length,
       },
       { label: 'ModuleDuration', value: (row) => `=TEXT(${row.details.duration}/24/60; "mm:ss")` },
       {

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -177,7 +177,7 @@
         },
         {
           "id": "73ac3644-7637-4cee-86d4-1a75f53f0b9c",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "Vidéo de présentation de Pix",
           "components": [
             {
@@ -465,7 +465,7 @@
         },
         {
           "id": "cf436761-f56d-4b01-83f9-942afe9ce72c",
-          "type": "lesson",
+          "type": "short-lesson",
           "title": "test qab",
           "components": [
             {


### PR DESCRIPTION
## 🍂 Problème

Le script d'extraction CSV `get-modules-csv.js` ne prend pas en compte le nouveau type de grain `short-lesson`.

## 🌰 Proposition

Ajouter le nouveau type de grain quand on compte le nombre de leçons par Module.

## 🍁 Remarques

RAS

## 🪵 Pour tester

Avec la branche en local:
- Lancer le script get-modules-csv.js avec `node`
- Vérifier par exemple que pour le module bac-a-sable, on a bien un total de 6 leçons
