### PR TITLE
[FEATURE] Afficher un bouton de création d'orga fille depuis la page d'une orga mère (PIX-20049)

### DIFF
--- a/admin/app/components/organizations/children/actions-section.gjs
+++ b/admin/app/components/organizations/children/actions-section.gjs
@@ -1,0 +1,32 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import { hash } from '@ember/helper';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+import AttachChildForm from './attach-child-form';
+
+export default class ActionsSection extends Component {
+  @service accessControl;
+
+  <template>
+    <section class="page-section">
+      <div class="content-text content-text--small organization-children__actions-section">
+        {{#unless @organization.parentOrganizationId}}
+
+          <PixButtonLink
+            @iconBefore="add"
+            @variant="secondary"
+            @route="authenticated.organizations.new"
+            @query={{hash parentOrganizationId=@organization.id parentOrganizationName=@organization.name}}
+          >{{t "components.organizations.children.create-child-organization-button"}}</PixButtonLink>
+
+        {{/unless}}
+
+        {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
+          <AttachChildForm @onFormSubmitted={{@onAttachChildSubmitForm}} />
+        {{/if}}
+      </div>
+    </section>
+  </template>
+}

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -7,6 +7,7 @@ export default class NewController extends Controller {
   @service pixToast;
   @service router;
   @service intl;
+  @service store;
 
   queryParams = ['parentOrganizationId', 'parentOrganizationName'];
 
@@ -38,6 +39,12 @@ export default class NewController extends Controller {
     try {
       await this.model.save();
       this.pixToast.sendSuccessNotification({ message: 'L’organisation a été créée avec succès.' });
+
+      if (this.model.parentOrganizationId) {
+        const parentOrganization = await this.store.findRecord('organization', this.model.parentOrganizationId);
+        await parentOrganization.hasMany('children').reload();
+      }
+
       this.router.transitionTo('authenticated.organizations.get.all-tags', this.model.id);
     } catch {
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -17,6 +17,7 @@
 @use 'authenticated/certification-center/index' as *;
 @use 'authenticated/organizations/get' as *;
 @use 'authenticated/organizations/all-tags' as *;
+@use 'authenticated/organizations/children.scss' as *;
 @use 'authenticated/sessions/list' as *;
 @use 'authenticated/sessions/session/certifications' as *;
 @use 'authenticated/sessions/session/informations' as *;

--- a/admin/app/styles/authenticated/organizations/children.scss
+++ b/admin/app/styles/authenticated/organizations/children.scss
@@ -1,0 +1,6 @@
+.organization-children__actions-section {
+  display: flex;
+  gap: var(--pix-spacing-10x);
+  align-items: end;
+  justify-content: flex-start;
+}

--- a/admin/app/templates/authenticated/organizations/get/children.gjs
+++ b/admin/app/templates/authenticated/organizations/get/children.gjs
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
-import AttachChildForm from 'pix-admin/components/organizations/children/attach-child-form';
+import ActionsSection from 'pix-admin/components/organizations/children/actions-section';
 import List from 'pix-admin/components/organizations/children/list';
 
 export default class Children extends Component {
@@ -13,13 +13,14 @@ export default class Children extends Component {
 
   <template>
     {{pageTitle "Children"}}
-    {{#if @controller.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
-      <section class="page-section">
-        <div class="content-text content-text--small">
-          <AttachChildForm @onFormSubmitted={{@controller.handleFormSubmitted}} />
-        </div>
-      </section>
+    {{#if @controller.accessControl.hasAccessToOrganizationActionsScope}}
+
+      <ActionsSection
+        @onAttachChildSubmitForm={{@controller.handleFormSubmitted}}
+        @organization={{@model.organization}}
+      />
     {{/if}}
+
     <section class="page-section">
       <header class="page-section__header">
         <h2 class="page-section__title">{{t "pages.organization-children.title"}}</h2>

--- a/admin/tests/integration/components/organizations/children/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/children/actions-section-test.gjs
@@ -1,0 +1,124 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { t } from 'ember-intl/test-support';
+import ActionsSection from 'pix-admin/components/organizations/children/actions-section';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/children/actions-section', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let store;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('create child organization button', function (hooks) {
+    hooks.beforeEach(async function () {
+      class AccessControlStub extends Service {}
+      this.owner.register('service:access-control', AccessControlStub);
+    });
+
+    test('it should display create child organization button', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', {
+        id: 1,
+        name: 'Orga 1',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+
+    test('it should not display create child organization button if organization is already a child', async function (assert) {
+      // given
+      const childOrganization = store.createRecord('organization', {
+        id: 2,
+        name: 'Orga 2',
+        parentOrganizationId: '1234',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection
+            @organization={{childOrganization}}
+            @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}}
+          />
+        </template>,
+      );
+
+      assert.notOk(
+        screen.queryByRole('link', { name: t('components.organizations.children.create-child-organization-button') }),
+      );
+    });
+  });
+
+  module('when user have access to attach child organization actions scope', function () {
+    test('it should display attach child organization form', async function (assert) {
+      // given
+      class AccessControlStub extends Service {
+        hasAccessToAttachChildOrganizationActionsScope = true;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const organization = store.createRecord('organization', {
+        id: 1,
+        name: 'Orga 1',
+      });
+
+      const onAttachChildSubmitFormStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template>
+          <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+        </template>,
+      );
+
+      assert.ok(screen.getByRole('form', { name: t('components.organizations.children.attach-child-form.name') }));
+    });
+
+    module('when user does not have access to attach child organization actions scope', function () {
+      test('it should not display attach child organization form ', async function (assert) {
+        // given
+        class AccessControlStub extends Service {
+          hasAccessToAttachChildOrganizationActionsScope = false;
+        }
+        this.owner.register('service:access-control', AccessControlStub);
+
+        const organization = store.createRecord('organization', {
+          id: 1,
+          name: 'Orga 1',
+        });
+
+        const onAttachChildSubmitFormStub = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <ActionsSection @organization={{organization}} @onAttachChildSubmitForm={{onAttachChildSubmitFormStub}} />
+          </template>,
+        );
+
+        assert.notOk(
+          screen.queryByRole('form', { name: t('components.organizations.children.attach-child-form.name') }),
+        );
+      });
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/new-test.js
@@ -1,12 +1,90 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntl from '../../../../helpers/setup-intl';
 
 module('Unit | Controller | authenticated/organizations/new', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    const controller = this.owner.lookup('controller:authenticated/organizations/new');
-    assert.ok(controller);
+  let controller;
+  let store;
+  let notifications;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/organizations/new');
+    store = this.owner.lookup('service:store');
+    notifications = this.owner.lookup('service:pixToast');
+    sinon.stub(notifications, 'sendSuccessNotification');
+  });
+
+  module('#addOrganization', function (hooks) {
+    let event;
+
+    hooks.beforeEach(function () {
+      event = {
+        preventDefault: sinon.stub(),
+      };
+    });
+
+    module('when creating child organization with parentOrganizationId', function () {
+      test('it should call reload children model', async function (assert) {
+        // given
+        const reloadStub = sinon.stub();
+
+        const organizationModelStub = {
+          parentOrganizationId: '123',
+          name: 'New Child Orga',
+          type: 'SCO',
+          administrationTeamId: '456',
+          save: sinon.stub(),
+        };
+        controller.model = organizationModelStub;
+
+        const parentOrganizationModelStub = {
+          hasMany: sinon.stub(),
+        };
+        parentOrganizationModelStub.hasMany.withArgs('children').returns({ reload: reloadStub });
+
+        const findParentOrganizationModelStub = sinon
+          .stub(store, 'findRecord')
+          .withArgs('organization', organizationModelStub.parentOrganizationId);
+
+        findParentOrganizationModelStub.returns(parentOrganizationModelStub);
+
+        // when
+        await controller.addOrganization(event);
+
+        // then
+        assert.true(findParentOrganizationModelStub.calledOnce);
+        assert.true(reloadStub.calledOnce);
+      });
+    });
+
+    module('when creating organization with no parentOrganizationId', function (hooks) {
+      let organizationModelStub;
+      hooks.beforeEach(function () {
+        organizationModelStub = {
+          parentOrganizationId: null,
+          name: 'New Orga',
+          type: 'SCO',
+          administrationTeamId: '456',
+          save: sinon.stub(),
+        };
+        controller.model = organizationModelStub;
+      });
+
+      test('it should not call find parent organization model', async function (assert) {
+        // given
+        const findParentOrganizationModelStub = sinon.stub(store, 'findRecord');
+
+        // when
+        await controller.addOrganization(event);
+
+        // then
+        assert.true(findParentOrganizationModelStub.notCalled);
+      });
+    });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -546,7 +546,8 @@
           "input-information": "ID of organisation(s) to add",
           "input-label": "Add one or more child organisations",
           "name": "Add child organisation(s) form"
-        }
+        },
+        "create-child-organization-button": "Create a child organization"
       },
       "children-list": {
         "actions": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -547,7 +547,8 @@
           "input-information": "ID d'organisation(s) à ajouter",
           "input-label": "Ajouter une ou plusieurs organisations filles",
           "name": "Formulaire d'ajout d'organisation(s) fille(s)"
-        }
+        },
+        "create-child-organization-button": "Créer une organisation fille"
       },
       "children-list": {
         "actions": {


### PR DESCRIPTION
## 🍂 Problème

Actuellement sur Pix Admin, pour créer une organisation fille, il faut créer une organisation "classique" puis la rattacher depuis la page de la mère. On souhaite simplifier ce processus.

## 🌰 Proposition

Depuis la page d'une orga, ajouter un bouton permettant de créer directement une orga fille déjà rattachée à sa mère.
Cette PR est la suite de celle-ci: https://github.com/1024pix/pix/pull/13956

## 🍁 Remarques

La création d'orga fille est limitée aux rôles ayant l'autorisation de créer une orga "classique" (SUPER_ADMIN, METIER, SUPPORT). Lorsqu'on est sur la page d'une orga fille, on ne souhaite pas afficher ce bouton car il n'est pour le moment pas possible pour une orga fille d'avoir des orgas filles (un seul niveau).

## 🪵 Pour tester

Sur Pix Admin, connecté en tant que SUPER_ADMIN, METIER ou SUPPORT:
- aller sur la page d'une orga classique ou d'une orga mère
- sur l'onglet **Organisations filles**, constater la présence d'un bouton **Créer une organisation fille** à côté du formulaire de rattachement
- au clique sur ce bouton, constater qu'on est redirigé vers le formulaire de création d'orga fille
- remplir les infos de base et soumettre le formulaire
- sans recharger la page, naviguer vers la page de l'orga mère et constater dans l'onglet **Organisations filles** que la nouvelle orga fille s'est ajoutée à la liste

- naviguer sur la page d'une orga fille
- constater que le bouton n'est pas accessible

Sur Pix Admin, connecté en tant que CERTIF:
- constater que le bouton n'est pas accessible

<img width="920" height="452" alt="Capture d’écran 2025-10-30 à 17 01 47" src="https://github.com/user-attachments/assets/ffeaae6f-ef6e-4224-9683-5dae843bc5d1" />
