### PR TITLE
[FEATURE] Rendre plus robuste la récupération des métadonnées des images (PIX-20227)

### DIFF
--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -209,7 +209,7 @@ export class ModuleFactory {
       alternativeText: element.alternativeText,
       legend: element.legend,
       licence: element.licence,
-      infos: await getAssetInfos(element.url),
+      infos: await ModuleFactory.getAssetMetadata(element.url),
     });
   }
 
@@ -249,7 +249,7 @@ export class ModuleFactory {
             image: {
               altText: card.image?.altText,
               url: card.image?.url,
-              information: card.image?.url ? await getAssetInfos(card.image.url) : {},
+              information: card.image?.url ? await ModuleFactory.getAssetMetadata(card.image.url) : {},
             },
           });
         }),
@@ -350,7 +350,7 @@ export class ModuleFactory {
       instruction: element.instruction,
       introImage: {
         url: element.introImage.url,
-        information: element.introImage?.url ? await getAssetInfos(element.introImage.url) : {},
+        information: element.introImage?.url ? await ModuleFactory.getAssetMetadata(element.introImage.url) : {},
       },
       cards: await Promise.all(
         element.cards.map(async (card) => {
@@ -360,14 +360,14 @@ export class ModuleFactory {
               text: card.recto.text,
               image: {
                 url: card.recto.image?.url,
-                information: card.recto.image?.url ? await getAssetInfos(card.recto.image.url) : {},
+                information: card.recto.image?.url ? await ModuleFactory.getAssetMetadata(card.recto.image.url) : {},
               },
             },
             verso: {
               text: card.verso.text,
               image: {
                 url: card.verso.image?.url,
-                information: card.verso.image?.url ? await getAssetInfos(card.verso.image.url) : {},
+                information: card.verso.image?.url ? await ModuleFactory.getAssetMetadata(card.verso.image.url) : {},
               },
             },
           });

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -375,4 +375,13 @@ export class ModuleFactory {
       ),
     });
   }
+
+  static async getAssetMetadata(url) {
+    try {
+      return await getAssetInfos(url);
+    } catch (error) {
+      logger.debug(`Error when getting assets metadata with url ${url}: ${error}`);
+      return {};
+    }
+  }
 }

--- a/api/tests/shared/integration/infrastructure/repositories/pix-assets-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/pix-assets-repository_test.js
@@ -41,13 +41,25 @@ describe('Integration | Infrastructure | Repository | PixAssets', function () {
   });
 
   describe('#getAssetInfos', function () {
-    describe('when not from assets.pix.org', function () {
+    context('when not from assets.pix.org', function () {
       it('should throw', async function () {
         // when
         const error = await catchErr(getAssetInfos)('https://images.pix.fr/modules/placeholder-details.svg');
 
         // then
         expect(error.message).to.equal(`Asset URL "images.pix.fr" hostname is not handled. Use "assets.pix.org"`);
+      });
+    });
+
+    context('when assetsUrl is not a valid URL', function () {
+      it('should throw an error', async function () {
+        // when
+        const assetUrl = 'this.is.not.a.valid.url';
+        const error = await catchErr(getAssetInfos)(assetUrl);
+
+        // then
+        expect(error).to.be.instanceOf(Error);
+        expect(error.message).to.equal(`Asset URL "${assetUrl}" is invalid`);
       });
     });
 


### PR DESCRIPTION
## 🍂 Problème

Actuellement, si la récupération des métadonnées d’une image dans un module échoue (image qui n’existe plus…), alors l’api `/modules/:moduleId` renvoie une erreur 502 ce qui empêche de passer le module.

## 🌰 Proposition

Renvoyer, en cas d’erreur lors de la récupération un objet vide. Cela fera que côté front, uniquement le contenu de la balise `alt` sera affiché.

## 🍁 Remarques

- Un commit a été ajouté pour tester ce cas. A supprimer avant de merge !

## 🪵 Pour tester

- Afficher la console développeur 
- Aller sur le module [bac-a-sable](https://app-pr14049.review.pix.fr/modules/bac-a-sable/passage) et commencer le module
- Vérifier qu'on peut bien commencer et que le contenu de la balise alt s'affiche bien sur le 1er élément
- Vérifier, dans le Network, que l'appel `GET https://assets.pix.org/draft/flamenco.jpg` renvoie bien une erreur 404 !
