### PR TITLE
[FEATURE] Redirige l'utilisateur vers le lien configuré sur la campagne quand il quitte l'évaluation (PIX-20226)

### DIFF
--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -30,6 +30,7 @@ const getAssessmentWithNextChallenge = async function (request) {
 
     return sharedUsecases.updateAssessmentWithNextChallenge({ assessment: assessmentWithoutChallenge, userId, locale });
   });
+
   return assessmentSerializer.serialize(assessment.toDto());
 };
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get_test.js
@@ -210,6 +210,11 @@ describe('Acceptance | API | assessment-controller-get', function () {
                 related: `/api/answers?assessmentId=${assessmentId}`,
               },
             },
+            campaign: {
+              links: {
+                related: `/api/campaigns?filter[code]=${campaign.code}`,
+              },
+            },
             progression: {
               data: {
                 id: `progression-${assessmentId}`,

--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-tabs/trainings.gjs
@@ -11,7 +11,6 @@ import TrainingCard from '../../../../training/card';
 export default class EvaluationResultsTabsTrainings extends Component {
   @service currentUser;
   @service pixMetrics;
-  @service campaignParticipationResult;
   @service store;
 
   @tracked isShareResultsLoading = false;

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -37,6 +37,7 @@ export default class Assessment extends Model {
   @belongsTo('course', { async: true, inverse: null }) course;
   @belongsTo('progression', { async: true, inverse: null }) progression;
   @belongsTo('challenge', { async: false, inverse: null }) nextChallenge;
+  @belongsTo('campaign', { async: true, inverse: null }) campaign;
 
   // methods
   @equal('type', 'CERTIFICATION') isCertification;

--- a/mon-pix/app/templates/assessments/challenge.gjs
+++ b/mon-pix/app/templates/assessments/challenge.gjs
@@ -44,7 +44,7 @@ import TimedChallengeInstructions from 'mon-pix/components/timed-challenge-instr
         />
       {{else}}
         <AssessmentBanner
-          @title={{@model.assessment.title}}
+          @assessment={{@model.assessment}}
           @displayHomeLink={{@controller.displayHomeLink}}
           @isTextToSpeechActivated={{@controller.isTextToSpeechActivated}}
           @toggleTextToSpeech={{@controller.toggleTextToSpeech}}

--- a/mon-pix/app/templates/assessments/checkpoint.gjs
+++ b/mon-pix/app/templates/assessments/checkpoint.gjs
@@ -13,7 +13,7 @@ import ResultItem from 'mon-pix/components/result-item';
 
     <div class="challenge__banner">
       <AssessmentBanner
-        @title={{@model.title}}
+        @assessment={{@model}}
         @displayHomeLink={{@controller.displayHomeLink}}
         @displayTextToSpeechActivationButton={{false}}
       />

--- a/mon-pix/app/templates/assessments/results.gjs
+++ b/mon-pix/app/templates/assessments/results.gjs
@@ -11,7 +11,7 @@ import ResultItem from 'mon-pix/components/result-item';
 
     <div class="assessment-results__assessment-banner">
       <AssessmentBanner
-        @title={{@model.title}}
+        @assessment={{@model}}
         @checkpoint={{false}}
         @displayHomeLink={{false}}
         @displayTextToSpeechActivationButton={{false}}


### PR DESCRIPTION
## 🍂 Problème

Quand l'utilisateur clique sur le bouton quitter au cours d'une évaluation il est redirigé vers la page d'accueil de Pix. Cependant, quand une url est configuré sur la campagne on souhaite éviter ce comportement.

## 🌰 Proposition

Rediriger l'utilisateur vers l'url configuré sur la campagne quand il clique sur quitter au cours d'une évaluation.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Tester sur la campagne PROASSIMP que le bouton quitter à toujours le comportement prévu (retour à l'actuel) ✅ 
- Tester dans le cadre d'un parcours combiné que cliquer sur le bouton quitter pendant le diag fait revenir au parcours combiné (sauf sur la page de résultats) ✅ 
- Idéalement, tester aussi avec une campagne qui pointe vers une url externe à Pix ✅ 
