### PR TITLE
[TECH] Mettre à jour la table oidc-providers pour gérer de manière générique sur quel TLD un SSO doit être disponible (PIX-20160)

### DIFF
--- a/api/db/migrations/20251028094520_update-oidc-providers-for-application-tld.js
+++ b/api/db/migrations/20251028094520_update-oidc-providers-for-application-tld.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'oidc-providers';
+const COLUMN_NAME = 'applicationTld';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .string(COLUMN_NAME)
+      .defaultTo(null)
+      .comment('TLD of the application for which this client configuration is for');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Le schéma de la table `oidc-providers` ne permet pas de gérer de manière générique quels sont les SSO qui doivent être affichés sur quels domaines (TLD), c’est à dire concrètement quels SSO doivent être affichés sur le TLD `.fr` ou sur le TLD `.org`.

## 🌰 Proposition

Faire évoluer la table `oidc-providers` pour gérer de manière générique sur quel TLD (`.fr`, `.org`) un SSO doit être disponible.

Pour cela on propose la migration SQL suivante qui ajoute 1 nouvelle colonne : 

* Attribut à ajouter pour déterminer l’application cliente de la config :
   * nom : `applicationTld`
   * valeur : TLD de l’application pour lequel le SSO doit être disponible (`.fr`, `.org`)
   * structure : type `string`, optionnel (uniquement pour l’instant mais obligatoire après reprise des données)

## 🍁 Remarques

RAS

## 🪵 Pour tester

1. Réaliser la validation de la migration de la DB : 
   1. Exécuter la commande `npm run db:migrate` en local
   2. Vérifier que la table `oidc-providers` a bien été modifiée avec l'ajout d'une nouvelle colonne `applicationTld`
   3.  Exécuter la commande `npm run db:rollback:latest` et vérifier que la table `oidc-providers` ne contient plus la nouvelle colonne `applicationTld`
2. Vérifier en local que la création des configurations d’OIDC Providers fonctionne toujours bien : 
   ```shell
   export OIDC_PROVIDERS=$(cat OIDC_PROVIDERS.json)
   npm run db:reset
   ```
3. Vérifier qu’on peut bien toujours se connecter par SSO à Pix App avec un SSO OIDC au choix parmi les SSO venant d’être créés précédemment.
