### PR TITLE
[TECH] Exclure les `organization_learners` qui n'ont pas de userId rattaché "dissocier" (PIX-20058).

### DIFF
--- a/api/src/prescription/scripts/create-or-update-organization-learner-participations-for-passages.js
+++ b/api/src/prescription/scripts/create-or-update-organization-learner-participations-for-passages.js
@@ -103,7 +103,8 @@ class CreateOrUpdateOrganizationLearnerParticipationsForPassages extends Script 
             .from('organization_learner_participations')
             .where({ type: OrganizationLearnerParticipationTypes.PASSAGE })
             .whereNotNull('referenceId');
-        });
+        })
+        .whereNotNull('view-active-organization-learners.userId');
       logger.info(
         `create-or-update-organization-learner-participations-for-passages | organizationLearnerWithoutPassagesOnCombinedCourse to process : ${organizationLearnerWithoutPassagesOnCombinedCourse.length}`,
       );

--- a/api/tests/prescription/scripts/integration/create-or-update-organization-learner-participations-for-passages_test.js
+++ b/api/tests/prescription/scripts/integration/create-or-update-organization-learner-participations-for-passages_test.js
@@ -32,7 +32,7 @@ describe('Integration | Prescription | Script | Prod | create-or-update-organiza
       const { id: organizationLearner1Id, organizationId: organization1Id } =
         databaseBuilder.factory.buildOrganizationLearner();
       const { questId: ques1tId } = databaseBuilder.factory.buildCombinedCourse({
-        code: 'COMBINED_COURSE_1',
+        code: 'COMBINED_COURSE_WITH_ANONYMIZED_LEARNER',
         organizationId: organization1Id,
       });
       databaseBuilder.factory.buildCombinedCourseParticipation({
@@ -95,6 +95,71 @@ describe('Integration | Prescription | Script | Prod | create-or-update-organiza
     const moduleId3 = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
     let organizationLearner1, organizationLearnerId2;
     beforeEach(async function () {
+      // Anonymized learner with combined course participations
+      const anonymizedOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({ userId: null });
+      const { id: anonymizedCampaignId } = databaseBuilder.factory.buildCampaign({
+        organizationId: anonymizedOrganizationLearner.organizationId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: anonymizedCampaignId,
+        userId: anonymizedOrganizationLearner.userId,
+        organizationLearnerId: anonymizedOrganizationLearner.id,
+        status: 'SHARED',
+      });
+      const { questId: anonymizedQuestId } = databaseBuilder.factory.buildCombinedCourse({
+        code: 'COMBINED_COURSE_WITH_ANONYMIZED_LEARNER',
+        organizationId: anonymizedOrganizationLearner.organizationId,
+        successRequirements: [
+          {
+            requirement_type: 'campaignParticipations',
+            comparison: 'all',
+            data: {
+              campaignId: {
+                data: anonymizedCampaignId,
+                comparison: 'equal',
+              },
+              status: {
+                data: 'SHARED',
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId1,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: moduleId3,
+                comparison: 'equal',
+              },
+              isTerminated: {
+                data: true,
+                comparison: 'equal',
+              },
+            },
+          },
+        ],
+      });
+      databaseBuilder.factory.buildCombinedCourseParticipation({
+        combinedCourseId: null,
+        questId: anonymizedQuestId,
+        organizationLearnerId: anonymizedOrganizationLearner.id,
+      });
+
       // First learner with combined course participations
       organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
       const { id: campaign1Id } = databaseBuilder.factory.buildCampaign({


### PR DESCRIPTION
## 🍂 Problème

Le script executé ne passe pas en recette suite à l'absence de userId dans la table organization_learners

## 🌰 Proposition

Ajouter cette condition qui permet d'exclure les utilisateur dissocié ayant déjà participé à un parcours combiné

## 🍁 Remarques

NB : les utilisateur supprimé sont de facto exclu puisque nous utilisons la vue `view-active-organization-learners`

## 🪵 Pour tester

CI au vert. et si on veut pousser le bouchon plus loin. 
il faudrait faire une participation sur combinix1 . dissocier l'utilisateur. modifier en bdd pour mettre le referenceId a null ( je ne pense pas qu'on ai un JDD pour réaslier ces conditions sur combinix1 )