### PR TITLE
[TECH] Utiliser des methodes du model pour fournir les champs à mettre à jour sur les parcours combiné (PIX-20261).

### DIFF
--- a/api/src/quest/domain/models/OrganizationLearnerParticipation.js
+++ b/api/src/quest/domain/models/OrganizationLearnerParticipation.js
@@ -36,6 +36,39 @@ export class OrganizationLearnerParticipation {
     this.referenceId = referenceId;
   }
 
+  get fieldsForUpdate() {
+    return {
+      id: this.id,
+      updatedAt: this.updatedAt,
+      status: this.status,
+      completedAt: this.completedAt,
+    };
+  }
+
+  static buildFromCombinedCourse({
+    id,
+    organizationLearnerId,
+    createdAt,
+    updatedAt,
+    deletedAt,
+    deletedBy,
+    status,
+    combinedCourseId,
+  }) {
+    return new OrganizationLearnerParticipation({
+      id,
+      organizationLearnerId,
+      createdAt,
+      updatedAt,
+      completedAt: status === OrganizationLearnerParticipationStatuses.COMPLETED ? updatedAt : null,
+      deletedAt,
+      deletedBy,
+      status,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      referenceId: combinedCourseId.toString(),
+    });
+  }
+
   static buildFromPassage({
     id,
     organizationLearnerId,

--- a/api/src/quest/domain/usecases/update-combined-course.js
+++ b/api/src/quest/domain/usecases/update-combined-course.js
@@ -1,4 +1,5 @@
 import { COMBINED_COURSE_ITEM_TYPES } from '../models/CombinedCourseItem.js';
+import { OrganizationLearnerParticipation } from '../models/OrganizationLearnerParticipation.js';
 
 export async function updateCombinedCourse({
   userId,
@@ -31,9 +32,10 @@ export async function updateCombinedCourse({
 
   if (isCombinedCourseCompleted) {
     combinedCourseDetails.participation.complete();
-    return combinedCourseParticipationRepository.update({
-      combinedCourseParticipation: combinedCourseDetails.participation,
-    });
+    const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourse(
+      combinedCourseDetails.participation,
+    );
+    await combinedCourseParticipationRepository.update(organizationLearnerParticipation.fieldsForUpdate);
   }
 
   return combinedCourseDetails.participation;

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -4,6 +4,7 @@ import { filterByFullName } from '../../../shared/infrastructure/utils/filter-ut
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
 import { CombinedCourseParticipation } from '../../domain/models/CombinedCourseParticipation.js';
 import {
+  OrganizationLearnerParticipation,
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../domain/models/OrganizationLearnerParticipation.js';
@@ -98,17 +99,13 @@ function addSearchFilters(queryBuilder, filters = {}) {
   }
 }
 
-export const update = async function ({ combinedCourseParticipation }) {
+export const update = async function ({ id, ...updateFields }) {
   const knexConnection = DomainTransaction.getConnection();
   const updatedRow = await knexConnection('organization_learner_participations')
-    .where({ id: combinedCourseParticipation.id })
-    .update({
-      updatedAt: combinedCourseParticipation.updatedAt,
-      status: combinedCourseParticipation.status,
-      completedAt: combinedCourseParticipation.completedAt,
-    })
+    .where({ id })
+    .update(updateFields)
     .returning('*');
-  return new CombinedCourseParticipation(updatedRow[0]);
+  return new OrganizationLearnerParticipation(updatedRow[0]);
 };
 
 /**

--- a/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/quest/unit/domain/models/OrganizationLearnerParticipation_test.js
@@ -7,7 +7,7 @@ import {
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', function () {
-  describe('buildFromPassage', function () {
+  describe('#buildFromPassage', function () {
     it('should instantiate an OrganizationLearnerParticipation with passage data', function () {
       // given && when
       const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromPassage({
@@ -23,6 +23,7 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
       });
 
       // then
+      expect(organizationLearnerParticipation).instanceOf(OrganizationLearnerParticipation);
       expect(organizationLearnerParticipation.id).to.equal(12);
       expect(organizationLearnerParticipation.organizationLearnerId).to.equal(15);
       expect(organizationLearnerParticipation.createdAt).deep.to.equal(new Date('2024-01-01'));
@@ -63,6 +64,79 @@ describe('Quest | Unit | Domain | Models | OrganizationLearnerParticipation', fu
 
         // then
         expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.NOT_STARTED);
+      });
+    });
+  });
+
+  describe('#buildFromCombinedCourse', function () {
+    it('should instantiate an OrganizationLearnerParticipation with combined course data', function () {
+      // given && when
+      const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourse({
+        id: 12,
+        organizationLearnerId: 15,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-01-01'),
+        deletedAt: new Date('2025-03-01'),
+        deletedBy: 13,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        combinedCourseId: 666,
+      });
+
+      // then
+      expect(organizationLearnerParticipation).instanceOf(OrganizationLearnerParticipation);
+      expect(organizationLearnerParticipation.id).to.equal(12);
+      expect(organizationLearnerParticipation.organizationLearnerId).to.equal(15);
+      expect(organizationLearnerParticipation.createdAt).deep.to.equal(new Date('2024-01-01'));
+      expect(organizationLearnerParticipation.updatedAt).deep.to.equal(new Date('2025-01-01'));
+      expect(organizationLearnerParticipation.completedAt).deep.to.equal(new Date('2025-01-01'));
+      expect(organizationLearnerParticipation.deletedAt).deep.to.equal(new Date('2025-03-01'));
+      expect(organizationLearnerParticipation.deletedBy).to.equal(13);
+      expect(organizationLearnerParticipation.status).to.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
+      expect(organizationLearnerParticipation.type).to.equal(OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+      expect(organizationLearnerParticipation.referenceId).deep.equal('666');
+    });
+
+    it('should instantiate completedAt to null when status is not COMPLETED', function () {
+      // given && when
+      const organizationLearnerParticipation = OrganizationLearnerParticipation.buildFromCombinedCourse({
+        id: 12,
+        organizationLearnerId: 15,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-01-01'),
+        deletedAt: new Date('2025-03-01'),
+        deletedBy: 13,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+        combinedCourseId: 666,
+      });
+
+      // then
+      expect(organizationLearnerParticipation.completedAt).null;
+    });
+  });
+
+  describe('fieldsForUpdate', function () {
+    it('should return an object with the fields to update', function () {
+      // given
+      const organizationLearnerParticipation = new OrganizationLearnerParticipation({
+        id: 12,
+        organizationLearnerId: 15,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        referenceId: '666',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2025-01-01'),
+        completedAt: new Date('2025-01-01'),
+      });
+
+      //when
+      const expectedFieldToUpdate = organizationLearnerParticipation.fieldsForUpdate;
+
+      // then
+      expect(expectedFieldToUpdate).to.deep.equal({
+        id: 12,
+        status: OrganizationLearnerParticipationStatuses.COMPLETED,
+        updatedAt: new Date('2025-01-01'),
+        completedAt: new Date('2025-01-01'),
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Actuellement c'est le repository qui gère ce qu'il met dans la methode update. 

## 🌰 Proposition

Déporter cette logique côté model afin que l'on appel la méthode update via le usecase avec les données que l'on souahite seulement mettre à jour

## 🍁 Remarques

ça permettra d'utiliser cette méthode générique dans le cas de la suppression de parcours combiné avec une méthode du model qui mettra à jour les données qui vont bien. 

## 🪵 Pour tester

CI au vert. faire un parcours au global et vérifier que tout va bien. 