### PR TITLE
[FEATURE] Modification d'un lien URL afin qu'il pointe vers le contenu en NL (PIX-20178)

### DIFF
--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1141,7 +1141,7 @@
           },
           "description": "Pix laat je kiezen welk bestandsformaat je wilt downloaden. Als je niet weet welke optie je moet kiezen, houd dan de standaardkeuze aan. Dit is het bestandsformaat dat door het grootste aantal softwaretoepassingen wordt ondersteund.",
           "file-type": "bestand .{fileExtension}",
-          "help": "Hulp nodig bij het '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, wijzig of vind dit bestand (openen in nieuw venster)\">'openen, wijzigen of vinden van dit bestand'</a>'?"
+          "help": "Hulp nodig bij het '<a href=\"https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, wijzig of vind dit bestand (openen in nieuw venster)\">'openen, wijzigen of vinden van dit bestand'</a>'?"
         },
         "sr-only": {
           "alternative-instruction": "Deze proefdruk bevat een illustratie met een tekstalternatief.",


### PR DESCRIPTION
## 🍂 Problème

Certaines épreuves proposent à l'utilisateur d'avoir une aide pour manipuler des fichiers. Cette aide est hébergée sur Pix Site. Lorsque l'utilisateur est néerlandophone, l'URL pointe vers le contenu en anglais au lieu du contenu en néerlandais.

## 🌰 Proposition

Lorsque l'utilisateur clique sur le lien, il arrive sur le contenu en néerlandais.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

https://editor.pix.fr/api/challenges/rec2Q7gDClZYysUJ4/preview?locale=nl 
https://editor.pix.fr/api/challenges/recH3lcXFAAX6U6aj/preview?locale=nl 

-> Vérifier que le lien dans chacune des épreuves pointe bien vers le contenu en NL : https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen