### PR TITLE
[FEATURE] Créer des variables d'env pour gérer les délais pour apparition feedback (PIX-20001)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -17,8 +17,9 @@ import QrocmElement from 'mon-pix/components/module/element/qrocm';
 import SeparatorElement from 'mon-pix/components/module/element/separator';
 import TextElement from 'mon-pix/components/module/element/text';
 import VideoElement from 'mon-pix/components/module/element/video';
+import ENV from 'mon-pix/config/environment';
 
-export const VERIFY_RESPONSE_DELAY = 500;
+export const VERIFY_RESPONSE_DELAY = ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY;
 
 export default class ModulixElement extends Component {
   @action

--- a/mon-pix/app/components/module/element/qrocm.gjs
+++ b/mon-pix/app/components/module/element/qrocm.gjs
@@ -11,8 +11,9 @@ import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 import ModuleElement from 'mon-pix/components/module/element/module-element';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
-import ENV from 'mon-pix/config/environment';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
+
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 
 export default class ModuleQrocm extends ModuleElement {
   @tracked selectedValues = {};
@@ -102,7 +103,7 @@ export default class ModuleQrocm extends ModuleElement {
       return;
     }
 
-    await this.#waitFor(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY);
+    await this.#waitFor(VERIFY_RESPONSE_DELAY);
 
     const answerIsValid = this.answerIsValid;
     const status = answerIsValid ? 'ok' : 'ko';

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -134,7 +134,7 @@ module.exports = function (environment) {
       COMBINIX_SURVEY_LINK:
         process.env.COMBINIX_SURVEY_LINK ||
         'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms',
-      MODULIX_QROCM_VERIFICATION_DELAY: 500,
+      MODULIX_VERIFICATION_RESPONSE_DELAY: 500,
     },
 
     fontawesome: {
@@ -221,7 +221,7 @@ module.exports = function (environment) {
       usingProxy: false,
     };
 
-    ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = 0;
+    ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY = 0;
   }
 
   if (environment === 'production') {

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -578,6 +578,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
     module('when element is a qcm', function (hooks) {
       let clock;
+
       hooks.beforeEach(function () {
         clock = sinon.useFakeTimers();
       });
@@ -623,7 +624,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
           await click(screen.getByLabelText('checkbox2'));
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
@@ -631,7 +631,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
 
       module('when verify button is clicked with no selected answers', function () {
-        test('should first disable, and then enable skip activity button', async function (assert) {
+        test('should disable skip activity button', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const element = { type: 'qcm', isAnswerable: true };
@@ -648,13 +648,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
           await click(verifyButton);
-          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
 
           // then
           assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).hasAttribute('aria-disabled', 'true');
-          await clock.tickAsync(Math.round(VERIFY_RESPONSE_DELAY / 2));
-
-          assert.dom(screen.getByRole('button', { name: 'Passer l’activité' })).doesNotHaveAttribute('aria-disabled');
         });
       });
     });

--- a/mon-pix/tests/integration/components/module/qrocm_test.gjs
+++ b/mon-pix/tests/integration/components/module/qrocm_test.gjs
@@ -13,7 +13,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | QROCM', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  const originalDelay = ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY;
+  const originalDelay = ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY;
   let passageEventService, passageEventRecordStub;
 
   hooks.beforeEach(function () {
@@ -23,7 +23,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
 
   hooks.afterEach(function () {
     passageEventRecordStub.restore();
-    ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = originalDelay;
+    ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY = originalDelay;
   });
 
   test('should display a block QROCM', async function (assert) {
@@ -300,7 +300,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
       };
       const userResponse = 'user-response';
       const onElementAnswerSpy = sinon.spy();
-      ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = 10;
+      ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY = 10;
 
       // when
       const screen = await render(
@@ -314,7 +314,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
 
       // then
       assert.dom(input).hasAttribute('readonly');
-      await clock.tick(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY);
+      await clock.tick(ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY);
       sinon.assert.calledWith(onElementAnswerSpy, {
         userResponse: [
           {
@@ -547,7 +547,7 @@ module('Integration | Component | Module | QROCM', function (hooks) {
           },
           type: 'qrocm',
         };
-        ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY = 10;
+        ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY = 10;
         const onElementAnswerSpy = sinon.stub();
 
         // when
@@ -559,12 +559,12 @@ module('Integration | Component | Module | QROCM', function (hooks) {
         await click(verifyButton);
 
         // then
-        await clock.tick(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY + 1);
+        await clock.tick(ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY + 1);
         assert.dom(input).hasNoAttribute('readonly');
 
         await fillIn(screen.getByLabelText('Réponse 1'), 'Réponse 1');
         await click(verifyButton);
-        await clock.tickAsync(ENV.APP.MODULIX_QROCM_VERIFICATION_DELAY + 1);
+        await clock.tickAsync(ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY + 1);
         assert.dom(screen.getByText('Correct!')).exists();
         assert.dom(screen.getByText('Good job!')).exists();
         assert.ok(true);


### PR DESCRIPTION
## 🍂 Problème

Il n'y a pas d'uniformité dans les délais utilisés selon certains composants :
- Le QROCM utilise une variable d'environnement qui existe dans le fichier `environment.js`
- Les autres éléments pour lesquels on veut simuler un délai de réponse (QCM, QCU) utilise comme valeur de délai une constante déclarée dans `element.gjs` 

## 🌰 Proposition

Utiliser une seule et même variable d'env, `MODULIX_VERIFICATION_RESPONSE_DELAY`, pour tous les components _answerable_ des modules. 
Cela permet de donner une valeur de 0 pour ce délai pour les tests, et ainsi les accélérer.

## 🍁 Remarques

- Dans les tests des grains, pour le QCM, il y a un cas erroné à corriger ultérieurement : si l'utilisateur ne sélectionne aucune réponse et clique sur `Vérifier`, aucun délai ne doit apparaître

## 🪵 Pour tester

// Dans Modulix
- Aller dans le [bac-a-sable](https://app-pr14034.review.pix.fr/modules/bac-a-sable)
- Dans le premier stepper, répondre à toutes les étapes en vérifiant que le comportement est identique à ce qu'il y a en prod


// Dans la CI
- Les tests doivent être OK

