### PR TITLE
[BUGFIX] Récupérer l'URL localisée du lien "Comment se certifier ?"  (PIX-20304).

### DIFF
--- a/mon-pix/app/components/certification-banners/congratulations-certification-banner.gjs
+++ b/mon-pix/app/components/certification-banners/congratulations-certification-banner.gjs
@@ -1,34 +1,40 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import EligibleDoubleCertificationBanner from 'mon-pix/components/certification-banners/eligible-double-certification-banner';
 
-<template>
-  <div class="congratulations-banner">
-    <p class="congratulations-banner__message">
-      {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
-    </p>
-    {{#if @doubleCertification.isBadgeValid}}
-      <EligibleDoubleCertificationBanner @doubleCertification={{@doubleCertification}} />
-    {{/if}}
-    <div class="congratulations-banner__links">
-      <PixButtonLink
-        @href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
-        class="congratulations-banner-links__link"
-        target="_blank"
-        @variant="transparent-dark"
-        rel="noopener noreferrer"
-      >
-        {{t "pages.certification-joiner.congratulation-banner.link.text"}}
-        <PixIcon @name="openNew" @plainIcon={{true}} @title={{t "navigation.external-link-title"}} />
-      </PixButtonLink>
-      <PixButtonLink
-        @route="authenticated.user-certifications"
-        @variant="transparent-dark"
-        class="congratulations-banner-links__link"
-      >{{t "pages.certification-start.link-to-user-certification"}}
-        <PixIcon @name="eye" @plainIcon={{true}} @ariaHidden={{true}} />
-      </PixButtonLink>
+export default class Index extends Component {
+  @service url;
+
+  <template>
+    <div class="congratulations-banner">
+      <p class="congratulations-banner__message">
+        {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
+      </p>
+      {{#if @doubleCertification.isBadgeValid}}
+        <EligibleDoubleCertificationBanner @doubleCertification={{@doubleCertification}} />
+      {{/if}}
+      <div class="congratulations-banner__links">
+        <PixButtonLink
+          @href={{this.url.certificationHowToUrl}}
+          class="congratulations-banner-links__link"
+          target="_blank"
+          @variant="transparent-dark"
+          rel="noopener noreferrer"
+        >
+          {{t "pages.certification-joiner.congratulation-banner.link.text"}}
+          <PixIcon @name="openNew" @plainIcon={{true}} @title={{t "navigation.external-link-title"}} />
+        </PixButtonLink>
+        <PixButtonLink
+          @route="authenticated.user-certifications"
+          @variant="transparent-dark"
+          class="congratulations-banner-links__link"
+        >{{t "pages.certification-start.link-to-user-certification"}}
+          <PixIcon @name="eye" @plainIcon={{true}} @ariaHidden={{true}} />
+        </PixButtonLink>
+      </div>
     </div>
-  </div>
-</template>
+  </template>
+}

--- a/mon-pix/app/services/url-base.js
+++ b/mon-pix/app/services/url-base.js
@@ -141,4 +141,14 @@ export const PIX_WEBSITE_PATHS = {
     'es-419': 'understand-certification-results',
     fr: 'certification-comprendre-score-niveau',
   },
+  CERTIFICATION_HOW_TO: {
+    'fr-FR': 'se-certifier',
+    'fr-BE': 'se-certifier',
+    'nl-BE': 'mijn-digitale-vaardigheden-certificeren',
+    nl: 'mijn-digitale-vaardigheden-certificeren',
+    en: 'certify-my-digital-skills',
+    es: 'certify-my-digital-skills',
+    'es-419': 'certify-my-digital-skills',
+    fr: 'se-certifier',
+  },
 };

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -33,4 +33,8 @@ export default class Url extends UrlBaseService {
   get certificationResultsExplanationUrl() {
     return this.getPixWebsiteUrlFor('CERTIFICATION_RESULTS_EXPLANATION');
   }
+
+  get certificationHowToUrl() {
+    return this.getPixWebsiteUrlFor('CERTIFICATION_HOW_TO');
+  }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -821,8 +821,7 @@
           "outdated": "<strong>Vous n'êtes plus éligible à la certification {doubleCertificationName} suite à son évolution.</strong><br />Recontactez votre établissement ou l’organisation vous ayant proposé le parcours afin de repasser une campagne et ainsi redevenir éligible. Votre progression a été conservée et vous n'aurez qu'à jouer les nouvelles épreuves, cela devrait être rapide."
         },
         "link": {
-          "text": "How do I certify my digital skills?",
-          "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+          "text": "How do I certify my digital skills?"
         },
         "message": "Well done, {fullName}, your Pix profile can now be certified."
       },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -817,8 +817,7 @@
           "outdated": "<strong>Ya no eres elegible para la certificación {doubleCertificationName} después de su evolución.</strong><br />Ponte de nuevo en contacto con tu centro o la organización que te ofreció el test para realizar de nuevo una campaña y volver a ser elegible. Tu progreso se ha conservado y solo tendrás que hacer las pruebas nuevas, debería ir rápido."
         },
         "link": {
-          "text": "¿Cómo puedo obtener el certificado?",
-          "url": "https://pix.fr/se-certifier#slice-2"
+          "text": "¿Cómo puedo obtener el certificado?"
         },
         "message": "Enhorabuena {fullName}, tu perfil Pix se puede certificar."
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -817,8 +817,7 @@
           "outdated": "<strong>Ya no eres elegible para la certificación {doubleCertificationName} después de su evolución.</strong><br />Ponte de nuevo en contacto con tu centro o la organización que te ofreció el test para realizar de nuevo una campaña y volver a ser elegible. Tu progreso se ha conservado y solo tendrás que hacer las pruebas nuevas, debería ir rápido."
         },
         "link": {
-          "text": "¿Cómo puedo obtener el certificado?",
-          "url": "https://pix.fr/se-certifier#slice-2"
+          "text": "¿Cómo puedo obtener el certificado?"
         },
         "message": "Enhorabuena {fullName}, tu perfil Pix se puede certificar."
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -822,8 +822,7 @@
           "outdated": "<strong>Vous n'êtes plus éligible à la certification {doubleCertificationName} suite à son évolution.</strong><br />Recontactez votre établissement ou l’organisation vous ayant proposé le parcours afin de repasser une campagne et ainsi redevenir éligible. Votre progression a été conservée et vous n'aurez qu'à jouer les nouvelles épreuves, cela devrait être rapide."
         },
         "link": {
-          "text": "Comment se certifier ?",
-          "url": "https://pix.fr/se-certifier#slice-2"
+          "text": "Comment se certifier ?"
         },
         "message": "Bravo {fullName}, votre profil Pix est certifiable."
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -820,8 +820,7 @@
           "outdated": "<strong>Je komt niet langer in aanmerking voor de {doubleCertificationName}-certificering na de evolutie ervan.</strong><br />Neem contact op met je school of de organisatie die je de cursus heeft aangeboden om opnieuw een campagne te doen en zo weer in aanmerking te komen. Je voortgang is bewaard gebleven en je hoeft alleen nog maar de nieuwe evenementen te spelen, wat snel zou moeten gaan."
         },
         "link": {
-          "text": "Hoe word ik gecertificeerd?",
-          "url": "https://pix.fr/se-certifier#slice-2"
+          "text": "Hoe word ik gecertificeerd?"
         },
         "message": "Gefeliciteerd {fullName}, je Pix-profiel is certificeerbaar."
       },


### PR DESCRIPTION
## 🍂 Problème

- Un candidat se connecte sur son compte Pix App sur .org

- Il change sa langue en allant dans l’onglet “Mon compte” puis dans la rubrique “Choisir ma langue”

- Puis il va dans l’onglet “Certification” et clique sur le bouton “Comment se certifier ?”

- Quelque soit la langue, il est redirigé vers une page du site vitrine **FR** expliquant comment valoriser ses compétences du numérique

## 🌰 Proposition

- **EN et ES** : l'URL devient "https://pix.org/en/certify-my-digital-skills"
- **NL** : l'URL devient "https://pix.org/nl-be/mijn-digitale-vaardigheden-certificeren"
- **FR-BE** : l'URL devient "https://pix.org/fr-be/se-certifier"

## 🪵 Pour tester

- Aller sur [PixApp (org) en RA](https://app-pr14062.review.pix.org/), et vérifier dans les différentes langues le lien sur le bouton “Comment se certifier ?” de la page "Certification".
