### PR TITLE
[TECH] :truck: Déplace une série de tests unitaires du répertoire générique vers le répertoire du contexte `devcomp`

### DIFF
--- a/api/tests/devcomp/unit/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/unit/application/campaign-participations/campaign-participation-controller_test.js
@@ -1,6 +1,6 @@
-import { campaignParticipationController } from '../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
-import { usecases as devcompUsecases } from '../../../../src/devcomp/domain/usecases/index.js';
-import { expect, sinon } from '../../../test-helper.js';
+import { campaignParticipationController } from '../../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
+import { usecases as devcompUsecases } from '../../../../../src/devcomp/domain/usecases/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Controller | Campaign-Participation', function () {
   describe('#findTrainings', function () {

--- a/api/tests/devcomp/unit/application/campaign-participations/index_test.js
+++ b/api/tests/devcomp/unit/application/campaign-participations/index_test.js
@@ -1,6 +1,6 @@
-import { campaignParticipationController } from '../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
-import * as moduleUnderTest from '../../../../src/devcomp/application/campaign-participations/campaign-participation-route.js';
-import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { campaignParticipationController } from '../../../../../src/devcomp/application/campaign-participations/campaign-participation-controller.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/campaign-participations/campaign-participation-route.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Router | campaign-participation-router ', function () {
   describe('GET /api/campaign-participations/{id}/trainings', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
@@ -1,10 +1,10 @@
-import { TutorialEvaluation } from '../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
-import { UserSavedTutorial } from '../../../../../src/devcomp/domain/models/UserSavedTutorial.js';
-import { TutorialForUser } from '../../../../../src/devcomp/domain/read-models/TutorialForUser.js';
-import * as serializer from '../../../../../src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js';
-import { Correction } from '../../../../../src/shared/domain/models/Correction.js';
-import { Hint } from '../../../../../src/shared/domain/models/Hint.js';
-import { expect } from '../../../../test-helper.js';
+import { TutorialEvaluation } from '../../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
+import { UserSavedTutorial } from '../../../../../../src/devcomp/domain/models/UserSavedTutorial.js';
+import { TutorialForUser } from '../../../../../../src/devcomp/domain/read-models/TutorialForUser.js';
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js';
+import { Correction } from '../../../../../../src/shared/domain/models/Correction.js';
+import { Hint } from '../../../../../../src/shared/domain/models/Hint.js';
+import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | correction-serializer', function () {
   describe('#serialize()', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer_test.js
@@ -1,6 +1,6 @@
-import { TutorialEvaluation } from '../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
-import * as serializer from '../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { TutorialEvaluation } from '../../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
+import * as serializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | tutorial-evaluation-serializer', function () {
   describe('#serialize', function () {


### PR DESCRIPTION
## 🍂 Problème

Une poignée de tests unitaires concernant devcomp sont dans le répertoire générique (`tests/unit/`)

## 🌰 Proposition

Déplacer cette série de tests unitaires du répertoire générique vers le répertoire du contexte `tests/devcomp`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Les tests sont verts
