### PR TITLE
[TECH] Mise à jour majeure de epreuves-components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^1.5.1",
+        "@1024pix/epreuves-components": "^2.0.0",
         "@1024pix/eslint-plugin": "^2.1.13",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.5.1.tgz",
-      "integrity": "sha512-5vq444nj2LBdg4H9VbOn49ENM/+NpX6dFQz1VAMh0/rEZpyFWSp0poMwE8STty0fVK1C+3ZaI+PN4MXoF1Gq8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.0.0.tgz",
+      "integrity": "sha512-oCqljBnUsu9vAxBzLy5p9z4dOBQY2ebkoM/y2a6rAU6Maho6n50nab2juFlCLc4rNBGUIcRz3D02qrxI4aZ2ug==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -450,7 +450,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.896.0.tgz",
       "integrity": "sha512-UETVuMLQRqgrWxTnavotY0TlB/jaR9sL3hkIFPx4KtjmigNBdwRaiVfOuTnIXKd+w9RPINYG//nnrK+5gIyZkA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1187,6 +1186,7 @@
       "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1265,6 +1265,7 @@
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -1292,6 +1293,7 @@
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -1306,6 +1308,7 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -1354,6 +1357,7 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1364,6 +1368,7 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -2018,7 +2023,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.3.tgz",
       "integrity": "sha512-Q7g0ZY4gxU69wabFKH75qR0AFOdiOECj6vGqTHBSO5Lrwe6TwD8r9LkYQIbvtG8N423VDpdVsiZP8MnBwmD6Hw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@hapi/accept": "^6.0.3",
         "@hapi/ammo": "^6.0.1",
@@ -2419,6 +2423,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2430,6 +2435,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2441,6 +2447,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -2474,6 +2481,7 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -3077,7 +3085,8 @@
       "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3936,7 +3945,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -4363,7 +4371,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4678,7 +4685,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4838,7 +4844,6 @@
       "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5223,7 +5228,8 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-js-compat": {
       "version": "3.45.1",
@@ -5870,7 +5876,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5960,7 +5965,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7142,6 +7146,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7568,7 +7573,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7852,7 +7856,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.0.tgz",
       "integrity": "sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.4.0",
         "cluster-key-slot": "^1.1.0",
@@ -8062,6 +8065,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
@@ -8079,6 +8083,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8093,6 +8098,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -8114,7 +8120,6 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -8846,6 +8851,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -8881,7 +8887,6 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -10145,7 +10150,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10513,7 +10517,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10742,7 +10745,8 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/read-package-json-fast": {
       "version": "4.0.0",
@@ -11567,7 +11571,6 @@
       "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.5",
@@ -12277,7 +12280,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -12725,7 +12727,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^1.5.1",
+    "@1024pix/epreuves-components": "^2.0.0",
     "@1024pix/eslint-plugin": "^2.1.13",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -563,28 +563,7 @@
                 "tagName": "capacity-calculation",
                 "props": {
                   "titleLevel": 0,
-                  "images": {
-                    "initial": {
-                      "capacityImg": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity1.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-initial.svg"
-                    },
-                    "normal_weak": {
-                      "capacityImg": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity2.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                    },
-                    "normal_medium": {
-                      "capacityImg": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity3.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                    },
-                    "warning": {
-                      "capacityImg": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity4.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-warning.svg"
-                    },
-                    "error": {
-                      "capacityImg": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity5.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-error.svg"
-                    }
-                  }
+                  "capacityImage": "https://assets.pix.org/modules/les-ia-consomment/poi-requetes-multiples/supercalculator_capacity1.svg"
                 }
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -38,28 +38,7 @@
                 "tagName": "capacity-calculation",
                 "props": {
                   "titleLevel": 2,
-                  "images": {
-                    "initial": {
-                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-initial.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-initial.svg"
-                    },
-                    "normal_weak": {
-                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                    },
-                    "normal_medium": {
-                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-normal.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-normal.svg"
-                    },
-                    "warning": {
-                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-warning.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-warning.svg"
-                    },
-                    "error": {
-                      "capacityImg": "https://assets.pix.org/modules/capacity-calculation/capacity-error.svg",
-                      "consumptionImg": "https://assets.pix.org/modules/capacity-calculation/consumption-error.svg"
-                    }
-                  }
+                  "capacityImage": "https://assets.pix.org/modules/capacity-calculation/capacity-initial.svg"
                 }
               }
             }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.24",
-        "@1024pix/epreuves-components": "^1.5.1",
+        "@1024pix/epreuves-components": "^2.0.0",
         "@1024pix/eslint-plugin": "^2.1.13",
         "@1024pix/pix-ui": "^55.30.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.5.1.tgz",
-      "integrity": "sha512-5vq444nj2LBdg4H9VbOn49ENM/+NpX6dFQz1VAMh0/rEZpyFWSp0poMwE8STty0fVK1C+3ZaI+PN4MXoF1Gq8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.0.0.tgz",
+      "integrity": "sha512-oCqljBnUsu9vAxBzLy5p9z4dOBQY2ebkoM/y2a6rAU6Maho6n50nab2juFlCLc4rNBGUIcRz3D02qrxI4aZ2ug==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -788,7 +788,6 @@
       "integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "autoprefixer": "^9.0.0",
         "balanced-match": "^1.0.0",
@@ -961,7 +960,6 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2696,7 +2694,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2720,7 +2717,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2811,7 +2807,6 @@
       "integrity": "sha512-JNaR41QlA4R1mXJKbI2S2+Zdy3ysoArAQmfnHouDXWezQD6NpgKgmfLmCqxtdHkAVQ8ttnAMx/S/A2fPTVaeyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -2830,7 +2825,6 @@
       "integrity": "sha512-n0Woiu4oEiJmqfLa5xM9fbhY7+nntncdgWrJfYO1IMEcuO0fbmZVLPye1wTjUIog7uwmjD1uP0u63MnKyqOSeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -2851,7 +2845,6 @@
       "integrity": "sha512-b043cU5k+gT+E2YT4ujHoea/81gmYrZTu6Yvt5n87YoCP0p5UxJWji11BTYfJAYN0sf1QAl+OkxI1BX7Ed1Q0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -2883,7 +2876,6 @@
       "integrity": "sha512-vg7hIzQmDXCDapUZc6kawKE2IAD9A4RowQBmBD7gR7TWtzinmoSygHYHjZpVdAEV4JE3EI1gjbyQesRLoAub1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.16.1",
@@ -2929,7 +2921,6 @@
       "integrity": "sha512-urAzDc+MvpmIzr2olMphG9DhwKrdYJOyywhT+fHnzCvezQoMgoBpkr40uCM2IX4Ge0+a9MklcSViA6kpLq2izQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0",
         "@embroider/macros": "^1.16.1",
@@ -2948,7 +2939,6 @@
       "integrity": "sha512-cMcSoxRLv7mhHABeFWLivZhp7k9Lp0UZB+KPNrnbCXZ7T+b4C/BhQvbpTXYJwj7V/m47dlPzM/c0I2cfdmhzNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -3007,7 +2997,6 @@
       "integrity": "sha512-ZxqHgiKZrqXdetlriv4VOPjqrEre2rqaLFWOHkjjKqzsp2AkmGkcrh/DS6i9Y4/5F9hYxb9lxyyJqOW7sr57yQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -3028,7 +3017,6 @@
       "integrity": "sha512-1zbz1yDgx8HDditG3DHnl8xsvBAwguT/WcBRZRj5kEtDVELwCY1N+cCtxMRPVgunKgP2UCVJPfnXkgqYvEsG4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -3852,7 +3840,6 @@
       "integrity": "sha512-hZ+fZCz8uPKdCoZM4fMsn3dxmJq4/v86PKgrorrFlqeMqSQ3JrYM/tL4uwfKx1VQtYSWTRSsPMv1YoiWBTucsA==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.8.7",
@@ -3871,7 +3858,6 @@
       "integrity": "sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -4633,7 +4619,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5042,7 +5027,6 @@
       "integrity": "sha512-5vt2lX0jss/8Qk5ls9NrIpXx5dYMb1uuiMC2yTEj8vaBo+5Im/YJoJ0HR3VS4EGy1OB69yAASu+noyPajU7fvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -6873,6 +6857,7 @@
       "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       },
@@ -6885,21 +6870,24 @@
       "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
       "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/hoek": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
       "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
       "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/tlds": {
       "version": "1.1.3",
@@ -6907,6 +6895,7 @@
       "integrity": "sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6917,6 +6906,7 @@
       "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       }
@@ -7234,7 +7224,8 @@
       "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
       "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -7770,7 +7761,8 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -8137,7 +8129,6 @@
       "integrity": "sha512-GHQE+woaGdRDGj6VG3Qt0uGBNog1zq5XO2Ccce35cYPpM3FOCOdmqB4Wt0miD1bBdbAuWQZmmQOIYAMSMCOdZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.1",
         "@warp-drive/build-config": "0.0.0-beta.6"
@@ -8365,7 +8356,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8439,7 +8429,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11092,7 +11081,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -15393,7 +15381,6 @@
       "integrity": "sha512-ZFd0dxTCkX5OHe/Xdfpglg+3OELsd0xNFziogoKV0JPLzyXmasn/8vAeHeUta9rAJDYH8lix3/1t6iIeY+DzYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember-data/adapter": "5.3.8",
         "@ember-data/debug": "5.3.8",
@@ -15562,7 +15549,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -19343,7 +19329,6 @@
       "integrity": "sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -20112,7 +20097,6 @@
       "integrity": "sha512-9DgjczFG7ZjINmwWFYDtUF8McbYqQir82hyFp/ZbMOLkpFvHCKPw1mtKcpcdLnLAAYJpwR2/MCyPNiEMkR11aA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.6",
         "@embroider/macros": "^1.13.1",
@@ -20849,7 +20833,6 @@
       "integrity": "sha512-abDPPq9gHB5u5kOY125QBUlm5D1oc+n9Pm2zRciFpxwRV9WXfqiAHMmEhcIWD0uV1E3jhBgqXoHP8CCGBcI2WA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
@@ -22640,7 +22623,6 @@
       "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -22730,7 +22712,6 @@
       "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "build/bin/cli.js"
       },
@@ -23675,7 +23656,8 @@
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
       "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -25592,7 +25574,8 @@
       "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
       "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/inflection": {
       "version": "2.0.1",
@@ -27644,7 +27627,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -29320,7 +29302,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -29660,7 +29641,6 @@
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -29688,6 +29668,7 @@
       "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fake-xml-http-request": "^2.1.2",
         "route-recognizer": "^0.3.3"
@@ -29699,7 +29680,6 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -29977,7 +29957,6 @@
       "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.24.0.tgz",
       "integrity": "sha512-i+rJThg6YxrIAywbcS0Qr/KEO6bBH92LOeuTNC0dfFR2FbdtonVm6LQHDGwz/BB1fOuFSaE4+FEmNbxnxl+OFg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
@@ -30811,8 +30790,7 @@
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
       "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/router_js": {
       "version": "8.0.6",
@@ -30844,7 +30822,6 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -32618,7 +32595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -33131,7 +33107,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -33568,7 +33543,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -35200,7 +35174,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -35260,7 +35233,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -35305,7 +35277,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.24",
-    "@1024pix/epreuves-components": "^1.5.1",
+    "@1024pix/epreuves-components": "^2.0.0",
     "@1024pix/eslint-plugin": "^2.1.13",
     "@1024pix/pix-ui": "^55.30.0",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.24",
-        "@1024pix/epreuves-components": "^1.5.1",
+        "@1024pix/epreuves-components": "^2.0.0",
         "@1024pix/eslint-plugin": "^2.1.13",
         "@1024pix/pix-ui": "^55.31.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-1.5.1.tgz",
-      "integrity": "sha512-5vq444nj2LBdg4H9VbOn49ENM/+NpX6dFQz1VAMh0/rEZpyFWSp0poMwE8STty0fVK1C+3ZaI+PN4MXoF1Gq8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.0.0.tgz",
+      "integrity": "sha512-oCqljBnUsu9vAxBzLy5p9z4dOBQY2ebkoM/y2a6rAU6Maho6n50nab2juFlCLc4rNBGUIcRz3D02qrxI4aZ2ug==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1873,7 +1873,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3679,7 +3678,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3703,7 +3701,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3819,7 +3816,6 @@
       "integrity": "sha512-F1gC7F/WyZHuR2Y14uYnPMMVAjoOIBiKr5WUGUb6or6JQBcV4eJpJnIELvJFPnBPdI+dD0acWLNx/78ibdy6Bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -3838,7 +3834,6 @@
       "integrity": "sha512-aBXnYPRLYkU1JKxLyzbUQXva7suZ7o/New7QMC/LWi408lbrqPYgKENW72Nd8XmWVvRubBxMEJd4hbPcsQ+zdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0",
@@ -3861,7 +3856,6 @@
       "integrity": "sha512-tnnBJzrU4Np7ThVHPAPUMiWdz4CRpv/AH2WMdc77O2gshBb5GkUsu2IAMTW47s0dJSVvibJAZ082TbNHCBqj5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -3894,7 +3888,6 @@
       "integrity": "sha512-/F1YWrGDCE9kNEAGgisfx2wzTgYC2yWIRocjrDe8e+opskv+bJAM/a5N/jqfJSzNipLc26BOTStvo8HPtCTu4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.16.12",
@@ -3930,7 +3923,6 @@
       "integrity": "sha512-Omu39FbKiDylq8PVnKnXsjljWa6qIyQx65O0hNAasNi2rV1Uhv04g0UBZ3L0L+7R6Od8n1/9aqbrcfK/oNEhHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -3949,7 +3941,6 @@
       "integrity": "sha512-tObMa2LIYqQ+QPNasbv4UNN44t5r/z5It2nuhcG2m04nJRBnOGvT0HPRwvdznANRNSDEv9L4QwRCrvIW+xbOwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -4010,7 +4001,6 @@
       "integrity": "sha512-4Oa3ObaqkSZ0ESRuLcITn1fmXdhkbcsvfFskH3sh4VmQW1kylTgS7qlU5n2nJE7GqMw43IM2ta/s1F0DFKC9Vw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -4041,7 +4031,6 @@
       "deprecated": "Use @warp-drive/ember",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -4082,7 +4071,6 @@
       "integrity": "sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6"
       },
@@ -4782,7 +4770,6 @@
       "integrity": "sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.8.7",
@@ -4798,7 +4785,6 @@
       "integrity": "sha512-qRFA0OumYv7/C3hmx4ETC2dlPzyD549D+naPhcrnV2xCnc3AZlKouWyoFnNF+Cje918kRp9aEefVgV3vmGL5Bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.9.0",
         "@embroider/macros": "^1.16.9"
@@ -4856,7 +4842,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5950,7 +5935,6 @@
       "integrity": "sha512-0oytko2+iaYS31TG9Axj7Py0e0FAccUhu9J1h7ldEnQegK+Eu5+OINU0dYQgt0ijp6f2yF4+o3J7u9CJCLZ1gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -10354,6 +10338,7 @@
       "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       },
@@ -10366,21 +10351,24 @@
       "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
       "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/hoek": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
       "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
       "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@hapi/tlds": {
       "version": "1.1.3",
@@ -10388,6 +10376,7 @@
       "integrity": "sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -10398,6 +10387,7 @@
       "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       }
@@ -11280,7 +11270,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -11598,7 +11587,8 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -11606,7 +11596,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -12156,7 +12145,6 @@
       "integrity": "sha512-PWc3QI9Ykc6zqGH0UUEuSthIaPN60WjKBUsievhD4YB5sjMVqRFIawrrD1Z9SOd2cgmidAJWDNT/zWsi7OI2OQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.12",
         "@warp-drive/build-config": "5.5.0"
@@ -12415,7 +12403,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12449,7 +12436,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15022,7 +15008,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -18324,7 +18309,6 @@
       "integrity": "sha512-2qNqaD3iIFeFcYiKsgrsP0qdEilvT820+vX2Fz1x32XIgcsmy79ufc0rHrsHmEiazSQLC9XKUskwEzFBWjy54g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pnpm/find-workspace-dir": "^1000.1.0",
         "babel-remove-types": "^1.0.1",
@@ -21030,7 +21014,6 @@
       "integrity": "sha512-qAuVKeCXn4tiqON9orbjS7H3iitCw5GC+XGdbqRk4Ow2phn/RRsCWf98KJLtB8tmflyp4l3Q1o4nJwjsNeDpeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember-data/adapter": "5.5.0",
         "@ember-data/debug": "5.5.0",
@@ -21929,7 +21912,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -24950,7 +24932,6 @@
       "integrity": "sha512-pPYBAGyczX0hedGWQFQOEiL9s45KS9efKxJxUQkMLjQyh+1Uef1mcmAGsdw2KmvNupITkE/nXxmVO1kZ9tt3ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -25701,7 +25682,6 @@
       "integrity": "sha512-t+FD5/EWAR3WvGVj1etblFJJ6CaJqddDxusNcYYFZmW7zrQpCnQ9ziwpXM5/sw1sWabkhJZgYPXCn8bDRRhOfg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.9.0",
         "@embroider/macros": "^1.16.12",
@@ -27126,7 +27106,6 @@
       "integrity": "sha512-se8UFNu9n017VmKry124jc+Mh1ybZ8sAf9IthYYGpdPYH4PRLxBbxa+YEUdtu1vWoKZG2lVthtOUbCmIAjNrpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
@@ -27268,7 +27247,6 @@
       "integrity": "sha512-uh5WU2sJKkQgDgIQovwv1D0fw2/RJnmyAHqIhaTYk68CfKQ/O5v31c1iXNu71qv3xeONi3QPl/rBW0EMdIFXWA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lint-todo/utils": "^13.1.1",
         "content-tag": "^3.1.1"
@@ -29159,7 +29137,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -29250,7 +29227,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -34506,7 +34482,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -34622,7 +34597,6 @@
       "integrity": "sha512-MGZAq0Q3OuRYgZKvlB69z4gLN4G3PvgC4A2zhkCXCXrLD5wm2cCnwNB59xOBVA+srZ0zEes6u+VylcPIkB4SqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
         "inflected": "^2.0.4",
@@ -36265,7 +36239,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -36648,7 +36621,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -36673,7 +36645,6 @@
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -36712,7 +36683,6 @@
       "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -37007,7 +36977,6 @@
       "integrity": "sha512-Eu0k/5JDjx0QnqxsE1WavnDNDgL1zgMZKsMw/AoAxnsl9p4RgyLODyo2N7abZY7CEAnvl5YUqFZdkImzbgXzSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
@@ -37856,8 +37825,7 @@
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
       "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/router_js": {
       "version": "8.0.6",
@@ -37889,7 +37857,6 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -39779,7 +39746,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -40519,7 +40485,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -41068,7 +41033,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -42190,7 +42154,6 @@
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -42249,7 +42212,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.24",
-    "@1024pix/epreuves-components": "^1.5.1",
+    "@1024pix/epreuves-components": "^2.0.0",
     "@1024pix/eslint-plugin": "^2.1.13",
     "@1024pix/pix-ui": "^55.31.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🍂 Problème
Des modifications du POI `capacity-calculation` provoquent une mise à jour majeure du package concerné.
### Breaking Change
Les props se limitent maintenant à deux propriétés `titleLevel` et `capacityImage`

## 🌰 Proposition
Mettre à jour le package, modifier la page de démo de modules ET les (ici le) module(s) utilisant le POI `capacity-calculation`

## 🍁 Remarques
On vérifie les PR en draft pour modifier dès maintenant les props du POI.

## 🪵 Pour tester
Aller sur la page de démo et vérifier que le POI capacity calculation fonctionne toujours. (Il y a aussi un changement dans le design, ainsi que sur le wording)