### PR TITLE
[FEATURE] Blocage de la publication des sessions contenant des Pix+ V3 (PIX-20191).

### DIFF
--- a/api/src/certification/session-management/domain/errors.js
+++ b/api/src/certification/session-management/domain/errors.js
@@ -47,6 +47,16 @@ class SessionWithAbortReasonOnCompletedCertificationCourseError extends DomainEr
   }
 }
 
+class SessionWithPixPlusNotPublishableError extends DomainError {
+  constructor(
+    sessionId,
+    message = `Publication de la session ${sessionId} impossible. Cette session contient au moins une certification Pix+ V3`,
+  ) {
+    super(message);
+    this.code = 'SESSION_WITH_PIX_PLUS_NOT_PUBLISHABLE';
+  }
+}
+
 class SessionWithMissingAbortReasonError extends DomainError {
   constructor(
     message = "Une ou plusieurs certifications non terminées n'ont pas de “Raison de l’abandon” renseignées. La session ne peut donc pas être finalisée.",
@@ -126,4 +136,5 @@ export {
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
+  SessionWithPixPlusNotPublishableError,
 };

--- a/api/src/certification/session-management/domain/models/PixPlusCertificationCourse.js
+++ b/api/src/certification/session-management/domain/models/PixPlusCertificationCourse.js
@@ -1,0 +1,8 @@
+class PixPlusCertificationCourse {
+  constructor({ id, createdAt }) {
+    this.id = id;
+    this.createdAt = createdAt;
+  }
+}
+
+export { PixPlusCertificationCourse };

--- a/api/src/certification/session-management/domain/services/session-publication-service.js
+++ b/api/src/certification/session-management/domain/services/session-publication-service.js
@@ -9,6 +9,7 @@ import {
   CertificationCourseNotPublishableError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
+  SessionWithPixPlusNotPublishableError,
 } from '../errors.js';
 import { SessionAlreadyPublishedError } from '../errors.js';
 
@@ -23,6 +24,7 @@ import { logger } from '../../../../shared/infrastructure/utils/logger.js';
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {SharedSessionRepository} params.sharedSessionRepository
+ * @param {PixPlusCertificationRepository} params.pixPlusCertificationRepository
  */
 async function publishSession({
   publishedAt = new Date(),
@@ -31,10 +33,20 @@ async function publishSession({
   finalizedSessionRepository,
   sessionRepository,
   sharedSessionRepository,
+  pixPlusCertificationRepository,
 }) {
   const session = await sharedSessionRepository.getWithCertificationCandidates({ id: sessionId });
+
   if (session.isPublished()) {
     throw new SessionAlreadyPublishedError();
+  }
+
+  if (_hasComplementaryCertification(session)) {
+    const pixPlusCertificationCourses = await pixPlusCertificationRepository.getBySessionId(session.id);
+
+    if (pixPlusCertificationCourses.length > 0) {
+      throw new SessionWithPixPlusNotPublishableError(sessionId);
+    }
   }
 
   const certificationStatuses = await certificationRepository.getStatusesBySessionId(sessionId);
@@ -207,6 +219,10 @@ function _hasCertificationInError(certificationStatus) {
 
 function _hasCertificationWithNoScoring(certificationStatuses) {
   return certificationStatuses.some(({ pixCertificationStatus }) => pixCertificationStatus === null);
+}
+
+function _hasComplementaryCertification(session) {
+  return session.certificationCandidates.some((candidate) => Boolean(candidate.complementaryCertification));
 }
 
 export { manageEmails, publishSession };

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -19,6 +19,7 @@ import {
   competenceMarkRepository,
   cpfExportRepository,
   flashAlgorithmConfigurationRepository,
+  pixPlusCertificationRepository,
   repositories,
   sessionSummaryRepository,
   sharedCompetenceMarkRepository,
@@ -67,6 +68,7 @@ import * as sessionPublicationService from '../services/session-publication-serv
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationRescoringRepository} CertificationRescoringRepository
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationCandidateForSupervisingRepository} CertificationCandidateForSupervisingRepository
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationCenterAccessRepository} CertificationCenterAccessRepository
+ * @typedef {import('../../infrastructure/repositories/index.js').PixPlusCertificationRepository} PixPlusCertificationRepository
  * @typedef {import('../../../../identity-access-management/infrastructure/repositories/user.respository.js').UserRepository} UserRepository
  **/
 
@@ -112,12 +114,14 @@ import * as sessionPublicationService from '../services/session-publication-serv
  * @typedef {certificationCandidateRepository} CertificationCandidateRepository
  * @typedef {certificationCompanionAlertRepository} CertificationCompanionAlertRepository
  * @typedef {userRepository} UserRepository
+ * @typedef {pixPlusCertificationRepository} PixPlusCertificationRepository
  * @typedef {CertificationCandidateForSupervisingRepository} CertificationCandidateForSupervisingRepository
  **/
 const dependencies = {
   ...repositories,
   sessionSummaryRepository,
   assessmentRepository,
+  pixPlusCertificationRepository,
   assessmentResultRepository,
   answerRepository,
   sharedCompetenceMarkRepository,

--- a/api/src/certification/session-management/domain/usecases/publish-session.js
+++ b/api/src/certification/session-management/domain/usecases/publish-session.js
@@ -11,6 +11,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  * @param {SessionRepository} params.sessionRepository
  * @param {SharedSessionRepository} params.sharedSessionRepository
+ * @param {PixPlusCertificationRepository} params.pixPlusCertificationRepository
  * @param {SessionPublicationService} params.sessionPublicationService
  */
 const publishSession = async function ({
@@ -22,6 +23,7 @@ const publishSession = async function ({
   sharedSessionRepository,
   sessionRepository,
   sessionPublicationService,
+  pixPlusCertificationRepository,
 }) {
   return DomainTransaction.execute(async function () {
     const { session, startedCertificationCoursesUserIds } = await sessionPublicationService.publishSession({
@@ -31,6 +33,7 @@ const publishSession = async function ({
       finalizedSessionRepository,
       sessionRepository,
       sharedSessionRepository,
+      pixPlusCertificationRepository,
     });
 
     await sessionPublicationService.manageEmails({

--- a/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
+++ b/api/src/certification/session-management/domain/usecases/publish-sessions-in-batch.js
@@ -13,6 +13,7 @@ const publishSessionsInBatch = async function ({
   sessionRepository,
   sharedSessionRepository,
   sessionPublicationService,
+  pixPlusCertificationRepository,
 }) {
   const result = new SessionPublicationBatchResult(batchId);
   for (const sessionId of sessionIds) {
@@ -25,6 +26,7 @@ const publishSessionsInBatch = async function ({
           finalizedSessionRepository,
           sharedSessionRepository,
           sessionRepository,
+          pixPlusCertificationRepository,
         });
 
         await sessionPublicationService.manageEmails({

--- a/api/src/certification/session-management/infrastructure/repositories/index.js
+++ b/api/src/certification/session-management/infrastructure/repositories/index.js
@@ -32,6 +32,7 @@ import * as finalizedSessionRepository from './finalized-session-repository.js';
 import * as juryCertificationRepository from './jury-certification-repository.js';
 import * as juryCertificationSummaryRepository from './jury-certification-summary-repository.js';
 import * as jurySessionRepository from './jury-session-repository.js';
+import * as pixPlusCertificationRepository from './pix-plus-certification-repository.js';
 import * as sessionForInvigilatorKitRepository from './session-for-invigilator-kit-repository.js';
 import * as sessionForSupervisingRepository from './session-for-supervising-repository.js';
 import * as sessionJuryCommentRepository from './session-jury-comment-repository.js';
@@ -81,6 +82,7 @@ import * as v3CertificationCourseDetailsForAdministrationRepository from './v3-c
  * @typedef {typeof certificationCompanionAlertRepository} CertificationCompanionAlertRepository
  * @typedef {certificationRescoringRepository} CertificationRescoringRepository
  * @typedef {certificationCenterAccessRepository} CertificationCenterAccessRepository
+ * @typedef {pixPlusCertificationRepository} PixPlusCertificationRepository
  */
 const repositoriesWithoutInjectedDependencies = {
   assessmentRepository,
@@ -117,6 +119,7 @@ const repositoriesWithoutInjectedDependencies = {
   certificationCompanionAlertRepository,
   certificationRescoringRepository,
   certificationCenterAccessRepository,
+  pixPlusCertificationRepository,
 };
 
 /**
@@ -141,6 +144,7 @@ export {
   competenceMarkRepository,
   cpfExportRepository,
   flashAlgorithmConfigurationRepository,
+  pixPlusCertificationRepository,
   repositories,
   sessionSummaryRepository,
   sharedCompetenceMarkRepository,

--- a/api/src/certification/session-management/infrastructure/repositories/pix-plus-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/pix-plus-certification-repository.js
@@ -1,0 +1,36 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
+import { PixPlusCertificationCourse } from '../../domain/models/PixPlusCertificationCourse.js';
+
+const getBySessionId = async function (sessionId) {
+  const knexConn = DomainTransaction.getConnection();
+  const PIX_PLUS_START_DATE = '2025-07-01';
+
+  const certificationCourses = await knexConn('certification-courses').where({ sessionId });
+
+  const certificationCourseIds = certificationCourses.map((course) => course.id);
+
+  const pixPlusCertificationCourses = await knexConn('complementary-certification-courses')
+    .select({
+      id: 'complementary-certification-courses.id',
+      createdAt: 'complementary-certification-courses.createdAt',
+    })
+    .join(
+      'complementary-certifications',
+      'complementary-certifications.id',
+      'complementary-certification-courses.complementaryCertificationId',
+    )
+    .where('complementary-certification-courses.createdAt', '>=', PIX_PLUS_START_DATE)
+    .andWhere('complementary-certifications.key', '!=', ComplementaryCertificationKeys.CLEA)
+    .whereIn('certificationCourseId', certificationCourseIds);
+
+  return _toDomain(pixPlusCertificationCourses);
+};
+
+const _toDomain = (pixPlusCertificationCourses) => {
+  return pixPlusCertificationCourses.map((pixPlusCertificationCourses) => {
+    return new PixPlusCertificationCourse(pixPlusCertificationCourses);
+  });
+};
+
+export { getBySessionId };

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/pix-plus-certification-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/pix-plus-certification-repository_test.js
@@ -1,0 +1,61 @@
+import * as pixPlusCertificationRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/pix-plus-certification-repository.js';
+import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Session Management | Integration | Infrastructure | Repositories | Pix Plus Certification', function () {
+  describe('#getBySessionId', function () {
+    describe('when there is no pix plus certification', function () {
+      it('returns an empty array', async function () {
+        // given / when
+        const pixPlusCertificationCourses = await pixPlusCertificationRepository.getBySessionId(1);
+
+        // then
+        expect(pixPlusCertificationCourses).to.deep.equal([]);
+      });
+    });
+
+    it('returns the non double V3 certifications', async function () {
+      // given
+      const v2certificationCourseDate = new Date('2020-01-01');
+      const v3certificationCourseDate = new Date('2026-01-01');
+
+      const session = databaseBuilder.factory.buildSession();
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        sessionId: session.id,
+      });
+      const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+      const doubleCertification = databaseBuilder.factory.buildComplementaryCertification({
+        key: ComplementaryCertificationKeys.CLEA,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        complementaryCertificationId: complementaryCertification.id,
+        certificationCourseId: certificationCourse.id,
+        createdAt: v2certificationCourseDate,
+      });
+      const pixPlusCertificationCourse = databaseBuilder.factory.buildComplementaryCertificationCourse({
+        complementaryCertificationId: complementaryCertification.id,
+        certificationCourseId: certificationCourse.id,
+        createdAt: v3certificationCourseDate,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        complementaryCertificationId: doubleCertification.id,
+        certificationCourseId: certificationCourse.id,
+        createdAt: v3certificationCourseDate,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const pixPlusCertificationCourses = await pixPlusCertificationRepository.getBySessionId(session.id);
+
+      // then
+      const expectedResult = [
+        domainBuilder.certification.sessionManagement.buildPixPlusCertificationCourse({
+          id: pixPlusCertificationCourse.id,
+          createdAt: pixPlusCertificationCourse.createdAt,
+        }),
+      ];
+      expect(pixPlusCertificationCourses).to.deep.equal(expectedResult);
+    });
+  });
+});

--- a/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/certification/session-management/unit/domain/services/session-publication-service_test.js
@@ -1,4 +1,7 @@
-import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
+import {
+  SessionAlreadyPublishedError,
+  SessionWithPixPlusNotPublishableError,
+} from '../../../../../../src/certification/session-management/domain/errors.js';
 import {
   CertificationCourseNotPublishableError,
   SendingEmailToRefererError,
@@ -20,6 +23,7 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
     sharedSessionRepository,
     finalizedSessionRepository,
     certificationCenterRepository,
+    pixPlusCertificationRepository,
     mailService;
   let now;
   const sessionDate = '2020-05-08';
@@ -88,6 +92,9 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
         finalizedSessionRepository = {
           get: sinon.stub(),
           save: sinon.stub(),
+        };
+        pixPlusCertificationRepository = {
+          getBySessionId: sinon.stub(),
         };
         sharedSessionRepository.getWithCertificationCandidates.withArgs({ id: sessionId }).resolves(originalSession);
       });
@@ -205,6 +212,43 @@ describe('Certification | Session Management | Unit | Domain | Services | sessio
 
           // then
           expect(error).to.be.instanceOf(CertificationCourseNotPublishableError);
+        });
+      });
+
+      context('when at least one certification is a V3 complementary certification', function () {
+        it('should throw a CertificationCourseNotPublishableError', async function () {
+          // given
+          const pixPlusCertificationCourses = [
+            domainBuilder.certification.sessionManagement.buildPixPlusCertificationCourse({
+              id: 1,
+              createdAt: new Date(),
+            }),
+          ];
+          const session = domainBuilder.certification.sessionManagement.buildSession({
+            id: 'sessionId',
+            publishedAt: null,
+            certificationCandidates: [
+              domainBuilder.buildCertificationCandidate({
+                complementaryCertification: domainBuilder.certification.shared.buildComplementaryCertification(),
+              }),
+            ],
+          });
+          const sharedSessionRepository = { getWithCertificationCandidates: sinon.stub() };
+          sharedSessionRepository.getWithCertificationCandidates.withArgs({ id: session.id }).resolves(session);
+          pixPlusCertificationRepository.getBySessionId.withArgs(session.id).resolves(pixPlusCertificationCourses);
+
+          // when
+          const error = await catchErr(publishSession)({
+            sessionId: session.id,
+            publishedAt: now,
+            finalizedSessionRepository: undefined,
+            sessionRepository,
+            sharedSessionRepository,
+            pixPlusCertificationRepository,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(SessionWithPixPlusNotPublishableError);
         });
       });
     });

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-session_test.js
@@ -22,7 +22,11 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
       publishSession: sinon.stub(),
       manageEmails: sinon.stub(),
     };
+    const pixPlusCertificationRepository = {
+      getBySessionId: sinon.stub(),
+    };
     sessionPublicationService.publishSession.resolves({ session, startedCertificationCoursesUserIds: [123] });
+    pixPlusCertificationRepository.getBySessionId.resolves([]);
 
     // when
     const result = await publishSession({
@@ -32,6 +36,7 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
       finalizedSessionRepository,
       sessionRepository,
       sharedSessionRepository,
+      pixPlusCertificationRepository,
       sessionPublicationService,
       publishedAt,
     });
@@ -44,6 +49,7 @@ describe('Certification | Session-Management | Unit | Domain | Use Cases | Publi
       finalizedSessionRepository,
       sessionRepository,
       sharedSessionRepository,
+      pixPlusCertificationRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session,

--- a/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -8,7 +8,8 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     finalizedSessionRepository,
     sessionRepository,
     certificationCenterRepository,
-    sharedSessionRepository;
+    sharedSessionRepository,
+    pixPlusCertificationRepository;
 
   beforeEach(function () {
     certificationRepository = Symbol('certificationRepository');
@@ -20,6 +21,10 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     sessionPublicationService = {
       publishSession: sinon.stub(),
       manageEmails: sinon.stub(),
+    };
+
+    pixPlusCertificationRepository = {
+      getBySessionId: sinon.stub(),
     };
 
     sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda());
@@ -39,6 +44,8 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
     sessionPublicationService.publishSession
       .onCall(1)
       .resolves({ session: session2, startedCertificationCoursesUserIds: startedCertificationCoursesUserIds2 });
+    pixPlusCertificationRepository.getBySessionId.onCall(0).resolves([]);
+    pixPlusCertificationRepository.getBySessionId.onCall(1).resolves([]);
 
     // when
     await publishSessionsInBatch({
@@ -51,6 +58,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       sessionRepository,
       sharedSessionRepository,
       sessionPublicationService,
+      pixPlusCertificationRepository,
     });
 
     // then
@@ -61,6 +69,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       finalizedSessionRepository,
       sessionRepository,
       sharedSessionRepository,
+      pixPlusCertificationRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session: session1,
@@ -77,6 +86,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       finalizedSessionRepository,
       sharedSessionRepository,
       sessionRepository,
+      pixPlusCertificationRepository,
     });
     expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
       session: session2,
@@ -95,6 +105,9 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       const publishedAt = Symbol('a publication date');
       const startedCertificationCoursesUserIds2 = [201, 202];
 
+      pixPlusCertificationRepository.getBySessionId.onCall(0).resolves([]);
+      pixPlusCertificationRepository.getBySessionId.onCall(1).resolves([]);
+
       sessionPublicationService.publishSession
         .withArgs({
           sessionId: session1.id,
@@ -103,6 +116,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
           finalizedSessionRepository,
           sessionRepository,
           sharedSessionRepository,
+          pixPlusCertificationRepository,
         })
         .rejects(new Error('an error'));
       sessionPublicationService.publishSession
@@ -120,6 +134,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         sessionRepository,
         sharedSessionRepository,
         sessionPublicationService,
+        pixPlusCertificationRepository,
       });
 
       expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
@@ -129,6 +144,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         finalizedSessionRepository,
         sessionRepository,
         sharedSessionRepository,
+        pixPlusCertificationRepository,
       });
       expect(sessionPublicationService.manageEmails).to.have.been.calledWithExactly({
         session: session2,
@@ -145,6 +161,9 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
       const sessionId2 = Symbol('second session id');
       const publishedAt = Symbol('a publication date');
 
+      pixPlusCertificationRepository.getBySessionId.onCall(0).resolves([]);
+      pixPlusCertificationRepository.getBySessionId.onCall(1).resolves([]);
+
       const error1 = new Error('an error');
       const error2 = new Error('another error');
       sessionPublicationService.publishSession
@@ -155,6 +174,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
           finalizedSessionRepository,
           sessionRepository,
           sharedSessionRepository,
+          pixPlusCertificationRepository,
         })
         .rejects(error1);
       sessionPublicationService.publishSession
@@ -165,6 +185,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
           finalizedSessionRepository,
           sessionRepository,
           sharedSessionRepository,
+          pixPlusCertificationRepository,
         })
         .rejects(error2);
 
@@ -179,6 +200,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', function () {
         sessionRepository,
         sharedSessionRepository,
         sessionPublicationService,
+        pixPlusCertificationRepository,
       });
 
       // then

--- a/api/tests/tooling/domain-builder/factory/certification/session-management/build-pix-plus-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session-management/build-pix-plus-certification-course.js
@@ -1,0 +1,5 @@
+import { PixPlusCertificationCourse } from '../../../../../../src/certification/session-management/domain/models/PixPlusCertificationCourse.js';
+
+export const buildPixPlusCertificationCourse = function ({ id, createdAt } = {}) {
+  return new PixPlusCertificationCourse({ id, createdAt });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -208,6 +208,7 @@ import { buildCertificationCandidate as buildSessionManagementCandidate } from '
 import { buildCertificationDetails } from './certification/session-management/build-certification-details.js';
 import { buildCertificationSessionComplementaryCertification } from './certification/session-management/build-certification-session-complementary-certification.js';
 import { buildJurySessionCounters } from './certification/session-management/build-jury-session-counters.js';
+import { buildPixPlusCertificationCourse } from './certification/session-management/build-pix-plus-certification-course.js';
 import { buildSessionManagement } from './certification/session-management/build-session.js';
 import { buildCompetenceForScoring } from './certification/shared/build-competence-for-scoring.js';
 import { buildComplementaryCertification as buildSharedComplementaryCertification } from './certification/shared/build-complementary-certification.js';
@@ -284,6 +285,7 @@ const certification = {
     buildSession: buildSessionManagement,
     buildCertificationCandidate: buildSessionManagementCandidate,
     buildJurySessionCounters,
+    buildPixPlusCertificationCourse,
   },
   shared: {
     buildCertificationCompanionLiveAlert,


### PR DESCRIPTION
## 🍂 Problème

Les nouvelles certifications Pix+ vont bientôt pouvoir être passées par nos utilisateurs.
Elles ne seront cependant pas scorées tout de suite.
Afin de pouvoir les scorer une fois que le scoring sera implémenté, il nous faut empêcher la publication des sessions contenant des certifications Pix+ V3 (sauf CLEA)

Les potentielles sessions contenant des complémentaires V2 qui sont non publiées doivent quant à elles pouvoir continuer de l'être.

## 🌰 Proposition

- Création de nouveaus repository/modèle temporaire dans `session-management` pour récupérer les nouvelles certifications Pix+ (appelées pixPlus pour l'occasion - notamment pour éviter des conflits - nommage possiblement à revoir, j'en suis pas spécialement satisfait même si c'est du provisoire)

## 🍁 Remarques

RAS

## 🪵 Pour tester

**Pix Coeur**
- Création d'une session de certification (`certif-prescriptor@example.net`)
- Ajout d'un candidat
- Passage de la certif
- Finalisation
- Publication POSSIBLE ✅ 

**Double Certification**
- Création d'une session de certification (`certif-prescriptor@example.net`)
- Ajout d'un candidat
- Passage de la certif
- Finalisation
- Publication POSSIBLE ✅ 

**Pix+**
- Création d'une session de certification (`certif-prescriptor@example.net`)
- Ajout d'un candidat PIX+DROIT
- Passage de la certif
- Finalisation
- Publication IMPOSSIBLE 🚫 

Ne pouvant pas passer de certification V2, cette partie de test devra être faite en recette.