### PR TITLE
[TECH] Enlever les anciens fichiers json présents du gitignore  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,13 @@ docker/data/
 # Claude Code documentation
 CLAUDE.md
 .claude/
+
+# Allow JSON files in translations directories
+!**/translations/*.json
+
+# Allow package.json and package-lock.json
+!package.json
+!package-lock.json
+
+# Allow JSON files in learning-content/modules directory
+!learning-content/modules/*.json


### PR DESCRIPTION
## 🍂 Problème

Afin d'éviter de commiter un référentiel en json, on a choisi d'ignorer tout les fichiers json pour éviter de commiter ces fichier par erreur.
Certains éditeurs se base sur le contenu du fichier `.gitignore` pour leur recherche / fuzzy find.
Or on utilise régulièrement des fichiers json pour les traductions ou les descripteurs de fichiers.

## 🌰 Proposition

Être un peu plus fin dans la gestion des fichiers json et rajouter les fichiers déjà existants.

## 🍁 Remarques

Voir la PR #8619

## 🪵 Pour tester

- Depuis  Zed Faire une recherche `fr.json`. 
- voir les fichiers de trad remontés.