### PR TITLE
[FEATURE] Ajouter une colonne "countryCode" sur la table organizations (PIX-20134)

### DIFF
--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -23,6 +23,7 @@ const buildOrganization = function buildOrganization({
   identityProviderForCampaigns = null,
   parentOrganizationId = null,
   administrationTeamId = null,
+  countryCode = null,
 } = {}) {
   if (!administrationTeamId) {
     administrationTeamId = buildAdministrationTeam().id;
@@ -50,6 +51,7 @@ const buildOrganization = function buildOrganization({
     identityProviderForCampaigns,
     parentOrganizationId,
     administrationTeamId,
+    countryCode,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20251104101626_add-country-code-column-to-organizations.js
+++ b/api/db/migrations/20251104101626_add-country-code-column-to-organizations.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'countryCode';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .specificType(COLUMN_NAME, `integer CHECK ("${COLUMN_NAME}" BETWEEN 99000 AND 99999)`)
+      .nullable()
+      .comment('Country code (INSEE): five-digit numeric country code starting with 99.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -33,6 +33,7 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
     'schoolCode',
     'sessionExpirationDate',
     'administrationTeamId',
+    'countryCode',
   ];
 
   let clock;


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de l'épix qui permettra de choisir le pays d'une organisation. Nous avons besoin de pouvoir stocker cette information en base.

## 🌰 Proposition

Ajouter une colonne countryCode à la table "organizations"


## 🪵 Pour tester

- Cas d'échecs:
  - Essayer de faire un update sql sur une orga avec un countryCode en string
  - Essayer de faire un update sql sur une orga avec un countryCode avec un nombre inférieur à 99000
  - Essayer de faire un update sql sur une orga avec un countryCode avec un nombre supérieur à 99999
  - Constater une erreur pour chaque cas
  
- Cas passant:
  -  Essayer de faire un update sql sur une orga avec un countryCode avec un nombre entre 99000 et 99999
  - Constater que la ligne a bien été mise à jour