### PR TITLE
[TECH] Supprimer des contraintes sur les challenges de framework de certif  pour pouvoir decommissioner le code relie (PIX-20148).

### DIFF
--- a/api/db/migrations/20251027155145_drop-constraint-on-version-column-in-certification-frameworks-challenges.js
+++ b/api/db/migrations/20251027155145_drop-constraint-on-version-column-in-certification-frameworks-challenges.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'certification-frameworks-challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropUnique(['version', 'challengeId', 'complementaryCertificationKey']);
+    table.string('version').nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('version').notNullable().alter();
+    table.unique(['version', 'challengeId', 'complementaryCertificationKey']);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Pour pouvoir decommissioner les colonnes complementaryCertificationKey et version dans le code, il faut ne pas etre bloque par la BDD. Sachant que on est dans les derniers bouts de code qui utilisent ces colonnes.

## 🌰 Proposition

Suppression de la contrainte pour liberer les derniers usages du code dans une PR a part

## 🍁 Remarques

Migration a part du code, pour cause de retrocompatibilite entre les MEP

## 🪵 Pour tester

Tests au vert, de toute maniere on enleve des contraintes rien de plus.
