### PR TITLE
[TECH] Retirer la quote lors de la génération du JSON lorsque l'on utilise l'id du profile cible (PIX-20013).

### DIFF
--- a/admin/app/components/combined-courses/form.gjs
+++ b/admin/app/components/combined-courses/form.gjs
@@ -36,7 +36,7 @@ export default class CombineCourseForm extends Component {
         comparison: 'all',
         data: {
           targetProfileId: {
-            data: this.itemId,
+            data: Number(this.itemId),
             comparison: 'equal',
           },
         },

--- a/admin/app/templates/authenticated/combined-course-creator.gjs
+++ b/admin/app/templates/authenticated/combined-course-creator.gjs
@@ -1,0 +1,3 @@
+import CombinedCourseForm from 'pix-admin/components/combined-courses/form';
+
+<template><CombinedCourseForm /></template>

--- a/admin/app/templates/authenticated/combined-course-creator.hbs
+++ b/admin/app/templates/authenticated/combined-course-creator.hbs
@@ -1,1 +1,0 @@
-<CombinedCourses::Form />


### PR DESCRIPTION
## 🍂 Problème

Lorsque l'on générer un JSON de quêtes pour un parcours combiné. nous laisson l'id du profil cible comme une string alors que c'est un Number

## 🌰 Proposition

Caster l'input en number pour l'ajout de l'id du profile cible

## 🍁 Remarques

Passage du template en gjs, c'est plus joli

## 🪵 Pour tester

aller sur PixAdmin /combined-course-creator 

Vérifier que lorsque l'on génére un JSON avec un targetProfileId celui ci est bien casté en Number et non en String
