### PR TITLE
[TECH] 🗃️ Supprime la contrainte `not null` de la colonne `version` de la table `certification-frameworks-challenges` (pix-20148)

### DIFF
--- a/api/db/migrations/20251027132926_remove-not-null-version-constraint-on-consolidated-frameworks-challenges-table.js
+++ b/api/db/migrations/20251027132926_remove-not-null-version-constraint-on-consolidated-frameworks-challenges-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+const COLUMN_NAME = 'version';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

La colonne `version` de la table `certification-frameworks-challenges` ne peut pas être nulle. 

Nous devons déplacer l'utilisation de cette colonne vers l'utilisation de la table `certification_versions`. Mais avec cette contrainte, nous ne pouvons pas le faire.

## 🌰 Proposition

Supprimer la contrainte sur cette colonne pour pouvoir modifier son utilisation.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

déploiement de RA ok
migration ok
test ok

