### PR TITLE
[FEATURE] Intégrer le formulaire de connexion suite à une invitation (PIX-19802)

### DIFF
--- a/orga/app/controllers/join.js
+++ b/orga/app/controllers/join.js
@@ -1,6 +1,13 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default class JoinController extends Controller {
+  @service featureToggles;
+
+  get isNewAuthDesignEnabled() {
+    return this.featureToggles.featureToggles.usePixOrgaNewAuthDesign;
+  }
+
   queryParams = ['code', 'invitationId'];
   code = null;
   invitationId = null;

--- a/orga/app/templates/join.gjs
+++ b/orga/app/templates/join.gjs
@@ -1,13 +1,41 @@
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
+import LoginForm from 'pix-orga/components/auth/login-form';
 import LoginOrRegister from 'pix-orga/components/auth/login-or-register';
+import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+
 <template>
-  {{pageTitle (t "pages.login-or-register.title" organizationName=@model.organizationName)}}
-  <div class="join-page">
-    <LoginOrRegister
-      @organizationInvitationId={{@controller.invitationId}}
-      @organizationInvitationCode={{@controller.code}}
-      @organizationName={{@model.organizationName}}
-    />
-  </div>
+  {{#if @controller.isNewAuthDesignEnabled}}
+    {{pageTitle (t "pages.login-or-register.title" organizationName=@model.organizationName)}}
+
+    <AuthenticationLayout class="signin-page-layout">
+      <:header>
+      </:header>
+
+      <:content>
+        <div>
+          <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>
+          <h2 class="pix-body-l">{{t "pages.login.with-pix-account"}}</h2>
+        </div>
+
+        <LoginForm
+          @isWithInvitation={{true}}
+          @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
+          @isInvitationCancelled={{@controller.isInvitationCancelled}}
+          @organizationInvitationId={{@controller.invitationId}}
+          @organizationInvitationCode={{@controller.code}}
+          @organizationName={{@model.organizationName}}
+        />
+      </:content>
+    </AuthenticationLayout>
+  {{else}}
+    {{pageTitle (t "pages.login-or-register.title" organizationName=@model.organizationName)}}
+    <div class="join-page">
+      <LoginOrRegister
+        @organizationInvitationId={{@controller.invitationId}}
+        @organizationInvitationCode={{@controller.code}}
+        @organizationName={{@model.organizationName}}
+      />
+    </div>
+  {{/if}}
 </template>

--- a/orga/app/templates/join.gjs
+++ b/orga/app/templates/join.gjs
@@ -1,3 +1,4 @@
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import LoginForm from 'pix-orga/components/auth/login-form';
@@ -13,6 +14,10 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </:header>
 
       <:content>
+        <PixNotificationAlert @type="communication-orga">
+          {{t "pages.login.join-invitation" organizationName=@model.organizationName}}
+        </PixNotificationAlert>
+
         <div>
           <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>
           <h2 class="pix-body-l">{{t "pages.login.with-pix-account"}}</h2>

--- a/orga/app/templates/join.gjs
+++ b/orga/app/templates/join.gjs
@@ -29,7 +29,6 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
           @isInvitationCancelled={{@controller.isInvitationCancelled}}
           @organizationInvitationId={{@controller.invitationId}}
           @organizationInvitationCode={{@controller.code}}
-          @organizationName={{@model.organizationName}}
         />
       </:content>
     </AuthenticationLayout>

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -30,29 +30,57 @@ module('Acceptance | join', function (hooks) {
 
   module('When prescriber tries to go on join page', function () {
     module('when organization-invitation exists', function () {
-      test('remains on join page', async function (assert) {
-        // given
-        const code = 'ABCDEFGH01';
-        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
-        const organizationInvitationId = server.create('organizationInvitation', {
-          organizationId,
-          email: 'random@email.com',
-          status: 'pending',
-          code,
-        }).id;
+      module('when new authentication design is enabled', function () {
+        test('remains on join page and displays AuthenticationLayout component', async function (assert) {
+          // given
+          const code = 'ABCDEFGH01';
+          server.create('feature-toggle', {
+            id: 0,
+            usePixOrgaNewAuthDesign: true,
+          });
+          const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+          const organizationInvitationId = server.create('organizationInvitation', {
+            organizationId,
+            email: 'random@email.com',
+            status: 'pending',
+            code,
+          }).id;
 
-        // when
-        await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          // when
+          const screen = await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
-        // then
-        assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+          // then
+          assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+          assert.ok(screen.getByText('Vous êtes invité(e) à rejoindre :'));
+        });
+      });
+
+      module('when new authentication design is disabled', function () {
+        test('remains on join page and displays LoginOrRegister component', async function (assert) {
+          // given
+          const code = 'ABCDEFGH01';
+          const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
+          const organizationInvitationId = server.create('organizationInvitation', {
+            organizationId,
+            email: 'random@email.com',
+            status: 'pending',
+            code,
+          }).id;
+
+          // when
+          await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+
+          // then
+          assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
+          assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        });
       });
     });
     module(
       'When accessing the login page with "English" as selected language in url query params and select another language',
       function () {
-        test('remains on join page whithout the query params', async function (assert) {
+        test('remains on join page without the query params', async function (assert) {
           // given
           const code = 'ABCDEFGH01';
           const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1082,6 +1082,7 @@
       "organization-code": "UAI/RNE de l'établissement"
     },
     "login": {
+      "join-invitation": "You have been invited to join: {organizationName}",
       "title": "Log in",
       "with-pix-account": "with your Pix Account"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1070,6 +1070,7 @@
       "organization-code": "UAI/RNE de l'établissement"
     },
     "login": {
+      "join-invitation": "Vous êtes invité(e) à rejoindre : {organizationName}",
       "title": "Connectez-vous",
       "with-pix-account": "avec votre compte Pix"
     },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1070,6 +1070,7 @@
       "organization-code": "UAI/RNE van de instelling"
     },
     "login": {
+      "join-invitation": "Je bent uitgenodigd om lid te worden van: {organizationName}",
       "title": "Inloggen",
       "with-pix-account": "met uw Pix-account"
     },


### PR DESCRIPTION
## 🍂 Problème
Quand un utilisateur est invité à Pix Orga, il est invité à se connecter au nom de l’organisation.
Cette page doit être intégrée dans le nouveau design d’authentification.

## 🌰 Proposition
Intégrer le formulaire de login via invitation dans le nouveau layout d’authentification.
- Sur la route join (/rejoindre), sous le feature toggle usePixOrgaNewAuthDesign
- Mettre en place le nouveau layout et utiliser le login form.
- Le nom de l’organisation doit être affiché dans un nouveau bandeau
- La gestion des erreurs d’invitation doit être géré comme avant (invitation invalide ou non trouvée)
- Le bouton “S’inscrire sur Pix” ne doit pas être ajouté pour le moment, il sera fait dans un ticket suivant.
- Ajouter des tests d’acceptance et d’intégration pour rejoindre une organisation.

## 🪵 Pour tester
- Se connecter à Pix Orga avec admin-orga et inviter un nouveau membre
- Suivre le lien reçu dans l'invitation
- La page affichée est celle de connexion à Pix Orga
- Vérifier que le message "Vous êtes invité(e) à rejoindre : Nom de l'orga" s'affiche dans un encadré bleu
- Vérifier que la connexion fonctionne
