### PR TITLE
[FEATURE] Permettre d'identifier des campagnes / module / parcours dans plausible (PIX-20318)

### DIFF
--- a/mon-pix/app/routes/campaigns.js
+++ b/mon-pix/app/routes/campaigns.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 export default class CampaignsRoute extends Route {
   @service store;
   @service router;
+  @service metrics;
 
   async model(params) {
     const verifiedCode = await this.store.findRecord('verified-code', params.code);
@@ -12,5 +13,15 @@ export default class CampaignsRoute extends Route {
     } else {
       this.router.replaceWith('combined-courses', verifiedCode.id);
     }
+  }
+
+  activate() {
+    this.metrics.context.code = this.paramsFor('campaigns').code;
+    this.metrics.context.type = 'campaigns';
+  }
+
+  deactivate() {
+    delete this.metrics.context.code;
+    delete this.metrics.context.type;
   }
 }

--- a/mon-pix/app/routes/combined-courses/presentation.js
+++ b/mon-pix/app/routes/combined-courses/presentation.js
@@ -5,6 +5,7 @@ export default class CombinedCoursePresentationRoute extends Route {
   @service store;
   @service router;
   @service accessStorage;
+  @service metrics;
 
   async beforeModel(transition) {
     const { code } = this.paramsFor('combined-courses');
@@ -31,5 +32,15 @@ export default class CombinedCoursePresentationRoute extends Route {
 
   afterModel(combinedCourse) {
     this.accessStorage.clear(combinedCourse.organizationId);
+  }
+
+  activate() {
+    this.metrics.context.code = this.paramsFor('combined-courses').code;
+    this.metrics.context.type = 'combined-course';
+  }
+
+  deactivate() {
+    delete this.metrics.context.code;
+    delete this.metrics.context.type;
   }
 }

--- a/mon-pix/app/routes/module.js
+++ b/mon-pix/app/routes/module.js
@@ -3,8 +3,19 @@ import { service } from '@ember/service';
 
 export default class ModuleRoute extends Route {
   @service store;
+  @service metrics;
 
   model(params) {
     return this.store.queryRecord('module', { slug: params.slug, encryptedRedirectionUrl: params.redirection });
+  }
+
+  activate() {
+    this.metrics.context.code = this.paramsFor('module').slug;
+    this.metrics.context.type = 'module';
+  }
+
+  deactivate() {
+    delete this.metrics.context.code;
+    delete this.metrics.context.type;
   }
 }

--- a/mon-pix/tests/unit/routes/campaigns-test.js
+++ b/mon-pix/tests/unit/routes/campaigns-test.js
@@ -1,0 +1,40 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | campaigns', function (hooks) {
+  setupTest(hooks);
+
+  test('activate should set metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:campaigns');
+    route.metrics = { context: {} };
+    const paramsForStub = sinon.stub(route, 'paramsFor').returns({ code: 'CAMPAIGN_CODE' });
+
+    // When
+    route.activate();
+
+    // Then
+    assert.deepEqual(route.metrics.context.code, 'CAMPAIGN_CODE');
+    assert.strictEqual(route.metrics.context.type, 'campaigns');
+    assert.ok(paramsForStub.calledWith('campaigns'));
+  });
+
+  test('deactivate should unset metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:campaigns');
+    route.metrics = {
+      context: {
+        code: 'CAMPAIGN_CODE',
+        type: 'campaigns',
+      },
+    };
+
+    // When
+    route.deactivate();
+
+    // Then
+    assert.strictEqual(route.metrics.context.code, undefined);
+    assert.strictEqual(route.metrics.context.type, undefined);
+  });
+});

--- a/mon-pix/tests/unit/routes/combined-courses/presentation-test.js
+++ b/mon-pix/tests/unit/routes/combined-courses/presentation-test.js
@@ -1,0 +1,40 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | combined-courses | presentation', function (hooks) {
+  setupTest(hooks);
+
+  test('activate should set metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:combined-courses/presentation');
+    route.metrics = { context: {} };
+    const paramsForStub = sinon.stub(route, 'paramsFor').returns({ code: 'COMBINIX' });
+
+    // When
+    route.activate();
+
+    // Then
+    assert.deepEqual(route.metrics.context.code, 'COMBINIX');
+    assert.strictEqual(route.metrics.context.type, 'combined-course');
+    assert.ok(paramsForStub.calledWith('combined-courses'));
+  });
+
+  test('deactivate should unset metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:combined-courses/presentation');
+    route.metrics = {
+      context: {
+        code: 'COMBINIX',
+        type: 'combined-course',
+      },
+    };
+
+    // When
+    route.deactivate();
+
+    // Then
+    assert.strictEqual(route.metrics.context.code, undefined);
+    assert.strictEqual(route.metrics.context.type, undefined);
+  });
+});

--- a/mon-pix/tests/unit/routes/module-test.js
+++ b/mon-pix/tests/unit/routes/module-test.js
@@ -1,0 +1,40 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | module', function (hooks) {
+  setupTest(hooks);
+
+  test('activate should set metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:module');
+    route.metrics = { context: {} };
+    const paramsForStub = sinon.stub(route, 'paramsFor').returns({ slug: 'MODULE_SLUG' });
+
+    // When
+    route.activate();
+
+    // Then
+    assert.deepEqual(route.metrics.context.code, 'MODULE_SLUG');
+    assert.strictEqual(route.metrics.context.type, 'module');
+    assert.ok(paramsForStub.calledWith('module'));
+  });
+
+  test('deactivate should unset metrics context', function (assert) {
+    // Given
+    const route = this.owner.lookup('route:module');
+    route.metrics = {
+      context: {
+        code: 'MODULE_SLUG',
+        type: 'module',
+      },
+    };
+
+    // When
+    route.deactivate();
+
+    // Then
+    assert.strictEqual(route.metrics.context.code, undefined);
+    assert.strictEqual(route.metrics.context.type, undefined);
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Maintenant que le caviardage est en place, il est impossible d’avoir du reporting sur une campagne particulière. On propose de faire remonter le code campagne et le code du module afin de pouvoir identifier le trafic sur des campagnes précises.

## 🌰 Proposition

On ajoute les infos (code / type) dans le context lorsqu'on est sur les routes 
- `/campagnes/...`
- `/modules/...`
- `/combined-courses/...`


## 🍁 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Activer le tracking sur la Pr
- Faire un parcours combiné 
- Regarder dans les devtools que les infos de context sont bonne sur les parcours / campagne / module
- Allez sur la page compétences et valider que les infos ne sont plus présentes
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
