### PR TITLE
[TECH] Script de suppression des challenges des certifications Pix+ (PIX-20093).

### DIFF
--- a/api/scripts/certification/delete-complementary-certification-frameworks-challenges.js
+++ b/api/scripts/certification/delete-complementary-certification-frameworks-challenges.js
@@ -1,0 +1,55 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class DeleteComplementaryCertificationFrameworksChallenges extends Script {
+  constructor() {
+    super({
+      description: 'Delete complementary certification frameworks challenges',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const allChallenges = await trx('certification-frameworks-challenges');
+      const challengesToBeDeleted = await trx('certification-frameworks-challenges').whereNotNull(
+        'complementaryCertificationKey',
+      );
+      logger.info(`Number of challenges to be deleted: ${challengesToBeDeleted.length}`);
+
+      await trx('certification-frameworks-challenges').whereNotNull('complementaryCertificationKey').delete();
+
+      if (dryRun) {
+        await trx.rollback();
+        logger.info(`${challengesToBeDeleted.length} would have been deleted`);
+        return;
+      }
+
+      const remainingChallenges = await trx('certification-frameworks-challenges');
+
+      logger.info(`Number of expected remaining challenges: ${allChallenges.length - challengesToBeDeleted.length}`);
+      logger.info(`Number of remaining challenges: ${remainingChallenges.length}`);
+
+      await trx.commit();
+      logger.info(`${challengesToBeDeleted.length} have been successfully deleted`);
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteComplementaryCertificationFrameworksChallenges);


### PR DESCRIPTION
## 🍂 Problème

En production, les challenges déjà importés via profil cible ne sont pas ceux attendus. Le code utilisé pour importer les challenges disponibles en production n'était pas conforme aux attentes en ce qui concerne les filtres de locale et de status.

Nous souhaitons donc les supprimer via l'utilisation d'un script.

## 🌰 Proposition

Création d'un script pour supprimer les challenges dont la `complementaryCertificationKey` n'est pas nulle (challenge de certification Pix+)

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Exécuter le script avec `dryRun=true`

```
scalingo -a pix-api-review-pr13977 run "node scripts/certification/delete-complementary-certification-frameworks-challenges.js --dryRun=true"
```

Si pas de problème, exécuter de nouveau avec `dryRun=false`

```
scalingo -a pix-api-review-pr13977 run "node scripts/certification/delete-complementary-certification-frameworks-challenges.js --dryRun=false"
```

Vérifier en BDD dans `certification-frameworks-challenges` qu'il ne reste que des challenges dont `complementaryCertificationKey` est `null`