### PR TITLE
[FEATURE] Redirige l'utilisateur vers le parcours combiné quand il clique sur Quitter dans un module (PIX-20184)

### DIFF
--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -1,4 +1,8 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import ModuleObjectives from 'mon-pix/components/module/instruction/objectives';
 import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
@@ -9,19 +13,9 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
   {{/if}}
 
   <main class="module-recap">
-    {{#unless @module.redirectionUrl}}
-      <div class="module-recap__header">
-        <PixButtonLink
-          @size="large"
-          @route="authenticated.user-dashboard"
-          @variant="tertiary"
-          @iconAfter="doorOpen"
-          class="module-recap-header__icon"
-        >
-          {{t "pages.modulix.recap.backToModuleDetails"}}
-        </PixButtonLink>
-      </div>
-    {{/unless}}
+    <div class="module-recap__header">
+      <QuitButton @redirectionUrl={{@module.redirectionUrl}} />
+    </div>
 
     <img class="module-recap__illustration" src="/images/modulix/recap-success.svg" alt="" width="228" height="200" />
 
@@ -46,3 +40,48 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
     </div>
   </main>
 </template>
+
+class QuitButton extends Component {
+  @service router;
+
+  @action
+  transitionToRedirectionUrl() {
+    if (this.isRedirectionUrlInternal) {
+      this.router.transitionTo(this.args.redirectionUrl);
+    } else {
+      window.location = this.args.redirectionUrl;
+    }
+  }
+
+  get isRedirectionUrlInternal() {
+    try {
+      return Boolean(this.router.recognize(this.args.redirectionUrl));
+    } catch {
+      return false;
+    }
+  }
+
+  <template>
+    {{#if @redirectionUrl}}
+      <PixButton
+        @size="large"
+        @variant="tertiary"
+        @iconAfter="doorOpen"
+        class="module-recap-header__icon"
+        @triggerAction={{this.transitionToRedirectionUrl}}
+      >
+        {{t "pages.modulix.recap.backToModuleDetails"}}
+      </PixButton>
+    {{else}}
+      <PixButtonLink
+        @size="large"
+        @route="authenticated.user-dashboard"
+        @variant="tertiary"
+        @iconAfter="doorOpen"
+        class="module-recap-header__icon"
+      >
+        {{t "pages.modulix.recap.backToModuleDetails"}}
+      </PixButtonLink>
+    {{/if}}
+  </template>
+}

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -1,7 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModuleRecap from 'mon-pix/components/module/instruction/recap';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -105,20 +107,25 @@ module('Integration | Component | Module | Recap', function (hooks) {
       assert.strictEqual(button.getAttribute('href'), module.redirectionUrl);
     });
 
-    test('should not display quit link', async function (assert) {
+    test('should call transitionTo with custom url from application', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const router = this.owner.lookup('service:router');
+      const transitionToStub = sinon.stub(router, 'transitionTo');
       const module = store.createRecord('module', {
         id: 'mon-slug',
         title: 'Module title',
         isBeta: true,
-        redirectionUrl: 'https//some-url.fr',
+        redirectionUrl: '/parcours/combinix3',
       });
       // when
       const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+      const button = screen.queryByRole('button', { name: 'Quitter' });
+      await click(button);
 
       // then
-      assert.strictEqual(screen.queryByRole('link', { name: 'Quitter' }), null);
+
+      assert.ok(transitionToStub.calledWithExactly(module.redirectionUrl));
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Dans une PR précédente, nous avons caché le bouton Quitter lors du passage d'un module si une url de redirection est configurée. Après discussion avec l'équipe Design, nous avons décidé de remettre ce bouton mais d'altérer son comportement.

## 🌰 Proposition

Le bouton Quitter redirige l'utilisateur vers l'url de redirection configurée.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Aller à la fin d'un module dans le parcours combiné COMBINIX1 et constater qu'on est bien redirigé vers le parcours combiné.