### PR TITLE
[FEATURE] Trier la liste des parcours apprenants par date de création (PIX-20015)

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -196,8 +196,18 @@ function buildProCombinedCourseQuest(databaseBuilder, organizationId) {
     }),
   );
 
+  databaseBuilder.factory.buildCombinedCourse({
+    name: 'Combinix 3',
+    code: 'COMBINIX3',
+    createdAt: new Date('2024-01-01'),
+    description: 'Combinix créé à une date antérieure au Combinix 2 pour tester le tri par date de création',
+    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
+    organizationId,
+    eligibilityRequirements: [],
+    successRequirements: [],
+  });
   const combinix2 = databaseBuilder.factory.buildCombinedCourse({
-    name: 'Combinix',
+    name: 'Combinix 2',
     code: 'COMBINIX2',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',

--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -37,7 +37,8 @@ const findByOrganizationId = async ({ organizationId }) => {
 
   const combinedCourses = await knexConn('combined_courses')
     .select('id', 'organizationId', 'code', 'name', 'description', 'illustration', 'questId')
-    .where('organizationId', organizationId);
+    .where('organizationId', organizationId)
+    .orderBy('createdAt', 'desc');
 
   return combinedCourses.map((quest) => new CombinedCourse(quest));
 };

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -63,18 +63,20 @@ describe('Quest | Integration | Repository | combined-course', function () {
   });
 
   describe('#findByOrganizationId', function () {
-    it('should return all combined courses for a given organization', async function () {
+    it('should return all combined courses for a given organization ordered by creation date', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const combinedCourse1 = databaseBuilder.factory.buildCombinedCourse({
         code: 'COURSE1',
         name: 'Parcours 1',
         organizationId,
+        createdAt: new Date('2024-01-01'),
       });
       const combinedCourse2 = databaseBuilder.factory.buildCombinedCourse({
         code: 'COURSE2',
         name: 'Parcours 2',
         organizationId,
+        createdAt: new Date('2025-01-01'),
       });
       await databaseBuilder.commit();
 
@@ -85,8 +87,8 @@ describe('Quest | Integration | Repository | combined-course', function () {
       expect(combinedCourses).to.have.lengthOf(2);
       expect(combinedCourses[0]).to.be.an.instanceof(CombinedCourse);
       expect(combinedCourses[1]).to.be.an.instanceof(CombinedCourse);
-      expect(combinedCourses[0]).to.deep.equal(new CombinedCourse(combinedCourse1));
-      expect(combinedCourses[1]).to.deep.equal(new CombinedCourse(combinedCourse2));
+      expect(combinedCourses[0]).to.deep.equal(new CombinedCourse(combinedCourse2));
+      expect(combinedCourses[1]).to.deep.equal(new CombinedCourse(combinedCourse1));
     });
 
     it('should return an empty array when organization has no combined courses', async function () {


### PR DESCRIPTION
## 🍂 Problème

Actuellement, la liste des parcours apprenants n'est pas ordonnée par date de création, contrairement aux autres onglets dans "Campagnes".

## 🌰 Proposition

On trie la liste des parcours apprenants par date de création (du plus récent au plus ancien) pour être iso par rapport aux autres onglets.

## 🍁 Remarques

On crée un nouveau parcours combiné COMBINIX3 dans les seeds (sans success requirements) avant le COMBINIX2 et avec une date plus ancienne, pour montrer qu'il apparaît bien après COMBINIX2 dans la liste (car il est plus ancien).

## 🪵 Pour tester

Se connecter à Pix Orga
Changer d'organisation pour Pro Classic
Aller dans l'onglet Parcours apprenants des Campagnes
Voir que COMBINIX3 est bien affiché après COMBINIX2
