### PR TITLE
[TECH] Mettre à jour la table oidc-providers pour gérer du SSO pour chaque application de manière générique (PIX-20119)

### DIFF
--- a/api/db/migrations/20251023102453_update-oidc-providers-for-all-apps-generic-sso.js
+++ b/api/db/migrations/20251023102453_update-oidc-providers-for-all-apps-generic-sso.js
@@ -1,0 +1,38 @@
+const TABLE_NAME = 'oidc-providers';
+const APPLICATION_COLUMN_NAME = 'application';
+const CONNECTION_METHOD_CODE_COLUMN_NAME = 'connectionMethodCode';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string(APPLICATION_COLUMN_NAME)
+      .defaultTo(null)
+      .comment('Name of the application for which this client configuration is for');
+  });
+
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string(CONNECTION_METHOD_CODE_COLUMN_NAME)
+      .defaultTo(null)
+      .comment(
+        'Optional identity provider code to group the corresponding authentication method to another authentication method',
+      );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(APPLICATION_COLUMN_NAME);
+    table.dropColumn(CONNECTION_METHOD_CODE_COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Le schéma de la table `oidc-providers` ne permet pas de gérer des SSO pour Pix Orga.

## 🌰 Proposition

Faire évoluer la table `oidc-providers` de manière à permettre de gérer des SSO de manière générique pour n’importe quelle application Front Pix (Pix App, Pix Admin, Pix Orga, mais aussi dans le futur Pix Certif, etc.).

Pour cela on propose la migration SQL suivante qui ajoute 2 nouvelles colonnes : 

* Attribut à ajouter pour déterminer l’application cliente de la config :
   * nom : `application`
   * valeur : nom de l’application retournée par le _RequestedApplication_ (ex : `app`, `admin`, `orga`, etc.)
   * structure : type `string`, optionnel (uniquement pour l’instant mais obligatoire après reprise des données)
* Attribut à ajouter pour gérer le code des méthodes de connexion :
   * nom : `connectionMethodCode`
   * valeur : code d’identityProvider d’une autre configuration 
   * structure : type `string`, optionnel

## 🍁 Remarques

:bulb: On ne peut pas rendre la colonne `application` obligatoire avec cette migration. En effet il y a déjà, en _recette_ et en **production**, des valeurs dans la table `oidc-providers` qui n’ont pas de valeur pour cette colonne `application`. On pourra rendre  la colonne `application` obligatoire avec une autre migration du schéma de la BDD une fois que la reprise de données des OIDC Providers actuels (requête SQL en production et recette) aura été réalisée.

## 🪵 Pour tester

1. Réaliser la validation de la migration de la DB : 
   1. Exécuter la commande `npm run db:migrate` en local
   2. Vérifier que la table `oidc-providers` a bien été modifiée avec l'ajout d'une nouvelle colonne `application` et d’une nouvelle colonne `connectionMethodCode`
   3.  Exécuter la commande `npm run db:rollback:latest` et vérifier que la table `oidc-providers` ne contient plus la nouvelle colonne `application` et la nouvelle colonne `connectionMethodCode`
2. Vérifier en local que la création des configurations d’OIDC Providers fonctionne toujours bien : 
   ```shell
   export OIDC_PROVIDERS=$(cat OIDC_PROVIDERS.json)
   npm run db:reset
   ```
3. Vérifier qu’on peut bien toujours se connecter par SSO à Pix App avec un SSO OIDC au choix parmi les SSO venant d’être créés précédemment.