### PR TITLE
[FEATURE] Conditionner l'affichage de la colonne Campagnes et Modules d'un parcours combiné (PIX-20112) 

### DIFF
--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -196,16 +196,58 @@ function buildProCombinedCourseQuest(databaseBuilder, organizationId) {
     }),
   );
 
-  databaseBuilder.factory.buildCombinedCourse({
-    name: 'Combinix 3',
-    code: 'COMBINIX3',
-    createdAt: new Date('2024-01-01'),
-    description: 'Combinix créé à une date antérieure au Combinix 2 pour tester le tri par date de création',
+  const combinix4 = databaseBuilder.factory.buildCombinedCourse({
+    name: 'Combinix 4',
+    code: 'COMBINIX4',
+    createdAt: new Date('2023-01-01'),
+    description: 'Parcours combiné sans campagne.',
     illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
     organizationId,
     eligibilityRequirements: [],
-    successRequirements: [],
+    successRequirements: [
+      {
+        requirement_type: 'passages',
+        comparison: 'all',
+        data: {
+          moduleId: {
+            data: '65b761ab-3ebd-44a9-84b7-8b5e151aee76',
+            comparison: 'equal',
+          },
+          isTerminated: {
+            data: true,
+            comparison: 'equal',
+          },
+        },
+      },
+    ],
   });
+
+  const combinix3 = databaseBuilder.factory.buildCombinedCourse({
+    name: 'Combinix 3',
+    code: 'COMBINIX3',
+    createdAt: new Date('2024-01-01'),
+    description: 'Parcours combiné sans module.',
+    illustration: 'https://assets.pix.org/combined-courses/illu_ia.svg',
+    organizationId,
+    eligibilityRequirements: [],
+    successRequirements: [
+      {
+        requirement_type: 'campaignParticipations',
+        comparison: 'all',
+        data: {
+          campaignId: {
+            data: campaign.id,
+            comparison: 'equal',
+          },
+          status: {
+            data: 'SHARED',
+            comparison: 'equal',
+          },
+        },
+      },
+    ],
+  });
+
   const combinix2 = databaseBuilder.factory.buildCombinedCourse({
     name: 'Combinix 2',
     code: 'COMBINIX2',
@@ -287,6 +329,18 @@ function buildProCombinedCourseQuest(databaseBuilder, organizationId) {
   });
   databaseBuilder.factory.buildOrganizationLearnerParticipation({
     combinedCourseId: combinix2.id,
+    type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+    organizationLearnerId: bernardLearner.id,
+    status: OrganizationLearnerParticipationStatuses.STARTED,
+  });
+  databaseBuilder.factory.buildOrganizationLearnerParticipation({
+    combinedCourseId: combinix3.id,
+    type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+    organizationLearnerId: bernardLearner.id,
+    status: OrganizationLearnerParticipationStatuses.STARTED,
+  });
+  databaseBuilder.factory.buildOrganizationLearnerParticipation({
+    combinedCourseId: combinix4.id,
     type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
     organizationLearnerId: bernardLearner.id,
     status: OrganizationLearnerParticipationStatuses.STARTED,

--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -72,6 +72,14 @@ export class CombinedCourseDetails extends CombinedCourse {
     this.participation = participation;
   }
 
+  get hasCampaigns() {
+    return this.campaignIds.length > 0;
+  }
+
+  get hasModules() {
+    return this.moduleIds.length > 0;
+  }
+
   get campaignIds() {
     return this.quest.successRequirements
       .filter((requirement) => requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS)

--- a/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-details-serializer.js
@@ -4,7 +4,15 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (combinedCourse) {
   return new Serializer('combined-courses', {
-    attributes: ['name', 'code', 'campaignIds', 'combinedCourseParticipations', 'combinedCourseStatistics'],
+    attributes: [
+      'name',
+      'code',
+      'hasCampaigns',
+      'hasModules',
+      'campaignIds',
+      'combinedCourseParticipations',
+      'combinedCourseStatistics',
+    ],
     combinedCourseStatistics: {
       ref: 'id',
       nullIfMissing: true,

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -22,6 +22,7 @@ import { domainBuilder, expect } from '../../../../test-helper.js';
 describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
   describe('CombinedCourseDetails', function () {
     let id, organizationId, name, code, questId;
+
     beforeEach(function () {
       id = 1;
       questId = 2;
@@ -29,6 +30,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
       name = 'name';
       code = 'code';
     });
+
     describe('#campaignIds', function () {
       it('should only return ids of all campaigns included in the given combined course', function () {
         // given
@@ -67,10 +69,46 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         );
 
         // when
+        const hasCampaigns = combinedCourse.hasCampaigns;
         const campaignIds = combinedCourse.campaignIds;
 
         // then
+        expect(hasCampaigns).equal(true);
         expect(campaignIds).to.deep.equal([campaignId]);
+      });
+
+      it('should return false to hasCampaign if no campaign on combined course', function () {
+        // given
+        const questWithoutCampaign = new Quest({
+          id: questId,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'passages',
+              comparison: 'all',
+              data: {
+                moduleId: {
+                  data: 7,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code, questId }),
+          questWithoutCampaign,
+        );
+
+        // when
+        const hasCampaigns = combinedCourse.hasCampaigns;
+        const campaignIds = combinedCourse.campaignIds;
+
+        // then
+        expect(hasCampaigns).equal(false);
+        expect(campaignIds).deep.equal([]);
       });
     });
 
@@ -112,10 +150,46 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         );
 
         // when
+        const hasModules = combinedCourse.hasModules;
         const moduleIds = combinedCourse.moduleIds;
 
         // then
+        expect(hasModules).equal(true);
         expect(moduleIds).to.deep.equal([moduleId]);
+      });
+
+      it('should return false to hasModules if no module on combined course', function () {
+        // given
+        const questWithoutModules = new Quest({
+          id: questId,
+          rewardId: null,
+          rewardType: null,
+          eligibilityRequirements: [],
+          successRequirements: [
+            {
+              requirement_type: 'campaignParticipations',
+              comparison: 'all',
+              data: {
+                campaignId: {
+                  data: 2,
+                  comparison: 'equal',
+                },
+              },
+            },
+          ],
+        });
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code, questId }),
+          questWithoutModules,
+        );
+
+        // when
+        const hasModules = combinedCourse.hasModules;
+        const moduleIds = combinedCourse.moduleIds;
+
+        // then
+        expect(hasModules).equal(false);
+        expect(moduleIds).deep.equal([]);
       });
     });
 

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-details-serializer_test.js
@@ -24,6 +24,16 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-details'
               },
             },
           },
+          {
+            requirement_type: 'passages',
+            comparison: 'all',
+            data: {
+              moduleId: {
+                data: 7,
+                comparison: 'equal',
+              },
+            },
+          },
         ],
       }),
     });
@@ -37,6 +47,8 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-details'
         attributes: {
           name: 'Mon parcours',
           code: 'COMBINIX1',
+          'has-campaigns': true,
+          'has-modules': true,
           'campaign-ids': [1],
         },
         relationships: {

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -11,7 +11,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import { eq } from 'ember-truth-helpers';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
 import ParticipationStatus from 'pix-orga/components/ui/participation-status';
 import ENV from 'pix-orga/config/environment';
@@ -106,34 +105,41 @@ export default class CombinedCourse extends Component {
               <ParticipationStatus @status={{participation.status}} />
             </:cell>
           </PixTableColumn>
-          <PixTableColumn @context={{context}} @type="number">
-            <:header>
-              {{t "pages.combined-course.table.column.campaigns"}}
 
-              <Tooltip @content={{t "pages.combined-course.table.tooltip.campaigns-column"}} />
-            </:header>
-            <:cell>
-              <CompletionDisplay
-                @type="campaign"
-                @nbItems={{participation.nbCampaigns}}
-                @nbItemsCompleted={{participation.nbCampaignsCompleted}}
-              />
-            </:cell>
-          </PixTableColumn>
-          <PixTableColumn @context={{context}} @type="number">
-            <:header>
-              {{t "pages.combined-course.table.column.modules"}}
+          {{#if @hasCampaigns}}
+            <PixTableColumn @context={{context}} @type="number">
+              <:header>
+                {{t "pages.combined-course.table.column.campaigns"}}
 
-              <Tooltip @content={{t "pages.combined-course.table.tooltip.modules-column"}} />
-            </:header>
-            <:cell>
-              <CompletionDisplay
-                @type="module"
-                @nbItems={{participation.nbModules}}
-                @nbItemsCompleted={{participation.nbModulesCompleted}}
-              />
-            </:cell>
-          </PixTableColumn>
+                <Tooltip @content={{t "pages.combined-course.table.tooltip.campaigns-column"}} />
+              </:header>
+              <:cell>
+                <CompletionDisplay
+                  @translationKey="pages.combined-course.table.campaign-completion"
+                  @nbItems={{participation.nbCampaigns}}
+                  @nbItemsCompleted={{participation.nbCampaignsCompleted}}
+                />
+              </:cell>
+            </PixTableColumn>
+          {{/if}}
+
+          {{#if @hasModules}}
+            <PixTableColumn @context={{context}} @type="number">
+              <:header>
+                {{t "pages.combined-course.table.column.modules"}}
+
+                <Tooltip @content={{t "pages.combined-course.table.tooltip.modules-column"}} />
+              </:header>
+              <:cell>
+                <CompletionDisplay
+                  @translationKey="pages.combined-course.table.module-completion"
+                  @nbItems={{participation.nbModules}}
+                  @nbItemsCompleted={{participation.nbModulesCompleted}}
+                />
+              </:cell>
+            </PixTableColumn>
+          {{/if}}
+
         </:columns>
       </PixTable>
       {{#if @participations.meta}}
@@ -146,27 +152,10 @@ export default class CombinedCourse extends Component {
 }
 
 const CompletionDisplay = <template>
-  {{#if @nbItems}}
-    <span aria-hidden="true">{{@nbItemsCompleted}}/{{@nbItems}}</span>
-    {{#if (eq @type "campaign")}}
-      <span class="screen-reader-only">{{t
-          "pages.combined-course.table.campaign-completion"
-          count=@nbItemsCompleted
-          nbCampaigns=@nbItems
-        }}
-      </span>
-    {{else}}
-      <span class="screen-reader-only">{{t
-          "pages.combined-course.table.module-completion"
-          count=@nbItemsCompleted
-          nbModules=@nbItems
-        }}
-      </span>
-    {{/if}}
-  {{else}}
-    <span aria-hidden="true">-</span>
-    <span class="screen-reader-only">{{t "pages.combined-course.table.no-module"}}</span>
-  {{/if}}
+  <span aria-hidden="true">{{@nbItemsCompleted}}/{{@nbItems}}</span>
+  <span class="screen-reader-only">
+    {{t @translationKey count=@nbItemsCompleted nbCampaigns=@nbItems}}
+  </span>
 </template>;
 
 const tooltipId = uniqueId();

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -154,7 +154,7 @@ export default class CombinedCourse extends Component {
 const CompletionDisplay = <template>
   <span aria-hidden="true">{{@nbItemsCompleted}}/{{@nbItems}}</span>
   <span class="screen-reader-only">
-    {{t @translationKey count=@nbItemsCompleted nbCampaigns=@nbItems}}
+    {{t @translationKey nbItems=@nbItems nbItemsCompleted=@nbItemsCompleted}}
   </span>
 </template>;
 

--- a/orga/app/models/combined-course.js
+++ b/orga/app/models/combined-course.js
@@ -5,6 +5,8 @@ export default class CombinedCourse extends Model {
   @attr('string') code;
   @attr('number') participationsCount;
   @attr('number') completedParticipationsCount;
+  @attr('boolean') hasCampaigns;
+  @attr('boolean') hasModules;
   @attr({ defaultValue: () => [] }) campaignIds;
 
   @hasMany('combined-course-participation', { async: true, inverse: null }) combinedCourseParticipations;

--- a/orga/app/routes/authenticated/combined-course/participations.js
+++ b/orga/app/routes/authenticated/combined-course/participations.js
@@ -31,6 +31,6 @@ export default class CombinedCourseRoute extends Route {
         this.router.replaceWith('not-found');
       });
 
-    return combinedCourseParticipations;
+    return { combinedCourse, combinedCourseParticipations };
   }
 }

--- a/orga/app/templates/authenticated/combined-course/participations.gjs
+++ b/orga/app/templates/authenticated/combined-course/participations.gjs
@@ -2,7 +2,9 @@ import CombinedCourseParticipations from 'pix-orga/components/combined-course/pa
 
 <template>
   <CombinedCourseParticipations
-    @participations={{@model}}
+    @hasCampaigns={{@model.combinedCourse.hasCampaigns}}
+    @hasModules={{@model.combinedCourse.hasModules}}
+    @participations={{@model.combinedCourseParticipations}}
     @onFilter={{@controller.triggerFiltering}}
     @statusFilter={{@controller.statuses}}
     @fullNameFilter={{@controller.fullName}}

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -36,6 +36,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
   setupIntlRenderingTest(hooks);
   module('table', function () {
     test('it should have a caption to describe the table ', async function (assert) {
+      // when
       const screen = await render(
         <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
@@ -51,6 +52,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       );
 
       const table = screen.getByRole('table');
+
       // then
       assert.ok(
         within(table).getByRole('columnheader', {
@@ -87,6 +89,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       const campaignHeader = screen.getByRole('columnheader', {
         name: new RegExp(t('pages.combined-course.table.column.campaigns')),
       });
+
+      // then
       assert.ok(within(campaignHeader).getByText(t('pages.combined-course.table.tooltip.campaigns-column')));
     });
 
@@ -98,6 +102,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       const campaignHeader = screen.getByRole('columnheader', {
         name: new RegExp(t('pages.combined-course.table.column.modules')),
       });
+
+      // then
       assert.ok(within(campaignHeader).getByText(t('pages.combined-course.table.tooltip.modules-column')));
     });
   });
@@ -109,6 +115,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     );
 
     const table = screen.getByRole('table');
+
     // then
     assert.ok(
       within(table).getByRole('cell', {
@@ -152,6 +159,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       <template><CombinedCourseParticipations @participations={{noParticipation}} @onFilter={{onFilter}} /></template>,
     );
 
+    // then
     assert.notOk(screen.queryByRole('table'));
     assert.ok(screen.getByText(t('pages.campaign.empty-state')));
   });
@@ -164,12 +172,17 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       const screen = await render(
         <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
+
+      // then
       assert.ok(screen.getByLabelText(/items/));
     });
     test('should display pagination', async function (assert) {
+      //when
       const screen = await render(
         <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
       );
+
+      // then
       assert.ok(screen.getByText(/1-1 sur 2 éléments/));
       assert.ok(screen.getByLabelText("Nombre d'élément à afficher par page"));
       assert.ok(screen.getByRole('button', { name: 'Aller à la page précédente' }));
@@ -185,6 +198,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
 
         const statusFilter = [];
 
+        // when
         const screen = await render(
           <template>
             <CombinedCourseParticipations
@@ -196,7 +210,6 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
           </template>,
         );
 
-        // when
         await screen.getByRole('button', { name: t('common.filters.actions.clear') }).click();
 
         // then
@@ -210,6 +223,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
         const onFilter = sinon.stub();
         const fullNameFilter = '';
 
+        // when
         const screen = await render(
           <template>
             <CombinedCourseParticipations
@@ -220,7 +234,6 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
           </template>,
         );
 
-        // when
         const input = screen.getByLabelText(t('common.filters.fullname.label'));
 
         assert.ok(screen.getByPlaceholderText(t('common.filters.fullname.placeholder')));
@@ -272,6 +285,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
 
         const statusFilter = [];
 
+        // when
         const screen = await render(
           <template>
             <CombinedCourseParticipations
@@ -281,7 +295,7 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
             />
           </template>,
         );
-        // when
+
         const select = screen.getByLabelText(t('pages.combined-course.filters.by-status'));
 
         await click(select);

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -95,6 +95,62 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       );
     });
 
+    test('it should not display campaigns column when no campaigns on combined course', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{false}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
+      );
+
+      const table = screen.getByRole('table');
+
+      // then
+      assert.notOk(
+        within(table).queryByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.campaigns')),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.modules')),
+        }),
+      );
+    });
+
+    test('it should not display modules column when no modules on combined course', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{false}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
+      );
+
+      const table = screen.getByRole('table');
+
+      // then
+      assert.notOk(
+        within(table).queryByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.modules')),
+        }),
+      );
+      assert.ok(
+        within(table).getByRole('columnheader', {
+          name: new RegExp(t('pages.combined-course.table.column.campaigns')),
+        }),
+      );
+    });
+
     test('it should render a tooltip for campaign column', async function (assert) {
       // when
       const screen = await render(
@@ -170,16 +226,16 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     assert.ok(
       within(table).getByText(
         t('pages.combined-course.table.campaign-completion', {
-          count: participations[0].nbCampaignsCompleted,
-          nbCampaigns: participations[0].nbCampaigns,
+          nbItemsCompleted: participations[0].nbCampaignsCompleted,
+          nbItems: participations[0].nbCampaigns,
         }),
       ),
     );
     assert.ok(
       within(table).getByText(
         t('pages.combined-course.table.module-completion', {
-          count: participations[0].nbModulesCompleted,
-          nbModules: participations[0].nbModules,
+          nbItemsCompleted: participations[0].nbModulesCompleted,
+          nbItems: participations[0].nbModules,
         }),
       ),
     );

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -143,45 +143,6 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     );
   });
 
-  test('it should display a dash when there is no module', async function (assert) {
-    // given
-    const participations = [
-      {
-        id: 123,
-        firstName: 'Marcelle',
-        lastName: 'Labe',
-        status: 'COMPLETED',
-        nbCampaigns: 1,
-        nbModules: 0,
-        nbCampaignsCompleted: 1,
-        nbModulesCompleted: 0,
-      },
-    ];
-
-    // when
-    const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
-    );
-
-    const table = screen.getByRole('table');
-
-    // then
-    assert.ok(
-      within(table).getByText(
-        t('pages.combined-course.table.campaign-completion', {
-          count: participations[0].nbCampaignsCompleted,
-          nbCampaigns: participations[0].nbCampaigns,
-        }),
-      ),
-    );
-    assert.ok(
-      within(table).getByRole('cell', {
-        name: t('pages.combined-course.table.no-module'),
-      }),
-    );
-    ('');
-  });
-
   test('it should display empty state', async function (assert) {
     // given
     const noParticipation = [];

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -38,7 +38,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('it should have a caption to describe the table ', async function (assert) {
       // when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
       );
 
       // then
@@ -48,7 +55,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('it should display column headers', async function (assert) {
       // when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
       );
 
       const table = screen.getByRole('table');
@@ -84,7 +98,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('it should render a tooltip for campaign column', async function (assert) {
       // when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            onFilter={{onFilter}}
+          />
+        </template>,
       );
       const campaignHeader = screen.getByRole('columnheader', {
         name: new RegExp(t('pages.combined-course.table.column.campaigns')),
@@ -97,7 +118,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('it should render a tooltip for module column', async function (assert) {
       // when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            onFilter={{onFilter}}
+          />
+        </template>,
       );
       const campaignHeader = screen.getByRole('columnheader', {
         name: new RegExp(t('pages.combined-course.table.column.modules')),
@@ -111,7 +139,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
   test('it should display participation details', async function (assert) {
     // when
     const screen = await render(
-      <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+      <template>
+        <CombinedCourseParticipations
+          @hasCampaigns={{true}}
+          @hasModules={{true}}
+          @participations={{participations}}
+          @onFilter={{onFilter}}
+        />
+      </template>,
     );
 
     const table = screen.getByRole('table');
@@ -156,7 +191,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
 
     // when
     const screen = await render(
-      <template><CombinedCourseParticipations @participations={{noParticipation}} @onFilter={{onFilter}} /></template>,
+      <template>
+        <CombinedCourseParticipations
+          @hasCampaigns={{true}}
+          @hasModules={{true}}
+          @participations={{noParticipation}}
+          @onFilter={{onFilter}}
+        />
+      </template>,
     );
 
     // then
@@ -170,7 +212,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
       const locale = this.owner.lookup('service:locale');
       locale.setCurrentLocale('en');
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
       );
 
       // then
@@ -179,7 +228,14 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
     test('should display pagination', async function (assert) {
       //when
       const screen = await render(
-        <template><CombinedCourseParticipations @participations={{participations}} @onFilter={{onFilter}} /></template>,
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
       );
 
       // then
@@ -202,6 +258,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
         const screen = await render(
           <template>
             <CombinedCourseParticipations
+              @hasCampaigns={{true}}
+              @hasModules={{true}}
               @statusFilter={{statusFilter}}
               @clearFilters={{clearFilters}}
               @participations={{participations}}
@@ -227,6 +285,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
         const screen = await render(
           <template>
             <CombinedCourseParticipations
+              @hasCampaigns={{true}}
+              @hasModules={{true}}
               @fullNameFilter={{fullNameFilter}}
               @onFilter={{onFilter}}
               @participations={{participations}}
@@ -254,6 +314,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
         const screen = await render(
           <template>
             <CombinedCourseParticipations
+              @hasCampaigns={{true}}
+              @hasModules={{true}}
               @fullNameFilter={{fullNameFilter}}
               @onFilter={{onFilter}}
               @participations={{participations}}
@@ -289,6 +351,8 @@ module('Integration | Component | CombinedCourse | Participations', function (ho
         const screen = await render(
           <template>
             <CombinedCourseParticipations
+              @hasCampaigns={{true}}
+              @hasModules={{true}}
               @statusFilter={{statusFilter}}
               @onFilter={{onFilter}}
               @participations={{participations}}

--- a/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participations-test.js
@@ -35,8 +35,9 @@ module('Unit | Route | authenticated/combined-course-participations', function (
 
       // when
       const result = await route.model({});
+
       // then
-      assert.deepEqual(result, combinedCourseParticipations);
+      assert.deepEqual(result, { combinedCourse, combinedCourseParticipations });
     });
 
     test('fetch combined-course participations with pagination', async function (assert) {
@@ -67,7 +68,7 @@ module('Unit | Route | authenticated/combined-course-participations', function (
       const result = await route.model({ pageNumber: 2, pageSize: 20, fullName: 'fullName', statuses: ['STARTED'] });
 
       // then
-      assert.deepEqual(result, combinedCourseParticipations);
+      assert.deepEqual(result, { combinedCourse, combinedCourseParticipations });
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1039,7 +1039,7 @@
         "total-participations": "Total participations"
       },
       "table": {
-        "campaign-completion": "{count, plural, =0 {No campaign completed out of {nbCampaigns}} =1 {One campaign completed out of {nbCampaigns}} other {{count} campaigns completed out of {nbCampaigns}}}.",
+        "campaign-completion": "{nbItemsCompleted, plural, =0 {No campaign completed out of {nbItems}} =1 {One campaign completed out of {nbItems}} other {{nbItemsCompleted} campaigns completed out of {nbItems}}}.",
         "column": {
           "campaigns": "Campaigns",
           "first-name": "First name",
@@ -1048,7 +1048,7 @@
           "status": "Status"
         },
         "description": "List of learning courses participations",
-        "module-completion": "{count, plural, =0 {No module completed out of {nbModules}} =1 {One module completed out of {nbModules}} other {{count} modules completed out of {nbModules}}}.",
+        "module-completion": "{nbItemsCompleted, plural, =0 {No module completed out of {nbItems}} =1 {One module completed out of {nbItems}} other {{nbItemsCompleted} modules completed out of {nbItems}}}.",
         "no-module": "No modules recommended.",
         "tooltip": {
           "campaigns-column": "'x / y' indicates the participant’s progress : they have completed x campaigns out of a total of y. For example, 1/2 means they have completed 1 campaign out of 2.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1027,7 +1027,7 @@
         "total-participations": "Total des participations"
       },
       "table": {
-        "campaign-completion": "{count, plural, =0 {Aucune campagne complétée sur {nbCampaigns}} =1 {Une campagne complétée sur {nbCampaigns}} other {{count} campagnes complétées sur {nbCampaigns}}}.",
+        "campaign-completion": "{nbItemsCompleted, plural, =0 {Aucune campagne complétée sur {nbItems}} =1 {Une campagne complétée sur {nbItems}} other {{nbItemsCompleted} campagnes complétées sur {nbItems}}}.",
         "column": {
           "campaigns": "Campagnes",
           "first-name": "Prénom",
@@ -1036,7 +1036,7 @@
           "status": "Statut"
         },
         "description": "Listes des participations au parcours",
-        "module-completion": "{count, plural, =0 {Aucun module complété sur {nbModules}} =1 {Un module complété sur {nbModules}} other {{count} modules complétés sur {nbModules}}}.",
+        "module-completion": "{nbItemsCompleted, plural, =0 {Aucun module complété sur {nbItems}} =1 {Un module complété sur {nbItems}} other {{nbItemsCompleted} modules complétés sur {nbItems}}}.",
         "no-module": "Aucun module recommandé.",
         "tooltip": {
           "campaigns-column": "'x / y' indique la progression du participant : il a terminé x campagnes sur un total de y. Par exemple, 1/2 signifie qu’il a terminé 1 campagne sur 2.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1027,7 +1027,7 @@
         "total-participations": "Totaal van de deelnemingen"
       },
       "table": {
-        "campaign-completion": "{count, plural, =0 {Geen enkele campagne voltooid op {nbCampaigns}} =1 {1 van de {nbCampaigns} campagnes voltooid} other {{count} van de {nbCampaigns} campagnes voltooid}}.",
+        "campaign-completion": "{nbItemsCompleted, plural, =0 {Geen enkele campagne voltooid op {nbItems}} =1 {1 van de {nbItems} campagnes voltooid} other {{nbItemsCompleted} van de {nbItems} campagnes voltooid}}.",
         "column": {
           "campaigns": "Campagnes",
           "first-name": "Voornaam",
@@ -1036,7 +1036,7 @@
           "status": "Status"
         },
         "description": "List of the combined course participations",
-        "module-completion": "{count, plural, =0 {geen module voltooid op {nbModules}} =1 {1 van de {nbModules} modules voltooid} other {{count} van de {nbModules} modules voltooid}}.",
+        "module-completion": "{nbItemsCompleted, plural, =0 {geen module voltooid op {nbItems}} =1 {1 van de {nbItems} modules voltooid} other {{nbItemsCompleted} van de {nbItems} modules voltooid}}.",
         "no-module": "Geen aanbevolen module.",
         "tooltip": {
           "campaigns-column": "'x / y' geeft de voortgang van de deelnemer aan: hij/zij heeft x campagnes voltooid van een totaal van y. Bijvoorbeeld: 1/2 betekent dat hij/zij 1 campagne van de 2 heeft voltooid.",


### PR DESCRIPTION
## 🍂 Problème

Actuellement, sur la page d'un parcours combiné, on affiche la colonne Campagnes lorsque le parcours n'a pas de campagnes associées, affichant ainsi 0/0. 
Idem pour la colonne Modules qui s'affiche si aucun module associé.

## 🌰 Proposition

On masque la colonne Campagnes si le parcours n'a pas de campagnes, et la colonne Modules s'il n'a pas de modules.

## 🍁 Remarques

On supprime la condition affichant un dash "-" dans le cas où il n'y a pas de modules, qui n'est plus utilisée.

## 🪵 Pour tester

Se connecter à Pix Orga
Se rendre sur l'onglet Parcours Apprenants de Campagnes
Aller sur la page du Combinix 3
Constater l'absence de la colonne Campagnes
Aller sur la page du Combinix 4
Constater l'absence de la colonne Modules
