### PR TITLE
[FEATURE] Ajouter la pagination aux parcours combinés (PIX-19815)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -27,9 +27,10 @@ const getById = async (request, _, dependencies = { combinedCourseDetailsSeriali
 
 const getByOrganizationId = async (request, _, dependencies = { combinedCourseListSerializer }) => {
   const organizationId = request.params.organizationId;
-  const combinedCourses = await usecases.getCombinedCoursesByOrganizationId({ organizationId });
+  const page = request.query.page;
+  const { combinedCourses, meta } = await usecases.getCombinedCoursesByOrganizationId({ organizationId, page });
 
-  return dependencies.combinedCourseListSerializer.serialize(combinedCourses);
+  return dependencies.combinedCourseListSerializer.serialize(combinedCourses, meta);
 };
 
 const getStatistics = async (request, _, dependencies = { combinedCourseStatisticsSerializer }) => {

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -50,6 +50,12 @@ const register = async function (server) {
           params: Joi.object({
             organizationId: identifiersType.organizationId,
           }),
+          query: Joi.object({
+            page: {
+              number: Joi.number().integer().empty('').default(1),
+              size: Joi.number().integer().empty('').default(25),
+            },
+          }),
         },
         notes: ["- Récupération de la liste des parcours apprenants liés a l'organisation"],
         tags: ['api', 'quest', 'combined-course'],

--- a/api/src/quest/domain/usecases/get-combined-courses-by-organization-id.js
+++ b/api/src/quest/domain/usecases/get-combined-courses-by-organization-id.js
@@ -1,8 +1,12 @@
-export default async ({ organizationId, combinedCourseRepository, combinedCourseParticipationRepository }) => {
-  const combinedCourses = await combinedCourseRepository.findByOrganizationId({ organizationId });
+export default async ({ organizationId, page, combinedCourseRepository, combinedCourseParticipationRepository }) => {
+  const { combinedCourses, meta } = await combinedCourseRepository.findByOrganizationId({
+    organizationId,
+    page: page?.number,
+    size: page?.size,
+  });
 
   if (combinedCourses.length === 0) {
-    return [];
+    return { combinedCourses: [], meta };
   }
 
   const combinedCourseIds = combinedCourses.map((combinedCourse) => combinedCourse.id);
@@ -12,12 +16,14 @@ export default async ({ organizationId, combinedCourseRepository, combinedCourse
     combinedCourseParticipationRepository,
   });
 
-  return combinedCourses.map((combinedCourse) => {
+  const combinedCoursesWithParticipations = combinedCourses.map((combinedCourse) => {
     combinedCourse.participations = allCombinedCourseParticipations.filter(
       (participation) => participation.combinedCourseId === combinedCourse.id,
     );
     return combinedCourse;
   });
+
+  return { combinedCourses: combinedCoursesWithParticipations, meta };
 };
 
 async function getAllCombinedCourseParticipations({ combinedCourseIds, combinedCourseParticipationRepository }) {

--- a/api/src/quest/infrastructure/serializers/combined-course-list-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-list-serializer.js
@@ -2,9 +2,10 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (combinedCourse) {
+const serialize = function (combinedCourse, meta) {
   return new Serializer('combined-courses', {
     attributes: ['name', 'code', 'participationsCount', 'completedParticipationsCount'],
+    meta,
   }).serialize(combinedCourse);
 };
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
@@ -8,7 +8,7 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-organization-id', function () {
-  it('should return combined courses for an organization with their participations', async function () {
+  it('should return combined courses for an organization with their participations and pagination metadata', async function () {
     // given
     const { id: organizationId } = databaseBuilder.factory.buildOrganization();
     const { id: combinedCourseId1 } = databaseBuilder.factory.buildCombinedCourse({
@@ -63,12 +63,18 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const result = await usecases.getCombinedCoursesByOrganizationId({ organizationId });
 
     // then
-    expect(result).to.have.lengthOf(2);
-    expect(result[0]).to.be.an.instanceof(CombinedCourse);
-    expect(result[1]).to.be.an.instanceof(CombinedCourse);
+    expect(result.combinedCourses).to.have.lengthOf(2);
+    expect(result.combinedCourses[0]).to.be.an.instanceof(CombinedCourse);
+    expect(result.combinedCourses[1]).to.be.an.instanceof(CombinedCourse);
+    expect(result.meta).to.deep.include({
+      page: 1,
+      pageSize: 10,
+      rowCount: 2,
+      pageCount: 1,
+    });
 
-    const firstCourse = result.find((course) => course.id === combinedCourseId1);
-    const secondCourse = result.find((course) => course.id === combinedCourseId2);
+    const firstCourse = result.combinedCourses.find((course) => course.id === combinedCourseId1);
+    const secondCourse = result.combinedCourses.find((course) => course.id === combinedCourseId2);
 
     expect(firstCourse.code).to.equal('COURSE1');
     expect(firstCourse.name).to.equal('First Combined Course');
@@ -102,11 +108,11 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const result = await usecases.getCombinedCoursesByOrganizationId({ organizationId });
 
     // then
-    expect(result).to.have.lengthOf(1);
-    expect(result[0]).to.be.an.instanceof(CombinedCourse);
-    expect(result[0].id).to.equal(combinedCourseId1);
-    expect(result[0].code).to.equal('COURSE3');
-    expect(result[0].participations).to.deep.equal([]);
+    expect(result.combinedCourses).to.have.lengthOf(1);
+    expect(result.combinedCourses[0]).to.be.an.instanceof(CombinedCourse);
+    expect(result.combinedCourses[0].id).to.equal(combinedCourseId1);
+    expect(result.combinedCourses[0].code).to.equal('COURSE3');
+    expect(result.combinedCourses[0].participations).to.deep.equal([]);
   });
 
   it('should return empty array when no combined courses exist for organization', async function () {
@@ -118,7 +124,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const result = await usecases.getCombinedCoursesByOrganizationId({ organizationId });
 
     // then
-    expect(result).to.deep.equal([]);
+    expect(result.combinedCourses).to.deep.equal([]);
   });
 
   it('should not return combined courses from other organizations', async function () {
@@ -141,8 +147,8 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const result = await usecases.getCombinedCoursesByOrganizationId({ organizationId: organizationId1 });
 
     // then
-    expect(result).to.have.lengthOf(1);
-    expect(result[0].code).to.equal('ORG1COURSE');
+    expect(result.combinedCourses).to.have.lengthOf(1);
+    expect(result.combinedCourses[0].code).to.equal('ORG1COURSE');
   });
 
   it('should not include participations from other combined courses', async function () {
@@ -187,8 +193,8 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const result = await usecases.getCombinedCoursesByOrganizationId({ organizationId });
 
     // then
-    const firstCourse = result.find((course) => course.id === combinedCourseId1);
-    const secondCourse = result.find((course) => course.id === combinedCourseId2);
+    const firstCourse = result.combinedCourses.find((course) => course.id === combinedCourseId1);
+    const secondCourse = result.combinedCourses.find((course) => course.id === combinedCourseId2);
 
     expect(firstCourse.participations).to.have.lengthOf(1);
     expect(firstCourse.participations[0].firstName).to.equal('Alice');

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -63,7 +63,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
   });
 
   describe('#findByOrganizationId', function () {
-    it('should return all combined courses for a given organization ordered by creation date', async function () {
+    it('should return all combined courses for a given organization ordered by creation date descending with pagination metadata', async function () {
       // given
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const combinedCourse1 = databaseBuilder.factory.buildCombinedCourse({
@@ -81,14 +81,20 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await databaseBuilder.commit();
 
       // when
-      const combinedCourses = await combinedCourseRepository.findByOrganizationId({ organizationId });
+      const result = await combinedCourseRepository.findByOrganizationId({ organizationId, page: 1, size: 10 });
 
       // then
-      expect(combinedCourses).to.have.lengthOf(2);
-      expect(combinedCourses[0]).to.be.an.instanceof(CombinedCourse);
-      expect(combinedCourses[1]).to.be.an.instanceof(CombinedCourse);
-      expect(combinedCourses[0]).to.deep.equal(new CombinedCourse(combinedCourse2));
-      expect(combinedCourses[1]).to.deep.equal(new CombinedCourse(combinedCourse1));
+      expect(result.combinedCourses).to.have.lengthOf(2);
+      expect(result.combinedCourses[0]).to.be.an.instanceof(CombinedCourse);
+      expect(result.combinedCourses[1]).to.be.an.instanceof(CombinedCourse);
+      expect(result.combinedCourses[0]).to.deep.equal(new CombinedCourse(combinedCourse2));
+      expect(result.combinedCourses[1]).to.deep.equal(new CombinedCourse(combinedCourse1));
+      expect(result.meta).to.deep.include({
+        page: 1,
+        pageSize: 10,
+        rowCount: 2,
+        pageCount: 1,
+      });
     });
 
     it('should return an empty array when organization has no combined courses', async function () {
@@ -97,10 +103,16 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await databaseBuilder.commit();
 
       // when
-      const combinedCourses = await combinedCourseRepository.findByOrganizationId({ organizationId });
+      const result = await combinedCourseRepository.findByOrganizationId({ organizationId, page: 1, size: 10 });
 
       // then
-      expect(combinedCourses).to.deep.equal([]);
+      expect(result.combinedCourses).to.deep.equal([]);
+      expect(result.meta).to.deep.include({
+        page: 1,
+        pageSize: 10,
+        rowCount: 0,
+        pageCount: 0,
+      });
     });
 
     it('should not return combined courses from other organizations', async function () {
@@ -120,13 +132,15 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await databaseBuilder.commit();
 
       // when
-      const combinedCourses = await combinedCourseRepository.findByOrganizationId({
+      const result = await combinedCourseRepository.findByOrganizationId({
         organizationId: organization1Id,
+        page: 1,
+        size: 10,
       });
 
       // then
-      expect(combinedCourses).to.have.lengthOf(1);
-      expect(combinedCourses[0].organizationId).to.equal(organization1Id);
+      expect(result.combinedCourses).to.have.lengthOf(1);
+      expect(result.combinedCourses[0].organizationId).to.equal(organization1Id);
     });
   });
 

--- a/orga/app/adapters/combined-course.js
+++ b/orga/app/adapters/combined-course.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class CombinedCourseAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    if (query.organizationId) {
+      const { organizationId } = query;
+      delete query.organizationId;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/combined-courses`;
+    }
+    return super.urlForQuery(...arguments);
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/combined-courses.js
+++ b/orga/app/controllers/authenticated/campaigns/combined-courses.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+const DEFAULT_PAGE_NUMBER = 1;
+
+export default class CombinedCoursesController extends Controller {
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 25;
+
+  get combinedCoursesCount() {
+    return this.model.combinedCourses.meta?.rowCount || 0;
+  }
+}

--- a/orga/app/routes/authenticated/campaigns/combined-courses.js
+++ b/orga/app/routes/authenticated/campaigns/combined-courses.js
@@ -5,10 +5,35 @@ export default class CampaignCombinedCoursesRoute extends Route {
   @service store;
   @service currentUser;
   @service router;
+  queryParams = {
+    pageNumber: {
+      refreshModel: true,
+    },
+    pageSize: {
+      refreshModel: true,
+    },
+  };
 
-  async model() {
-    return {
-      combinedCourses: this.currentUser.combinedCourses || [],
-    };
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 25;
+    }
+  }
+
+  async model(params) {
+    const organization = this.currentUser.organization;
+    const combinedCourses = await this.store.query(
+      'combined-course',
+      {
+        organizationId: organization.id,
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      },
+      { reload: true },
+    );
+    return { combinedCourses };
   }
 }

--- a/orga/app/templates/authenticated/campaigns/combined-courses.gjs
+++ b/orga/app/templates/authenticated/campaigns/combined-courses.gjs
@@ -1,3 +1,4 @@
+import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 import ListHeader from 'pix-orga/components/campaign/list-header';
@@ -8,7 +9,7 @@ import CombinedCourseList from 'pix-orga/components/combined-course/list';
 
   <article>
     <ListHeader />
-
     <CombinedCourseList @combinedCourses={{@model.combinedCourses}} />
+    <PixPagination @pagination={{@model.combinedCourses.meta}} />
   </article>
 </template>

--- a/orga/tests/unit/routes/authenticated/campaigns/combined-courses-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/combined-courses-test.js
@@ -1,0 +1,73 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/combined-courses', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+  let store;
+  let currentUser;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/campaigns/combined-courses');
+    store = this.owner.lookup('service:store');
+    currentUser = this.owner.lookup('service:current-user');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('model', function () {
+    test('should query combined-courses with organizationId and pagination params', async function (assert) {
+      // given
+      const organizationId = Symbol('organization-id');
+      const pageNumber = 2;
+      const pageSize = 10;
+      const combinedCoursesSymbol = Symbol('combined-courses');
+
+      currentUser.organization = { id: organizationId };
+
+      sinon
+        .stub(store, 'query')
+        .withArgs(
+          'combined-course',
+          {
+            organizationId,
+            page: {
+              number: pageNumber,
+              size: pageSize,
+            },
+          },
+          { reload: true },
+        )
+        .resolves(combinedCoursesSymbol);
+
+      // when
+      const result = await route.model({ pageNumber, pageSize });
+
+      // then
+      assert.deepEqual(result, { combinedCourses: combinedCoursesSymbol });
+    });
+  });
+
+  module('resetController', function () {
+    test('should reset pageNumber and pageSize when exiting the route', function (assert) {
+      // given
+      const controller = {
+        pageNumber: 5,
+        pageSize: 50,
+      };
+
+      // when
+      route.resetController(controller, true);
+
+      // then
+      assert.deepEqual(controller, {
+        pageNumber: 1,
+        pageSize: 25,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Les parcours combinés n'avaient pas de pagination côté API et frontend Orga, ce qui pouvait poser des problèmes de performance avec un grand nombre de parcours.

## 🌰 Proposition

### API
- Ajout de la pagination dans le endpoint GET /api/combined-courses avec les paramètres `page[number]` et `page[size]`
- Mise à jour du use case `get-combined-courses-by-organization-id` pour gérer la pagination
- Mise à jour du repository `combined-course-repository` pour supporter les paramètres de pagination
- Mise à jour du serializer pour retourner les métadonnées de pagination

### Orga
- Ajout d'un adapter pour gérer la pagination côté Ember
- Ajout de queryParams `pageNumber` et `pageSize` dans le controller (défaut: page 1, taille 25)
- Mise à jour de la route pour passer les paramètres de pagination à l'API
- Ajout de tests unitaires pour la route

### Tests
- Ajout de données supplémentaires dans le seed pour tester la pagination
- Ajout de tests pour le use case, repository et route

## 🪵 Pour tester

1. Se connecter à Orga avec un compte d'une organisation ayant plusieurs parcours combinés ( Pro classic )
2. Accéder à la page des parcours combinés
3. Vérifier que la pagination fonctionne correctement avec les paramètres par défaut (25 éléments par page)
4. Modifier les paramètres de pagination et vérifier que cela fonctionne