### PR TITLE
[FEATURE] Passer par les versions de certifications pour le scoring des certifs V3 (PIX-20275).

### DIFF
--- a/api/src/certification/evaluation/domain/services/index.js
+++ b/api/src/certification/evaluation/domain/services/index.js
@@ -11,12 +11,14 @@ import * as sharedChallengeRepository from '../../../../shared/infrastructure/re
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import * as challengeRepository from '../../../evaluation/infrastructure/repositories/challenge-repository.js';
 import * as certificationAssessmentRepository from '../../../shared/infrastructure/repositories/certification-assessment-repository.js';
+import * as sharedCertificationCandidateRepository from '../../../shared/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCourseRepository from '../../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as competenceMarkRepository from '../../../shared/infrastructure/repositories/competence-mark-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../../shared/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../../shared/infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as scoringConfigurationRepository from '../../../shared/infrastructure/repositories/scoring-configuration-repository.js';
+import * as versionRepository from '../../../shared/infrastructure/repositories/version-repository.js';
 import * as certificationAssessmentHistoryRepository from '../../infrastructure/repositories/certification-assessment-history-repository.js';
 import * as certificationCandidateRepository from '../../infrastructure/repositories/certification-candidate-repository.js';
 import * as challengeCalibrationRepository from '../../infrastructure/repositories/challenge-calibration-repository.js';
@@ -70,6 +72,8 @@ const dependencies = {
   complementaryCertificationCourseResultRepository,
   complementaryCertificationScoringCriteriaRepository,
   sharedChallengeRepository,
+  sharedCertificationCandidateRepository,
+  versionRepository,
 };
 
 import { findByCertificationCourseIdAndAssessmentId } from './scoring/calibrated-challenge-service.js';

--- a/api/src/certification/evaluation/domain/services/index.js
+++ b/api/src/certification/evaluation/domain/services/index.js
@@ -18,7 +18,7 @@ import * as complementaryCertificationBadgesRepository from '../../../shared/inf
 import * as complementaryCertificationCourseResultRepository from '../../../shared/infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as flashAlgorithmConfigurationRepository from '../../../shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as scoringConfigurationRepository from '../../../shared/infrastructure/repositories/scoring-configuration-repository.js';
-import * as versionRepository from '../../../shared/infrastructure/repositories/version-repository.js';
+import * as sharedVersionRepository from '../../../shared/infrastructure/repositories/version-repository.js';
 import * as certificationAssessmentHistoryRepository from '../../infrastructure/repositories/certification-assessment-history-repository.js';
 import * as certificationCandidateRepository from '../../infrastructure/repositories/certification-candidate-repository.js';
 import * as challengeCalibrationRepository from '../../infrastructure/repositories/challenge-calibration-repository.js';
@@ -48,6 +48,8 @@ import * as flashAlgorithmService from './algorithm-methods/flash.js';
  * @typedef {certificationAssessmentRepository} CertificationAssessmentRepository
  * @typedef {complementaryCertificationCourseResultRepository} ComplementaryCertificationCourseResultRepository *
  * @typedef {complementaryCertificationScoringCriteriaRepository} ComplementaryCertificationScoringCriteriaRepository
+ * @typedef {sharedCertificationCandidateRepository} SharedCertificationCandidateRepository
+ * @typedef {sharedVersionRepository} SharedVersionRepository
  * @typedef {sharedChallengeRepository} SharedChallengeRepository
  */
 const dependencies = {
@@ -73,7 +75,7 @@ const dependencies = {
   complementaryCertificationScoringCriteriaRepository,
   sharedChallengeRepository,
   sharedCertificationCandidateRepository,
-  versionRepository,
+  sharedVersionRepository,
 };
 
 import { findByCertificationCourseIdAndAssessmentId } from './scoring/calibrated-challenge-service.js';

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -6,11 +6,10 @@
  * @typedef {import('../index.js').CertificationAssessmentHistoryRepository} CertificationAssessmentHistoryRepository
  * @typedef {import('../index.js').CertificationChallengeRepository} CertificationChallengeRepository
  * @typedef {import('../index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
- * @typedef {import('../index.js').FlashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
+ * @typedef {import('../index.js').VersionRepository} VersionRepository
+ * @typedef {import('../index.js').SharedCertificationCandidateRepository} SharedCertificationCandidateRepository
  * @typedef {import('../index.js').AnswerRepository} AnswerRepository
  * @typedef {import('../index.js').FlashAlgorithmService} FlashAlgorithmService
- * @typedef {import('../index.js').ChallengeRepository} ChallengeRepository
- * @typedef {import('../index.js').ScoringDegradationService} ScoringDegradationService
  */
 
 import CertificationCancelled from '../../../../../../src/shared/domain/events/CertificationCancelled.js';
@@ -31,25 +30,26 @@ export const handleV3CertificationScoring = withTransaction(
    * @param {CertificationAssessmentHistoryRepository} params.certificationAssessmentHistoryRepository
    * @param {CertificationChallengeRepository} params.certificationChallengeRepository
    * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
-   * @param {FlashAlgorithmConfigurationRepository} params.flashAlgorithmConfigurationRepository
+   * @param {VersionRepository} params.versionRepository
+   * @param {SharedCertificationCandidateRepository} params.sharedCertificationCandidateRepository
    * @param {AnswerRepository} params.answerRepository
    * @param {FlashAlgorithmService} params.flashAlgorithmService
-   * @param {ChallengeRepository} params.challengeRepository
    * @param {ScoringDegradationService} params.scoringDegradationService
    */
   async ({
     event,
-    certificationAssessment,
     locale,
+    certificationAssessment,
     answerRepository,
     assessmentResultRepository,
     certificationAssessmentHistoryRepository,
     certificationCourseRepository,
     competenceMarkRepository,
-    flashAlgorithmConfigurationRepository,
+    versionRepository,
     flashAlgorithmService,
     scoringDegradationService,
     scoringConfigurationRepository,
+    sharedCertificationCandidateRepository,
     dependencies,
   }) => {
     const { certificationCourseId, id: assessmentId } = certificationAssessment;
@@ -66,13 +66,21 @@ export const handleV3CertificationScoring = withTransaction(
 
     const abortReason = certificationCourse.getAbortReason();
 
-    const configuration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
-      certificationCourse.getStartDate(),
-    );
+    const certificationCandidate = await sharedCertificationCandidateRepository.getBySessionIdAndUserId({
+      sessionId: certificationCourse.getSessionId(),
+      userId: certificationCourse.getUserId(),
+    });
+
+    const scope = await certificationCourseRepository.getCertificationScope({ courseId: certificationCourse.getId() });
+
+    const version = await versionRepository.getByScopeAndReconciliationDate({
+      scope,
+      reconciliationDate: certificationCandidate.reconciledAt,
+    });
 
     const algorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,
-      configuration,
+      configuration: version.challengesConfiguration,
     });
 
     const v3CertificationScoring = await scoringConfigurationRepository.getLatestByDateAndLocale({

--- a/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
+++ b/api/src/certification/evaluation/domain/services/scoring/scoring-v3.js
@@ -6,7 +6,7 @@
  * @typedef {import('../index.js').CertificationAssessmentHistoryRepository} CertificationAssessmentHistoryRepository
  * @typedef {import('../index.js').CertificationChallengeRepository} CertificationChallengeRepository
  * @typedef {import('../index.js').ScoringConfigurationRepository} ScoringConfigurationRepository
- * @typedef {import('../index.js').VersionRepository} VersionRepository
+ * @typedef {import('../index.js').SharedVersionRepository} SharedVersionRepository
  * @typedef {import('../index.js').SharedCertificationCandidateRepository} SharedCertificationCandidateRepository
  * @typedef {import('../index.js').AnswerRepository} AnswerRepository
  * @typedef {import('../index.js').FlashAlgorithmService} FlashAlgorithmService
@@ -30,7 +30,7 @@ export const handleV3CertificationScoring = withTransaction(
    * @param {CertificationAssessmentHistoryRepository} params.certificationAssessmentHistoryRepository
    * @param {CertificationChallengeRepository} params.certificationChallengeRepository
    * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
-   * @param {VersionRepository} params.versionRepository
+   * @param {SharedVersionRepository} params.SharedVersionRepository
    * @param {SharedCertificationCandidateRepository} params.sharedCertificationCandidateRepository
    * @param {AnswerRepository} params.answerRepository
    * @param {FlashAlgorithmService} params.flashAlgorithmService
@@ -45,7 +45,7 @@ export const handleV3CertificationScoring = withTransaction(
     certificationAssessmentHistoryRepository,
     certificationCourseRepository,
     competenceMarkRepository,
-    versionRepository,
+    sharedVersionRepository,
     flashAlgorithmService,
     scoringDegradationService,
     scoringConfigurationRepository,
@@ -73,7 +73,7 @@ export const handleV3CertificationScoring = withTransaction(
 
     const scope = await certificationCourseRepository.getCertificationScope({ courseId: certificationCourse.getId() });
 
-    const version = await versionRepository.getByScopeAndReconciliationDate({
+    const version = await sharedVersionRepository.getByScopeAndReconciliationDate({
       scope,
       reconciliationDate: certificationCandidate.reconciledAt,
     });

--- a/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,6 +1,5 @@
 //@ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../domain/models/FlashAssessmentAlgorithmConfiguration.js';
 
 /**
@@ -15,23 +14,6 @@ export const getMostRecent = async () => {
 
   if (!flashAlgorithmConfiguration?.challengesConfiguration) {
     return _toDomain({});
-  }
-
-  return _toDomain({ ...flashAlgorithmConfiguration.challengesConfiguration });
-};
-
-// A supprimer une fois remplacée dans scoring-V3
-export const getMostRecentBeforeDate = async (date) => {
-  const knexConn = DomainTransaction.getConnection();
-  const flashAlgorithmConfiguration = await knexConn('certification-configurations')
-    .where('startingDate', '<=', date)
-    .andWhere((queryBuilder) => {
-      queryBuilder.whereNull('expirationDate').orWhere('expirationDate', '>', date);
-    })
-    .first();
-
-  if (!flashAlgorithmConfiguration) {
-    throw new NotFoundError('Configuration not found');
   }
 
   return _toDomain({ ...flashAlgorithmConfiguration.challengesConfiguration });

--- a/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -20,6 +20,7 @@ export const getMostRecent = async () => {
   return _toDomain({ ...flashAlgorithmConfiguration.challengesConfiguration });
 };
 
+// A supprimer une fois remplacée dans scoring-V3
 export const getMostRecentBeforeDate = async (date) => {
   const knexConn = DomainTransaction.getConnection();
   const flashAlgorithmConfiguration = await knexConn('certification-configurations')

--- a/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-rescoring-route_test.js
@@ -66,6 +66,16 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           skillId: 'recSkill0_0',
         });
 
+        databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2009-02-01'),
+          expirationDate: new Date('2010-02-01'),
+          challengesConfiguration: null,
+        });
+        databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2010-02-01'),
+          expirationDate: null,
+        });
+
         databaseBuilder.factory.buildCertificationConfiguration({
           startingDate: new Date('2009-02-01'),
           expirationDate: new Date('2010-02-01'),
@@ -197,6 +207,20 @@ describe('Certification | Evaluation | Acceptance | Application |  certification
           challengeId: 'recChallenge0_0_0',
           alpha: 3.3,
           delta: 4.4,
+        });
+
+        databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2010-02-01'),
+          expirationDate: new Date('2024-02-01'),
+          challengesConfiguration: {
+            maximumAssessmentLength: 1,
+          },
+        });
+
+        databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2024-02-01'),
+          expirationDate: null,
+          challengesConfiguration: null,
         });
 
         databaseBuilder.factory.buildCertificationConfiguration({

--- a/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/application/jobs/certification-completed-job-controller_test.js
@@ -388,6 +388,8 @@ describe('Certification | Evaluation | Integration | Application | Certification
 
       databaseBuilder.factory.buildCertificationConfiguration();
 
+      databaseBuilder.factory.buildCertificationVersion();
+
       await databaseBuilder.commit();
     });
 

--- a/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
+++ b/api/tests/certification/evaluation/integration/evaluation/jobs/certification-completed-job-controller_test.js
@@ -387,6 +387,8 @@ describe('Integration | Certification | Application | jobs | CertificationComple
     certificationCompletedJobController = new CertificationCompletedJobController();
 
     databaseBuilder.factory.buildCertificationConfiguration();
+    databaseBuilder.factory.buildCertificationVersion();
+
     await databaseBuilder.commit();
   });
 

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -28,8 +28,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
       scoringDegradationService,
       scoringConfigurationRepository,
       sharedCertificationCandidateRepository,
-      versionRepository,
-      baseFlashAlgorithmConfiguration,
+      sharedVersionRepository,
       dependencies;
     let clock;
     const now = new Date('2019-01-01T05:06:07Z');
@@ -52,7 +51,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
         getCertificationScope: sinon.stub(),
       };
       competenceMarkRepository = { save: sinon.stub().rejects(new Error('Args mismatch')) };
-      flashAlgorithmConfigurationRepository = { getMostRecentBeforeDate: sinon.stub() };
       flashAlgorithmService = {
         getCapacityAndErrorRate: sinon.stub().callsFake((a) => {
           throw new Error(`Args mismatch, was called with ${JSON.stringify(a.challenges)}`);
@@ -70,13 +68,9 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
       sharedCertificationCandidateRepository = {
         getBySessionIdAndUserId: sinon.stub(),
       };
-      versionRepository = {
+      sharedVersionRepository = {
         getByScopeAndReconciliationDate: sinon.stub(),
       };
-
-      baseFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-        maximumAssessmentLength,
-      });
 
       dependencies = {
         findByCertificationCourseIdAndAssessmentId: sinon.stub(),
@@ -99,7 +93,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
       const certificationCourseStartDate = new Date('2022-02-01');
       let scoringConfiguration;
       const scoreForCapacity = 438;
-      let baseFlashAlgorithmConfig;
 
       beforeEach(function () {
         event = new CertificationCompletedJob({
@@ -140,10 +133,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
         assessmentResultRepository.save.resolves(assessmentResult);
         competenceMarkRepository.save.resolves();
-
-        baseFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-          maximumAssessmentLength,
-        });
       });
 
       it('should save the score', async function () {
@@ -182,10 +171,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           capacityHistory,
         });
 
-        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-          .withArgs(certificationCourseStartDate)
-          .resolves(baseFlashAlgorithmConfig);
-
         answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
         certificationCourseRepository.get
@@ -203,7 +188,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           .withArgs({ courseId: abortedCertificationCourse.getId() })
           .resolves(Frameworks.CORE);
 
-        versionRepository.getByScopeAndReconciliationDate
+        sharedVersionRepository.getByScopeAndReconciliationDate
           .withArgs({
             scope: Frameworks.CORE,
             reconciliationDate: candidate.reconciledAt,
@@ -262,7 +247,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           flashAlgorithmService,
           scoringConfigurationRepository,
           sharedCertificationCandidateRepository,
-          versionRepository,
+          sharedVersionRepository,
           dependencies,
         });
 
@@ -333,9 +318,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
 
             answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
             certificationCourseRepository.get.withArgs({ id: certificationCourseId }).resolves(certificationCourse);
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfiguration);
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 challenges: answeredChallenges,
@@ -359,7 +341,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: certificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -393,7 +375,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -468,9 +450,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               scoringConfigurationRepository.getLatestByDateAndLocale
                 .withArgs({ locale: 'fr', date: certificationCourse.getStartDate() })
                 .resolves(scoringConfiguration);
-              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-                .withArgs(certificationCourseStartDate)
-                .resolves(baseFlashAlgorithmConfig);
               answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
               certificationCourseRepository.get
                 .withArgs({ id: certificationAssessment.certificationCourseId })
@@ -486,7 +465,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({ courseId: certificationCourse.getId() })
                 .resolves(Frameworks.CORE);
 
-              versionRepository.getByScopeAndReconciliationDate
+              sharedVersionRepository.getByScopeAndReconciliationDate
                 .withArgs({
                   scope: Frameworks.CORE,
                   reconciliationDate: candidate.reconciledAt,
@@ -534,7 +513,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 flashAlgorithmService,
                 scoringConfigurationRepository,
                 sharedCertificationCandidateRepository,
-                versionRepository,
+                sharedVersionRepository,
                 dependencies,
               });
 
@@ -617,15 +596,12 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({ courseId: certificationCourse.getId() })
                 .resolves(Frameworks.CORE);
 
-              versionRepository.getByScopeAndReconciliationDate
+              sharedVersionRepository.getByScopeAndReconciliationDate
                 .withArgs({
                   scope: Frameworks.CORE,
                   reconciliationDate: candidate.reconciledAt,
                 })
                 .resolves(version);
-              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-                .withArgs(certificationCourseStartDate)
-                .resolves(baseFlashAlgorithmConfiguration);
               flashAlgorithmService.getCapacityAndErrorRate
                 .withArgs({
                   challenges: allChallenges,
@@ -664,7 +640,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 flashAlgorithmService,
                 scoringConfigurationRepository,
                 sharedCertificationCandidateRepository,
-                versionRepository,
+                sharedVersionRepository,
                 dependencies,
               });
 
@@ -693,8 +669,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
     });
 
     context('for rescoring certification', function () {
-      let baseFlashAlgorithmConfig,
-        scoringConfiguration,
+      let scoringConfiguration,
         assessmentId,
         candidate,
         version,
@@ -720,9 +695,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           certificationCourseId,
           id: assessmentId,
           version: AlgorithmEngineVersion.V3,
-        });
-        baseFlashAlgorithmConfig = domainBuilder.buildFlashAlgorithmConfiguration({
-          maximumAssessmentLength,
         });
 
         scoringConfiguration = domainBuilder.buildV3CertificationScoring({
@@ -787,7 +759,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -797,10 +769,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
             scoringConfigurationRepository.getLatestByDateAndLocale
               .withArgs({ locale: 'fr', date: abortedCertificationCourse.getStartDate() })
               .resolves(scoringConfiguration);
-
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfiguration);
 
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
@@ -844,7 +812,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -897,10 +865,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               capacityHistory,
             });
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfiguration);
-
             dependencies.findByCertificationCourseIdAndAssessmentId.resolves({
               allChallenges: answeredChallenges,
               askedChallengesWithoutLiveAlerts: answeredChallenges,
@@ -923,7 +887,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -971,7 +935,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -1040,10 +1004,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               capacityHistory,
             });
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfiguration);
-
             dependencies.findByCertificationCourseIdAndAssessmentId.resolves({
               allChallenges: answeredChallenges,
               askedChallengesWithoutLiveAlerts: answeredChallenges,
@@ -1071,7 +1031,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -1116,7 +1076,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -1203,16 +1163,13 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfiguration);
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 challenges: [challengeExcludedFromCalibration, ...challengesAfterCalibration],
@@ -1256,7 +1213,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
               scoringDegradationService,
             });
@@ -1341,16 +1298,12 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
               })
               .resolves(version);
-
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(abortedCertificationCourse.getStartDate())
-              .resolves(baseFlashAlgorithmConfig);
 
             flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
@@ -1394,7 +1347,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -1461,10 +1414,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ locale: 'fr', date: abortedCertificationCourse.getStartDate() })
               .resolves(scoringConfiguration);
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfig);
-
             answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
             certificationCourseRepository.get
@@ -1482,7 +1431,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -1532,7 +1481,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 
@@ -1596,10 +1545,6 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ locale: 'fr', date: abortedCertificationCourse.getStartDate() })
               .resolves(scoringConfiguration);
 
-            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
-              .withArgs(certificationCourseStartDate)
-              .resolves(baseFlashAlgorithmConfig);
-
             answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
             certificationCourseRepository.get
@@ -1617,7 +1562,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({ courseId: abortedCertificationCourse.getId() })
               .resolves(Frameworks.CORE);
 
-            versionRepository.getByScopeAndReconciliationDate
+            sharedVersionRepository.getByScopeAndReconciliationDate
               .withArgs({
                 scope: Frameworks.CORE,
                 reconciliationDate: candidate.reconciledAt,
@@ -1677,7 +1622,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               flashAlgorithmService,
               scoringConfigurationRepository,
               sharedCertificationCandidateRepository,
-              versionRepository,
+              sharedVersionRepository,
               dependencies,
             });
 

--- a/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/cancellation-route_test.js
@@ -157,6 +157,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
     context('when certification is v3', function () {
       it('should create a new cancelled assessment-result', async function () {
         // given
+        databaseBuilder.factory.buildCertificationVersion();
         const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
         const session = databaseBuilder.factory.buildSession({
           version: AlgorithmEngineVersion.V3,
@@ -280,6 +281,7 @@ describe('Certification | Session-management | Acceptance | Application | Routes
   describe('PATCH /api/admin/certification-courses/{certificationCourseId}/uncancel', function () {
     it('should uncancel the certification with a new assessment-result', async function () {
       // given
+      databaseBuilder.factory.buildCertificationVersion();
       const juryMember = databaseBuilder.factory.buildUser.withRole({ roles: PIX_ADMIN.ROLES.SUPER_ADMIN });
       const session = databaseBuilder.factory.buildSession({
         version: AlgorithmEngineVersion.V3,

--- a/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-course-route_test.js
@@ -223,6 +223,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             },
           ],
         });
+        databaseBuilder.factory.buildCertificationVersion({
+          startDate: new Date('2018-12-01T01:02:03Z'),
+        });
 
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
@@ -291,6 +294,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       });
 
       databaseBuilder.factory.buildCertificationConfiguration();
+      databaseBuilder.factory.buildCertificationVersion();
 
       const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
         sessionId: session.id,

--- a/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/finalize-route_test.js
@@ -394,6 +394,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
       context('when session is v3', function () {
         beforeEach(async function () {
           ({ options, session } = await _createSession({ version: 3 }));
+          databaseBuilder.factory.buildCertificationVersion();
           databaseBuilder.factory.buildCertificationConfiguration();
           await databaseBuilder.commit();
         });
@@ -924,6 +925,9 @@ const _createSessionWithoutChallenge = async () => {
   const session = databaseBuilder.factory.buildSession({ version });
   databaseBuilder.factory.buildCertificationConfiguration({
     startingDate: new Date('2024-01-01'),
+  });
+  databaseBuilder.factory.buildCertificationVersion({
+    startDate: new Date('2024-01-01'),
   });
   databaseBuilder.factory.buildCertificationCenterMembership({
     userId,

--- a/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/integration/domain/usecases/process-auto-jury_test.js
@@ -384,6 +384,7 @@ describe('Certification | Session Management | Integration | Domain | UseCase | 
         await mockLearningContent(learningContentObjects);
 
         databaseBuilder.factory.buildCertificationConfiguration();
+        databaseBuilder.factory.buildCertificationVersion();
         await databaseBuilder.commit();
       });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -1,9 +1,6 @@
-import dayjs from 'dayjs';
-
 import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/shared/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Shared | Integration | Infrastructure | Repository | FlashAlgorithmConfigurationRepository', function () {
   describe('#getMostRecent', function () {
@@ -84,99 +81,6 @@ describe('Certification | Shared | Integration | Infrastructure | Repository | F
 
         // then
         expect(configResult).to.be.instanceOf(FlashAssessmentAlgorithmConfiguration);
-      });
-    });
-  });
-
-  describe('#getMostRecentBeforeDate', function () {
-    const firstConfigDate = new Date('2020-01-01T08:00:00Z');
-    const firstConfigVariationPercent = 0.1;
-
-    const secondConfigDate = new Date('2021-01-01T08:00:00Z');
-    const secondConfigVariationPercent = 0.2;
-
-    const thirdConfigDate = new Date('2022-01-01T08:00:00Z');
-    const thirdConfigVariationPercent = 0.3;
-
-    describe('when there are saved configurations', function () {
-      beforeEach(async function () {
-        databaseBuilder.factory.buildCertificationConfiguration({
-          startingDate: firstConfigDate,
-          expirationDate: secondConfigDate,
-          challengesConfiguration: {
-            variationPercent: firstConfigVariationPercent,
-          },
-        });
-        databaseBuilder.factory.buildCertificationConfiguration({
-          startingDate: secondConfigDate,
-          expirationDate: thirdConfigDate,
-          challengesConfiguration: {
-            variationPercent: secondConfigVariationPercent,
-          },
-        });
-        databaseBuilder.factory.buildCertificationConfiguration({
-          startingDate: thirdConfigDate,
-          expirationDate: null,
-          challengesConfiguration: {
-            variationPercent: thirdConfigVariationPercent,
-          },
-        });
-        await databaseBuilder.commit();
-      });
-
-      describe('when date is more recent than the latest configuration', function () {
-        it('should return the latest configuration', async function () {
-          // given
-          const date = dayjs(thirdConfigDate).add(7, 'day').toDate();
-          const expectedConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-            challengesBetweenSameCompetence: 2,
-            createdAt: undefined,
-            enablePassageByAllCompetences: false,
-            limitToOneQuestionPerTube: false,
-            maximumAssessmentLength: 32,
-            variationPercent: thirdConfigVariationPercent,
-          });
-
-          // when
-          const configResult = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(date);
-
-          // then
-          expect(configResult).to.deep.equal(expectedConfiguration);
-        });
-      });
-
-      describe('when date is between the first and second configuration', function () {
-        it('should return the first configuration', async function () {
-          // given
-          const date = dayjs(firstConfigDate).add(7, 'day').toDate();
-          const expectedConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
-            challengesBetweenSameCompetence: 2,
-            createdAt: undefined,
-            enablePassageByAllCompetences: false,
-            limitToOneQuestionPerTube: false,
-            maximumAssessmentLength: 32,
-            variationPercent: firstConfigVariationPercent,
-          });
-
-          // when
-          const configResult = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(date);
-
-          // then
-          expect(configResult).to.deep.equal(expectedConfiguration);
-        });
-      });
-    });
-
-    describe('when there is no saved configuration', function () {
-      it('should throw a not found error', async function () {
-        // given
-        const configDate = new Date('2020-01-01T08:00:00Z');
-
-        // when
-        const error = await catchErr(flashAlgorithmConfigurationRepository.getMostRecentBeforeDate)(configDate);
-
-        // then
-        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Le scoring des certifications V3 n'utilise pas encore le système de versions comme cela est le cas ailleurs dans le code. (simulation, get-next-challenge)

## 🌰 Proposition

On remplace par le nouveau système de version

## 🍁 Remarques

On ne s'occupe dans cette PR que du remplacement de `getMostRecentBeforeDate` pour récupérer la configuration de challenges et le scope
Les configurations de score (général et par compétence) seront remplacées dans une autre PR.

## 🪵 Pour tester

- Créer une session de certification V3 (non Pix+) et y ajouter un candidat
- Passer la session et obtenir un score
