### PR TITLE
[FEATURE] Fixer la navigation des modules en haut de l'écran en format mobile (PIX-20167)

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -228,6 +228,16 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
   padding: 0;
   }
 
+  & > .pix-app-layout__navigation{
+    position: sticky;
+    z-index: 1;
+
+    @include breakpoints.device-is('mobile') {
+      top: 0;
+      padding: calc(var(--pix-app-layout-top) + var(--pix-spacing-2x)) var(--pix-spacing-2x) 0 var(--pix-spacing-2x);
+    }
+  }
+
   &--page-without-navbar {
     & > .pix-app-layout__navigation{
       @include breakpoints.device-is('desktop') {


### PR DESCRIPTION
## 🍂 Problème

Le chantier de la nouvelle navigation des modules sur Pix App est en cours, sous feature toggle.
En format mobile, la navigation disparaît lorsqu'on scroll. On veut pouvoir y avoir accès en permanence pour changer de section à tout moment.

## 🌰 Proposition

Fixer la nav en haut de l'écran en format mobile.

## 🍁 Remarques

J'ai appliqué un padding sur le menu en cas de bannière de communication (en mobile)

## 🪵 Pour tester

https://app-pr14033.review.pix.fr/modules/tmp-ia-premier-prompt/details

Vérifier en format mobile, que la navigation est fixé.

https://github.com/user-attachments/assets/c5193aaf-6d21-4016-b3fd-f8833fc8e7bb


En ajoutant une communication banner, le menu est toujours disponible, il se place en dessous.

https://github.com/user-attachments/assets/43d43c9d-317d-4cc9-925c-901229526ba8

Vérifier que le format desktop n'est pas impacté par les modification, avec et sans bannière de com.
