### PR TITLE
[FEATURE] Gestion de la progression sur la nouvelle navigation coté module (PIX-20105).

### DIFF
--- a/mon-pix/app/components/module/layout/_navigation.scss
+++ b/mon-pix/app/components/module/layout/_navigation.scss
@@ -22,6 +22,29 @@ img.module-navigation {
   }
 
   &__button {
+
+    &--current {
+      background-color: rgb(var(--pix-primary-700-inline), 0.60);
+
+      .pix-icon {
+        fill: var(--pix-neutral-0);
+      }
+    }
+
+    &--disabled {
+      background-color: var(--pix-neutral-0);
+      border: 1px solid var(--pix-primary-100);
+
+    .pix-icon {
+      fill: rgb(var(--pix-neutral-800-inline), 0.50);
+    }
+
+    }
+
+    &--enabled {
+      background-color: rgb(var(--pix-primary-700-inline), 0.2);
+    }
+
     width: 3.375rem;
     background-color: rgb(var(--pix-primary-700-inline), 0.2);
     border-radius: var(--pix-spacing-2x);

--- a/mon-pix/app/components/module/layout/_navigation.scss
+++ b/mon-pix/app/components/module/layout/_navigation.scss
@@ -68,10 +68,9 @@ img.module-navigation {
     &--disabled {
       background-color: unset;
 
-      &:hover{
+      &:focus{
         background-color: var(--pix-neutral-0);
         border: 1px solid var(--pix-primary-100);
-
       }
 
       .pix-icon {

--- a/mon-pix/app/components/module/layout/_navigation.scss
+++ b/mon-pix/app/components/module/layout/_navigation.scss
@@ -12,6 +12,16 @@ img.module-navigation {
     padding: 0;
   }
 
+  .pix-icon-button:not([aria-disabled="true"]){
+    &:hover{
+        background-color: var(--pix-neutral-0);
+    }
+
+    &:focus{
+      background-color: unset;
+    }
+  }
+
   & .pix-navigation__nav {
     gap: var(--pix-spacing-4x);
     align-items: center;
@@ -22,9 +32,33 @@ img.module-navigation {
   }
 
   &__button {
+    @include breakpoints.device-is('mobile') {
+      .pix-navigation-button {
+        border-radius: var(--pix-spacing-2x);
+      }
+    }
+
+    width: 3.375rem;
+    background-color: rgb(var(--pix-primary-700-inline), 0.2);
+  }
+
+  &__button, &__mobile-button {
+    border-radius: var(--pix-spacing-2x);
 
     &--current {
       background-color: rgb(var(--pix-primary-700-inline), 0.60);
+
+      @include breakpoints.device-is('mobile') {
+        color: var(--pix-neutral-0);
+        background-color: rgb(var(--pix-primary-700-inline), 0.60);
+      }
+
+      &.pix-icon-button:not([aria-disabled="true"]){
+        &:hover,&:focus{
+          background-color: rgb(var(--pix-primary-700-inline), 0.60)
+        }
+
+      }
 
       .pix-icon {
         fill: var(--pix-neutral-0);
@@ -32,21 +66,33 @@ img.module-navigation {
     }
 
     &--disabled {
-      background-color: var(--pix-neutral-0);
-      border: 1px solid var(--pix-primary-100);
+      background-color: unset;
 
-    .pix-icon {
-      fill: rgb(var(--pix-neutral-800-inline), 0.50);
-    }
+      &:hover{
+        background-color: var(--pix-neutral-0);
+        border: 1px solid var(--pix-primary-100);
+
+      }
+
+      .pix-icon {
+        fill: rgb(var(--pix-neutral-800-inline), 0.50);
+      }
 
     }
 
     &--enabled {
       background-color: rgb(var(--pix-primary-700-inline), 0.2);
-    }
 
-    width: 3.375rem;
-    background-color: rgb(var(--pix-primary-700-inline), 0.2);
-    border-radius: var(--pix-spacing-2x);
+      &.pix-icon-button:not([aria-disabled="true"]){
+        &:focus, &:hover{
+          color:var(--pix-neutral-800);
+          background-color: rgb(var(--pix-primary-700-inline), 0.2);
+        }
+      }
+    }
+  }
+
+  &__mobile-button {
+    margin-bottom: var(--pix-spacing-1x);
   }
 }

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -30,6 +30,14 @@ export default class ModulixNavigationButton extends Component {
     return '--disabled';
   }
 
+  get isDisabled() {
+    return !this.args.isPastSection && !this.args.isCurrentSection;
+  }
+
+  get isCurrentSection() {
+    return this.args.isCurrentSection;
+  }
+
   @action
   dummyFunction() {}
 
@@ -39,6 +47,8 @@ export default class ModulixNavigationButton extends Component {
         class="module-navigation__mobile-button module-navigation__mobile-button{{this.buttonClass}}"
         href={{concat "#section_" @section.type}}
         @icon={{this.sectionTitleIcon @section.type}}
+        aria-disabled="{{this.isDisabled}}"
+        aria-current="{{this.isCurrentSection}}"
       >{{this.sectionTitle @section.type}}</PixNavigationButton>
     {{else}}
       <PixIconButton
@@ -46,6 +56,8 @@ export default class ModulixNavigationButton extends Component {
         @ariaLabel={{this.sectionTitle @section.type}}
         @triggerAction={{this.dummyFunction}}
         @iconName={{this.sectionTitleIcon @section.type}}
+        @isDisabled={{this.isDisabled}}
+        aria-current="{{this.isCurrentSection}}"
       />
     {{/if}}
   </template>

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -31,7 +31,7 @@ export default class ModulixNavigationButton extends Component {
       >{{this.sectionTitle @section.type}}</PixNavigationButton>
     {{else}}
       <PixIconButton
-        class="module-navigation__button"
+        class="module-navigation__button module-navigation__button{{if @isCurrentSection '--current' '--enabled'}}"
         @ariaLabel={{this.sectionTitle @section.type}}
         @triggerAction={{this.dummyFunction}}
         @iconName={{this.sectionTitleIcon @section.type}}

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -20,18 +20,29 @@ export default class ModulixNavigationButton extends Component {
     return SECTION_TITLE_ICONS[type];
   }
 
+  get buttonClass() {
+    if (this.args.isCurrentSection) {
+      return '--current';
+    }
+    if (this.args.isPastSection) {
+      return '--enabled';
+    }
+    return '--disabled';
+  }
+
   @action
   dummyFunction() {}
 
   <template>
     {{#if this.media.isMobile}}
       <PixNavigationButton
+        class="module-navigation__mobile-button module-navigation__mobile-button{{this.buttonClass}}"
         href={{concat "#section_" @section.type}}
         @icon={{this.sectionTitleIcon @section.type}}
       >{{this.sectionTitle @section.type}}</PixNavigationButton>
     {{else}}
       <PixIconButton
-        class="module-navigation__button module-navigation__button{{if @isCurrentSection '--current' '--enabled'}}"
+        class="module-navigation__button module-navigation__button{{this.buttonClass}}"
         @ariaLabel={{this.sectionTitle @section.type}}
         @triggerAction={{this.dummyFunction}}
         @iconName={{this.sectionTitleIcon @section.type}}

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -7,10 +7,11 @@ import { t } from 'ember-intl';
 import ModulixNavigationButton from './navigation-button';
 
 export default class ModulixNavigation extends Component {
-  @service intl;
+  @service modulixNavigationProgress;
 
-  @action
-  dummyFunction() {}
+  @action isCurrentSection(index) {
+    return this.modulixNavigationProgress.currentSectionIndex === index;
+  }
 
   <template>
     <PixNavigation
@@ -23,8 +24,8 @@ export default class ModulixNavigation extends Component {
         <img class="module-navigation__logo" src="/images/modulix-pix-logo.svg" alt={{t "navigation.homepage"}} />
       </:brand>
       <:navElements>
-        {{#each @sections as |section|}}
-          <ModulixNavigationButton @section={{section}} />
+        {{#each @sections as |section index|}}
+          <ModulixNavigationButton @section={{section}} @isCurrentSection={{this.isCurrentSection index}} />
         {{/each}}
       </:navElements>
     </PixNavigation>

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -13,6 +13,10 @@ export default class ModulixNavigation extends Component {
     return this.modulixNavigationProgress.currentSectionIndex === index;
   }
 
+  @action isPastSection(index) {
+    return this.modulixNavigationProgress.currentSectionIndex > index;
+  }
+
   <template>
     <PixNavigation
       class="app-navigation module-navigation"
@@ -25,7 +29,11 @@ export default class ModulixNavigation extends Component {
       </:brand>
       <:navElements>
         {{#each @sections as |section index|}}
-          <ModulixNavigationButton @section={{section}} @isCurrentSection={{this.isCurrentSection index}} />
+          <ModulixNavigationButton
+            @section={{section}}
+            @isCurrentSection={{this.isCurrentSection index}}
+            @isPastSection={{this.isPastSection index}}
+          />
         {{/each}}
       </:navElements>
     </PixNavigation>

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -18,11 +18,15 @@ export default class ModulePassage extends Component {
   @service modulixAutoScroll;
   @service passageEvents;
   @service featureToggles;
+  @service modulixNavigationProgress;
 
-  get sectionsWithFirstGrain() {
-    return this.args.module.sections.map((section) => {
+  get enrichedSections() {
+    return this.args.module.sections.map((section, index) => {
       return {
         firstGrainId: section.grains[0].id,
+        lastGrainId: section.grains[section.grains.length - 1].id,
+        sectionId: section.id,
+        sectionIndex: index,
         sectionType: section.type,
       };
     });
@@ -30,12 +34,12 @@ export default class ModulePassage extends Component {
 
   @action
   getSectionTypeForGrain(grain) {
-    return this.sectionsWithFirstGrain.find((section) => section.firstGrainId === grain.id).sectionType;
+    return this.enrichedSections.find((section) => section.firstGrainId === grain.id).sectionType;
   }
 
   @action
   shouldDisplaySectionTitle(grain) {
-    return this.sectionsWithFirstGrain.some(
+    return this.enrichedSections.some(
       (section) => section.firstGrainId === grain.id && section.sectionType !== 'blank',
     );
   }
@@ -76,7 +80,7 @@ export default class ModulePassage extends Component {
   @action
   onGrainSkip() {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
-
+    this.modulixNavigationProgress.determineCurrentSection(this.enrichedSections, currentGrain);
     this.addNextGrainToDisplay();
 
     this.passageEvents.record({
@@ -90,6 +94,8 @@ export default class ModulePassage extends Component {
   @action
   onGrainContinue() {
     const currentGrain = this.displayableGrains[this.currentGrainIndex];
+
+    this.modulixNavigationProgress.determineCurrentSection(this.enrichedSections, currentGrain);
 
     this.addNextGrainToDisplay();
 

--- a/mon-pix/app/services/modulix-navigation-progress.js
+++ b/mon-pix/app/services/modulix-navigation-progress.js
@@ -1,0 +1,26 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ModulixNavigationProgress extends Service {
+  @tracked currentSectionIndex = 0;
+
+  setCurrentSectionIndex(currentSectionIndex) {
+    if (currentSectionIndex < 0) {
+      this.currentSectionIndex = 0;
+      return;
+    }
+    this.currentSectionIndex = currentSectionIndex;
+  }
+
+  determineCurrentSection(enrichedSections, currentGrain) {
+    const currentSection = enrichedSections.find((section) => section.lastGrainId === currentGrain.id);
+
+    if (currentSection) {
+      const currentSectionIndex = currentSection.sectionIndex;
+
+      if (currentSectionIndex < enrichedSections.length - 1) {
+        this.setCurrentSectionIndex(currentSectionIndex + 1);
+      }
+    }
+  }
+}

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -1,0 +1,196 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import NavigationButton from 'mon-pix/components/module/layout/navigation-button';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | NavigationButton', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when screen is desktop', function () {
+    test('should display a button with an icon', async function (assert) {
+      const type = 'question-yourself';
+      const section = {
+        type,
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t(`pages.modulix.section.${type}`) })).exists();
+      assert.dom(screen.getByRole('img', { hidden: true })).exists();
+    });
+
+    module('when isCurrentSection and isPastSection arguments are false', function () {
+      test('should disable the navigation button', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button')).hasAttribute('aria-disabled', 'true');
+      });
+    });
+
+    module('when isCurrentSection argument is true', function () {
+      test('should enable the navigation button', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{true}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
+      });
+    });
+
+    module('when isPactSection argument is true', function () {
+      test('should enable the navigation button', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{false}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
+      });
+    });
+  });
+
+  module('when screen is mobile', function (hooks) {
+    hooks.beforeEach(function () {
+      class MediaServiceStub extends Service {
+        isMobile = true;
+        toto = true;
+      }
+      this.owner.register('service:media', MediaServiceStub);
+    });
+
+    test('should display a link with an icon', async function (assert) {
+      // given
+      const type = 'question-yourself';
+      const section = {
+        type,
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link', { href: '#question-yourself' })).exists();
+    });
+
+    module('when isCurrentSection and isPastSection arguments are false', function () {
+      test('should disable the navigation link', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('link')).hasAria('disabled', 'true');
+      });
+    });
+
+    module('when isCurrentSection argument is true', function () {
+      test('should enable the navigation link', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{true}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('link')).hasAria('disabled', 'false');
+      });
+    });
+
+    module('when isPactSection argument is true', function () {
+      test('should enable the navigation link', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{false}} />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('link')).hasAria('disabled', 'false');
+      });
+    });
+
+    test('should set aria-current attribute to NavigationButton element', async function (assert) {
+      // given
+      class MediaServiceStub extends Service {
+        isMobile = true;
+      }
+      this.owner.register('service:media', MediaServiceStub);
+      const section = {
+        type: 'question-yourself',
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{true}} />
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('link', { name: t('pages.modulix.section.question-yourself') }))
+        .hasAria('current', 'true');
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
@@ -1,0 +1,46 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ModulixNavigation from 'mon-pix/components/module/layout/navigation';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Navigation', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when current section is second section', function () {
+    test('should set aria-current attribute to the second NavigationButton element', async function (assert) {
+      // given
+      const modulixNavigationProgressService = this.owner.lookup('service:modulix-navigation-progress');
+      modulixNavigationProgressService.setCurrentSectionIndex(1);
+      const sections = [
+        {
+          type: 'question-yourself',
+        },
+        {
+          type: 'explore-to-understand',
+        },
+        {
+          type: 'retain-the-essentials',
+        },
+        {
+          type: 'practise',
+        },
+        {
+          type: 'go-further',
+        },
+      ];
+
+      // when
+      const screen = await render(<template><ModulixNavigation @sections={{sections}} /></template>);
+
+      // then
+      assert
+        .dom(await screen.findByRole('button', { name: t('pages.modulix.section.explore-to-understand') }))
+        .hasAria('current', 'true');
+      assert
+        .dom(screen.getByRole('button', { name: t('pages.modulix.section.question-yourself') }))
+        .hasAria('current', 'false');
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/modulix-navigation-progress-test.js
+++ b/mon-pix/tests/unit/services/modulix-navigation-progress-test.js
@@ -1,0 +1,136 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Services | Module | ModulixNavigationProgress', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {});
+
+  module('#setCurrentSectionIndex', function () {
+    test('should set currentSectionIndex to given one', function (assert) {
+      // given
+      const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+      const nextIndex = 1;
+
+      // when
+      ModulixNavigationProgress.setCurrentSectionIndex(nextIndex);
+
+      // then
+      assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, 1);
+    });
+
+    test('should set currentSectionIndex to 0 if provided one is negative', function (assert) {
+      // given
+      const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+      const nextIndex = -1;
+
+      // when
+      ModulixNavigationProgress.setCurrentSectionIndex(nextIndex);
+
+      // then
+      assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, 0);
+    });
+  });
+
+  module('#determineCurrentSection', function () {
+    const enrichedSections = [
+      {
+        firstGrainId: '533c69b8-a836-41be-8ffc-8d4636e31224',
+        lastGrainId: 'a39ce6eb-f3db-447f-808f-aa6a06b940c9',
+        sectionId: 'cfaefec9-e185-43b8-8258-e8beff6dd56b',
+        sectionIndex: 0,
+        sectionType: 'question-yourself',
+      },
+      {
+        firstGrainId: 'd6ed29e2-fb0b-4f03-9e26-61029ecde2e3',
+        lastGrainId: '8bbfb1ef-3d35-48ce-bb3f-b63a8df9a8ac',
+        sectionId: '1d2e3c80-0b23-40c6-bb56-4fa957207ac6',
+        sectionIndex: 1,
+        sectionType: 'blank',
+      },
+      {
+        firstGrainId: 'b14df125-82d5-4d55-a660-7b34cd9ea1ab',
+        lastGrainId: '358e6d74-4adf-463a-9bf4-69ddca521d87',
+        sectionId: 'b0d428ab-a4ae-45e0-83fd-786fbd9c03dc',
+        sectionIndex: 2,
+        sectionType: 'practise',
+      },
+      {
+        firstGrainId: '628bd37d-e5da-411f-9b06-1035b073411b',
+        lastGrainId: '628bd37d-e5da-411f-9b06-1035b073411b',
+        sectionId: '2cb5a4fa-a54f-4d94-9b1f-5f504821846a',
+        sectionIndex: 3,
+        sectionType: 'explore-to-understand',
+      },
+      {
+        firstGrainId: 'df111992-ff3a-4c3f-ae5a-78bc359af23c',
+        lastGrainId: '0d4ef09a-ebb8-4514-a037-8fb22e540d7c',
+        sectionId: 'ea5ebe5d-f29f-4b03-8e9f-7c77606a014f',
+        sectionIndex: 4,
+        sectionType: 'retain-the-essentials',
+      },
+      {
+        firstGrainId: '0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c',
+        lastGrainId: '7cf75e70-8749-4392-8081-f2c02badb0fb',
+        sectionId: '4a3c5230-3c60-4c1a-9395-7b65537dda25',
+        sectionIndex: 5,
+        sectionType: 'go-further',
+      },
+    ];
+    module('When current grain is first grain in section ', function () {
+      test('should not change currentSectionIndex', function (assert) {
+        // given
+        const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+        const currentGrain = { id: enrichedSections[0].firstGrainId };
+        const expectedCurrentSectionIndex = 0;
+        // when
+        ModulixNavigationProgress.determineCurrentSection(enrichedSections, currentGrain);
+
+        // then
+        assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, expectedCurrentSectionIndex);
+      });
+    });
+    module('When current grain is not first, neither last grain in section ', function () {
+      test('should not change currentSectionIndex', function (assert) {
+        // given
+        const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+        const currentGrain = { id: 'in between grain' };
+        const expectedCurrentSectionIndex = 0;
+        // when
+        ModulixNavigationProgress.determineCurrentSection(enrichedSections, currentGrain);
+
+        // then
+        assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, expectedCurrentSectionIndex);
+      });
+    });
+    module('When current grain is last grain in section ', function () {
+      test('should set currentSectionIndex to the next one', function (assert) {
+        // given
+        const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+        const currentGrain = { id: enrichedSections[0].lastGrainId };
+        const expectedCurrentSectionIndex = 1;
+        // when
+        ModulixNavigationProgress.determineCurrentSection(enrichedSections, currentGrain);
+
+        // then
+        assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, expectedCurrentSectionIndex);
+      });
+    });
+    module('When current grain is last grain in last section ', function () {
+      test('should not change currentSectionIndex to the next one', function (assert) {
+        // given
+        const ModulixNavigationProgress = this.owner.lookup('service:modulix-navigation-progress');
+        const currentSectionIndex = enrichedSections.length - 1;
+        ModulixNavigationProgress.setCurrentSectionIndex(currentSectionIndex);
+        const currentGrain = { id: enrichedSections[currentSectionIndex].lastGrainId };
+        const expectedCurrentSectionIndex = currentSectionIndex;
+
+        // when
+        ModulixNavigationProgress.determineCurrentSection(enrichedSections, currentGrain);
+
+        //then
+        assert.strictEqual(ModulixNavigationProgress.currentSectionIndex, expectedCurrentSectionIndex);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Sur Pix App, les utilisateurs ont remonté le souhait de pouvoir naviguer dans les différentes sections d’un module. Cette navigation permettrait également de situer dans quelle section on se trouve.

## 🌰 Proposition

Faire la gestion des boutons selon le placement de l'utilisateur sur le module.

## 🍁 Remarques
Suite de la PR https://github.com/1024pix/pix/pull/13970

## 🪵 Pour tester

- Aller sur le module : https://app-pr14025.review.pix.fr/modules/les-ia-generatives-consomment
- Au format `desktopeuh`
  - Parcourir le bouton et voir la progression des boutons (comparer avec Figma)
  - Constater que les boutons des sections pas encore vu sont disabled
  - Coté console, constater que le bouton de la section en cours possède un aria-current `true`
<img width="304" height="400" alt="Capture d’écran 2025-10-31 à 15 49 58" src="https://github.com/user-attachments/assets/0399133b-0a95-4ac3-b34a-0ff8586cfef2" />

Au format `mobile`
<img width="419" height="336" alt="Capture d’écran 2025-10-31 à 15 50 55" src="https://github.com/user-attachments/assets/307c4a0b-594d-4ac9-b0b5-7dacea06451e" />


