### PR TITLE
[FEATURE] Filtrer les OIDC providers filtrés par app sur Pix App et Pix Admin (PIX-19809)

### DIFF
--- a/admin/tests/unit/services/current-domain-test.js
+++ b/admin/tests/unit/services/current-domain-test.js
@@ -75,7 +75,7 @@ module('Unit | Service | currentDomain', function (hooks) {
 
   module('#domain', function () {
     module('when location is localhost', function () {
-      test('returns locahost as domain', function (assert) {
+      test('returns localhost as domain', function (assert) {
         // given
 
         sinon.stub(Location, 'getHref').returns('http://localhost:4200/foo?bar=baz');

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -146,10 +146,14 @@ async function getRedirectLogoutUrl(request, h) {
   const userId = request.auth.credentials.userId;
   const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
 
+  const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
+
   const redirectLogoutUrl = await usecases.getRedirectLogoutUrl({
     identityProvider,
     logoutUrlUUID,
     userId,
+    requestedApplication,
   });
 
   return h.response({ redirectLogoutUrl }).code(200);

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -8,11 +8,6 @@ export const oidcProviderRoutes = [
     method: 'GET',
     path: '/api/oidc/identity-providers',
     options: {
-      validate: {
-        query: Joi.object({
-          target: Joi.string().optional().default('app'), // Now useless, will soon be removed
-        }),
-      },
       auth: false,
       cache: false,
       handler: (request, h) => oidcProviderController.getIdentityProviders(request, h),

--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.route.js
@@ -6,7 +6,7 @@ import { oidcProviderController } from './oidc-provider.controller.js';
 export const oidcProviderRoutes = [
   {
     method: 'GET',
-    path: '/api/oidc/identity-providers',
+    path: '/api/oidc/identity-providers/{any*}',
     options: {
       auth: false,
       cache: false,

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -7,7 +7,6 @@ import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authenti
 
 export class OidcAuthenticationServiceRegistry {
   #allOidcProviderServices = null;
-  #readyOidcProviderServicesForPixAdmin = null;
   #readyOidcProviderServicesByRequestedApplications = {};
 
   constructor(dependencies = {}) {
@@ -31,10 +30,6 @@ export class OidcAuthenticationServiceRegistry {
    */
   getAllOidcProviderServices() {
     return this.#allOidcProviderServices;
-  }
-
-  getReadyOidcProviderServicesForPixAdmin() {
-    return this.#readyOidcProviderServicesForPixAdmin;
   }
 
   getReadyOidcProviderServicesByRequestedApplication(requestedApplication) {
@@ -78,10 +73,6 @@ export class OidcAuthenticationServiceRegistry {
 
     this.#allOidcProviderServices = oidcProviderServices;
 
-    this.#readyOidcProviderServicesForPixAdmin = this.#allOidcProviderServices.filter(
-      (oidcProviderService) => oidcProviderService.isReadyForPixAdmin,
-    );
-
     this.#readyOidcProviderServicesByRequestedApplications = Object.groupBy(
       this.#allOidcProviderServices.filter(
         (oidcProviderService) => oidcProviderService.isReady || oidcProviderService.isReadyForPixAdmin,
@@ -94,7 +85,6 @@ export class OidcAuthenticationServiceRegistry {
 
   testOnly_reset() {
     this.#allOidcProviderServices = null;
-    this.#readyOidcProviderServicesForPixAdmin = null;
     this.#readyOidcProviderServicesByRequestedApplications = {};
   }
 }

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -30,6 +30,8 @@ export class OidcAuthenticationService {
     {
       accessTokenLifespan = '48h',
       additionalRequiredProperties,
+      application,
+      applicationTld,
       claimsToStore,
       clientId,
       clientSecret,
@@ -53,6 +55,8 @@ export class OidcAuthenticationService {
   ) {
     this.accessTokenLifespanMs = ms(accessTokenLifespan);
     this.additionalRequiredProperties = additionalRequiredProperties;
+    this.application = application;
+    this.applicationTld = applicationTld;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.enabled = enabled;

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -62,6 +62,7 @@ async function createOidcUser({
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
   const userId = await oidcAuthenticationService.createUserAccount({

--- a/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
@@ -12,7 +12,7 @@ const getReadyIdentityProviders = async function ({ requestedApplication, oidcAu
     return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
   }
 
-  return oidcAuthenticationServiceRegistry.getReadyOidcProviderServices();
+  return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
 };
 
 export { getReadyIdentityProviders };

--- a/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
@@ -8,10 +8,6 @@
 const getReadyIdentityProviders = async function ({ requestedApplication, oidcAuthenticationServiceRegistry }) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
-  if (requestedApplication?.isPixAdmin) {
-    return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
-  }
-
   return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
 };
 

--- a/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
@@ -7,12 +7,19 @@
  * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
  * @return {Promise<string>}
  */
-async function getRedirectLogoutUrl({ identityProvider, logoutUrlUUID, userId, oidcAuthenticationServiceRegistry }) {
+async function getRedirectLogoutUrl({
+  identityProvider,
+  logoutUrlUUID,
+  userId,
+  requestedApplication,
+  oidcAuthenticationServiceRegistry,
+}) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
   return oidcAuthenticationService.getRedirectLogoutUrl({

--- a/api/src/identity-access-management/infrastructure/utils/network.js
+++ b/api/src/identity-access-management/infrastructure/utils/network.js
@@ -40,10 +40,13 @@ export function getForwardedOrigin(headers) {
 
 export class RequestedApplication {
   /**
-   * @param {string} applicationName
+   * @param {Object} params
+   * @param {string} params.applicationName
+   * @param {string} params.applicationTld
    */
-  constructor(applicationName) {
+  constructor({ applicationName, applicationTld }) {
     this.applicationName = applicationName;
+    this.applicationTld = applicationTld;
   }
 
   get isPixApp() {
@@ -79,10 +82,12 @@ export class RequestedApplication {
     }
 
     let applicationName;
+    let applicationTld;
 
     if (url.hostname == 'localhost') {
       applicationName = localhostApplicationPortMapping[url.port];
-      return new RequestedApplication(applicationName);
+      applicationTld = '';
+      return new RequestedApplication({ applicationName, applicationTld });
     }
 
     const hostnameParts = url.hostname.split('.');
@@ -91,6 +96,7 @@ export class RequestedApplication {
     }
 
     const urlFirstLabel = hostnameParts[0];
+    applicationTld = `.${hostnameParts.at(-1)}`;
 
     const urlFirstLabelParts = urlFirstLabel.split('-');
     if (urlFirstLabelParts.length == 2) {
@@ -100,7 +106,7 @@ export class RequestedApplication {
       applicationName = urlFirstLabel;
     }
 
-    return new RequestedApplication(applicationName);
+    return new RequestedApplication({ applicationName, applicationTld });
   }
 }
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
   let server;
 
   beforeEach(async function () {
-    await createMockedTestOidcProvider();
+    await createMockedTestOidcProvider({ application: 'admin', applicationTld: '.fr' });
     server = await createServer();
   });
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -149,9 +149,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           refresh_token: 'refresh_token',
         });
 
-        const headers = generateAuthenticatedUserRequestHeaders();
-        headers.cookie = cookies[0];
-
         // when
         const response = await server.inject({
           method: 'POST',
@@ -267,9 +264,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             expires_in: 60,
             refresh_token: 'refresh_token',
           });
-
-          const headers = generateAuthenticatedUserRequestHeaders();
-          headers.cookie = cookies[0];
 
           // when
           const response = await server.inject({

--- a/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
@@ -162,7 +162,7 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
   });
 
   describe('#getOidcProviderServiceByCode', function () {
-    it('returns a ready OIDC Provider for Pix App', async function () {
+    it('returns the ready OIDC Providers for Pix App', async function () {
       // given
       const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
       await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
@@ -177,21 +177,19 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
       expect(service.code).to.equal('OIDC_EXAMPLE');
     });
 
-    describe('when the requestedApplication is admin', function () {
-      it('returns a ready OIDC provider for Pix Admin', async function () {
-        // given
-        const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
-        await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
+    it('returns the ready OIDC Providers for Pix Admin', async function () {
+      // given
+      const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
+      await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
-        // when
-        const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
-          identityProviderCode: 'OIDC_EXAMPLE_FOR_PIX_ADMIN',
-          requestedApplication,
-        });
-
-        // then
-        expect(service.code).to.equal('OIDC_EXAMPLE_FOR_PIX_ADMIN');
+      // when
+      const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+        identityProviderCode: 'OIDC_EXAMPLE_FOR_PIX_ADMIN',
+        requestedApplication,
       });
+
+      // then
+      expect(service.code).to.equal('OIDC_EXAMPLE_FOR_PIX_ADMIN');
     });
 
     describe('when the OIDC Provider is not for the requestedApplication', function () {

--- a/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
@@ -132,32 +132,31 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
     it('returns ready OIDC Providers by requestedApplication', async function () {
       // given
       await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
-      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
+      const requestedApplicationForApp = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
+      const requestedApplicationForAdmin = new RequestedApplication({
+        applicationName: 'admin',
+        applicationTld: '.fr',
+      });
 
       // when
-      const services =
-        oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
+      const readyServicesForApp =
+        oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(
+          requestedApplicationForApp,
+        );
+      const readyServicesForAdmin =
+        oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(
+          requestedApplicationForAdmin,
+        );
 
       // then
-      const serviceCodes = services.map((service) => service.code);
-      expect(serviceCodes).to.have.lengthOf(2);
-      expect(serviceCodes).to.contain('OIDC_EXAMPLE');
-      expect(serviceCodes).to.contain('FWB');
-    });
-  });
+      const serviceCodesForApp = readyServicesForApp.map((service) => service.code);
+      expect(serviceCodesForApp).to.have.lengthOf(2);
+      expect(serviceCodesForApp).to.contain('OIDC_EXAMPLE');
+      expect(serviceCodesForApp).to.contain('FWB');
 
-  describe('#getReadyOidcProviderServicesForPixAdmin', function () {
-    it('returns ready OIDC Providers for Pix Admin', async function () {
-      // given
-      await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
-
-      // when
-      const services = oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
-
-      // then
-      const serviceCodes = services.map((service) => service.code);
-      expect(serviceCodes).to.have.lengthOf(1);
-      expect(serviceCodes).to.contain('OIDC_EXAMPLE_FOR_PIX_ADMIN');
+      const serviceCodesForAdmin = readyServicesForAdmin.map((service) => service.code);
+      expect(serviceCodesForAdmin).to.have.lengthOf(1);
+      expect(serviceCodesForAdmin).to.contain('OIDC_EXAMPLE_FOR_PIX_ADMIN');
     });
   });
 

--- a/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
@@ -41,6 +41,8 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
     await databaseBuilder.factory.buildOidcProvider(genericDisabledOidcProviderProperties);
 
     const genericOidcProviderFoxPixAdminProperties = {
+      application: 'admin',
+      applicationTld: '.fr',
       enabledForPixAdmin: true,
       accessTokenLifespan: '7d',
       clientId: 'client',
@@ -49,7 +51,7 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
       identityProvider: 'OIDC_EXAMPLE_FOR_PIX_ADMIN',
       openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
       organizationName: 'OIDC Example',
-      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      redirectUri: 'https://admin.dev.pix.fr/connexion/oidc-example-net',
       scope: 'openid profile',
       slug: 'oidc-example-net',
       source: 'oidcexamplenet',
@@ -167,7 +169,7 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
     describe('when the requestedApplication is admin', function () {
       it('returns a ready OIDC provider for Pix Admin', async function () {
         // given
-        const requestedApplication = new RequestedApplication('admin');
+        const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
         await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
         // when

--- a/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -6,6 +6,8 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Identity Access Management | Domain | UseCases | get-ready-identity-providers', function () {
   beforeEach(async function () {
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'app',
+      applicationTld: '.org',
       identityProvider: 'OIDC_PROVIDER_FOR_APP',
       organizationName: 'OIDC Provider For App',
       slug: 'oidc-provider-for-app',
@@ -20,6 +22,8 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     });
 
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'app',
+      applicationTld: '.org',
       identityProvider: 'OIDC_PROVIDER_DISABLED',
       organizationName: 'OIDC Provider Disabled',
       slug: 'oidc-provider-disabled',
@@ -34,6 +38,8 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     });
 
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'admin',
+      applicationTld: '.fr',
       identityProvider: 'OIDC_PROVIDER_FOR_ADMIN',
       organizationName: 'OIDC Provider For Admin',
       slug: 'oidc-provider-for-admin',
@@ -43,7 +49,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
       clientSecret: 'plainTextSecret',
       accessTokenLifespan: '7d',
       openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
-      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      redirectUri: 'https://admin.dev.pix.fr/connexion/oidc-example-net',
       scope: 'openid profile',
     });
 
@@ -52,7 +58,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
 
   it('returns enabled oidc providers (excluding the PixAdmin ones)', async function () {
     // given
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
 
     // when
     const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });
@@ -69,7 +75,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
   describe('when the provided requestedApplication is Pix Admin', function () {
     it('returns enabled oidc providers for PixAdmin only', async function () {
       // given
-      const requestedApplication = new RequestedApplication('admin');
+      const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
       // when
       const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });

--- a/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -56,7 +56,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     await databaseBuilder.commit();
   });
 
-  it('returns enabled oidc providers (excluding the PixAdmin ones)', async function () {
+  it('returns the ready OIDC Providers for Pix App', async function () {
     // given
     const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
 
@@ -72,21 +72,19 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     expect(returnedIdentityProvider.identityProvider).to.equal('OIDC_PROVIDER_FOR_APP');
   });
 
-  describe('when the provided requestedApplication is Pix Admin', function () {
-    it('returns enabled oidc providers for PixAdmin only', async function () {
-      // given
-      const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
+  it('returns the ready OIDC Providers for Pix Admin', async function () {
+    // given
+    const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
-      // when
-      const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });
+    // when
+    const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });
 
-      // then
-      expect(identityProviders).to.be.instanceOf(Array);
-      expect(identityProviders.length).to.equal(1);
+    // then
+    expect(identityProviders).to.be.instanceOf(Array);
+    expect(identityProviders.length).to.equal(1);
 
-      const returnedIdentityProvider = identityProviders[0];
-      expect(returnedIdentityProvider).to.be.instanceOf(OidcAuthenticationService);
-      expect(returnedIdentityProvider.identityProvider).to.equal('OIDC_PROVIDER_FOR_ADMIN');
-    });
+    const returnedIdentityProvider = identityProviders[0];
+    expect(returnedIdentityProvider).to.be.instanceOf(OidcAuthenticationService);
+    expect(returnedIdentityProvider.identityProvider).to.equal('OIDC_PROVIDER_FOR_ADMIN');
   });
 });

--- a/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -1,3 +1,4 @@
+import { oidcAuthenticationServiceRegistry } from '../../../../../lib/domain/usecases/index.js';
 import { OidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
@@ -54,6 +55,9 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     });
 
     await databaseBuilder.commit();
+
+    oidcAuthenticationServiceRegistry.testOnly_reset();
+    await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   });
 
   it('returns the ready OIDC Providers for Pix App', async function () {

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -15,7 +15,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     const identityProvider = 'OIDC_EXAMPLE_NET';
     const pixAccessToken = 'pixAccessToken';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
     const locale = 'fr-FR';
 
     let request;
@@ -147,7 +147,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         locale: 'fr-FR',
         language: 'fr',
         audience: 'https://app.pix.fr',
-        requestedApplication: new RequestedApplication('app'),
+        requestedApplication: new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' }),
       });
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal({
@@ -229,7 +229,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       //then
       expect(usecases.getAuthorizationUrl).to.have.been.calledWithExactly({
         identityProvider: 'OIDC',
-        requestedApplication: new RequestedApplication('app'),
+        requestedApplication: new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' }),
       });
       expect(request.yar.set).to.have.been.calledTwice;
       expect(request.yar.set.getCall(0)).to.have.been.calledWithExactly(
@@ -287,7 +287,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           authenticationKey: '123abc',
         },
       };
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       sinon.stub(usecases, 'reconcileOidcUser').resolves({
         accessToken: 'accessToken',

--- a/api/tests/identity-access-management/unit/application/saml/saml.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/saml/saml.controller.test.js
@@ -15,7 +15,7 @@ describe('Unit | Identity Access Management | Application | Controller | Authent
       const externalUserToken = 'SamlJacksonToken';
       const expectedUserId = 1;
       const audience = 'https://app.pix.fr';
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       const request = {
         headers: {

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -46,7 +46,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
     const password = 'user_password';
     const source = 'pix';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
     /**
      * @see https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
@@ -55,17 +55,12 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         const allOidcProviderServices = oidcAuthenticationServiceRegistry.getAllOidcProviderServices();
         const readyOidcProviderServices =
           oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
-        const readyOidcProviderServicesForPixAdmin =
-          oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
 
         expect(result).to.be.true;
         expect(allOidcProviderServices).to.have.lengthOf(3);
 
         expect(readyOidcProviderServices).to.have.lengthOf(1);
         expect(readyOidcProviderServices.map((service) => service.code)).to.contain('OIDC');
-
-        expect(readyOidcProviderServicesForPixAdmin).to.have.lengthOf(1);
-        expect(readyOidcProviderServicesForPixAdmin.map((service) => service.code)).to.contain('OIDC_FOR_PIX_ADMIN');
       });
     });
 

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
@@ -4,6 +4,7 @@ import { OidcAuthenticationService } from '../../../../../src/identity-access-ma
 import { OidcAuthenticationServiceRegistry } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service-registry.js';
 import { PoleEmploiOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js';
 import { oidcProviderRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Services | oidc-authentication-service-registry', function () {
@@ -41,16 +42,19 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         // given
         const oidcProviderServices = [
           { code: 'ONE' },
-          { code: 'OIDC', isReady: true },
+          { code: 'OIDC', application: 'app', applicationTld: '.fr', isReady: true },
           { code: 'OIDC_FOR_PIX_ADMIN', isReadyForPixAdmin: true },
         ];
+
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
         // when
         const result = await oidcAuthenticationServiceRegistry.loadOidcProviderServices(oidcProviderServices);
 
         // then
         const allOidcProviderServices = oidcAuthenticationServiceRegistry.getAllOidcProviderServices();
-        const readyOidcProviderServices = oidcAuthenticationServiceRegistry.getReadyOidcProviderServices();
+        const readyOidcProviderServices =
+          oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
         const readyOidcProviderServicesForPixAdmin =
           oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
 

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -25,7 +25,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
   let userRepository;
   let userLoginRepository;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     pixAuthenticationService = {

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -55,7 +55,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
 
     context('check access by requestedApplication', function () {
       context('when requestedApplication is Pix Admin', function () {
-        const requestedApplication = new RequestedApplication('admin');
+        const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
         context('when user has no role and is therefore not an admin member', function () {
           it('throws an error', async function () {
@@ -278,7 +278,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
 
           // when
-          const requestedApplication = new RequestedApplication('app');
+          const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
           await authenticateOidcUser({
             requestedApplication,
             stateReceived: 'state',
@@ -316,7 +316,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       context('when the provider has an authentication complement', function () {
         it('updates the authentication method', async function () {
           // given
-          const requestedApplication = new RequestedApplication('app');
+          const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
           _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
           const user = domainBuilder.buildUser({ id: 10 });
           userRepository.findByExternalIdentifier.resolves(user);
@@ -373,7 +373,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let lastUserApplicationConnectionsRepository;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
     beforeEach(function () {
       oidcAuthenticationService = {
@@ -411,7 +411,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     context('when user has an account', function () {
       it('updates the authentication method', async function () {
         // given
-        const requestedApplication = new RequestedApplication('app');
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         const user = domainBuilder.buildUser({ id: 1 });
         userRepository.findByExternalIdentifier.resolves(user);
@@ -502,7 +502,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     context('when user is logged with their pix account but also has a separate oidc account', function () {
       it('updates the oidc authentication method', async function () {
         // given
-        const requestedApplication = new RequestedApplication('app');
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         const user = domainBuilder.buildUser({ id: 10 });
         userRepository.findByExternalIdentifier
@@ -606,7 +606,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         expiredDate: new Date(),
       });
       oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       // when
       await authenticateOidcUser({

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -104,7 +104,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     const idToken = 'idToken';
     const language = 'nl';
     const audience = 'htttps://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
     authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
       sessionContent: { idToken, accessToken: 'accessToken' },
       userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   let lastUserApplicationConnectionsRepository;
   let samlSettings;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     userRepository = {

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
@@ -16,7 +16,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
     oidcAuthenticationService;
   const identityProvider = 'genericOidcProviderCode';
   const audience = 'https://admin.pix.fr';
-  const requestedApplication = new RequestedApplication('admin');
+  const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
   beforeEach(function () {
     authenticationMethodRepository = {

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
@@ -10,7 +10,7 @@ import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-user', function () {
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   context('when identityProvider is generic', function () {
     let authenticationMethodRepository,

--- a/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
@@ -88,15 +88,17 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
 
   describe('RequestedApplication', function () {
     describe('constructor', function () {
-      it('initializes an applicationName property', function () {
+      it('creates an instance with properties', function () {
         // given
         const applicationName = 'orga';
+        const applicationTld = '.fr';
 
         // when
-        const requestedApplication = new RequestedApplication(applicationName);
+        const requestedApplication = new RequestedApplication({ applicationName, applicationTld });
 
         // then
         expect(requestedApplication.applicationName).to.equal('orga');
+        expect(requestedApplication.applicationTld).to.equal('.fr');
       });
     });
 
@@ -111,6 +113,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
         // then
         expect(requestedApplication).to.be.instanceOf(RequestedApplication);
         expect(requestedApplication.applicationName).to.equal('app');
+        expect(requestedApplication.applicationTld).to.equal('.org');
         expect(requestedApplication.isPixApp).to.be.true;
         expect(requestedApplication.isPixAdmin).to.be.false;
         expect(requestedApplication.isPixOrga).to.be.false;
@@ -129,6 +132,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
           // then
           expect(requestedApplication).to.be.instanceOf(RequestedApplication);
           expect(requestedApplication.applicationName).to.equal('app');
+          expect(requestedApplication.applicationTld).to.equal('.org');
           expect(requestedApplication.isPixApp).to.be.true;
           expect(requestedApplication.isPixAdmin).to.be.false;
           expect(requestedApplication.isPixOrga).to.be.false;
@@ -149,6 +153,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('app');
+            expect(requestedApplication.applicationTld).to.equal('');
             expect(requestedApplication.isPixApp).to.be.true;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -168,6 +173,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('orga');
+            expect(requestedApplication.applicationTld).to.equal('');
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.true;
@@ -187,6 +193,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('admin');
+            expect(requestedApplication.applicationTld).to.equal('');
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.true;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -206,6 +213,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('certif');
+            expect(requestedApplication.applicationTld).to.equal('');
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -225,6 +233,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('junior');
+            expect(requestedApplication.applicationTld).to.equal('');
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -15,7 +15,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
   beforeEach(async function () {
     audience = 'https://app.pix.fr';
-    requestedApplication = new RequestedApplication('app');
+    requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
   });
 
   context('When the token is invalid', function () {

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let studentRepository;
   let lastUserApplicationConnectionsRepository;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     userReconciliationService = {

--- a/api/tests/tooling/openid-client/openid-client-mocks.js
+++ b/api/tests/tooling/openid-client/openid-client-mocks.js
@@ -3,7 +3,6 @@ import { OidcAuthenticationService } from '../../../src/identity-access-manageme
 import { sinon } from '../../test-helper.js';
 
 const clientId = 'client';
-const redirectUri = 'https://app.dev.pix.org/connexion/oidc-example-net';
 const scope = 'openid profile';
 const openIdConfigurationResponse = {
   token_endpoint: 'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/token',
@@ -51,10 +50,12 @@ function createOpenIdClientMock(oidcProviderConfig = Symbol('oidcProviderConfig'
   };
 }
 
-async function createMockedTestOidcProvider() {
+async function createMockedTestOidcProvider({ application, applicationTld }) {
   oidcAuthenticationServiceRegistry.testOnly_reset();
 
   const openIdClientMock = createOpenIdClientMock(openIdConfigurationResponse);
+
+  const redirectUri = `https://${application}.dev.pix${applicationTld}/connexion/oidc-example-net`;
 
   const authorizationUrl = `${openIdConfigurationResponse.authorization_endpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}&state=state&nonce=nonce`;
   openIdClientMock.buildAuthorizationUrl.returns(authorizationUrl);
@@ -66,6 +67,8 @@ async function createMockedTestOidcProvider() {
     new OidcAuthenticationService(
       {
         accessTokenLifespanMs: 60000,
+        application,
+        applicationTld,
         clientId,
         clientSecret: 'secret',
         enabled: true,

--- a/mon-pix/app/adapters/oidc-identity-provider.js
+++ b/mon-pix/app/adapters/oidc-identity-provider.js
@@ -1,7 +1,11 @@
+import { service } from '@ember/service';
+
 import ApplicationAdapter from './application';
 
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
+  @service currentDomain;
+
   urlForFindAll() {
-    return `${this.host}/${this.namespace}/oidc/identity-providers`;
+    return `${this.host}/${this.namespace}/oidc/identity-providers/${this.currentDomain.getExtension()}`;
   }
 }

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -35,7 +35,7 @@ export default function (config) {
     };
   });
 
-  config.get('/oidc/identity-providers', () => {
+  config.get('/oidc/identity-providers/:cache_buster', () => {
     return {
       data: [
         {

--- a/mon-pix/tests/unit/services/current-domain-test.js
+++ b/mon-pix/tests/unit/services/current-domain-test.js
@@ -72,7 +72,7 @@ module('Unit | Service | currentDomain', function (hooks) {
 
   module('#domain', function () {
     module('when location is localhost', function () {
-      test('returns locahost as domain', function (assert) {
+      test('returns localhost as domain', function (assert) {
         // given
         _stubWindowUrl(this.owner, 'http://localhost:4200/foo?bar=baz');
         const service = this.owner.lookup('service:currentDomain');

--- a/orga/app/adapters/oidc-identity-provider.js
+++ b/orga/app/adapters/oidc-identity-provider.js
@@ -1,7 +1,11 @@
+import { service } from '@ember/service';
+
 import ApplicationAdapter from './application';
 
 export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
+  @service currentDomain;
+
   urlForFindAll() {
-    return `${this.host}/${this.namespace}/oidc/identity-providers`;
+    return `${this.host}/${this.namespace}/oidc/identity-providers/${this.currentDomain.getExtension()}`;
   }
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -698,7 +698,7 @@ function routes() {
     return schema.combinedCourseStatistics.find(combinedCourseId);
   });
 
-  this.get('/oidc/identity-providers', () => {
+  this.get('/oidc/identity-providers/:cache_buster', () => {
     return {
       data: [
         {

--- a/orga/tests/unit/services/current-domain-test.js
+++ b/orga/tests/unit/services/current-domain-test.js
@@ -101,7 +101,7 @@ module('Unit | Service | currentDomain', function (hooks) {
 
   module('#domain', function () {
     module('when location is localhost', function () {
-      test('returns locahost as domain', function (assert) {
+      test('returns localhost as domain', function (assert) {
         // given
 
         sinon.stub(Location, 'getHref').returns('http://localhost:4200/foo?bar=baz');


### PR DESCRIPTION
## 🍂 Problème

Le code actuel se base sur les colonnes `enabled` et `enabledForPixAdmin` pour déterminer quels SSO sont à proposer respectivement pour Pix App et Pix Admin. Ce traitement doit gérer des cas spéciaux au lieu d’être générique et ne permet pas de proposer des SSO pour d’autres applications que Pix App et Pix Admin.

Il faut bien prendre en compte la problématique de cache HTTP car la route va maintenant être appelée de manière générique par toutes les applications et à la fois sur le domaine `.fr` et le domaine `.org`.

## 🌰 Proposition

Filtrer les OIDC providers récupérés par Pix App, Pix Admin et autres en fonction des applications (en se basant sur la `requestedApplication`),

### HTTP Cache

Pour garantir qu’un même frontal, Pix App ou Pix Orga, sur des domaines différents, `.fr` et `.org`, ne va pas utiliser la même version en cache de la route `/api/oidc/identity-providers/` on rend cette route appelable avec des URL différents : 
* `/api/oidc/identity-providers/fr`
* `/api/oidc/identity-providers/org`

### Prochaines tâches à faire

Dans une tâche suivante on mettra à jour les enregistrements de la table `oidc-providers` ayant `enabledForPixAdmin=true` et on supprimera la colonne `enabledForPixAdmin`.

Dans une PR suivante on supprimera le code manipulant la propriété `enabledForPixAdmin`.

## 🍁 Remarques

Penser à utiliser l’option `Hide whitespace` pour la relecture des commits qui réorganisent les contextes de tests.

## 🪵 Pour tester

Les tests sont à effectuer en local.

* Aller sur Pix App sur le TLD `.fr`, constater que les SSO proposés sont bien ceux attendus et vérifier que tout fonctionne comme attendu de la connexion à la déconnexion,
* Aller sur Pix App sur le TLD `.org`, constater que les SSO proposés sont bien ceux attendus et vérifier que tout fonctionne comme attendu de la connexion à la déconnexion,
* Aller sur Pix Admin, constater que les SSO proposés sont bien ceux attendus et vérifier que tout fonctionne comme attendu de la connexion à la déconnexion.
* Vérifier que l’appel `GET /api/oidc/identity-providers/` fonctionne toujours et renvoie la même réponse que `GET /api/oidc/identity-providers/org` ou `GET /api/oidc/identity-providers/` de manière à ce que les déconnexions fonctionnent toujours pour Pix Admin et pour les anciennes versions des frontaux Pix App, Pix Orga.
