### PR TITLE
[FEATURE] Ajouter la possibilité de télécharger des templates de csv sur PixAdmin (PIX-20330)

### DIFF
--- a/admin/app/components/administration/access/anonymize-gar-import.gjs
+++ b/admin/app/components/administration/access/anonymize-gar-import.gjs
@@ -80,7 +80,7 @@ export default class AnonymizeGarImport extends Component {
         <PixButtonUpload
           @id="anonymize-gar-upload"
           @onChange={{this.anonymizeGar}}
-          @variant="secondary"
+          @variant="primary"
           disabled={{this.isLoading}}
           accept=".csv"
         >

--- a/admin/app/components/administration/access/anonymize-gar-import.gjs
+++ b/admin/app/components/administration/access/anonymize-gar-import.gjs
@@ -7,6 +7,7 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class AnonymizeGarImport extends Component {
   @service intl;
@@ -75,19 +76,21 @@ export default class AnonymizeGarImport extends Component {
       @title={{t "components.administration.anonymize-gar-import.title"}}
       @description={{t "components.administration.anonymize-gar-import.description"}}
     >
-      <PixButtonUpload
-        @id="anonymize-gar-upload"
-        @onChange={{this.anonymizeGar}}
-        @variant="secondary"
-        disabled={{this.isLoading}}
-        accept=".csv"
-      >
-        {{#if this.isLoading}}
-          {{t "common.forms.loading"}}
-        {{else}}
-          {{t "components.administration.anonymize-gar-import.upload-button"}}
-        {{/if}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/anonymize/gar/template">
+        <PixButtonUpload
+          @id="anonymize-gar-upload"
+          @onChange={{this.anonymizeGar}}
+          @variant="secondary"
+          disabled={{this.isLoading}}
+          accept=".csv"
+        >
+          {{#if this.isLoading}}
+            {{t "common.forms.loading"}}
+          {{else}}
+            {{t "components.administration.anonymize-gar-import.upload-button"}}
+          {{/if}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/access/oidc-providers-import.gjs
+++ b/admin/app/components/administration/access/oidc-providers-import.gjs
@@ -57,7 +57,7 @@ export default class OidcProvidersImport extends Component {
       <PixButtonUpload
         @id="oidc-providers-file-upload"
         @onChange={{this.importOidcProviders}}
-        @variant="secondary"
+        @variant="primary"
         accept=".json"
       >
         {{t "components.administration.oidc-providers-import.upload-button"}}

--- a/admin/app/components/administration/campaigns/campaigns-import.gjs
+++ b/admin/app/components/administration/campaigns/campaigns-import.gjs
@@ -49,7 +49,7 @@ export default class CampaignsImport extends Component {
         <PixButtonUpload
           @id="campaigns-file-upload"
           @onChange={{this.importCampaigns}}
-          @variant="secondary"
+          @variant="primary"
           accept=".csv"
         >
           {{t "components.administration.campaigns-import.upload-button"}}

--- a/admin/app/components/administration/common/add-organization-features-in-batch.gjs
+++ b/admin/app/components/administration/common/add-organization-features-in-batch.gjs
@@ -56,7 +56,7 @@ export default class AddOrganizationFeaturesInBatch extends Component {
           <PixButtonUpload
             @id="organizations-batch-update-file-upload"
             @onChange={{this.addOrganizationFeaturesInBatch}}
-            @variant="secondary"
+            @variant="primary"
             accept=".csv"
           >
             {{t "components.administration.add-organization-features-in-batch.upload-button"}}

--- a/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class CertificationCentersBatchArchive extends Component {
   @service intl;
@@ -57,14 +58,16 @@ export default class CertificationCentersBatchArchive extends Component {
       @title={{t "components.administration.certification-centers-batch-archive.title"}}
       @description={{t "components.administration.certification-centers-batch-archive.description"}}
     >
-      <PixButtonUpload
-        @id="archive-certification-centers-file-upload"
-        @onChange={{this.archiveCertificationCenters}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.certification-centers-batch-archive.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/certification-centers/batch-archive/template">
+        <PixButtonUpload
+          @id="archive-certification-centers-file-upload"
+          @onChange={{this.archiveCertificationCenters}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.certification-centers-batch-archive.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/certification-centers-batch-archive.gjs
@@ -62,7 +62,7 @@ export default class CertificationCentersBatchArchive extends Component {
         <PixButtonUpload
           @id="archive-certification-centers-file-upload"
           @onChange={{this.archiveCertificationCenters}}
-          @variant="secondary"
+          @variant="primary"
           accept=".csv"
         >
           {{t "components.administration.certification-centers-batch-archive.upload-button"}}

--- a/admin/app/components/administration/deployment/organization-tags-import.gjs
+++ b/admin/app/components/administration/deployment/organization-tags-import.gjs
@@ -67,7 +67,7 @@ export default class OrganizationTagsImport extends Component {
         <PixButtonUpload
           @id="organization-tags-import-file-upload"
           @onChange={{this.importOrganizationTags}}
-          @variant="secondary"
+          @variant="primary"
           accept=".csv"
         >
 

--- a/admin/app/components/administration/deployment/organization-tags-import.gjs
+++ b/admin/app/components/administration/deployment/organization-tags-import.gjs
@@ -6,6 +6,7 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class OrganizationTagsImport extends Component {
   @service intl;
@@ -62,15 +63,17 @@ export default class OrganizationTagsImport extends Component {
       @title={{t "components.administration.organization-tags-import.title"}}
       @description={{t "components.administration.organization-tags-import.description"}}
     >
-      <PixButtonUpload
-        @id="organization-tags-import-file-upload"
-        @onChange={{this.importOrganizationTags}}
-        @variant="secondary"
-        accept=".csv"
-      >
+      <DownloadTemplate @url="/api/admin/organizations/import-tags-csv/template">
+        <PixButtonUpload
+          @id="organization-tags-import-file-upload"
+          @onChange={{this.importOrganizationTags}}
+          @variant="secondary"
+          accept=".csv"
+        >
 
-        {{t "components.administration.organization-tags-import.upload-button"}}
-      </PixButtonUpload>
+          {{t "components.administration.organization-tags-import.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -74,7 +74,7 @@ export default class OrganizationsBatchArchive extends Component {
         <PixButtonUpload
           @id="organizations-file-upload"
           @onChange={{this.archiveOrganizations}}
-          @variant="secondary"
+          @variant="primary"
           accept=".csv"
         >
           {{t "components.administration.organizations-batch-archive.upload-button"}}

--- a/admin/app/components/administration/deployment/organizations-batch-archive.gjs
+++ b/admin/app/components/administration/deployment/organizations-batch-archive.gjs
@@ -6,6 +6,7 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class OrganizationsBatchArchive extends Component {
   @service intl;
@@ -68,14 +69,17 @@ export default class OrganizationsBatchArchive extends Component {
       @title={{t "components.administration.organizations-batch-archive.title"}}
       @description={{t "components.administration.organizations-batch-archive.description"}}
     >
-      <PixButtonUpload
-        @id="organizations-file-upload"
-        @onChange={{this.archiveOrganizations}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.organizations-batch-archive.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/organizations/batch-archive/template">
+
+        <PixButtonUpload
+          @id="organizations-file-upload"
+          @onChange={{this.archiveOrganizations}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.organizations-batch-archive.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/deployment/organizations-import.gjs
+++ b/admin/app/components/administration/deployment/organizations-import.gjs
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class OrganizationsImport extends Component {
   @service intl;
@@ -45,9 +46,16 @@ export default class OrganizationsImport extends Component {
       @title={{t "components.administration.organizations-import.title"}}
       @description={{t "components.administration.organizations-import.description"}}
     >
-      <PixButtonUpload @id="orga-file-upload" @onChange={{this.importOrganizations}} @variant="secondary" accept=".csv">
-        {{t "components.administration.organizations-import.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/organizations/import-csv/template">
+        <PixButtonUpload
+          @id="orga-file-upload"
+          @onChange={{this.importOrganizations}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.organizations-import.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/deployment/organizations-import.gjs
+++ b/admin/app/components/administration/deployment/organizations-import.gjs
@@ -47,12 +47,7 @@ export default class OrganizationsImport extends Component {
       @description={{t "components.administration.organizations-import.description"}}
     >
       <DownloadTemplate @url="/api/admin/organizations/import-csv/template">
-        <PixButtonUpload
-          @id="orga-file-upload"
-          @onChange={{this.importOrganizations}}
-          @variant="secondary"
-          accept=".csv"
-        >
+        <PixButtonUpload @id="orga-file-upload" @onChange={{this.importOrganizations}} @variant="primary" accept=".csv">
           {{t "components.administration.organizations-import.upload-button"}}
         </PixButtonUpload>
       </DownloadTemplate>

--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -6,6 +6,7 @@ import { t } from 'ember-intl';
 import ENV from 'pix-admin/config/environment';
 
 import AdministrationBlockLayout from '../block-layout';
+import DownloadTemplate from '../download-template';
 
 export default class UpdateOrganizationsInBatch extends Component {
   @service intl;
@@ -83,14 +84,16 @@ export default class UpdateOrganizationsInBatch extends Component {
       @title={{t "components.administration.update-organizations-in-batch.title"}}
       @description={{t "components.administration.update-organizations-in-batch.description"}}
     >
-      <PixButtonUpload
-        @id="update-organizations-in-batch-file-upload"
-        @onChange={{this.updateOrganizationsInBatch}}
-        @variant="secondary"
-        accept=".csv"
-      >
-        {{t "components.administration.update-organizations-in-batch.upload-button"}}
-      </PixButtonUpload>
+      <DownloadTemplate @url="/api/admin/organizations/update-organizations/template">
+        <PixButtonUpload
+          @id="update-organizations-in-batch-file-upload"
+          @onChange={{this.updateOrganizationsInBatch}}
+          @variant="secondary"
+          accept=".csv"
+        >
+          {{t "components.administration.update-organizations-in-batch.upload-button"}}
+        </PixButtonUpload>
+      </DownloadTemplate>
     </AdministrationBlockLayout>
   </template>
 }

--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -88,7 +88,7 @@ export default class UpdateOrganizationsInBatch extends Component {
         <PixButtonUpload
           @id="update-organizations-in-batch-file-upload"
           @onChange={{this.updateOrganizationsInBatch}}
-          @variant="secondary"
+          @variant="primary"
           accept=".csv"
         >
           {{t "components.administration.update-organizations-in-batch.upload-button"}}

--- a/admin/tests/integration/components/target-profiles/target-profile-test.gjs
+++ b/admin/tests/integration/components/target-profiles/target-profile-test.gjs
@@ -133,8 +133,6 @@ function _findByListItemText(screen, text) {
         .replace(/(\r\n|\n|\r)/gm, '')
         .trim()
         .replace(/  +/g, ' ');
-      console.log(text);
-      console.log(cleanListItemText);
       return cleanListItemText === text;
     }) || null
   );

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
@@ -1,7 +1,10 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { GarAnonymizationParser } from '../../domain/services/GarAnonymizationParser.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { anonymizeGarResultSerializer } from '../../infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js';
+
+const ANONYMIZE_GAR_DATA_HEADER = GarAnonymizationParser.CSV_HEADER;
 
 /**
  * @param request
@@ -21,6 +24,19 @@ async function anonymizeGarData(request, h) {
   return h.response(anonymizeGarResultSerializer.serialize(result)).code(200);
 }
 
+const getTemplateForAnonymizeGarData = async function (request, h) {
+  const fields = ANONYMIZE_GAR_DATA_HEADER.columns.map(({ name }) => name);
+
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=anonymize-gar-data')
+    .code(200);
+};
+
 export const anonymizationAdminController = {
   anonymizeGarData,
+  getTemplateForAnonymizeGarData,
 };

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.route.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.route.js
@@ -9,6 +9,24 @@ const ERRORS = {
 
 export const anonymizationAdminRoutes = [
   {
+    method: 'GET',
+    path: '/api/admin/anonymize/gar/template',
+    config: {
+      pre: [
+        {
+          method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+          assign: 'hasAuthorizationToAccessAdminScope',
+        },
+      ],
+      handler: (request, h) => anonymizationAdminController.getTemplateForAnonymizeGarData(request, h),
+      tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+      notes: [
+        "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+          '- Elle permet de télécharger un template de csv pour anonymiser les utilisateurs du GAR',
+      ],
+    },
+  },
+  {
     method: 'POST',
     path: '/api/admin/anonymize/gar',
     config: {

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.controller.js
@@ -1,6 +1,7 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/monitoring-tools.js';
 import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
+import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as certificationCenterSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center.serializer.js';
 import * as certificationCenterForAdminSerializer from '../../infrastructure/serializers/jsonapi/certification-center/certification-center-for-admin.serializer.js';
@@ -11,6 +12,18 @@ const archiveCertificationCenter = async function (request, h) {
   await usecases.archiveCertificationCenter({ certificationCenterId, userId });
 
   return h.response().code(204);
+};
+
+const getTemplateForArchiveInBatch = async function (request, h) {
+  const csvTemplateFileContent = generateCSVTemplate(
+    csvSerializer.requiredFieldNamesForCertificationCenterBatchArchive,
+  );
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=archive-certification-center-in-batch')
+    .code(200);
 };
 
 const archiveInBatch = async function (request, h) {
@@ -88,6 +101,7 @@ const update = async function (request) {
 
 const certificationCenterAdminController = {
   archiveCertificationCenter,
+  getTemplateForArchiveInBatch,
   archiveInBatch,
   create,
   findPaginatedFilteredCertificationCenters,

--- a/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
+++ b/api/src/organizational-entities/application/certification-center/certification-center.admin.route.js
@@ -157,6 +157,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/certification-centers/batch-archive/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => certificationCenterAdminController.getTemplateForArchiveInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'certification-centers'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger le template pour archiver des centres de certification en masse.',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/certification-centers/batch-archive',
       config: {

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -8,6 +8,19 @@ import { organizationTagCsvParser } from '../../infrastructure/parsers/csv/organ
 import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
 import { organizationForAdminSerializer } from '../../infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js';
 
+const ADD_TAGS_TO_ORGANIZATIONS_HEADER = organizationTagCsvParser.CSV_HEADER;
+
+const getTemplateForAddTagsToOrganizations = async function (request, h) {
+  const fields = ADD_TAGS_TO_ORGANIZATIONS_HEADER.columns.map(({ name }) => name);
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=add-tags-to-organizations')
+    .code(200);
+};
+
 const addTagsToOrganizations = async function (request, h) {
   const filePath = request.payload.path;
   const organizationTags = await organizationTagCsvParser.getCsvData(filePath);
@@ -132,6 +145,7 @@ const findChildrenOrganizations = async function (request, h, dependencies = { o
 };
 
 const organizationAdminController = {
+  getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
   create,
   createInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -81,6 +81,16 @@ const create = async function (request) {
   return serializedOrganization;
 };
 
+const getTemplateForCreateOrganizationsInBatch = async function (request, h) {
+  const csvTemplateFileContent = generateCSVTemplate(csvSerializer.requiredFieldNamesForOrganizationsImport);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=create-organizations-in-batch')
+    .code(200);
+};
+
 const createInBatch = async function (request, h) {
   const organizations = await csvSerializer.deserializeForOrganizationsImport(request.payload.path);
 
@@ -148,6 +158,7 @@ const organizationAdminController = {
   getTemplateForAddTagsToOrganizations,
   addTagsToOrganizations,
   create,
+  getTemplateForCreateOrganizationsInBatch,
   createInBatch,
   archiveOrganization,
   archiveInBatch,

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -99,6 +99,16 @@ const createInBatch = async function (request, h) {
   return h.response(organizationForAdminSerializer.serialize(createdOrganizations)).code(204);
 };
 
+const getTemplateForArchiveOrganizationsInBatch = async function (request, h) {
+  const csvTemplateFileContent = generateCSVTemplate(csvSerializer.requiredFieldNamesForOrganizationBatchArchive);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=archive-organizations-in-batch')
+    .code(200);
+};
+
 const archiveInBatch = async function (request, h) {
   const userId = extractUserIdFromRequest(request);
 
@@ -172,6 +182,7 @@ const organizationAdminController = {
   getTemplateForCreateOrganizationsInBatch,
   createInBatch,
   archiveOrganization,
+  getTemplateForArchiveOrganizationsInBatch,
   archiveInBatch,
   attachChildOrganization,
   detachParentOrganization,

--- a/api/src/organizational-entities/application/organization/organization.admin.controller.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.controller.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as csvSerializer from '../../../shared/infrastructure/serializers/csv/csv-serializer.js';
 import { generateCSVTemplate } from '../../../shared/infrastructure/serializers/csv/csv-template.js';
 import { extractUserIdFromRequest } from '../../../shared/infrastructure/utils/request-response-utils.js';
-import { ORGANIZATION_FEATURES_HEADER } from '../../domain/constants.js';
+import { ORGANIZATION_FEATURES_HEADER, ORGANIZATIONS_UPDATE_HEADER } from '../../domain/constants.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationTagCsvParser } from '../../infrastructure/parsers/csv/organization-tag-csv.parser.js';
 import * as organizationSerializer from '../../infrastructure/serializers/jsonapi/organization-serializer.js';
@@ -115,6 +115,17 @@ const getOrganizationDetails = async function (request, h, dependencies = { orga
   return dependencies.organizationForAdminSerializer.serialize(organizationDetails);
 };
 
+const getTemplateForUpdateOrganizationsInBatch = async function (request, h) {
+  const fields = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name);
+  const csvTemplateFileContent = generateCSVTemplate(fields);
+
+  return h
+    .response(csvTemplateFileContent)
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header('content-disposition', 'filename=update-organizations-in-batch')
+    .code(200);
+};
+
 const updateOrganizationsInBatch = async function (request, h) {
   await usecases.updateOrganizationsInBatch({ filePath: request.payload.path });
   return h.response().code(204);
@@ -167,6 +178,7 @@ const organizationAdminController = {
   getTemplateForAddOrganizationFeatureInBatch,
   addOrganizationFeatureInBatch,
   getOrganizationDetails,
+  getTemplateForUpdateOrganizationsInBatch,
   updateOrganizationsInBatch,
   updateOrganizationInformation,
   findPaginatedFilteredOrganizations,

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -435,6 +435,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/organizations/update-organizations/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationAdminController.getTemplateForUpdateOrganizationsInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            "- Elle permet de télécharger de template du csv pour mettre à jour des informations d'une ou plusieurs organisations",
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/organizations/{childOrganizationId}/detach-parent-organization',
       config: {

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -257,6 +257,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/organizations/batch-archive/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationAdminController.getTemplateForArchiveOrganizationsInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'tags'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger le template pour archiver des organisations en masse.',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/organizations/batch-archive',
       config: {

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -47,6 +47,24 @@ const register = async function (server) {
     },
     {
       method: 'GET',
+      path: '/api/admin/organizations/import-csv/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationAdminController.getTemplateForCreateOrganizationsInBatch(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'tags'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger le template pour créer de nouvelles organisations en masse.',
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/admin/organizations/{organizationId}/children',
       config: {
         pre: [

--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -300,6 +300,24 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/organizations/import-tags-csv/template',
+      config: {
+        pre: [
+          {
+            method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: (request, h) => organizationAdminController.getTemplateForAddTagsToOrganizations(request, h),
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'tags'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            '- Elle permet de télécharger le template pour ajouter en masse des tags à des organisations.',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/organizations/import-tags-csv',
       config: {

--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -1,5 +1,55 @@
 import { CsvColumn } from '../../../src/shared/infrastructure/serializers/csv/csv-column.js';
 
+export const ORGANIZATIONS_UPDATE_HEADER = {
+  columns: [
+    new CsvColumn({
+      isRequired: true,
+      name: 'Organization ID',
+      property: 'id',
+    }),
+    new CsvColumn({
+      name: 'Organization Name',
+      property: 'name',
+    }),
+    new CsvColumn({
+      name: 'Organization External ID',
+      property: 'externalId',
+    }),
+    new CsvColumn({
+      name: 'Organization Parent ID',
+      property: 'parentOrganizationId',
+    }),
+    new CsvColumn({
+      name: 'Organization Identity Provider Code',
+      property: 'identityProviderForCampaigns',
+    }),
+    new CsvColumn({
+      name: 'Organization Documentation URL',
+      property: 'documentationUrl',
+    }),
+    new CsvColumn({
+      name: 'Organization Province Code',
+      property: 'provinceCode',
+    }),
+    new CsvColumn({
+      name: 'DPO Last Name',
+      property: 'dataProtectionOfficerLastName',
+    }),
+    new CsvColumn({
+      name: 'DPO First Name',
+      property: 'dataProtectionOfficerFirstName',
+    }),
+    new CsvColumn({
+      name: 'DPO E-mail',
+      property: 'dataProtectionOfficerEmail',
+    }),
+    new CsvColumn({
+      name: 'Administration Team ID',
+      property: 'administrationTeamId',
+    }),
+  ],
+};
+
 export const ORGANIZATION_FEATURES_HEADER = {
   columns: [
     new CsvColumn({

--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -2,9 +2,9 @@ import { createReadStream } from 'node:fs';
 
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as emailValidationService from '../../../shared/domain/services/email-validation-service.js';
-import { CsvColumn } from '../../../shared/infrastructure/serializers/csv/csv-column.js';
 import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
 import { getDataBuffer } from '../../../shared/infrastructure/utils/buffer.js';
+import { ORGANIZATIONS_UPDATE_HEADER } from '../constants.js';
 import { OrganizationBatchUpdateDTO } from '../dtos/OrganizationBatchUpdateDTO.js';
 import {
   AdministrationTeamNotFound,
@@ -13,56 +13,6 @@ import {
   OrganizationNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../errors.js';
-
-const CSV_HEADER = {
-  columns: [
-    new CsvColumn({
-      isRequired: true,
-      name: 'Organization ID',
-      property: 'id',
-    }),
-    new CsvColumn({
-      name: 'Organization Name',
-      property: 'name',
-    }),
-    new CsvColumn({
-      name: 'Organization External ID',
-      property: 'externalId',
-    }),
-    new CsvColumn({
-      name: 'Organization Parent ID',
-      property: 'parentOrganizationId',
-    }),
-    new CsvColumn({
-      name: 'Organization Identity Provider Code',
-      property: 'identityProviderForCampaigns',
-    }),
-    new CsvColumn({
-      name: 'Organization Documentation URL',
-      property: 'documentationUrl',
-    }),
-    new CsvColumn({
-      name: 'Organization Province Code',
-      property: 'provinceCode',
-    }),
-    new CsvColumn({
-      name: 'DPO Last Name',
-      property: 'dataProtectionOfficerLastName',
-    }),
-    new CsvColumn({
-      name: 'DPO First Name',
-      property: 'dataProtectionOfficerFirstName',
-    }),
-    new CsvColumn({
-      name: 'DPO E-mail',
-      property: 'dataProtectionOfficerEmail',
-    }),
-    new CsvColumn({
-      name: 'Administration Team ID',
-      property: 'administrationTeamId',
-    }),
-  ],
-};
 
 /**
  * @typedef {function} updateOrganizationsInBatch
@@ -167,7 +117,7 @@ async function _checkOrganizationUpdate({
 async function _getCsvData(filePath) {
   const stream = createReadStream(filePath);
   const buffer = await getDataBuffer(stream);
-  const csvParser = new CsvParser(buffer, CSV_HEADER);
+  const csvParser = new CsvParser(buffer, ORGANIZATIONS_UPDATE_HEADER);
   const csvData = csvParser.parse('utf8');
   return csvData.map((row) => new OrganizationBatchUpdateDTO(row));
 }

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -100,29 +100,30 @@ function deserializeForSessionsImport({ parsedCsvData, hasBillingMode, certifica
   }));
 }
 
+const requiredFieldNamesForOrganizationsImport = [
+  'type',
+  'externalId',
+  'name',
+  'provinceCode',
+  'credit',
+  'emailInvitations',
+  'emailForSCOActivation',
+  'identityProviderForCampaigns',
+  'organizationInvitationRole',
+  'locale',
+  'tags',
+  'createdBy',
+  'documentationUrl',
+  'targetProfiles',
+  'isManagingStudents',
+  'DPOFirstName',
+  'DPOLastName',
+  'DPOEmail',
+  'administrationTeamId',
+  'parentOrganizationId',
+];
+
 async function deserializeForOrganizationsImport(file) {
-  const requiredFieldNames = [
-    'type',
-    'externalId',
-    'name',
-    'provinceCode',
-    'credit',
-    'emailInvitations',
-    'emailForSCOActivation',
-    'identityProviderForCampaigns',
-    'organizationInvitationRole',
-    'locale',
-    'tags',
-    'createdBy',
-    'documentationUrl',
-    'targetProfiles',
-    'isManagingStudents',
-    'DPOFirstName',
-    'DPOLastName',
-    'DPOEmail',
-    'administrationTeamId',
-    'parentOrganizationId',
-  ];
   const batchOrganizationOptionsWithHeader = {
     skipEmptyLines: true,
     header: true,
@@ -176,7 +177,7 @@ async function deserializeForOrganizationsImport(file) {
     },
   };
 
-  await checkCsvHeader({ filePath: file, requiredFieldNames });
+  await checkCsvHeader({ filePath: file, requiredFieldNames: requiredFieldNamesForOrganizationsImport });
 
   return await parseCsvWithHeader(file, batchOrganizationOptionsWithHeader);
 }
@@ -543,6 +544,7 @@ export {
   deserializeForSessionsImport,
   fieldNamesForCampaignsImport,
   parseForCampaignsImport,
+  requiredFieldNamesForOrganizationsImport,
   serializeLine,
   verifyColumnsValueAgainstConstraints,
 };

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -213,10 +213,10 @@ async function deserializeForCertificationCenterBatchArchive(
   return parsedData.map((data) => data['ID du centre de certification']);
 }
 
-async function deserializeForOrganizationBatchArchive(file, { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper) {
-  const columnName = "ID de l'organisation";
+const requiredFieldNamesForOrganizationBatchArchive = ["ID de l'organisation"];
 
-  await checkCsvHeader({ filePath: file, requiredFieldNames: [columnName] });
+async function deserializeForOrganizationBatchArchive(file, { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper) {
+  await checkCsvHeader({ filePath: file, requiredFieldNames: requiredFieldNamesForOrganizationBatchArchive });
   const cleanedData = await readCsvFile(file);
 
   const batchOrganizationOptionsWithHeader = {
@@ -238,7 +238,7 @@ async function deserializeForOrganizationBatchArchive(file, { checkCsvHeader, re
 
   const parsedData = await parseCsvData(cleanedData, batchOrganizationOptionsWithHeader);
 
-  return parsedData.map((data) => data[columnName]);
+  return parsedData.map((data) => data[requiredFieldNamesForOrganizationBatchArchive]);
 }
 
 const requiredFieldNamesForCampaignsImport = {
@@ -544,6 +544,7 @@ export {
   deserializeForSessionsImport,
   fieldNamesForCampaignsImport,
   parseForCampaignsImport,
+  requiredFieldNamesForOrganizationBatchArchive,
   requiredFieldNamesForOrganizationsImport,
   serializeLine,
   verifyColumnsValueAgainstConstraints,

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -182,13 +182,13 @@ async function deserializeForOrganizationsImport(file) {
   return await parseCsvWithHeader(file, batchOrganizationOptionsWithHeader);
 }
 
+const requiredFieldNamesForCertificationCenterBatchArchive = ['ID du centre de certification'];
+
 async function deserializeForCertificationCenterBatchArchive(
   file,
   { checkCsvHeader, readCsvFile, parseCsvData } = csvHelper,
 ) {
-  const requiredFieldNames = ['ID du centre de certification'];
-
-  await checkCsvHeader({ filePath: file, requiredFieldNames });
+  await checkCsvHeader({ filePath: file, requiredFieldNames: requiredFieldNamesForCertificationCenterBatchArchive });
   const cleanedData = await readCsvFile(file);
 
   const batchCertificationCenterOptionsWithHeader = {
@@ -544,6 +544,7 @@ export {
   deserializeForSessionsImport,
   fieldNamesForCampaignsImport,
   parseForCampaignsImport,
+  requiredFieldNamesForCertificationCenterBatchArchive,
   requiredFieldNamesForOrganizationBatchArchive,
   requiredFieldNamesForOrganizationsImport,
   serializeLine,

--- a/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
@@ -65,4 +65,25 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
       });
     });
   });
+
+  describe('GET /api/admin/anonymize/gar/template', function () {
+    it('responds with a 200 and serialized payload', async function () {
+      // given
+      const user = await insertUserWithRoleSuperAdmin();
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        url: '/api/admin/anonymize/gar/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/certification-center/certification-center.admin.route.test.js
@@ -424,6 +424,23 @@ describe('Acceptance | Organization Entities | Admin | Route | Certification Cen
     });
   });
 
+  describe('GET /api/admin/certification-centers/batch-archive/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: adminMember.id }),
+        url: '/api/admin/certification-centers/batch-archive/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/certification-centers/batch-archive', function () {
     context('success case', function () {
       it('returns a 204 http request', async function () {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -741,6 +741,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('GET /api/admin/organizations/batch-archive/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        url: '/api/admin/organizations/batch-archive/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/organizations/batch-archive', function () {
     context('success case', function () {
       it('returns a 204 http request', async function () {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -28,6 +28,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     server = await createServer();
   });
 
+  describe('GET /api/admin/organizations/import-csv/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        url: '/api/admin/organizations/import-csv/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/organizations/import-csv', function () {
     it('create organizations for the given csv file', async function () {
       // given

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1292,6 +1292,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('GET /api/admin/organizations/update-organizations/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        url: '/api/admin/organizations/update-organizations/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/organizations/update-organizations', function () {
     context('when a CSV file is loaded', function () {
       let firstOrganization, otherOrganization;

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1357,6 +1357,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     });
   });
 
+  describe('GET /api/admin/organizations/import-tags-csv/template', function () {
+    it('responds with a 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        url: '/api/admin/organizations/import-tags-csv/template',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/admin/organizations/import-tags-csv', function () {
     context('When a CSV file is loaded', function () {
       let firstTag;


### PR DESCRIPTION
## 🍂 Problème
Reprise d'une ancienne PR oubliée (RIP) : https://github.com/1024pix/pix/pull/11989


## 🌰 Proposition

Ajoute un bouton à côté des imports csv pour télécharger le template associé.

## 🍁 Remarques

On uniformise les variant des boutons pour qu'il soit tous du même type.
On en profite pour retirer deux console.log oubliés qui polluent pendant l'éxecution des tests

## 🪵 Pour tester

Vérifier le bon fonctionnement des téléchargement des templates pour : 
- Ajout de tags en masse sur des organisations
- Création d'organisations en masse
- Mise à jour d'organisations en masse
- Anonymiser les données du GAR
- Archiver les organisations en masse
- Archiver les centres de certif en masse
