### PR TITLE
[BUGFIX] Affichage Pix Admin : récupérer les challenges avec la locale et non la langue (PIX-20333).

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
+import { FRENCH_FRANCE, FRENCH_SPOKEN } from '../../../../shared/domain/services/locale-service.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
@@ -9,7 +9,7 @@ import * as thematicRepository from '../../../../shared/infrastructure/repositor
 import * as tubeRepository from '../../../../shared/infrastructure/repositories/tube-repository.js';
 
 async function getFrameworkReferential({ challengeIds }) {
-  const challenges = await challengeRepository.getMany(challengeIds, FRENCH_SPOKEN);
+  const challenges = await challengeRepository.getMany(challengeIds, FRENCH_FRANCE);
 
   const skillIds = challenges.map((challenge) => challenge.skill.id);
   const uniqSkillIds = _.uniq(skillIds);

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -477,7 +477,7 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
   });
 
   describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/current-consolidated-framework', function () {
-    it('should return the current framework for given complementaryCertificationKey', async function () {
+    it('should return the current framework for given complementary certification', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
 
@@ -491,7 +491,10 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
                 {
                   id: 'recThemCompetence1',
                   tubes: [
-                    { id: 'recTubeCompetence1', skills: [{ id: 'skillId@web3', challenges: [{ id: 'rec123' }] }] },
+                    {
+                      id: 'recTubeCompetence1',
+                      skills: [{ id: 'skillId@web3', challenges: [{ id: 'rec123', langues: ['Franco Français'] }] }],
+                    },
                   ],
                 },
               ],

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/learning-content-repository_test.js
@@ -1,4 +1,5 @@
-import * as learningContentRepository from '../../../../../../../api/src/certification/configuration/infrastructure/repositories/learning-content-repository.js';
+import * as learningContentRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/learning-content-repository.js';
+import { FRENCH_FRANCE } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Configuration | Integration | Infrastructure | Repository | LearningContentRepository', function () {
@@ -11,8 +12,16 @@ describe('Certification | Configuration | Integration | Infrastructure | Reposit
       const thematicId = databaseBuilder.factory.learningContent.buildCompetence({ id: 'thematic', competenceId }).id;
       const tubeId = databaseBuilder.factory.learningContent.buildTube({ id: 'tube', competenceId, thematicId }).id;
       const skillId = databaseBuilder.factory.learningContent.buildSkill({ id: 'skill', tubeId, competenceId }).id;
-      const challenge1 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'chall1', skillId });
-      const challenge2 = databaseBuilder.factory.learningContent.buildChallenge({ id: 'chall2', skillId });
+      const challenge1 = databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'chall1',
+        skillId,
+        locales: [FRENCH_FRANCE],
+      });
+      const challenge2 = databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'chall2',
+        skillId,
+        locales: [FRENCH_FRANCE],
+      });
 
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
 


### PR DESCRIPTION
## 🍂 Problème

Dans Admin, nous avons constaté que certaines compétences ne s’affichaient pas alors que les challenges souhaités étaient bien tous présents en BDD (table certification-frameworks-challenges)
La regle metier pour les Pix+ est que on va chercher tout ce qui est `fr-fr`

## 🌰 Proposition

Dans la route api/admin/complementary-certifications/KEY/current-consolidated-framework, on utilise la méthode de repository getFrameworkReferential qui filtre les challenges sur la langue `fr` au lieu de la locale `fr-fr`. Ce qui ne donne pas le meme resultat niveau LCMS.

Modifier pour utiliser la locale fr-fr.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

* Sur Pix Admin creer une referentiel de certification, en selectionnant une competence comprenant **que** du fr-fr cote LCMS
* Verifier que cette competence apparait bien cote interface
