### PR TITLE
[FEATURE] Filtrer les participations d'un parcours apprenants (PIX-19632)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -41,9 +41,11 @@ const getStatistics = async (request, _, dependencies = { combinedCourseStatisti
 const findParticipations = async (request, _, dependencies = { combinedCourseParticipationSerializer }) => {
   const combinedCourseId = request.params.combinedCourseId;
   const page = request.query.page;
+  const filters = request.query.filters;
   const { combinedCourseParticipations, meta } = await usecases.findCombinedCourseParticipations({
     combinedCourseId,
     page,
+    filters,
   });
   return dependencies.combinedCourseParticipationSerializer.serialize(combinedCourseParticipations, meta);
 };

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -4,6 +4,7 @@ const ERRORS = {
   PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
 };
 
+import { CombinedCourseParticipationStatuses } from '../../prescription/shared/domain/constants.js';
 import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { MAX_FILE_SIZE_UPLOAD } from '../../shared/domain/constants.js';
@@ -116,6 +117,17 @@ const register = async function (server) {
             page: {
               number: Joi.number().integer().empty('').default(1),
               size: Joi.number().integer().empty('').default(10),
+            },
+            filters: {
+              fullName: Joi.string().empty('').max(255).optional(),
+              statuses: Joi.array()
+                .items(
+                  Joi.string().valid(
+                    CombinedCourseParticipationStatuses.STARTED,
+                    CombinedCourseParticipationStatuses.COMPLETED,
+                  ),
+                )
+                .optional(),
             },
           }),
         },

--- a/api/src/quest/domain/usecases/find-combined-course-participations.js
+++ b/api/src/quest/domain/usecases/find-combined-course-participations.js
@@ -7,7 +7,7 @@ export const findCombinedCourseParticipations = async ({
   combinedCourseParticipationRepository,
   combinedCourseDetailsService,
 }) => {
-  const { userIds, meta } = await combinedCourseParticipationRepository.findUserIdsById({
+  const { userIds, meta } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
     combinedCourseId,
     page,
     filters,

--- a/api/src/quest/domain/usecases/find-combined-course-participations.js
+++ b/api/src/quest/domain/usecases/find-combined-course-participations.js
@@ -3,10 +3,15 @@ import { PromiseUtils } from '../../../shared/infrastructure/utils/promise-utils
 export const findCombinedCourseParticipations = async ({
   combinedCourseId,
   page,
+  filters,
   combinedCourseParticipationRepository,
   combinedCourseDetailsService,
 }) => {
-  const { userIds, meta } = await combinedCourseParticipationRepository.findUserIdsById({ combinedCourseId, page });
+  const { userIds, meta } = await combinedCourseParticipationRepository.findUserIdsById({
+    combinedCourseId,
+    page,
+    filters,
+  });
 
   const combinedCourseParticipations = await PromiseUtils.mapSeries(userIds, async (userId) => {
     const combinedCourseDetails = await combinedCourseDetailsService.getCombinedCourseDetails({

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -95,6 +95,9 @@ function addSearchFilters(queryBuilder, filters = {}) {
   if (filters.fullName) {
     filterByFullName(queryBuilder, filters.fullName, 'firstName', 'lastName');
   }
+  if (filters.statuses?.length > 0) {
+    queryBuilder.whereIn('combined_course_participations.status', filters.statuses);
+  }
 }
 
 export const update = async function ({ combinedCourseParticipation, combinedCourseId }) {

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -79,7 +79,8 @@ export const findUserIdsById = async function ({ combinedCourseId, page }) {
       'view-active-organization-learners.id',
       'combined_course_participations.organizationLearnerId',
     )
-    .where('combined_courses.id', combinedCourseId);
+    .where('combined_courses.id', combinedCourseId)
+    .orderBy(['lastName', 'firstName', 'userId']);
 
   const { results, pagination } = await fetchPage({ queryBuilder, paginationParams: page });
   return {

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -68,7 +68,7 @@ export const getByUserId = async function ({ userId, questId }) {
   return new CombinedCourseParticipation(questParticipations[0]);
 };
 
-export const findUserIdsById = async function ({ combinedCourseId, page, filters }) {
+export const findUserIdsByCombinedCourseId = async function ({ combinedCourseId, page, filters }) {
   const knexConnection = DomainTransaction.getConnection();
 
   const queryBuilder = knexConnection('combined_courses')

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -1,5 +1,6 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
+import { filterByFullName } from '../../../shared/infrastructure/utils/filter-utils.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { CombinedCourseParticipation } from '../../domain/models/CombinedCourseParticipation.js';
 import {
@@ -67,7 +68,7 @@ export const getByUserId = async function ({ userId, questId }) {
   return new CombinedCourseParticipation(questParticipations[0]);
 };
 
-export const findUserIdsById = async function ({ combinedCourseId, page }) {
+export const findUserIdsById = async function ({ combinedCourseId, page, filters }) {
   const knexConnection = DomainTransaction.getConnection();
 
   const queryBuilder = knexConnection('combined_courses')
@@ -82,12 +83,19 @@ export const findUserIdsById = async function ({ combinedCourseId, page }) {
     .where('combined_courses.id', combinedCourseId)
     .orderBy(['lastName', 'firstName', 'userId']);
 
+  queryBuilder.modify(addSearchFilters, filters);
   const { results, pagination } = await fetchPage({ queryBuilder, paginationParams: page });
   return {
     userIds: results.map((result) => result.userId),
     meta: pagination,
   };
 };
+
+function addSearchFilters(queryBuilder, filters = {}) {
+  if (filters.fullName) {
+    filterByFullName(queryBuilder, filters.fullName, 'firstName', 'lastName');
+  }
+}
 
 export const update = async function ({ combinedCourseParticipation, combinedCourseId }) {
   const knexConnection = DomainTransaction.getConnection();

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -71,7 +71,7 @@ export const findUserIdsById = async function ({ combinedCourseId, page }) {
   const knexConnection = DomainTransaction.getConnection();
 
   const queryBuilder = knexConnection('combined_courses')
-    .select('users.id')
+    .select('userId')
     .join('quests', 'quests.id', 'combined_courses.questId')
     .join('combined_course_participations', 'combined_course_participations.questId', 'quests.id')
     .join(
@@ -79,12 +79,11 @@ export const findUserIdsById = async function ({ combinedCourseId, page }) {
       'view-active-organization-learners.id',
       'combined_course_participations.organizationLearnerId',
     )
-    .join('users', 'users.id', 'view-active-organization-learners.userId')
     .where('combined_courses.id', combinedCourseId);
 
   const { results, pagination } = await fetchPage({ queryBuilder, paginationParams: page });
   return {
-    userIds: results.map((result) => result.id),
+    userIds: results.map((result) => result.userId),
     meta: pagination,
   };
 };

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -302,17 +302,32 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
           organizationId,
           successRequirements: [],
         });
-        const learner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+        const learner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          firstName: 'Paul',
+          lastName: 'Azerty',
+        });
+        const learner2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          firstName: 'Jacques',
+          lastName: 'Qwerty',
+        });
         databaseBuilder.factory.buildMembership({ userId, organizationId });
         databaseBuilder.factory.buildCombinedCourseParticipation({
           organizationLearnerId: learner.id,
           questId,
+          combinedCourseId,
+        });
+        databaseBuilder.factory.buildCombinedCourseParticipation({
+          organizationLearnerId: learner2.id,
+          questId,
+          combinedCourseId,
         });
         await databaseBuilder.commit();
 
         const options = {
           method: 'GET',
-          url: `/api/combined-courses/${combinedCourseId}/participations?page[number]=1&page[size]=5`,
+          url: `/api/combined-courses/${combinedCourseId}/participations?page[number]=1&page[size]=5&filters[fullName]=aze`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -156,4 +156,28 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
       },
     ]);
   });
+
+  it('should return a list on participations filtered by fullname', async function () {
+    // when
+    const { combinedCourseParticipations } = await usecases.findCombinedCourseParticipations({
+      combinedCourseId,
+      filters: { fullName: 'mar' },
+    });
+
+    // then
+    expect(combinedCourseParticipations).lengthOf(1);
+    expect(combinedCourseParticipations[0].id).equal(participation2.id);
+  });
+
+  it('should return a list on participations filtered by status', async function () {
+    // when
+    const { combinedCourseParticipations } = await usecases.findCombinedCourseParticipations({
+      combinedCourseId,
+      filters: { statuses: [CombinedCourseParticipationStatuses.STARTED] },
+    });
+
+    // then
+    expect(combinedCourseParticipations).lengthOf(1);
+    expect(combinedCourseParticipations[0].id).equal(participation1.id);
+  });
 });

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -4,12 +4,13 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipations', function () {
-  it('should return CombinedCourseParticipationDetails', async function () {
-    // given
+  let combinedCourseId, participation1, participation2, learner1, learner2;
+
+  beforeEach(async function () {
     const { id: campaignId, organizationId } = databaseBuilder.factory.buildCampaign();
-    const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+    const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
       code: 'COMBI1',
-      organizationId: organizationId,
+      organizationId,
       successRequirements: [
         {
           requirement_type: 'campaignParticipations',
@@ -41,47 +42,68 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         },
       ],
     });
-    const learner = databaseBuilder.factory.buildOrganizationLearner({
+    combinedCourseId = combinedCourse.id;
+
+    learner1 = databaseBuilder.factory.buildOrganizationLearner({
       firstName: 'Paul',
       lastName: 'Azerty',
       organizationId,
     });
-    databaseBuilder.factory.buildCampaignParticipation({
-      campaignId,
-      organizationLearnerId: learner.id,
-      userId: learner.userId,
-    });
-    const participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
-      organizationLearnerId: learner.id,
-      questId,
+    participation1 = databaseBuilder.factory.buildCombinedCourseParticipation({
+      organizationLearnerId: learner1.id,
+      questId: combinedCourse.questId,
       combinedCourseId,
       status: CombinedCourseParticipationStatuses.STARTED,
     });
-    const { questId: anotherquestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+    learner2 = databaseBuilder.factory.buildOrganizationLearner({
+      firstName: 'Marianne',
+      lastName: 'Klee',
+      organizationId,
+    });
+    participation2 = databaseBuilder.factory.buildCombinedCourseParticipation({
+      organizationLearnerId: learner2.id,
+      questId: combinedCourse.questId,
+      combinedCourseId,
+      status: CombinedCourseParticipationStatuses.COMPLETED,
+    });
+    databaseBuilder.factory.buildCampaignParticipation({
+      campaignId,
+      organizationLearnerId: learner2.id,
+      userId: learner2.userId,
+    });
+    databaseBuilder.factory.buildPassage({
+      moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+      userId: learner2.userId,
+      terminatedAt: new Date('2025-10-12'),
+    });
+
+    const { questId: anotherQuestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
       code: 'COMBI2',
     });
     databaseBuilder.factory.buildCombinedCourseParticipation({
-      organizationLearnerId: learner.id,
-      questId: anotherquestId,
+      organizationLearnerId: learner1.id,
+      questId: anotherQuestId,
       combinedCourseId: anotherCombinedCourseId,
       status: CombinedCourseParticipationStatuses.COMPLETED,
     });
 
     await databaseBuilder.commit();
+  });
 
+  it('should return participations with details from a combined course', async function () {
     // when
     const { combinedCourseParticipations } = await usecases.findCombinedCourseParticipations({
       combinedCourseId,
     });
 
     // then
-    expect(combinedCourseParticipations).lengthOf(1);
+    expect(combinedCourseParticipations).lengthOf(2);
     expect(combinedCourseParticipations[0]).instanceOf(CombinedCourseParticipationDetails);
     expect(combinedCourseParticipations).deep.equal([
       {
         id: participation1.id,
-        firstName: learner.firstName,
-        lastName: learner.lastName,
+        firstName: learner1.firstName,
+        lastName: learner1.lastName,
         status: CombinedCourseParticipationStatuses.STARTED,
         createdAt: participation1.createdAt,
         updatedAt: participation1.updatedAt,
@@ -89,91 +111,25 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
         nbModules: 1,
         nbModulesCompleted: 0,
         nbCampaigns: 1,
+        nbCampaignsCompleted: 0,
+      },
+      {
+        id: participation2.id,
+        firstName: learner2.firstName,
+        lastName: learner2.lastName,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
+        createdAt: participation2.createdAt,
+        updatedAt: participation2.updatedAt,
+        hasFormationItem: false,
+        nbModules: 1,
+        nbModulesCompleted: 1,
+        nbCampaigns: 1,
         nbCampaignsCompleted: 1,
       },
     ]);
   });
-  it('should return a paginated list of combinedCourseParticipation', async function () {
-    // given
-    const { id: campaignId, organizationId } = databaseBuilder.factory.buildCampaign();
-    const { questId, id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
-      code: 'COMBI1',
-      organizationId,
-      successRequirements: [
-        {
-          requirement_type: 'campaignParticipations',
-          comparison: 'all',
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: 'equal',
-            },
-            status: {
-              data: 'SHARED',
-              comparison: 'equal',
-            },
-          },
-        },
-        {
-          requirement_type: 'passages',
-          comparison: 'all',
-          data: {
-            moduleId: {
-              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-              comparison: 'equal',
-            },
-            isTerminated: {
-              data: true,
-              comparison: 'equal',
-            },
-          },
-        },
-      ],
-    });
-    const learner = databaseBuilder.factory.buildOrganizationLearner({
-      firstName: 'Paul',
-      lastName: 'Azerty',
-      organizationId,
-    });
-    databaseBuilder.factory.buildCombinedCourseParticipation({
-      organizationLearnerId: learner.id,
-      questId,
-      combinedCourseId,
-      status: CombinedCourseParticipationStatuses.COMPLETED,
-    });
-    const anotherLearner = databaseBuilder.factory.buildOrganizationLearner({
-      firstName: 'Marianne',
-      lastName: 'Klee',
-      organizationId,
-    });
-    const anotherParticipation = databaseBuilder.factory.buildCombinedCourseParticipation({
-      organizationLearnerId: anotherLearner.id,
-      questId,
-      combinedCourseId,
-      status: CombinedCourseParticipationStatuses.COMPLETED,
-    });
-    databaseBuilder.factory.buildCampaignParticipation({
-      campaignId,
-      organizationLearnerId: anotherLearner.id,
-      userId: anotherLearner.userId,
-    });
-    databaseBuilder.factory.buildPassage({
-      moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-      userId: anotherLearner.userId,
-      terminatedAt: new Date('2025-10-12'),
-    });
-    const { questId: anotherquestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
-      code: 'COMBI2',
-    });
-    databaseBuilder.factory.buildCombinedCourseParticipation({
-      organizationLearnerId: learner.id,
-      questId: anotherquestId,
-      combinedCourseId: anotherCombinedCourseId,
-      status: CombinedCourseParticipationStatuses.COMPLETED,
-    });
 
-    await databaseBuilder.commit();
-
+  it('should return a paginated list of participations with details', async function () {
     // when
     const { combinedCourseParticipations, meta } = await usecases.findCombinedCourseParticipations({
       combinedCourseId,
@@ -186,12 +142,12 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     expect(combinedCourseParticipations[0]).instanceOf(CombinedCourseParticipationDetails);
     expect(combinedCourseParticipations).deep.equal([
       {
-        id: anotherParticipation.id,
-        firstName: anotherLearner.firstName,
-        lastName: anotherLearner.lastName,
+        id: participation2.id,
+        firstName: learner2.firstName,
+        lastName: learner2.lastName,
         status: CombinedCourseParticipationStatuses.COMPLETED,
-        createdAt: anotherParticipation.createdAt,
-        updatedAt: anotherParticipation.updatedAt,
+        createdAt: participation2.createdAt,
+        updatedAt: participation2.updatedAt,
         hasFormationItem: false,
         nbModules: 1,
         nbModulesCompleted: 1,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -167,7 +167,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
-  describe('#findUserIdsById', function () {
+  describe('#findUserIdsByCombinedCourseId', function () {
     let combinedCourseId;
     const userId1 = 987;
     const userId2 = 456;
@@ -233,7 +233,9 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
     it('should return user ids only for given quest id', async function () {
       // when
-      const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({ combinedCourseId });
+      const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
+        combinedCourseId,
+      });
 
       // then
       expect(userIds).deep.equal([userId2, userId3, userId1]);
@@ -241,7 +243,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
     it('should return paginated user ids', async function () {
       // when
-      const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+      const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
         combinedCourseId,
         page: { size: 1, number: 3 },
       });
@@ -252,7 +254,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     describe('filters', function () {
       it('should return participations even with empty filters', async function () {
         // when
-        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
           combinedCourseId,
           filters: {},
         });
@@ -262,7 +264,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       });
       it('should return participation matching learner lastName', async function () {
         // when
-        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
           combinedCourseId,
           filters: { fullName: 'are' },
         });
@@ -272,7 +274,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       });
       it('should return participation matching learner firstName', async function () {
         // when
-        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
           combinedCourseId,
           filters: { fullName: 'GEO' },
         });
@@ -282,7 +284,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       });
       it('should return participation matching participation status', async function () {
         // when
-        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
           combinedCourseId,
           filters: { statuses: [CombinedCourseParticipationStatuses.STARTED] },
         });
@@ -292,7 +294,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       });
       it('should return participations even with empty status filter', async function () {
         // when
-        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsByCombinedCourseId({
           combinedCourseId,
           filters: { statuses: [] },
         });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -250,6 +250,16 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
 
     describe('filters', function () {
+      it('should return participations even with empty filters', async function () {
+        // when
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+          combinedCourseId,
+          filters: {},
+        });
+
+        // then
+        expect(userIds).deep.equal([userId2, userId3, userId1]);
+      });
       it('should return participation matching learner lastName', async function () {
         // when
         const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
@@ -269,6 +279,26 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
 
         // then
         expect(userIds).deep.equal([userId1]);
+      });
+      it('should return participation matching participation status', async function () {
+        // when
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+          combinedCourseId,
+          filters: { statuses: [CombinedCourseParticipationStatuses.STARTED] },
+        });
+
+        // then
+        expect(userIds).deep.equal([userId2, userId1]);
+      });
+      it('should return participations even with empty status filter', async function () {
+        // when
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+          combinedCourseId,
+          filters: { statuses: [] },
+        });
+
+        // then
+        expect(userIds).deep.equal([userId2, userId3, userId1]);
       });
     });
   });

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -167,46 +167,86 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
-  describe('#findUserIdsByQuestId', function () {
-    it('should return user ids only for given quest id', async function () {
+  describe('#findUserIdsById', function () {
+    let combinedCourseId;
+    const userId1 = 987;
+    const userId2 = 456;
+    const userId3 = 123;
+
+    beforeEach(async function () {
       //given
-      const { id: combinedCourseId, questId, organizationId } = databaseBuilder.factory.buildCombinedCourse();
+      const combinedCourse = databaseBuilder.factory.buildCombinedCourse();
+      combinedCourseId = combinedCourse.id;
 
-      const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
+      databaseBuilder.factory.buildUser({ id: userId1 });
+      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userId1,
+        firstName: 'Georges',
+        lastName: 'Zelio',
+        organizationId: combinedCourse.organizationId,
       });
-      const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
-        organizationId,
+      databaseBuilder.factory.buildUser({ id: userId2 });
+      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userId2,
+        firstName: 'Loubna',
+        lastName: 'Aresto',
+        organizationId: combinedCourse.organizationId,
+      });
+
+      databaseBuilder.factory.buildUser({ id: userId3 });
+      const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userId3,
+        firstName: 'Nour',
+        lastName: 'Aresto',
+        organizationId: combinedCourse.organizationId,
       });
 
       databaseBuilder.factory.buildCombinedCourseParticipation({
-        organizationLearnerId: organizationLearnerId1,
-        questId,
+        organizationLearnerId: organizationLearner1.id,
+        questId: combinedCourse.questId,
         combinedCourseId,
       });
       databaseBuilder.factory.buildCombinedCourseParticipation({
-        organizationLearnerId: organizationLearnerId2,
-        questId,
+        organizationLearnerId: organizationLearner2.id,
+        questId: combinedCourse.questId,
         combinedCourseId,
+      });
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        organizationLearnerId: organizationLearner3.id,
+        questId: combinedCourse.questId,
+        combinedCourseId,
+        status: CombinedCourseParticipationStatuses.COMPLETED,
       });
 
       const { questId: anotherQuestId, id: anotherCombinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
-        organizationId,
+        organizationId: combinedCourse.organizationId,
         code: 'anotherQuest',
       });
       databaseBuilder.factory.buildCombinedCourseParticipation({
-        organizationLearnerId: organizationLearnerId1,
+        organizationLearnerId: organizationLearner1.id,
         questId: anotherQuestId,
         combinedCourseId: anotherCombinedCourseId,
       });
 
       await databaseBuilder.commit();
+    });
 
+    it('should return user ids only for given quest id', async function () {
       // when
       const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({ combinedCourseId });
 
       // then
-      expect(userIds).deep.equal([userId1, userId2]);
+      expect(userIds).deep.equal([userId2, userId3, userId1]);
+    });
+
+    it('should return paginated user ids', async function () {
+      // when
+      const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+        combinedCourseId,
+        page: { size: 1, number: 3 },
+      });
+      // then
+      expect(userIds).deep.equal([userId1]);
     });
   });
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -248,6 +248,29 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       // then
       expect(userIds).deep.equal([userId1]);
     });
+
+    describe('filters', function () {
+      it('should return participation matching learner lastName', async function () {
+        // when
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+          combinedCourseId,
+          filters: { fullName: 'are' },
+        });
+
+        // then
+        expect(userIds).deep.equal([userId2, userId3]);
+      });
+      it('should return participation matching learner firstName', async function () {
+        // when
+        const { userIds } = await combinedCourseParticipationRepository.findUserIdsById({
+          combinedCourseId,
+          filters: { fullName: 'GEO' },
+        });
+
+        // then
+        expect(userIds).deep.equal([userId1]);
+      });
+    });
   });
 
   describe('#update', function () {

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -34,14 +34,15 @@ describe('Unit | Quest | Application | Controller | CombinedCourse', function ()
       const serializedCombinedCourseParticipations = Symbol('serializedCombinedCourseParticipations');
       const page = Symbol('page');
       const meta = Symbol('meta');
+      const filters = Symbol('filters');
       const request = {
         params: { combinedCourseId },
-        query: { page },
+        query: { page, filters },
       };
 
       sinon
         .stub(usecases, 'findCombinedCourseParticipations')
-        .withArgs({ combinedCourseId, page })
+        .withArgs({ combinedCourseId, page, filters })
         .resolves({ combinedCourseParticipations, meta });
       const combinedCourseParticipationSerializer = { serialize: sinon.stub() };
       combinedCourseParticipationSerializer.serialize

--- a/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
@@ -82,7 +82,7 @@ test('Combined courses', async ({ page }) => {
     ).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Summers' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Buffy' })).toBeVisible();
-    await expect(page.getByText('Terminé', { exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Terminé' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Une campagne complétée sur 1.' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Un module complété sur 1.' })).toBeVisible();
   });

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -1,22 +1,77 @@
+import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { uniqueId } from '@ember/helper';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
 import ParticipationStatus from 'pix-orga/components/ui/participation-status';
+import ENV from 'pix-orga/config/environment';
+import { COMBINED_COURSE_PARTICIPATION_STATUSES } from 'pix-orga/models/combined-course-participation.js';
+
+const debounceTime = ENV.pagination.debounce;
 
 export default class CombinedCourse extends Component {
   @service intl;
   @service locale;
   @service currentUser;
 
+  get statusOptions() {
+    return [
+      {
+        label: this.intl.t('pages.combined-course.filters.status.STARTED'),
+        value: COMBINED_COURSE_PARTICIPATION_STATUSES.STARTED,
+      },
+      {
+        label: this.intl.t('pages.combined-course.filters.status.COMPLETED'),
+        value: COMBINED_COURSE_PARTICIPATION_STATUSES.COMPLETED,
+      },
+    ];
+  }
+
+  @action
+  onSelectStatus(statuses) {
+    this.args.onFilter('statuses', statuses);
+  }
+
+  @action
+  onSearchFullName(name, value) {
+    this.args.onFilter('fullName', value);
+  }
+
   <template>
+    <PixFilterBanner @clearFiltersLabel={{t "common.filters.actions.clear"}} @onClearFilters={{@clearFilters}}>
+      <PixSearchInput
+        @debounceTimeInMs={{debounceTime}}
+        value={{@fullNameFilter}}
+        @placeholder={{t "common.filters.fullname.placeholder"}}
+        @screenReaderOnly={{true}}
+        @triggerFiltering={{this.onSearchFullName}}
+      >
+        <:label>{{t "common.filters.fullname.label"}}</:label>
+      </PixSearchInput>
+
+      <PixMultiSelect
+        @placeholder={{t "pages.combined-course.filters.status.placeholder"}}
+        @screenReaderOnly={{true}}
+        @options={{this.statusOptions}}
+        @onChange={{this.onSelectStatus}}
+        @values={{@statusFilter}}
+        @hideDefaultOption={{false}}
+      >
+        <:label>{{t "pages.combined-course.filters.by-status"}}</:label>
+        <:default as |option|>{{option.label}}</:default>
+      </PixMultiSelect>
+    </PixFilterBanner>
+
     {{#if @participations.length}}
       <PixTable
         @variant="orga"

--- a/orga/app/controllers/authenticated/combined-course/participations.js
+++ b/orga/app/controllers/authenticated/combined-course/participations.js
@@ -1,0 +1,21 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ParticipationsController extends Controller {
+  queryParams = ['fullName', 'statuses'];
+
+  @tracked fullName = '';
+  @tracked statuses = [];
+
+  @action
+  triggerFiltering(fieldName, value) {
+    this[fieldName] = value;
+  }
+
+  @action
+  clearFilters() {
+    this.fullName = '';
+    this.statuses = [];
+  }
+}

--- a/orga/app/models/combined-course-participation.js
+++ b/orga/app/models/combined-course-participation.js
@@ -9,3 +9,8 @@ export default class CombinedCourseParticipation extends Model {
   @attr('number') nbCampaignsCompleted;
   @attr('number') nbModulesCompleted;
 }
+
+export const COMBINED_COURSE_PARTICIPATION_STATUSES = {
+  STARTED: 'STARTED',
+  COMPLETED: 'COMPLETED',
+};

--- a/orga/app/routes/authenticated/combined-course/participations.js
+++ b/orga/app/routes/authenticated/combined-course/participations.js
@@ -8,6 +8,8 @@ export default class CombinedCourseRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    fullName: { refreshModel: true },
+    statuses: { refreshModel: true },
   };
 
   async model(params) {
@@ -18,6 +20,10 @@ export default class CombinedCourseRoute extends Route {
         page: {
           number: params.pageNumber,
           size: params.pageSize,
+        },
+        filters: {
+          fullName: params.fullName,
+          statuses: params.statuses,
         },
       })
       .catch((error) => {

--- a/orga/app/templates/authenticated/combined-course/participations.gjs
+++ b/orga/app/templates/authenticated/combined-course/participations.gjs
@@ -1,3 +1,11 @@
 import CombinedCourseParticipations from 'pix-orga/components/combined-course/participations';
 
-<template><CombinedCourseParticipations @participations={{@model}} /></template>
+<template>
+  <CombinedCourseParticipations
+    @participations={{@model}}
+    @onFilter={{@controller.triggerFiltering}}
+    @statusFilter={{@controller.statuses}}
+    @fullNameFilter={{@controller.fullName}}
+    @clearFilters={{@controller.clearFilters}}
+  />
+</template>

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -1,7 +1,9 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CombinedCourseParticipations from 'pix-orga/components/combined-course/participations';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -29,12 +31,13 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     },
   ];
   participations.meta = { page: 1, pageSize: 1, rowCount: 2, pageCount: 2 };
+  const onFilter = sinon.stub();
 
   setupIntlRenderingTest(hooks);
   module('table', function () {
     test('it should have a caption to describe the table ', async function (assert) {
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
 
       // then
@@ -44,7 +47,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('it should display column headers', async function (assert) {
       // when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
 
       const table = screen.getByRole('table');
@@ -102,7 +105,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
   test('it should display participation details', async function (assert) {
     // when
     const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
     );
 
     const table = screen.getByRole('table');
@@ -157,7 +160,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
 
     // when
     const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
     );
 
     const table = screen.getByRole('table');
@@ -185,7 +188,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
 
     // when
     const screen = await render(
-      <template><CombinedCourseParticipations @participations={{noParticipation}} /></template>,
+      <template><CombinedCourseParticipations @participations={{noParticipation}} @onFilter={{onFilter}} /></template>,
     );
 
     assert.notOk(screen.queryByRole('table'));
@@ -198,18 +201,136 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       const locale = this.owner.lookup('service:locale');
       locale.setCurrentLocale('en');
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
       assert.ok(screen.getByLabelText(/items/));
     });
     test('should display pagination', async function (assert) {
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
       assert.ok(screen.getByText(/1-1 sur 2 éléments/));
       assert.ok(screen.getByLabelText("Nombre d'élément à afficher par page"));
       assert.ok(screen.getByRole('button', { name: 'Aller à la page précédente' }));
       assert.ok(screen.getByRole('button', { name: 'Aller à la page suivante' }));
+    });
+  });
+
+  module('filters', function () {
+    module('clearFilters', function () {
+      test('it should trigger clearFilters', async function (assert) {
+        // given
+        const clearFilters = sinon.stub();
+
+        const statusFilter = [];
+
+        const screen = await render(
+          <template>
+            <CombinedCourseParticipations
+              @statusFilter={{statusFilter}}
+              @clearFilters={{clearFilters}}
+              @participations={{participations}}
+              @onFilter={{onFilter}}
+            />
+          </template>,
+        );
+
+        // when
+        await screen.getByRole('button', { name: t('common.filters.actions.clear') }).click();
+
+        // then
+        assert.true(clearFilters.calledOnce);
+      });
+    });
+
+    module('fullName filter', function () {
+      test('it should trigger onFilter on fullName change', async function (assert) {
+        // given
+        const onFilter = sinon.stub();
+        const fullNameFilter = '';
+
+        const screen = await render(
+          <template>
+            <CombinedCourseParticipations
+              @fullNameFilter={{fullNameFilter}}
+              @onFilter={{onFilter}}
+              @participations={{participations}}
+            />
+          </template>,
+        );
+
+        // when
+        const input = screen.getByLabelText(t('common.filters.fullname.label'));
+
+        assert.ok(screen.getByPlaceholderText(t('common.filters.fullname.placeholder')));
+
+        await fillIn(input, 'marcelle');
+
+        // then
+        assert.true(onFilter.calledOnce);
+        assert.deepEqual(onFilter.args[0], ['fullName', 'marcelle']);
+      });
+
+      test('it should init the fullName filter value', async function (assert) {
+        // given
+        const onFilter = sinon.stub();
+        const fullNameFilter = 'Marcelo';
+
+        // when
+        const screen = await render(
+          <template>
+            <CombinedCourseParticipations
+              @fullNameFilter={{fullNameFilter}}
+              @onFilter={{onFilter}}
+              @participations={{participations}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.ok(screen.getByDisplayValue('Marcelo'));
+      });
+    });
+
+    module('status filter', function () {
+      test('it should trigger onFilter on change statuses', async function (assert) {
+        // given
+        const onFilter = sinon.stub();
+        const participations = [
+          {
+            id: 123,
+            firstName: 'Marcelle',
+            lastName: 'Labe',
+            status: 'COMPLETED',
+            nbCampaigns: 1,
+            nbModules: 0,
+            nbCampaignsCompleted: 1,
+            nbModulesCompleted: 0,
+          },
+        ];
+
+        const statusFilter = [];
+
+        const screen = await render(
+          <template>
+            <CombinedCourseParticipations
+              @statusFilter={{statusFilter}}
+              @onFilter={{onFilter}}
+              @participations={{participations}}
+            />
+          </template>,
+        );
+        // when
+        const select = screen.getByLabelText(t('pages.combined-course.filters.by-status'));
+
+        await click(select);
+        await screen.findByRole('menu');
+        await click(screen.getByLabelText(t('pages.combined-course.filters.status.COMPLETED')));
+
+        // then
+        assert.true(onFilter.calledOnce);
+        assert.deepEqual(onFilter.args[0], ['statuses', ['COMPLETED']]);
+      });
     });
   });
 });

--- a/orga/tests/integration/templates/participations_test.gjs
+++ b/orga/tests/integration/templates/participations_test.gjs
@@ -1,0 +1,100 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import CombinedCourseParticipations from 'pix-orga/components/combined-course/participations';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Template | CombinedCourse | participations', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  const participations = [
+    {
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      status: 'STARTED',
+      nbCampaigns: 2,
+      nbCampaignsCompleted: 1,
+      nbModules: 4,
+      nbModulesCompleted: 2,
+    },
+  ];
+  participations.meta = { total: 20, count: 1, limit: 10, offset: 0 };
+
+  test('it renders empty state when there are no participations', async function (assert) {
+    // given
+    const noParticipations = [];
+
+    // when
+    const screen = await render(
+      <template><CombinedCourseParticipations @participations={{noParticipations}} /></template>,
+    );
+
+    // then
+    assert.notOk(screen.queryByRole('table'));
+    assert.ok(screen.getByText(t('pages.campaign.empty-state')));
+  });
+
+  test('it renders the table and filters when there are participations', async function (assert) {
+    // when
+    const screen = await render(
+      <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+    );
+
+    // then
+    const table = screen.getByRole('table', { name: t('pages.combined-course.table.description') });
+    assert.ok(table);
+    assert.ok(within(table).getByRole('cell', { name: 'Doe' }));
+    assert.ok(within(table).getByRole('cell', { name: 'John' }));
+  });
+
+  test('it calls onFilter when searching by full name', async function (assert) {
+    // given
+    const onFilter = sinon.spy();
+
+    // when
+    const screen = await render(
+      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+    );
+    const searchInput = screen.getByLabelText(t('common.filters.fullname.label'));
+    await fillIn(searchInput, 'Toto');
+
+    // then
+    assert.ok(onFilter.calledWith('fullName', 'Toto'));
+  });
+
+  test('it calls onFilter when filtering by status', async function (assert) {
+    // given
+    const onFilter = sinon.spy();
+
+    // when
+    const screen = await render(
+      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+    );
+    await click(screen.getByLabelText(t('pages.combined-course.filters.by-status')));
+    await screen.findByRole('menu');
+    await click(screen.getByLabelText(t('pages.combined-course.filters.status.STARTED')));
+
+    // then
+    assert.ok(onFilter.calledWith('statuses', ['STARTED']));
+  });
+
+  test('it calls clearFilters when clicking on the clear filters button', async function (assert) {
+    // given
+    const clearFilters = sinon.spy();
+
+    // when
+    const screen = await render(
+      <template>
+        <CombinedCourseParticipations @participations={{participations}} @clearFilters={{clearFilters}} />
+      </template>,
+    );
+    await click(screen.getByRole('button', { name: t('common.filters.actions.clear') }));
+
+    // then
+    assert.ok(clearFilters.calledOnce);
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/combined-course/participations-test.js
+++ b/orga/tests/unit/controllers/authenticated/combined-course/participations-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/combined-course/participations', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/combined-course/participations');
+  });
+  module('#clearFilters', function () {
+    test('it should clear filters', function (assert) {
+      // given
+      controller.fullName = 'nom1';
+      controller.statuses = ['STARTED'];
+
+      // when
+      controller.clearFilters();
+
+      // then
+      assert.strictEqual(controller.fullName, '');
+      assert.deepEqual(controller.statuses, []);
+    });
+  });
+  module('#triggerFiltering', function () {
+    module('when the filters contain defined values', function () {
+      test('update value', async function (assert) {
+        // given
+        controller.fullName = 'nom1';
+        controller.statuses = [];
+
+        // when
+        controller.triggerFiltering('fullName', 'nom2');
+        controller.triggerFiltering('statuses', ['STARTED']);
+
+        // then
+        assert.strictEqual(controller.fullName, 'nom2');
+        assert.deepEqual(controller.statuses, ['STARTED']);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
@@ -26,6 +26,10 @@ module('Unit | Route | authenticated/combined-course-participations', function (
             number: undefined,
             size: undefined,
           },
+          filters: {
+            fullName: undefined,
+            statuses: undefined,
+          },
         })
         .resolves(combinedCourseParticipations);
 
@@ -52,11 +56,15 @@ module('Unit | Route | authenticated/combined-course-participations', function (
             number: 2,
             size: 20,
           },
+          filters: {
+            fullName: 'fullName',
+            statuses: ['STARTED'],
+          },
         })
         .resolves(combinedCourseParticipations);
 
       // when
-      const result = await route.model({ pageNumber: 2, pageSize: 20 });
+      const result = await route.model({ pageNumber: 2, pageSize: 20, fullName: 'fullName', statuses: ['STARTED'] });
 
       // then
       assert.deepEqual(result, combinedCourseParticipations);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1033,7 +1033,7 @@
           "placeholder": "All statuses"
         }
       },
-      "introduction": "The learning pathways combine an assessment and learning modules, enabling teaching to be tailored to each participant's actual level.",
+      "introduction": "The learning courses combine assessments and personalised learning modules, enabling teaching to be tailored to each participant's level.",
       "statistics": {
         "completed-participations": "Completed participations",
         "total-participations": "Total participations"
@@ -1057,9 +1057,9 @@
       }
     },
     "combined-courses": {
-      "empty-state": "No learning program available at the moment.",
+      "empty-state": "No learning course available at the moment.",
       "table": {
-        "caption": "List of learning programs",
+        "caption": "List of learning courses",
         "column": {
           "code": "Code",
           "completed": "Participants who completed",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1025,6 +1025,14 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {See campaign details} other {See details of campaign no. {index}}}",
+      "filters": {
+        "by-status": "Search by participation statuses",
+        "status": {
+          "COMPLETED": "Completed",
+          "STARTED": "In progress",
+          "placeholder": "All statuses"
+        }
+      },
       "introduction": "The learning pathways combine an assessment and learning modules, enabling teaching to be tailored to each participant's actual level.",
       "statistics": {
         "completed-participations": "Completed participations",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1021,7 +1021,7 @@
           "placeholder": "Tous les statuts"
         }
       },
-      "introduction": "Les parcours apprenants articulent un diagnostic et des modules d’apprentissage, permettant une adaptation pédagogique fondée sur le niveau réel de chaque participant.",
+      "introduction": "Les parcours apprenants articulent des évaluations et des modules d’apprentissage personnalisés, permettant une adaptation pédagogique fondée sur le niveau de chaque participant.",
       "statistics": {
         "completed-participations": "Participations complétées",
         "total-participations": "Total des participations"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1013,6 +1013,14 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {Voir le détail de la campagne} other {Voir le détail de la campagne n°{index}}}",
+      "filters": {
+        "by-status": "Rechercher par le statut de la particpation",
+        "status": {
+          "COMPLETED": "Terminé",
+          "STARTED": "En cours",
+          "placeholder": "Tous les statuts"
+        }
+      },
       "introduction": "Les parcours apprenants articulent un diagnostic et des modules d’apprentissage, permettant une adaptation pédagogique fondée sur le niveau réel de chaque participant.",
       "statistics": {
         "completed-participations": "Participations complétées",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1021,7 +1021,7 @@
           "placeholder": "Alle statuten"
         }
       },
-      "introduction": "De leertrajecten bestaan uit een diagnose en leermodules, waardoor het onderwijs kan worden aangepast aan het werkelijke niveau van elke deelnemer.",
+      "introduction": "De leertrajecten bestaan uit beoordelingen en gepersonaliseerde leermodules, waardoor het onderwijs kan worden aangepast aan het niveau van elke deelnemer.",
       "statistics": {
         "completed-participations": "Voltooide deelnames",
         "total-participations": "Totaal van de deelnemingen"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1013,6 +1013,14 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {Bekijk de details van de campagne} other {Bekijk de details van campagne nr. {index}}}",
+      "filters": {
+        "by-status": "Zoeken op deelnamestatus",
+        "status": {
+          "COMPLETED": "Voltooid",
+          "STARTED": "Bezig",
+          "placeholder": "Alle statuten"
+        }
+      },
       "introduction": "De leertrajecten bestaan uit een diagnose en leermodules, waardoor het onderwijs kan worden aangepast aan het werkelijke niveau van elke deelnemer.",
       "statistics": {
         "completed-participations": "Voltooide deelnames",


### PR DESCRIPTION
## 🍂 Problème

Actuellement il est compliqué de retrouver la participation d’un prescrit lorsqu’il y a beaucoup de prescrit ayant suivi un parcours combiné.

## 🌰 Proposition

Permettre de filtrer par nom / prenom / statut de la participation

## 🍁 Remarques

RAS

## 🪵 Pour tester

- Se connecter sur PixOrga 
- Choisir l'organisation ProClassic 
- Afficher le parcours combiné `COMBINIX2`
- Filtrer les participations