### PR TITLE
[TECH] /api/context

### DIFF
--- a/api/src/shared/application/context/context.controller.js
+++ b/api/src/shared/application/context/context.controller.js
@@ -1,0 +1,33 @@
+import { usecases } from '../../../identity-access-management/domain/usecases/index.js';
+import {
+  getForwardedOrigin,
+  RequestedApplication,
+} from '../../../identity-access-management/infrastructure/utils/network.js';
+import { featureToggles } from '../../infrastructure/feature-toggles/index.js';
+import * as contextSerializer from '../../infrastructure/serializers/jsonapi/context.serializer.js';
+import { logger } from '../../infrastructure/utils/logger.js';
+
+const getContext = async function (request) {
+  const featureTogglesList = await featureToggles.withTag('frontend');
+
+  let identityProviders;
+  try {
+    const origin = getForwardedOrigin(request.headers);
+    const requestedApplication = RequestedApplication.fromOrigin(origin);
+
+    identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });
+  } catch (error) {
+    logger.error(error, `Error getting identityProviders.`);
+    identityProviders = [];
+  }
+
+  const context = {
+    featureToggles: featureTogglesList,
+    identityProviders,
+  };
+  return contextSerializer.serialize(context);
+};
+
+const contextController = { getContext };
+
+export { contextController };

--- a/api/src/shared/application/context/context.route.js
+++ b/api/src/shared/application/context/context.route.js
@@ -1,0 +1,20 @@
+import { contextController } from './context.controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/context',
+      options: {
+        auth: false,
+        handler: contextController.getContext,
+        notes: ['Cette route renvoie le contexte, constitué de propriétés'],
+        tags: ['shared', 'api', 'context'],
+        cache: false,
+      },
+    },
+  ]);
+};
+
+const name = 'context-api';
+export { name, register };

--- a/api/src/shared/infrastructure/serializers/jsonapi/context.serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/context.serializer.js
@@ -1,0 +1,16 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (context) {
+  return new Serializer('context', {
+    pluralizeType: false,
+    keyForAttribute: 'camelCase',
+    transform(context) {
+      return { id: 0, ...context };
+    },
+    attributes: Object.keys(context),
+  }).serialize(context);
+};
+
+export { serialize };

--- a/api/src/shared/routes.js
+++ b/api/src/shared/routes.js
@@ -1,8 +1,9 @@
 import * as assessmentsRoutes from './application/assessments/index.js';
 import * as challengesRoutes from './application/challenges/index.js';
+import * as contextRoutes from './application/context/context.route.js';
 import * as featureToggles from './application/feature-toggles/index.js';
 import * as healthcheck from './application/healthcheck/index.js';
 
-const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, featureToggles];
+const sharedRoutes = [healthcheck, assessmentsRoutes, challengesRoutes, contextRoutes, featureToggles];
 
 export { sharedRoutes };

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/context-serializer.test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/context-serializer.test.js
@@ -1,0 +1,36 @@
+import * as serializer from '../../../../../../src/shared/infrastructure/serializers/jsonapi/context.serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | context-serializer', function () {
+  describe('#serialize', function () {
+    it('converts context object into JSON API data', function () {
+      // given
+      const context = {
+        featureToggles: {
+          someFeatureToggle: true,
+          otherFeatureToggle: false,
+        },
+        identityProviders: [{}, {}],
+        autonomousCoursesOrganizationId: 999,
+      };
+
+      const expectedJSON = {
+        data: {
+          type: 'context',
+          id: '0',
+          attributes: {
+            featureToggles: { someFeatureToggle: true, otherFeatureToggle: false },
+            identityProviders: [{}, {}],
+            autonomousCoursesOrganizationId: 999,
+          },
+        },
+      };
+
+      // when
+      const json = serializer.serialize(context);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});

--- a/mon-pix/app/models/context.js
+++ b/mon-pix/app/models/context.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FrontendContext extends Model {
+  @attr() featureToggles;
+  @attr() identityProviders;
+}

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -5,6 +5,7 @@ import ENV from 'mon-pix/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service authentication;
+  @service frontendContext;
   @service featureToggles;
   @service intl;
   @service oidcIdentityProviders;
@@ -36,8 +37,15 @@ export default class ApplicationRoute extends Route {
     const queryParams = transition?.to?.queryParams;
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
-    await this.featureToggles.load().catch();
-    await this.oidcIdentityProviders.load().catch();
+
+    // await this.frontendContext.load().catch();
+    const context = await this.frontendContext.fetch().catch();
+    console.log('FEC:', context);
+    console.log('FEC1:', context.featureToggles);
+    console.log('FEC2:', context.identityProviders);
+    await this.featureToggles.set(context.featureToggles);
+    await this.oidcIdentityProviders.set(context.identityProviders);
+
     await this.authentication.handleAnonymousAuthentication(transition);
     await this.currentUser.load();
   }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -5,7 +5,7 @@ import ENV from 'mon-pix/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service authentication;
-  @service frontendContext;
+  @service('context') acontext;
   @service featureToggles;
   @service intl;
   @service oidcIdentityProviders;
@@ -38,13 +38,19 @@ export default class ApplicationRoute extends Route {
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
 
-    // await this.frontendContext.load().catch();
-    const context = await this.frontendContext.fetch().catch();
-    console.log('FEC:', context);
-    console.log('FEC1:', context.featureToggles);
-    console.log('FEC2:', context.identityProviders);
-    await this.featureToggles.set(context.featureToggles);
-    await this.oidcIdentityProviders.set(context.identityProviders);
+
+    console.log('featureToggles:', typeof this.featureToggles, this.featureToggles)
+    this.featureToggles.allo();
+
+    // await this.context.load().catch();
+    console.log('acontext:', typeof this.acontext, this.acontext)
+    this.acontext.allo();
+    // const context = await this.context.fetch().catch();
+    // console.log('FEC:', context);
+    // console.log('FEC1:', context.featureToggles);
+    // console.log('FEC2:', context.identityProviders);
+    // await this.featureToggles.set(context.featureToggles);
+    // await this.oidcIdentityProviders.set(context.identityProviders);
 
     await this.authentication.handleAnonymousAuthentication(transition);
     await this.currentUser.load();

--- a/mon-pix/app/services/context.js
+++ b/mon-pix/app/services/context.js
@@ -1,20 +1,23 @@
 import Service, { service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
-export default class FrontendContextService extends Service {
+export default class ContextService extends Service {
   @service requestManager;
 
-  frontendContext;
+  // frontendContext;
 
   // async load() {
   //   this.frontendContext = await this.store.queryRecord('frontend-context', { id: 0 });
   // }
 
-  async fetch() {
-    const response = await this.requestManager.request({
-      url: `${ENV.APP.API_HOST}/api/frontend-context`,
-      method: 'GET',
-    });
-    return response.content;
+  allo() {
+    console.log('ALLO')
   }
+  // async fetch() {
+  //   const response = await this.requestManager.request({
+  //     url: `${ENV.APP.API_HOST}/api/context`,
+  //     method: 'GET',
+  //   });
+  //   return response.content;
+  // }
 }

--- a/mon-pix/app/services/context.js
+++ b/mon-pix/app/services/context.js
@@ -1,0 +1,20 @@
+import Service, { service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
+
+export default class FrontendContextService extends Service {
+  @service requestManager;
+
+  frontendContext;
+
+  // async load() {
+  //   this.frontendContext = await this.store.queryRecord('frontend-context', { id: 0 });
+  // }
+
+  async fetch() {
+    const response = await this.requestManager.request({
+      url: `${ENV.APP.API_HOST}/api/frontend-context`,
+      method: 'GET',
+    });
+    return response.content;
+  }
+}

--- a/mon-pix/app/services/feature-toggles.js
+++ b/mon-pix/app/services/feature-toggles.js
@@ -1,15 +1,11 @@
-import Service, { service } from '@ember/service';
+import Service from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
-  @service store;
-
-  _featureToggles = undefined;
-
   get featureToggles() {
     return this._featureToggles;
   }
 
-  async load() {
-    this._featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+  async set(featureToggles) {
+    this._featureToggles = featureToggles;
   }
 }

--- a/mon-pix/app/services/feature-toggles.js
+++ b/mon-pix/app/services/feature-toggles.js
@@ -1,6 +1,10 @@
 import Service from '@ember/service';
 
 export default class FeatureTogglesService extends Service {
+  allo() {
+    console.log('ALLO')
+  }
+
   get featureToggles() {
     return this._featureToggles;
   }

--- a/mon-pix/app/services/oidc-identity-providers.js
+++ b/mon-pix/app/services/oidc-identity-providers.js
@@ -9,13 +9,14 @@ const FER_IDENTITY_PROVIDER_CODE = 'FER';
 const USER_ACCOUNT_RECOVERY_FOR_IDENTITY_PROVIDER_CODES = [FER_IDENTITY_PROVIDER_CODE];
 
 export default class OidcIdentityProviders extends Service {
-  @service store;
   @service currentDomain;
 
   @tracked isOidcProviderAuthenticationInProgress = false;
 
+  identityProviders = [];
+
   get list() {
-    return this.store.peekAll('oidc-identity-provider');
+    return this.identityProviders;
   }
 
   getIdentityProviderNamesByAuthenticationMethods(methods) {
@@ -49,10 +50,10 @@ export default class OidcIdentityProviders extends Service {
     return this.list.some((identityProvider) => !FEATURED_IDENTITY_PROVIDER_CODES.includes(identityProvider.code));
   }
 
-  async load() {
-    const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
-    oidcIdentityProviders.forEach((oidcIdentityProvider) => {
-      this[oidcIdentityProvider.id] = oidcIdentityProvider;
+  async set(identityProviders) {
+    this.identityProviders = identityProviders;
+    identityProviders.forEach((identityProvider) => {
+      this[identityProvider.id] = identityProvider;
     });
   }
 


### PR DESCRIPTION
## 🍂 Problème

Actuellement chaque frontal,  à son démarrage, appelle systématiquement 2 routes d’API qui fournissent des informations de contexte nécessaires dès son démarrage et l’affichage de la première page de connexion : 
* `/api/feature-toggles`
* `/api/oidc/identity-providers`

Ces 2 appels, fonctionnellement très similaires, gagneraient à être regroupés en 1 seul appel. Cela allégerait la charge sur l’API et éviterait une requête au démarrage des frontaux.

De plus il manque certaines informations de contexte aux frontaux et ces manques diminuent l’utilisabilité de certains fonctionnements ou obligent à faire des contournements plus ou moins sales :
* Le manque de l’information `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED` côté Front empêche de gérer proprement les différents comportements possibles de la page de login de Pix Admin
* Le manque de l’information `AUTONOMOUS_COURSES_ORGANIZATION_ID` côté Front fait définir côté Front une variable d’environnement `AUTONOMOUS_COURSES_ORGANIZATION_ID` qui a le risque d’être désynchronisée du Back (ce qui arrive souvent sur les RA, en local et potentiellement dès qu’un nouvel environnement est mis en place).

## 🌰 Proposition

Faire un nouveau endpoint `/api/context` porteur d’informations de contexte :
* `featureToggles`
* `identityProviders`
* properties :
   * `PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED`,
   * `AUTONOMOUS_COURSES_ORGANIZATION_ID`.

Faire utiliser ce nouveau endpoint à tous les frontaux mais ne pas supprimer les anciennes routes remplacées dans cette PR sauf si quelqu’un maîtrise la partie cache des Frontaux. On ne veut en effet pas être dans la situation où des navigateurs appelleraient encore les anciennes routes.
 
## 🍁 Remarques

Cette nouvelle route `/api/context` doit être mise en cache. → Relecture des captains requise.

## 🪵 Pour tester

1. Se rendre sur chaque frontal (Pix App, Pix Admin, etc.), vérifier que l’application s’affiche sans problème et que la route `/api/context` est bien appelée et renvoie un `200`
2. Modifier des feature toggles côté Back (par exemple `isSelfAccountDeletionEnabled`) : 
   ```shell
   npm run toggles -- --key isSelfAccountDeletionEnabled --value false
   npm run toggles -- --key isSelfAccountDeletionEnabled --value true
   ```
3. Redémarrer Pix Api
4. Recharger Pix App
5. Constater que ce/ces feature toggles ont bien été pris en compte (par exemple pour `isSelfAccountDeletionEnabled` possibilité de supprimer ou non un compte nouvellement créé dans la page _« Mon compte »_)
6. Modifier la variable d’environnement  `AUTONOMOUS_COURSES_ORGANIZATION_ID` côté Back
7. Redémarrer Pix API
8. Recharger Pix App
9. Constater que c’est bien la valeur qui est utilisée côté Front pour les parcours autonomes

### En local uniquement (parce qu’il est difficile de tester les SSO dans les RA)

Vérifier que les connexions SSO sont bien fonctionnelles sur Pix App et Pix Admin.
