### PR TITLE
[FEATURE] Permettre de se déplacer sur une section au clic sur les boutons de la nav (PIX-20268).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -387,42 +387,6 @@
       ]
     },
     {
-      "id": "1d2e3c80-0b23-40c6-bb56-4fa957207ac6",
-      "type": "blank",
-      "grains": [
-        {
-          "id": "d6ed29e2-fb0b-4f03-9e26-61029ecde2e3",
-          "type": "transition",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "08a8b1ea-4771-48ef-a5a5-665c664ba673",
-                "type": "text",
-                "content": "<p>Bonjour et bienvenue dans le bac à sable de Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>"
-              }
-            }
-          ]
-        },
-        {
-          "id": "8bbfb1ef-3d35-48ce-bb3f-b63a8df9a8ac",
-          "type": "lesson",
-          "title": "",
-          "components": [
-            {
-              "type": "element",
-              "element": {
-                "id": "60b9e09b-dbb8-4de8-83fd-665873ca2f03",
-                "type": "text",
-                "content": "<p>Ceci est un grain de type leçon, dédié au bon vieux pattern</p>"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "b0d428ab-a4ae-45e0-83fd-786fbd9c03dc",
       "type": "practise",
       "grains": [

--- a/mon-pix/app/components/module/layout/_navigation-button.scss
+++ b/mon-pix/app/components/module/layout/_navigation-button.scss
@@ -2,38 +2,8 @@
 @use 'pix-design-tokens/breakpoints';
 
 .module-navigation-button {
-  @include breakpoints.device-is('mobile') {
-    .pix-navigation-button {
-      border-radius: var(--pix-spacing-2x);
-    }
-  }
-
   width: 3.375rem;
   background-color: rgb(var(--pix-primary-700-inline), 0.2);
-}
-
-.module-navigation-button, .module-navigation-mobile-button {
-  border-radius: var(--pix-spacing-2x);
-
-  &--current {
-    background-color: rgb(var(--pix-primary-700-inline), 0.60);
-
-    @include breakpoints.device-is('mobile') {
-      color: var(--pix-neutral-0);
-      background-color: rgb(var(--pix-primary-700-inline), 0.60);
-    }
-
-    &.pix-icon-button:not([aria-disabled="true"]){
-      &:hover,&:focus{
-        background-color: rgb(var(--pix-primary-700-inline), 0.60)
-      }
-
-    }
-
-    .pix-icon {
-      fill: var(--pix-neutral-0);
-    }
-  }
 
   &--disabled {
     background-color: unset;
@@ -43,14 +13,12 @@
       border: 1px solid var(--pix-primary-100);
     }
 
-    .pix-icon {
+    .pix-icon{
       fill: rgb(var(--pix-neutral-800-inline), 0.50);
     }
-
   }
 
   &--enabled {
-    background-color: rgb(var(--pix-primary-700-inline), 0.2);
 
     &.pix-icon-button:not([aria-disabled="true"]){
       &:focus, &:hover{
@@ -61,8 +29,62 @@
   }
 }
 
+.module-navigation-button, .module-navigation-mobile-button {
+  border-radius: var(--pix-spacing-2x);
+
+  &--current {
+    background-color: rgb(var(--pix-primary-700-inline), 0.60);
+
+    &.pix-icon-button:not([aria-disabled="true"]){
+      &:hover,&:focus{
+        background-color: rgb(var(--pix-primary-700-inline), 0.60)
+      }
+    }
+
+    .pix-icon {
+      fill: var(--pix-neutral-0);
+    }
+  }
+
+  &--enabled {
+    background-color: rgb(var(--pix-primary-700-inline), 0.2);
+  }
+}
+
 .module-navigation-mobile-button {
+  @extend %pix-title-xxs;
+
+  justify-content: start;
+  width: 100%;
   margin-bottom: var(--pix-spacing-1x);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
+  font-weight: var(--pix-font-normal);
+  font-size: .875rem;
+
+  &--enabled {
+    color: var(--pix-neutral-900);
+  }
+
+  &--current {
+    color: var(--pix-neutral-0);
+    background-color: rgb(var(--pix-primary-700-inline), 0.60);
+  }
+
+  &.pix-button[aria-disabled="true"] {
+    color: var(--pix-neutral-900);
+    background-color: unset;
+    opacity: 1;
+
+    .pix-icon {
+      opacity: 0.5;
+      fill: var(--pix-neutral-800);
+    }
+  }
+
+  .pix-button__icon {
+   width: 1.5rem;
+   height: 1.5rem;
+  }
 }
 
 .navigation-tooltip {

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -1,7 +1,6 @@
 import onEscapeAction from '@1024pix/pix-ui/addon/modifiers/on-escape-action';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
-import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -12,6 +11,7 @@ import { SECTION_TITLE_ICONS } from 'mon-pix/models/section';
 export default class ModulixNavigationButton extends Component {
   @service intl;
   @service media;
+  @service modulixAutoScroll;
 
   @tracked isTooltipVisible = false;
 
@@ -48,7 +48,15 @@ export default class ModulixNavigationButton extends Component {
   }
 
   @action
-  dummyFunction() {}
+  scrollToSection() {
+    if (this.isDisabled) {
+      return;
+    }
+
+    const htmlElement = document.querySelector(`#section_${this.args.section.type}`);
+
+    this.modulixAutoScroll.focusAndScroll(htmlElement);
+  }
 
   @action
   showTooltip() {
@@ -75,7 +83,7 @@ export default class ModulixNavigationButton extends Component {
     {{#if this.media.isMobile}}
       <PixNavigationButton
         class="module-navigation-mobile-button module-navigation-mobile-button{{this.buttonClass}}"
-        href={{concat "#section_" @section.type}}
+        href={{this.scrollToSection}}
         @icon={{this.sectionTitleIcon @section.type}}
         aria-disabled="{{this.isDisabled}}"
         aria-current="{{this.isCurrentSection}}"
@@ -92,7 +100,7 @@ export default class ModulixNavigationButton extends Component {
         <PixIconButton
           class="module-navigation-button module-navigation-button{{this.buttonClass}}"
           @ariaLabel={{this.sectionTitle @section.type}}
-          @triggerAction={{this.dummyFunction}}
+          @triggerAction={{this.scrollToSection}}
           @iconName={{this.sectionTitleIcon @section.type}}
           @isDisabled={{this.isDisabled}}
           aria-current="{{this.isCurrentSection}}"

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -1,6 +1,6 @@
 import onEscapeAction from '@1024pix/pix-ui/addon/modifiers/on-escape-action';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
-import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -81,13 +81,13 @@ export default class ModulixNavigationButton extends Component {
 
   <template>
     {{#if this.media.isMobile}}
-      <PixNavigationButton
+      <PixButton
         class="module-navigation-mobile-button module-navigation-mobile-button{{this.buttonClass}}"
-        href={{this.scrollToSection}}
-        @icon={{this.sectionTitleIcon @section.type}}
-        aria-disabled="{{this.isDisabled}}"
+        @triggerAction={{this.scrollToSection}}
+        @iconBefore={{this.sectionTitleIcon @section.type}}
+        @isDisabled={{this.isDisabled}}
         aria-current="{{this.isCurrentSection}}"
-      >{{this.sectionTitle @section.type}}</PixNavigationButton>
+      >{{this.sectionTitle @section.type}}</PixButton>
     {{else}}
       <div
         class="navigation-tooltip {{if this.isTooltipVisible 'navigation-tooltip--visible' ''}}"


### PR DESCRIPTION
## 🍂 Problème

Le chantier de la nouvelle navigation coté modulix est en cours. On veut pouvoir scroller vers les sections actives au clic sur la nav.

## 🌰 Proposition

Permettre le scroll sur les sections.

## 🪵 Pour tester

- Aller sur un module https://app-pr14052.review.pix.fr/modules/bac-a-sable/details
- Cliquer sur un bouton disabled (les grisés)
- Constater qu'il ne se passe rien. En effet on ne souhaite pas que ces boutons soient activables car les sections en lien n'ont pas encore été découverte par l'utilisateur.
- Faire le module pour activer plusieurs boutons sur la nav
- Cliquer sur un bouton (courant ou enabled)
- Constater que l'on est ramené vers la section en lien.
- Faire ce même test en mobile.
