### PR TITLE
[TECH] :truck: Déplace le test unitaire de `FinalizedSession` dans le contexte `certification/session-management` (PIX-20300)

### DIFF
--- a/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
@@ -1,8 +1,8 @@
-import { FinalizedSession } from '../../../../src/certification/session-management/domain/models/FinalizedSession.js';
-import { JuryCertificationSummary } from '../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
-import { CertificationIssueReportCategory } from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { status as assessmentResultStatuses } from '../../../../src/shared/domain/models/AssessmentResult.js';
-import { domainBuilder, expect } from '../../../test-helper.js';
+import { FinalizedSession } from '../../../../../../src/certification/session-management/domain/models/FinalizedSession.js';
+import { JuryCertificationSummary } from '../../../../../../src/certification/session-management/domain/read-models/JuryCertificationSummary.js';
+import { CertificationIssueReportCategory } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | Models | FinalizedSession', function () {
   context('#isPublishable', function () {

--- a/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
@@ -4,7 +4,7 @@ import { CertificationIssueReportCategory } from '../../../../../../src/certific
 import { status as assessmentResultStatuses } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
-describe('Unit | Domain | Models | FinalizedSession', function () {
+describe('Unit | Certification | Session-Management | Domain | Models | FinalizedSession', function () {
   context('#isPublishable', function () {
     it('is not publishable when session has an examiner global comment', function () {
       // given / when


### PR DESCRIPTION
## 🍂 Problème

Le test unitaire de `FinalizedSession` est dans le répertoire des tests commun. Mais il teste un modèle qui est dans le contexte `certification/session-management`

## 🌰 Proposition

Déplacer le test unitaire de `FinalizedSession` dans le contexte `certification/session-management`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Les tests sont vert
