### PR TITLE
[FEATURE] Ajouter le nouvel élement short video au front (PIX-20278)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -15,6 +15,7 @@ import QcuDeclarativeElement from 'mon-pix/components/module/element/qcu-declara
 import QcuDiscoveryElement from 'mon-pix/components/module/element/qcu-discovery';
 import QrocmElement from 'mon-pix/components/module/element/qrocm';
 import SeparatorElement from 'mon-pix/components/module/element/separator';
+import ShortVideoElement from 'mon-pix/components/module/element/short-video';
 import TextElement from 'mon-pix/components/module/element/text';
 import VideoElement from 'mon-pix/components/module/element/video';
 import ENV from 'mon-pix/config/environment';
@@ -34,6 +35,8 @@ export default class ModulixElement extends Component {
       <ImageElement @image={{@element}} @onAlternativeTextOpen={{@onImageAlternativeTextOpen}} />
     {{else if (eq @element.type "video")}}
       <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
+    {{else if (eq @element.type "short-video")}}
+      <ShortVideoElement @element={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
     {{else if (eq @element.type "download")}}
       <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}

--- a/mon-pix/app/components/module/element/_short-video.scss
+++ b/mon-pix/app/components/module/element/_short-video.scss
@@ -1,0 +1,7 @@
+.element-short-video {
+
+  &__video {
+    width: 100%;
+    border-radius: var(--pix-spacing-2x);
+  }
+}

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -1,0 +1,41 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
+
+import ModuleElement from './module-element';
+
+export default class ModulixShortVideoElement extends ModuleElement {
+  @tracked modalIsOpen = false;
+
+  @action
+  showModal() {
+    this.modalIsOpen = true;
+    this.args.onTranscriptionOpen(this.args.element.id);
+  }
+
+  @action
+  closeModal() {
+    this.modalIsOpen = false;
+  }
+
+  <template>
+    <div class="element-short-video">
+      <video autoplay loop muted src={{@element.url}}></video>
+      <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
+        {{t "pages.modulix.buttons.element.transcription"}}
+      </PixButton>
+      <PixModal
+        @title={{t "pages.modulix.modals.transcription.title"}}
+        @showModal={{this.modalIsOpen}}
+        @onCloseButtonClick={{this.closeModal}}
+      >
+        <:content>
+          {{htmlUnsafe @element.transcription}}
+        </:content>
+      </PixModal>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -23,7 +23,7 @@ export default class ModulixShortVideoElement extends ModuleElement {
 
   <template>
     <div class="element-short-video">
-      <video autoplay loop muted src={{@element.url}}></video>
+      <video class="element-short-video__video" autoplay loop muted src={{@element.url}}></video>
       <PixButton @variant="tertiary" @triggerAction={{this.showModal}}>
         {{t "pages.modulix.buttons.element.transcription"}}
       </PixButton>

--- a/mon-pix/app/components/module/grain/grain.gjs
+++ b/mon-pix/app/components/module/grain/grain.gjs
@@ -40,6 +40,7 @@ export default class ModuleGrain extends Component {
     'qrocm',
     'separator',
     'text',
+    'short-video',
     'video',
   ];
   static AVAILABLE_GRAIN_TYPES = [

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -109,6 +109,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @use '../components/module/element/separator' as *;
 @use '../components/module/element/text' as *;
 @use '../components/module/element/video' as *;
+@use '../components/module/element/short-video' as *;
 @use 'components/navbar-burger-menu' as *;
 @use 'components/navbar-desktop-menu' as *;
 @use 'components/navbar-desktop-header' as *;

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -164,6 +164,24 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
   });
 
+  test('should display an element with a short video element', async function (assert) {
+    // given
+    const element = {
+      id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+      type: 'short-video',
+      title: 'Vidéo courte de présentation de Pix',
+      url: 'https://assets.pix.org/modules/placeholder-video.mp4',
+      transcription: '<p>transcription</p>',
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.strictEqual(findAll('.element-short-video').length, 1);
+    assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
+  });
+
   test('should display an element with an download element', async function (assert) {
     // given
     const element = {

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -4,7 +4,7 @@ import { t } from 'ember-intl/test-support';
 import ModulixElement from 'mon-pix/components/module/component/element';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Element', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -4,7 +4,7 @@ import ModulixShortVideo from 'mon-pix/components/module/element/short-video';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | ShortVideo', function (hooks) {
   setupIntlRenderingTest(hooks);

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -296,6 +296,28 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
+    module('when element is a short video', function () {
+      test('should display a short video element', async function (assert) {
+        // given
+        const url = 'https://assets.pix.org/modules/placeholder-video.mp4';
+        const shortVideoElement = {
+          id: 'f6869b46-30b8-4d41-b937-542e405862d1',
+          url,
+          transcription: 'transcription',
+          type: 'short-video',
+        };
+        const grain = {
+          components: [{ type: 'element', element: shortVideoElement }],
+        };
+
+        // when
+        await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+        // then
+        assert.dom('video').hasAttribute('src', url);
+      });
+    });
+
     module('when element is of type flashcards', function () {
       test('should display a flashcards element', async function (assert) {
         // given

--- a/mon-pix/tests/integration/components/module/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/short-video_test.gjs
@@ -1,0 +1,60 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import ModulixShortVideo from 'mon-pix/components/module/element/short-video';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | ShortVideo', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a video element with autoplay and loop attribute', async function (assert) {
+    // when
+    await render(<template><ModulixShortVideo /></template>);
+
+    // then
+    assert.dom('video').hasAttribute('autoplay');
+    assert.dom('video').hasAttribute('loop');
+    assert.dom('video').hasAttribute('muted');
+  });
+
+  test('it should display a video element with src attribute', async function (assert) {
+    // given
+    const element = {
+      url: 'https://assets.pix.org/modules/placeholder-video.mp4',
+    };
+
+    // when
+    await render(<template><ModulixShortVideo @element={{element}} /></template>);
+    // then
+    assert.dom('video').hasAttribute('src', 'https://assets.pix.org/modules/placeholder-video.mp4');
+  });
+
+  test('should be able to use the modal for transcription', async function (assert) {
+    // given
+    const url = 'https://assets.pix.org/modules/placeholder-video.mp4';
+
+    const shortVideoId = 'id';
+    const shortVideoElement = {
+      id: shortVideoId,
+      url,
+      title: 'title',
+      transcription: 'transcription',
+    };
+    const onShortVideoTranscriptionOpenStub = sinon.stub();
+
+    //  when
+    const screen = await render(
+      <template>
+        <ModulixShortVideo @element={{shortVideoElement}} @onTranscriptionOpen={{onShortVideoTranscriptionOpenStub}} />
+      </template>,
+    );
+
+    // then
+    await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
+    assert.ok(await screen.findByRole('dialog'));
+    assert.ok(screen.getByText('transcription'));
+    assert.ok(onShortVideoTranscriptionOpenStub.calledOnceWith(shortVideoId));
+  });
+});


### PR DESCRIPTION
## 🍂 Problème
Actuellement, on ne peut pas afficher l'élément de type vidéo courte dans le front. 

## 🌰 Proposition
Créer l'élément et l'afficher

## 🪵 Pour tester
- aller sur la galerie ou le [bac-a-sable](https://app-pr14090.review.pix.fr/modules/bac-a-sable)
- vérifier que l'élément se lit automatiquement et en boucle à la manière d'un gif
- vérifier que tout est ok au format mobile
