### PR TITLE
[FEATURE] Correction des traductions NL (PIX-20032)

### DIFF
--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -455,12 +455,12 @@
     "params": {
       "acceptInvitation": "Uitnodiging accepteren",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
-      "here": "hier",
+      "here": "Neem contact met ons op hier.",
       "moreAbout": "Ontdek meer over",
-      "needHelp": "Hulp nodig? Neem contact met ons op",
+      "needHelp": "Hulp nodig?",
       "oneTimeLink": "Deze link is voor eenmalig gebruik",
       "pixPresentation": "Pix is de openbare online service voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
-      "subtitle": "Met het Pix Orga platform kun je testcampagnes maken en beheren en de voortgang van je deelnemers volgen.",
+      "subtitle": "Met het Pix Orga-platform kun je testcampagnes aanmaken en beheren, en de voortgang van je deelnemers volgen.",
       "title": "Je bent uitgenodigd om lid te worden van Pix Orga",
       "yourOrganization": "Uw organisatie"
     },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -486,12 +486,12 @@
       "clickOnTheButton": "Klik op de knop hieronder om een nieuw wachtwoord te kiezen.",
       "contactUs": "neem hier contact met ons op",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet. Hulp nodig?",
-      "linkValidFor": "Deze link is 24 uur geldig. Als je dit verzoek niet hebt ingediend, negeer deze e-mail dan.",
+      "linkValidFor": "Deze link is 24 uur geldig. Heb je dit verzoek niet zelf ingediend? Negeer deze e-mail dan gewoon.",
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
       "resetMyPassword": "Een nieuw wachtwoord instellen",
       "title": "Wachtwoord opnieuw instellen",
-      "weCannotSendYourPassword": "Hallo, om veiligheidsredenen sturen we jouw wachtwoord niet per e-mail."
+      "weCannotSendYourPassword": "Hallo, Om veiligheidsredenen sturen we je wachtwoord niet per e-mail."
     },
     "subject": "Verzoek instellen nieuw wachtwoord Pix"
   },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -499,11 +499,11 @@
     "params": {
       "contactUs": "neem hier contact met ons op",
       "hello": "Hallo {firstName},",
-      "requestConfirmation": "Na je verzoek zullen we de verwijdering van je Pix-account en je persoonlijke gegevens bevestigen.",
-      "seeYouSoon": "We hopen je snel te zien voor nieuwe digitale avonturen.",
-      "signing": "Het Pix team",
+      "requestConfirmation": "We hebben je verzoek ontvangen om je Pix-account te verwijderen. Zodra het proces is afgerond, ontvang je een bevestiging van ons.",
+      "seeYouSoon": "We hopen je in de toekomst weer te mogen verwelkomen voor nieuwe digitale avonturen.",
+      "signing": "Groeten, Het Pix team",
       "title": "Je account verwijderen",
-      "warning": "Als u niet de bron van dit verzoek bent, neem dan contact op met ondersteuning."
+      "warning": "Was jij dit niet? Neem dan contact op met onze ondersteuning."
     },
     "subject": "Je account verwijderen"
   },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -471,12 +471,12 @@
       "askForHelp": "Hulp nodig? Neem contact met ons op",
       "disclaimer": "Als je de account niet hebt aangemaakt, kun je vragen om deze te verwijderen.",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
-      "goToPix": "Ik bevestig mijn e-mailadres",
+      "goToPix": "Mijn e-mailadres bevestigen",
       "helpdeskLinkLabel": "hier",
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
-      "subtitle": "Bedankt voor het aanmaken van je account. Er is nog één stap over om je account te beveiligen door je e-mailadres te valideren.",
-      "subtitleDescription": "Het is heel eenvoudig, klik op de knop hieronder en log in op je Pix-account.",
+      "subtitle": "Bedankt dat je een account hebt aangemaakt! Er is nog één stap nodig om je account te beveiligen: bevestig je e-mailadres.",
+      "subtitleDescription": "Klik op de knop hieronder om je e-mailadres te valideren en toegang te krijgen tot je Pix-account.",
       "title": "Hallo {firstName},"
     },
     "subject": "Je Pix-account is aangemaakt"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1379,7 +1379,7 @@
       },
       "started-competences": {
         "subtitle": "Ga door met je vaardigheidstests, vind de nieuwste hier.",
-        "title": "Een vaardigheid terugnemen"
+        "title": "Een vaardigheid hernemen"
       },
       "title": "Home",
       "welcome": "Welkom { firstName }"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -609,7 +609,7 @@
         "results": "{result, number, ::percent} succes",
         "resume": {
           "extra-information": "Hervat de {campaignTitle} route",
-          "information": "Overnemen"
+          "information": "Verder gaan"
         },
         "retry": "Verbeter mezelf",
         "see-more": "Zie details",
@@ -1287,7 +1287,7 @@
       "actions": {
         "continue": {
           "extra-information": "De competentie hervatten {competenceName}",
-          "label": "Overnemen"
+          "label": "Verder gaan"
         },
         "improve": {
           "description": {
@@ -1317,7 +1317,7 @@
         }
       },
       "for-competence": "de vaardigheid  {competence}",
-      "next-level-info": "{ remainingPixToNextLevel } pix voordat de niveau { level }",
+      "next-level-info": "Nog { remainingPixToNextLevel } pix voor niveau { level }",
       "title": "Bevoegdheid",
       "tutorials": {
         "description": "Hier is een selectie van tutorials om je te helpen Pix te verdienen.",
@@ -1888,7 +1888,7 @@
         },
         "actions": {
           "continue": "Ga verder met",
-          "resume": "Overnemen"
+          "resume": "Verder gaan"
         },
         "reminder-continue-campaign": "Je hebt je cursus niet afgerond",
         "reminder-continue-campaign-with-title": "Je hebt de \"{title}\" route niet voltooid",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -43,7 +43,7 @@
       "download": "Downloaden",
       "lets-go": "Laten we gaan!",
       "login": "Inloggen",
-      "quit": "Verlaat",
+      "quit": "Terug",
       "refresh-page": "Pagina verversen",
       "show-less": "Minder tonen",
       "show-more": "Meer bekijken",
@@ -1432,7 +1432,7 @@
       "mediacentre-start-campaign-modal": {
         "actions": {
           "continue": "Ga verder met",
-          "quit": "Verlaat"
+          "quit": "Terug"
         },
         "message": "Om toegang te krijgen tot de cursus :",
         "message-footer": "Maak verbinding met Pix via je Mediacenter",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1123,7 +1123,7 @@
         "qcm": "Selecteer ten minste twee antwoorden om te bevestigen. Zo niet, sla dan over.",
         "qcu": "Selecteer een antwoord om te bevestigen. Sla anders over.",
         "qroc": "Vul het tekstveld in om te valideren. Sla anders over.",
-        "qroc-auto-reply": "\"U kunt valideren\" wordt weergegeven wanneer de test is geslaagd. Probeer het opnieuw of slaag.",
+        "qroc-auto-reply": "\"U kunt valideren\" wordt weergegeven wanneer de proef is geslaagd. Probeer het opnieuw of ga verder.",
         "qroc-positive-number": "Voer om te valideren een getal in dat groter is dan of gelijk is aan 0, sla anders over.",
         "qrocm": "Vul alle antwoordvelden in om te valideren. Zo niet, sla dan over."
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2125,7 +2125,7 @@
     "timed-challenge-instructions": {
       "action": "Beginnen",
       "primary": "Je hebt '<span class=\"timed-challenge-instructies__time\">'{time}'</span>' om de volgende vraag te beantwoorden.",
-      "secondary": "Als je doorgaat wordt de opdracht niet als voltooid beschouwd.",
+      "secondary": "Daarna kun je nog antwoorden, maar wordt de opdracht niet als voltooid beschouwd.",
       "time": {
         "and": " en ",
         "minutes": "{minutes, plural, =0 {} =1 {# minuut} other {# minuten}}",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1535,7 +1535,7 @@
       "title": "Voor meer informatie"
     },
     "levelup-notif": {
-      "obtained-level": "Niveau {level} gewonnen!"
+      "obtained-level": "Niveau {level} behaald !"
     },
     "llm-preview": {
       "iframe-title": "ChatPix",


### PR DESCRIPTION
## 🍂 Problème

Un traducteur nous a fait des retours sur nos e-mails ainsi que quelques écrans. 

## 🌰 Proposition

Ajuster les clés de traduction.

## 🍁 Remarques

RAS

## 🪵 Pour tester

**E-mail de bienvenue** 

Hallo Test,

Bedankt dat je een account hebt aangemaakt!
Er is nog één stap nodig om je account te beveiligen: bevestig je e-mailadres.

Klik op de knop hieronder om je e-mailadres te valideren en toegang te krijgen tot je Pix-account.

[Mijn e-mailadres bevestigen]

Als je de account niet hebt aangemaakt, kun je vragen om deze te verwijderen. hier

-----

**E-mail d'invitation sur Pix Orga**

Ces éléments doivent apparaitre : 

* Met het Pix Orga-platform kun je testcampagnes aanmaken en beheren, en de voortgang van je deelnemers volgen.
* Hulp nodig? Neem contact met ons op.  (La partie après le point d'interrogation doit contenir un lien qui pointe vers le formulaire de contact)

-----

**E-mail de réinitialisation du mot de passe**

"Hallo,

Om veiligheidsredenen sturen we je wachtwoord niet per e-mail.
Klik op de knop hieronder om een nieuw wachtwoord te kiezen.

[Een nieuw wachtwoord instellen]

Deze link is 24 uur geldig. Heb je dit verzoek niet zelf ingediend? Negeer deze e-mail dan gewoon."

-----

**Suppression du compte utilisateur**

"Hallo Mathias,

We hebben je verzoek ontvangen om je Pix-account te verwijderen. Zodra het proces is afgerond, ontvang je een bevestiging van ons.

We hopen je in de toekomst weer te mogen verwelkomen voor nieuwe digitale avonturen.

Groeten,
Het Pix-team

Was jij dit niet? Neem dan contact op met onze ondersteuning."

----

https://editor.pix.fr/api/challenges/rec2Q7gDClZYysUJ4/preview - Pour la phrase suivante : 

Avant : Als je doorgaat wordt de opdracht niet als voltooid beschouwd.  
Après : Daarna kun je nog antwoorden, maar wordt de opdracht niet als voltooid beschouwd 

----

https://editor.pix.fr/api/challenges/challenge2cqrrdzUaUrbt6/preview

Il faut cliquer sur le bouton "Valider" puis constater l'affichage du message d'erreur qui contient le texte suivant :  "‘U kunt valideren’ wordt weergegeven wanneer de proef is geslaagd. Probeer het opnieuw of ga verder."

----

Les éléments contenus dans cette page : https://docs.google.com/document/d/1z6RAjXOBkBwXW5TaA1Ds8eDX--zH7FQz81B7NEBYB5E/edit?tab=t.0 

