### PR TITLE
[TECH] Permettre au bouton continuer sur la page des modules de rediriger vers l'application en utilisant le router interne (PIX-20273).

### DIFF
--- a/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
@@ -61,7 +61,7 @@ test('Combined courses', async ({ page }) => {
       await page.getByRole('button', { name: 'Commencer le module' }).click();
       await page.getByRole('button', { name: 'Terminer' }).click();
       await expect(page.getByRole('heading', { level: 1 })).toContainText('Module terminé !');
-      await page.getByRole('link', { name: 'Continuer' }).click();
+      await page.getByRole('button', { name: 'Continuer' }).click();
     });
 
     await test.step('End of combined course', async function () {

--- a/mon-pix/app/components/module/instruction/recap.gjs
+++ b/mon-pix/app/components/module/instruction/recap.gjs
@@ -14,7 +14,13 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
 
   <main class="module-recap">
     <div class="module-recap__header">
-      <QuitButton @redirectionUrl={{@module.redirectionUrl}} />
+      <ButtonAction
+        @redirectionUrl={{@module.redirectionUrl}}
+        @iconAfter="doorOpen"
+        @buttonText={{t "pages.modulix.recap.backToModuleDetails"}}
+        @buttonClass="module-recap-header__icon"
+        @variant="tertiary"
+      />
     </div>
 
     <img class="module-recap__illustration" src="/images/modulix/recap-success.svg" alt="" width="228" height="200" />
@@ -27,30 +33,21 @@ import ModuleBetaBanner from 'mon-pix/components/module/layout/beta-banner';
     </div>
 
     <div class="module-recap__link-details">
-      {{#if @module.redirectionUrl}}
-        <PixButtonLink @size="large" @href={{@module.redirectionUrl}} @variant="primary">
-          {{t "pages.modulix.recap.goToHomepage"}}
-        </PixButtonLink>
-      {{else}}
-        <PixButtonLink @size="large" @route="authenticated.user-dashboard" @variant="primary">
-          {{t "pages.modulix.recap.goToHomepage"}}
-        </PixButtonLink>
-      {{/if}}
-
+      <ButtonAction
+        @redirectionUrl={{@module.redirectionUrl}}
+        @buttonText={{t "pages.modulix.recap.goToHomepage"}}
+        @variant="primary"
+      />
     </div>
   </main>
 </template>
 
-class QuitButton extends Component {
+class ButtonAction extends Component {
   @service router;
 
   @action
   transitionToRedirectionUrl() {
-    if (this.isRedirectionUrlInternal) {
-      this.router.transitionTo(this.args.redirectionUrl);
-    } else {
-      window.location = this.args.redirectionUrl;
-    }
+    this.router.transitionTo(this.args.redirectionUrl);
   }
 
   get isRedirectionUrlInternal() {
@@ -63,24 +60,36 @@ class QuitButton extends Component {
 
   <template>
     {{#if @redirectionUrl}}
-      <PixButton
-        @size="large"
-        @variant="tertiary"
-        @iconAfter="doorOpen"
-        class="module-recap-header__icon"
-        @triggerAction={{this.transitionToRedirectionUrl}}
-      >
-        {{t "pages.modulix.recap.backToModuleDetails"}}
-      </PixButton>
+      {{#if this.isRedirectionUrlInternal}}
+        <PixButton
+          @size="large"
+          @variant={{@variant}}
+          @iconAfter={{@iconAfter}}
+          class={{@buttonClass}}
+          @triggerAction={{this.transitionToRedirectionUrl}}
+        >
+          {{@buttonText}}
+        </PixButton>
+      {{else}}
+        <PixButtonLink
+          @size="large"
+          @href={{@redirectionUrl}}
+          @variant={{@variant}}
+          @iconAfter={{@iconAfter}}
+          class={{@buttonClass}}
+        >
+          {{@buttonText}}
+        </PixButtonLink>
+      {{/if}}
     {{else}}
       <PixButtonLink
         @size="large"
         @route="authenticated.user-dashboard"
-        @variant="tertiary"
-        @iconAfter="doorOpen"
-        class="module-recap-header__icon"
+        @variant={{@variant}}
+        @iconAfter={{@iconAfter}}
+        class={{@buttonClass}}
       >
-        {{t "pages.modulix.recap.backToModuleDetails"}}
+        {{@buttonText}}
       </PixButtonLink>
     {{/if}}
   </template>

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -86,46 +86,92 @@ module('Integration | Component | Module | Recap', function (hooks) {
     const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Continuer' })).exists();
+    assert.dom(screen.getByRole('link', { name: t('pages.modulix.recap.goToHomepage') })).exists();
   });
 
   module('when a redirection url is set', function () {
-    test('should display link to a custom url', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const module = store.createRecord('module', {
-        id: 'mon-slug',
-        title: 'Module title',
-        isBeta: true,
-        redirectionUrl: 'https//some-url.fr',
-      });
-      // when
-      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+    module('Continue button', function () {
+      test('should display link to a custom url when not redict to internal Application', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const module = store.createRecord('module', {
+          id: 'mon-slug',
+          title: 'Module title',
+          isBeta: true,
+          redirectionUrl: 'https//some-url.fr',
+        });
+        // when
+        const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
 
-      // then
-      const button = screen.getByRole('link', { name: 'Continuer' });
-      assert.strictEqual(button.getAttribute('href'), module.redirectionUrl);
+        // then
+        const link = screen.getByRole('link', { name: t('pages.modulix.recap.goToHomepage') });
+
+        // then
+        assert.strictEqual(link.getAttribute('href'), module.redirectionUrl);
+      });
+
+      test('should call transitionTo with custom url when redirect to internal Application', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const router = this.owner.lookup('service:router');
+        const transitionToStub = sinon.stub(router, 'transitionTo');
+        const module = store.createRecord('module', {
+          id: 'mon-slug',
+          title: 'Module title',
+          isBeta: true,
+          redirectionUrl: '/parcours/combinix3',
+        });
+        // when
+        const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+        const button = screen.getByRole('button', { name: t('pages.modulix.recap.goToHomepage') });
+        await click(button);
+
+        // then
+
+        assert.ok(transitionToStub.calledWithExactly(module.redirectionUrl));
+      });
     });
 
-    test('should call transitionTo with custom url from application', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const router = this.owner.lookup('service:router');
-      const transitionToStub = sinon.stub(router, 'transitionTo');
-      const module = store.createRecord('module', {
-        id: 'mon-slug',
-        title: 'Module title',
-        isBeta: true,
-        redirectionUrl: '/parcours/combinix3',
+    module('Quit button', function () {
+      test('should display link to a custom url when not redict to internal Application', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const module = store.createRecord('module', {
+          id: 'mon-slug',
+          title: 'Module title',
+          isBeta: true,
+          redirectionUrl: 'https//some-url.fr',
+        });
+        // when
+        const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+
+        // then
+        const link = screen.getByRole('link', { name: t('pages.modulix.recap.backToModuleDetails') });
+
+        // then
+        assert.strictEqual(link.getAttribute('href'), module.redirectionUrl);
       });
-      // when
-      const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
-      const button = screen.queryByRole('button', { name: 'Quitter' });
-      await click(button);
 
-      // then
+      test('should call transitionTo with custom url when redirect to internal Application', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const router = this.owner.lookup('service:router');
+        const transitionToStub = sinon.stub(router, 'transitionTo');
+        const module = store.createRecord('module', {
+          id: 'mon-slug',
+          title: 'Module title',
+          isBeta: true,
+          redirectionUrl: '/parcours/combinix3',
+        });
+        // when
+        const screen = await render(<template><ModuleRecap @module={{module}} /></template>);
+        const button = screen.getByRole('button', { name: t('pages.modulix.recap.backToModuleDetails') });
+        await click(button);
 
-      assert.ok(transitionToStub.calledWithExactly(module.redirectionUrl));
+        // then
+
+        assert.ok(transitionToStub.calledWithExactly(module.redirectionUrl));
+      });
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Actuellement le bouton continuer dans un module recharge entièrement l'application lorsque nous sommes dans un contexte de parcours combiné.  ( appel réseaux en trop pour rien )

## 🌰 Proposition

Mutualiser le comportement du bouton quitter pour que le bouton continuer bénéficie de cette état. 

## 🍁 Remarques

RAS

## 🪵 Pour tester

Faire un combinix, vérifier qu'à la fin d'un module lorsque l'on clique sur continue on ne recharge pas toute l'app ( console => xhr merci bisous )