### PR TITLE
[FEATURE] Ajouter un tooltip pour les colonnes module et campagnes (PIX-19970)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
@@ -82,7 +82,7 @@ test('Combined courses', async ({ page }) => {
     ).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Summers' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Buffy' })).toBeVisible();
-    await expect(page.getByText('Terminé')).toBeVisible();
+    await expect(page.getByText('Terminé', { exact: true })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Une campagne complétée sur 1.' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'Un module complété sur 1.' })).toBeVisible();
   });

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -1,6 +1,9 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { uniqueId } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -48,9 +51,11 @@ export default class CombinedCourse extends Component {
               <ParticipationStatus @status={{participation.status}} />
             </:cell>
           </PixTableColumn>
-          <PixTableColumn @context={{context}}>
+          <PixTableColumn @context={{context}} @type="number">
             <:header>
               {{t "pages.combined-course.table.column.campaigns"}}
+
+              <Tooltip @content={{t "pages.combined-course.table.tooltip.campaigns-column"}} />
             </:header>
             <:cell>
               <CompletionDisplay
@@ -60,9 +65,11 @@ export default class CombinedCourse extends Component {
               />
             </:cell>
           </PixTableColumn>
-          <PixTableColumn @context={{context}}>
+          <PixTableColumn @context={{context}} @type="number">
             <:header>
               {{t "pages.combined-course.table.column.modules"}}
+
+              <Tooltip @content={{t "pages.combined-course.table.tooltip.modules-column"}} />
             </:header>
             <:cell>
               <CompletionDisplay
@@ -105,4 +112,29 @@ const CompletionDisplay = <template>
     <span aria-hidden="true">-</span>
     <span class="screen-reader-only">{{t "pages.combined-course.table.no-module"}}</span>
   {{/if}}
+</template>;
+
+const tooltipId = uniqueId();
+
+const Tooltip = <template>
+  <PixTooltip @id={{tooltipId}} @isWide={{true}}>
+    <:triggerElement>
+
+      <PixIcon
+        @name="help"
+        @plainIcon={{true}}
+        aria-label={{@content}}
+        aria-describedby={{tooltipId}}
+        @ariaHidden={{@ariaHiddenIcon}}
+        @ariaHiddenIcon={{true}}
+        class="tooltip-with-icon-small"
+      />
+
+    </:triggerElement>
+
+    <:tooltip>
+      {{@content}}
+    </:tooltip>
+
+  </PixTooltip>
 </template>;

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -31,49 +31,72 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
   participations.meta = { page: 1, pageSize: 1, rowCount: 2, pageCount: 2 };
 
   setupIntlRenderingTest(hooks);
+  module('table', function () {
+    test('it should have a caption to describe the table ', async function (assert) {
+      const screen = await render(
+        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      );
 
-  test('it should have a caption to describe the table ', async function (assert) {
-    const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} /></template>,
-    );
+      // then
+      assert.ok(screen.getByRole('table', { name: t('pages.combined-course.table.description') }));
+    });
 
-    // then
-    assert.ok(screen.getByRole('table', { name: t('pages.combined-course.table.description') }));
-  });
+    test('it should display column headers', async function (assert) {
+      // when
+      const screen = await render(
+        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      );
 
-  test('it should display column headers', async function (assert) {
-    // when
-    const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} /></template>,
-    );
+      const table = screen.getByRole('table');
+      // then
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: t('pages.combined-course.table.column.first-name'),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: t('pages.combined-course.table.column.last-name'),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: t('pages.combined-course.table.column.status'),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.campaigns')),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.modules')),
+        }),
+      );
+    });
 
-    const table = screen.getByRole('table');
-    // then
-    assert.ok(
-      within(table).getByRole('columnheader', {
-        name: t('pages.combined-course.table.column.first-name'),
-      }),
-    );
-    assert.ok(
-      within(table).getByRole('columnheader', {
-        name: t('pages.combined-course.table.column.last-name'),
-      }),
-    );
-    assert.ok(
-      within(table).getByRole('columnheader', {
-        name: t('pages.combined-course.table.column.status'),
-      }),
-    );
-    assert.ok(
-      within(table).getByRole('columnheader', {
-        name: t('pages.combined-course.table.column.campaigns'),
-      }),
-    );
-    assert.ok(
-      within(table).getByRole('columnheader', {
-        name: t('pages.combined-course.table.column.modules'),
-      }),
-    );
+    test('it should render a tooltip for campaign column', async function (assert) {
+      // when
+      const screen = await render(
+        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      );
+      const campaignHeader = screen.getByRole('columnheader', {
+        name: new RegExp(t('pages.combined-course.table.column.campaigns')),
+      });
+      assert.ok(within(campaignHeader).getByText(t('pages.combined-course.table.tooltip.campaigns-column')));
+    });
+
+    test('it should render a tooltip for module column', async function (assert) {
+      // when
+      const screen = await render(
+        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+      );
+      const campaignHeader = screen.getByRole('columnheader', {
+        name: new RegExp(t('pages.combined-course.table.column.modules')),
+      });
+      assert.ok(within(campaignHeader).getByText(t('pages.combined-course.table.tooltip.modules-column')));
+    });
   });
 
   test('it should display participation details', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1041,7 +1041,11 @@
         },
         "description": "List of learning courses participations",
         "module-completion": "{count, plural, =0 {No module completed out of {nbModules}} =1 {One module completed out of {nbModules}} other {{count} modules completed out of {nbModules}}}.",
-        "no-module": "No modules recommended."
+        "no-module": "No modules recommended.",
+        "tooltip": {
+          "campaigns-column": "'x / y' indicates the participant’s progress : they have completed x campaigns out of a total of y. For example, 1/2 means they have completed 1 campaign out of 2.",
+          "modules-column": "'x / y'  indicates the participant's progress : they have completed x modules out of a total of y. The total number of modules differs for each individual, depending on personalised recommendations."
+        }
       }
     },
     "combined-courses": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1025,7 +1025,7 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {See campaign details} other {See details of campaign no. {index}}}",
-      "introduction": "text d'intro",
+      "introduction": "The learning pathways combine an assessment and learning modules, enabling teaching to be tailored to each participant's actual level.",
       "statistics": {
         "completed-participations": "Completed participations",
         "total-participations": "Total participations"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1013,7 +1013,7 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {Voir le détail de la campagne} other {Voir le détail de la campagne n°{index}}}",
-      "introduction": "Un parcours apprenant est un parcours qui mixe campagnes d'évaluation et modules de formations. La selection des modules de formation sera adapter au niveau du prescrit",
+      "introduction": "Les parcours apprenants articulent un diagnostic et des modules d’apprentissage, permettant une adaptation pédagogique fondée sur le niveau réel de chaque participant.",
       "statistics": {
         "completed-participations": "Participations complétées",
         "total-participations": "Total des participations"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1029,7 +1029,11 @@
         },
         "description": "Listes des participations au parcours",
         "module-completion": "{count, plural, =0 {Aucun module complété sur {nbModules}} =1 {Un module complété sur {nbModules}} other {{count} modules complétés sur {nbModules}}}.",
-        "no-module": "Aucun module recommandé."
+        "no-module": "Aucun module recommandé.",
+        "tooltip": {
+          "campaigns-column": "'x / y' indique la progression du participant : il a terminé x campagnes sur un total de y. Par exemple, 1/2 signifie qu’il a terminé 1 campagne sur 2.",
+          "modules-column": "'x / y' indique la progression du participant : il a terminé x modules sur un total de y. Le total de modules diffère pour chacun, en fonction des recommandations personnalisées."
+        }
       }
     },
     "combined-courses": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1013,7 +1013,7 @@
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {Bekijk de details van de campagne} other {Bekijk de details van campagne nr. {index}}}",
-      "introduction": "text d'intro",
+      "introduction": "De leertrajecten bestaan uit een diagnose en leermodules, waardoor het onderwijs kan worden aangepast aan het werkelijke niveau van elke deelnemer.",
       "statistics": {
         "completed-participations": "Voltooide deelnames",
         "total-participations": "Totaal van de deelnemingen"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1029,7 +1029,11 @@
         },
         "description": "List of the combined course participations",
         "module-completion": "{count, plural, =0 {geen module voltooid op {nbModules}} =1 {1 van de {nbModules} modules voltooid} other {{count} van de {nbModules} modules voltooid}}.",
-        "no-module": "Geen aanbevolen module."
+        "no-module": "Geen aanbevolen module.",
+        "tooltip": {
+          "campaigns-column": "'x / y' geeft de voortgang van de deelnemer aan: hij/zij heeft x campagnes voltooid van een totaal van y. Bijvoorbeeld: 1/2 betekent dat hij/zij 1 campagne van de 2 heeft voltooid.",
+          "modules-column": "'x / y' geeft de voortgang van de deelnemer aan: hij/zij heeft x modules voltooid van een totaal van y. Het totale aantal modules verschilt per persoon, afhankelijk van de persoonlijke aanbevelingen."
+        }
       }
     },
     "combined-courses": {


### PR DESCRIPTION

## 🍂 Problème

La compréhension de la progression des campagnes et modules peut etre compliqué à appréhender.
On souhaite rajouter de l’information sur le contenu et le sens à donner à ces colonnes notamment modules qui peut évoluer au long de l’avancement d’un prescrit dans une parcours combiné.

## 🌰 Proposition

Rajouter un tooltip

## 🍁 Remarques

on profite de la PR pour modifier le wording d'introduction des parcours combiné

## 🪵 Pour tester

- Se connecter sur orga
- Afficher le parcours `COMBINIX2` de l'orga Pro CLASSIC
- voir les tooltip