### PR TITLE
[FEATURE] Afficher si une organisation a le blocage auto en cas de dépassement de places (PIX-20072)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -330,7 +330,7 @@ const FeaturesForm = <template>
               (fn @updateFormCheckBoxValue (concat "features." feature ".params.enableMaximumPlacesLimit"))
             }}
           ><:label>{{t
-                "components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT"
+                "components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label"
               }}</:label></PixCheckbox>
         </div>
       {{/if}}

--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -162,6 +162,14 @@ class FeaturesSection extends Component {
     );
   };
 
+  getOrganizationPlacesLimitText = (isActive) => {
+    if (isActive)
+      return this.intl.t(
+        'components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.enabled',
+      );
+    return this.intl.t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.disabled');
+  };
+
   <template>
     <ul class="organization-information-section__features">
       {{#each (keys Organization.featureList) as |feature|}}
@@ -184,6 +192,10 @@ class FeaturesSection extends Component {
           {{else if (eq feature "ATTESTATIONS_MANAGEMENT")}}
             <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
               {{formatList (this.attestationLabels organizationFeature.params)}}
+            </Feature>
+          {{else if (eq feature "PLACES_MANAGEMENT")}}
+            <Feature @label={{t featureLabel}} @value={{organizationFeature.active}}>
+              {{this.getOrganizationPlacesLimitText organizationFeature.params.enableMaximumPlacesLimit}}
             </Feature>
           {{else}}
             <Feature @label={{t featureLabel}} @value={{organizationFeature.active}} />

--- a/admin/app/styles/components/ui/description-list.scss
+++ b/admin/app/styles/components/ui/description-list.scss
@@ -19,7 +19,7 @@
     }
 
     dd {
-      grid-column: span 3 / span 3;
+      grid-column: span 4 / span 3;
 
       a {
         color: var(--pix-primary-500);

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -206,7 +206,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.notOk(
           screen.queryByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
           ),
         );
       });
@@ -227,7 +227,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.false(
           screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
           ).checked,
         );
       });
@@ -248,7 +248,7 @@ module('Integration | Component | organizations/information-section-edit', funct
         );
         assert.true(
           screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT'),
+            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
           ).checked,
         );
       });

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -421,6 +421,71 @@ module('Integration | Component | organizations/information-section-view', funct
         });
       });
 
+      module('Places', function () {
+        module('when places in pixOrga is enabled', function () {
+          test('should display block enabled message, if this features is enabled', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              features: {
+                PLACES_MANAGEMENT: { active: true, params: { enableMaximumPlacesLimit: true } },
+              },
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.ok(
+              screen.getByText(
+                `${t('components.organizations.information-section-view.features.PLACES_MANAGEMENT')} : ${t(
+                  'components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.enabled',
+                )}`,
+              ),
+            );
+          });
+          test('should display block disabled message, if this features is not enabled', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              features: {
+                PLACES_MANAGEMENT: { active: true, params: { enableMaximumPlacesLimit: false } },
+              },
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.ok(
+              screen.getByText(
+                `${t('components.organizations.information-section-view.features.PLACES_MANAGEMENT')} : ${t(
+                  'components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.disabled',
+                )}`,
+              ),
+            );
+          });
+        });
+
+        module('when places in pixOrga is not enabled', function () {
+          test('should display label with no', async function (assert) {
+            // given
+            const organization = EmberObject.create({
+              features: {
+                PLACES_MANAGEMENT: { active: false },
+              },
+            });
+
+            // when
+            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            // then
+            assert.ok(
+              screen.getByLabelText(
+                `${t('components.organizations.information-section-view.features.PLACES_MANAGEMENT')} : ${t(
+                  'common.words.no',
+                )}`,
+              ),
+            );
+          });
+        });
+      });
+
       module('Net Promoter Score', function () {
         module('when NPS is enabled', function () {
           test('should display a link to formNPSUrl', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -613,7 +613,11 @@
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Multiple sending on assessment campaigns",
-          "ORGANIZATION_PLACES_LIMIT": "Block organization in case of places limit exceeded",
+          "ORGANIZATION_PLACES_LIMIT": {
+            "disabled": "without auto block",
+            "enabled": "with auto block",
+            "label": "Block organization in case of places limit exceeded"
+          },
           "PLACES_MANAGEMENT": "Display the Places page on PixOrga",
           "SHOW_NPS": "Net Promoter Score display",
           "SHOW_SKILLS": "Displaying skills in the results export",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -614,7 +614,11 @@
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
           "LEARNER_IMPORT": "Import",
           "MULTIPLE_SENDING_ASSESSMENT": "Envoi multiple sur les campagnes d'évaluation",
-          "ORGANIZATION_PLACES_LIMIT": "Blocage de l'organisation en cas de dépassement des places",
+          "ORGANIZATION_PLACES_LIMIT": {
+            "disabled": "Sans blocage automatique",
+            "enabled": "Avec blocage automatique",
+            "label": "Blocage de l'organisation en cas de dépassement des places"
+          },
           "PLACES_MANAGEMENT": "Affichage de la page Places sur PixOrga",
           "SHOW_NPS": "Affichage du Net Promoter Score",
           "SHOW_SKILLS": "Affichage des acquis dans l'export de résultats",


### PR DESCRIPTION
## 🍂 Problème
Aujourd'hui on a la possibilité de bloquer certaines features dans PixOrga pour les organisations ayant dépassée leurs quota de places disponible. Or, on n'affiche pas si cette feature est active ou non dans le détail de l'orga sur PixAdmin, il faut passer par le formulaire d'édition pour voir si celle ci est active

## 🌰 Proposition
Ajouter à côté de la feature "Affichage de la page places sur PixOrga" l'info si oui ou non la feature de blocage est active ou non

## 🍁 Remarques
C'est une v0 pour afficher "rapidement" cette info car on va activer dans quelques jours en masse cette fonctionnalitée. On veut donc permettre de voir cette info avant d'activer plus globalement.
Il faudrait peut être revoir a terme la gestion/affichage des features/sous features, car actuellement c'est un peu rigide.

## 🪵 Pour tester
Se connecter à PixAdmin
Aller sur la page d'une organisation
- Dans le cas ou la feature d'affichage de la page place est pas activée : Aucun changement.
- Dans le cas ou la feature d'affichage est activée, si le blocage est actif : Voir " Avec blocage automatique " en plus
- Dans le cas ou la feature d'affichage est activée et le blocage non actif : Voir " Sans blocage automatique "  

🐈‍⬛ 
