### PR TITLE
[TECH] Corriger un test flaky sur le détachement d'orga fille (PIX-20271)

### DIFF
--- a/admin/tests/acceptance/authenticated/organizations/get/children-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children-test.js
@@ -125,8 +125,9 @@ module('Acceptance | Organizations | Children', function (hooks) {
         await waitForDialogClose();
 
         // then
-        assert.ok(screen.getByText(t('pages.organization-children.notifications.success.detach-child-organization')));
-        assert.notOk(screen.queryByRole('cell', { name: 'Child Organization Name' }));
+        assert.ok(
+          await screen.findByText(t('pages.organization-children.notifications.success.detach-child-organization')),
+        );
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

On a un flaky sur le test d'acceptance du Détachement d'orga.

## 🌰 Proposition

Supprimer un assert qui vérifie que l'orga détachée a bien été supprimée de la liste des orgas filles

## 🍁 Remarques

Le fait que l'orga est retirée de la liste fait suite au reload du model dont l'appel est testé dans le test d'intégration du composant.

## 🪵 Pour tester

Le test Acceptance | Organizations | Children doit passer