### PR TITLE
[FEATURE] Renforcer l'accessibilité sur la navigation (PIX-20265).

### DIFF
--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -41,7 +41,7 @@ export default class ModulixNavigationButton extends Component {
   }
 
   get isCurrentSection() {
-    return this.args.isCurrentSection;
+    return this.args.isCurrentSection ? 'step' : false;
   }
 
   get isPlainIcon() {
@@ -86,11 +86,9 @@ export default class ModulixNavigationButton extends Component {
   }
 
   get ariaLabelButton() {
-    const totalSections = this.args.sections.length;
-    const currentSectionIndex = this.args.sections.indexOf(this.args.section) + 1;
     const steps = this.intl.t('pages.modulix.navigation.buttons.aria-label.steps', {
-      indexSection: currentSectionIndex,
-      totalSections: totalSections,
+      indexSection: this.args.currentSectionIndex,
+      totalSections: this.args.sectionsLength,
     });
 
     if (this.isDisabled) {

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -85,6 +85,22 @@ export default class ModulixNavigationButton extends Component {
     this.hideTooltip(event);
   }
 
+  get ariaLabelButton() {
+    const totalSections = this.args.sections.length;
+    const currentSectionIndex = this.args.sections.indexOf(this.args.section) + 1;
+    const steps = this.intl.t('pages.modulix.navigation.buttons.aria-label.steps', {
+      indexSection: currentSectionIndex,
+      totalSections: totalSections,
+    });
+
+    if (this.isDisabled) {
+      return `${steps} ${this.intl.t('pages.modulix.navigation.buttons.aria-label.disabled')}`;
+    }
+    return `${steps} ${this.intl.t('pages.modulix.navigation.buttons.aria-label.enabled', {
+      sectionTitle: this.sectionTitle(this.args.section.type),
+    })}`;
+  }
+
   <template>
     {{#if this.media.isMobile}}
       <PixButton
@@ -92,6 +108,7 @@ export default class ModulixNavigationButton extends Component {
         @triggerAction={{this.scrollToSection}}
         @iconBefore={{this.sectionTitleIcon @section.type}}
         @isDisabled={{this.isDisabled}}
+        aria-label={{this.ariaLabelButton}}
         aria-current="{{this.isCurrentSection}}"
       >{{this.sectionTitle @section.type}}</PixButton>
     {{else}}
@@ -105,7 +122,7 @@ export default class ModulixNavigationButton extends Component {
       >
         <PixIconButton
           class="module-navigation-button module-navigation-button{{this.buttonClass}}"
-          @ariaLabel={{this.sectionTitle @section.type}}
+          @ariaLabel={{this.ariaLabelButton}}
           @triggerAction={{this.scrollToSection}}
           @iconName={{this.sectionTitleIcon @section.type}}
           @isDisabled={{this.isDisabled}}

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -128,6 +128,7 @@ export default class ModulixNavigationButton extends Component {
           @isDisabled={{this.isDisabled}}
           aria-current="{{this.isCurrentSection}}"
           @plainIcon={{this.isPlainIcon}}
+          {{on "keydown" @handleArrowKeyNavigation}}
         />
         <span
           role="tooltip"

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -112,7 +112,11 @@ export default class ModulixNavigationButton extends Component {
           aria-current="{{this.isCurrentSection}}"
           @plainIcon={{this.isPlainIcon}}
         />
-        <span role="tooltip" class="navigation-tooltip__content navigation-tooltip__content{{this.buttonClass}}">
+        <span
+          role="tooltip"
+          class="navigation-tooltip__content navigation-tooltip__content{{this.buttonClass}}"
+          aria-hidden="true"
+        >
           {{this.sectionTitle @section.type}}
         </span>
       </div>

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -23,24 +23,24 @@ export default class ModulixNavigation extends Component {
     const navigationButtonsList = triggeredButtonParent.parentNode.children;
     const triggeredButtonParentIndex = Array.from(navigationButtonsList).indexOf(triggeredButtonParent);
 
-    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-      event.preventDefault();
+    const trackedEventsKey = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft'];
 
-      if (triggeredButtonParentIndex + 1 < this.sectionsLength) {
-        const nextButton = triggeredButtonParent.nextElementSibling.firstElementChild;
-        nextButton.focus();
-      } else {
-        triggeredButton.focus();
-      }
-    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-      event.preventDefault();
+    if (trackedEventsKey.indexOf(event.key) === -1) return;
 
-      if (triggeredButtonParentIndex >= 1) {
-        const previousButton = triggeredButtonParent.previousElementSibling.firstElementChild;
-        previousButton.focus();
-      } else {
-        triggeredButton.focus();
-      }
+    event.preventDefault();
+
+    if (
+      (event.key === 'ArrowDown' || event.key === 'ArrowRight') &&
+      triggeredButtonParentIndex + 1 < this.sectionsLength
+    ) {
+      const nextButton = triggeredButtonParent.nextElementSibling.firstElementChild;
+      nextButton.focus();
+      return;
+    }
+
+    if ((event.key === 'ArrowUp' || event.key === 'ArrowLeft') && triggeredButtonParentIndex >= 1) {
+      const previousButton = triggeredButtonParent.previousElementSibling.firstElementChild;
+      previousButton.focus();
     }
   }
 

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -17,6 +17,35 @@ export default class ModulixNavigation extends Component {
     return this.modulixNavigationProgress.currentSectionIndex > index;
   }
 
+  @action handleArrowKeyNavigation(event) {
+    const triggeredButton = document.activeElement;
+    const triggeredButtonParent = triggeredButton.parentElement;
+    const navigationButtonsList = triggeredButtonParent.parentNode.children;
+    const triggeredButtonParentIndex = Array.from(navigationButtonsList).indexOf(triggeredButtonParent);
+
+    const totalSections = this.args.sections.length;
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      event.preventDefault();
+
+      if (triggeredButtonParentIndex + 1 < totalSections) {
+        const nextButton = triggeredButtonParent.nextElementSibling.firstElementChild;
+        nextButton.focus();
+      } else {
+        triggeredButton.focus();
+      }
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+
+      if (triggeredButtonParentIndex >= 1) {
+        const previousButton = triggeredButtonParent.previousElementSibling.firstElementChild;
+        previousButton.focus();
+      } else {
+        triggeredButton.focus();
+      }
+    }
+  }
+
   <template>
     <PixNavigation
       class="app-navigation module-navigation"
@@ -34,6 +63,7 @@ export default class ModulixNavigation extends Component {
             @isCurrentSection={{this.isCurrentSection index}}
             @isPastSection={{this.isPastSection index}}
             @sections={{@sections}}
+            @handleArrowKeyNavigation={{this.handleArrowKeyNavigation}}
           />
         {{/each}}
       </:navElements>

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -33,6 +33,7 @@ export default class ModulixNavigation extends Component {
             @section={{section}}
             @isCurrentSection={{this.isCurrentSection index}}
             @isPastSection={{this.isPastSection index}}
+            @sections={{@sections}}
           />
         {{/each}}
       </:navElements>

--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -23,12 +23,10 @@ export default class ModulixNavigation extends Component {
     const navigationButtonsList = triggeredButtonParent.parentNode.children;
     const triggeredButtonParentIndex = Array.from(navigationButtonsList).indexOf(triggeredButtonParent);
 
-    const totalSections = this.args.sections.length;
-
     if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
       event.preventDefault();
 
-      if (triggeredButtonParentIndex + 1 < totalSections) {
+      if (triggeredButtonParentIndex + 1 < this.sectionsLength) {
         const nextButton = triggeredButtonParent.nextElementSibling.firstElementChild;
         nextButton.focus();
       } else {
@@ -44,6 +42,14 @@ export default class ModulixNavigation extends Component {
         triggeredButton.focus();
       }
     }
+  }
+
+  get sectionsLength() {
+    return this.args.sections.length;
+  }
+
+  @action currentSectionIndex(section) {
+    return this.args.sections.indexOf(section) + 1;
   }
 
   <template>
@@ -62,7 +68,8 @@ export default class ModulixNavigation extends Component {
             @section={{section}}
             @isCurrentSection={{this.isCurrentSection index}}
             @isPastSection={{this.isPastSection index}}
-            @sections={{@sections}}
+            @sectionsLength={{this.sectionsLength}}
+            @currentSectionIndex={{this.currentSectionIndex section}}
             @handleArrowKeyNavigation={{this.handleArrowKeyNavigation}}
           />
         {{/each}}

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { pageTitle } from 'ember-page-title';
 
 import { inc } from '../../helpers/inc';
@@ -244,6 +245,14 @@ export default class ModulePassage extends Component {
     });
   }
 
+  get sectionsLength() {
+    return this.args.module.sections.length;
+  }
+
+  get currentStep() {
+    return this.modulixNavigationProgress.currentSectionIndex + 1;
+  }
+
   <template>
     {{pageTitle @module.title}}
     {{#unless this.featureToggles.featureToggles.isModulixNavEnabled}}
@@ -271,6 +280,13 @@ export default class ModulePassage extends Component {
         {{#each this.grainsToDisplay as |grain index|}}
           {{#if (this.shouldDisplaySectionTitle grain)}}
             <ModuleSectionTitle @sectionType={{this.getSectionTypeForGrain grain}} />
+            <h3 class="screen-reader-only">
+              {{t
+                "pages.modulix.flashcards.navigation.longCurrentStep"
+                current=this.currentStep
+                total=this.sectionsLength
+              }}
+            </h3>
           {{/if}}
           <ModuleGrain
             @grain={{grain}}

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -176,7 +176,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         });
 
         // then
-        assert.dom(firstSectionButton).hasAttribute('aria-current', 'true');
+        assert.dom(firstSectionButton).hasAttribute('aria-current', 'step');
         assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
 
         assert.dom(secondSectionButton).hasAttribute('aria-current', 'false');
@@ -190,7 +190,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         assert.dom(firstSectionButton).hasAttribute('aria-current', 'false');
         assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
 
-        assert.dom(secondSectionButton).hasAttribute('aria-current', 'true');
+        assert.dom(secondSectionButton).hasAttribute('aria-current', 'step');
         assert.dom(secondSectionButton).hasNoAttribute('aria-disabled');
       });
     });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -161,10 +161,18 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
         const navigation = screen.getByRole('navigation', { name: t('navigation.nav-bar.aria-label') });
         const firstSectionButton = within(navigation).getByRole('button', {
-          name: t('pages.modulix.section.explore-to-understand'),
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 1,
+            totalSections: 2,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+            sectionTitle: 'Explorer pour comprendre',
+          })}`,
         });
         const secondSectionButton = within(navigation).getByRole('button', {
-          name: t('pages.modulix.section.go-further'),
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 2,
+            totalSections: 2,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
         });
 
         // then

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -24,7 +24,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type,
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const handleArrowKeyNavigation = sinon.stub();
 
       // when
@@ -32,7 +33,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{false}}
             @isCurrentSection={{true}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -45,8 +47,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         .dom(
           screen.getByRole('button', {
             name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-              indexSection: 1,
-              totalSections: 1,
+              indexSection: currentSectionIndex,
+              totalSections: sectionsLength,
             })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
               sectionTitle: 'Se questionner',
             })}`,
@@ -62,7 +64,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -70,7 +73,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{false}}
               @isCurrentSection={{false}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -89,7 +93,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -97,7 +102,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{false}}
               @isCurrentSection={{true}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -116,7 +122,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -124,7 +131,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{true}}
               @isCurrentSection={{false}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -144,7 +152,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           id: 'section1',
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         //  when
@@ -152,7 +161,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isCurrentSection={{true}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
@@ -170,7 +180,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             id: 'section1',
             type: 'question-yourself',
           };
-          const sections = [section];
+          const sectionsLength = [section].length;
+          const currentSectionIndex = 1;
           const handleArrowKeyNavigation = sinon.stub();
 
           //  when
@@ -178,7 +189,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             <template>
               <NavigationButton
                 @section={{section}}
-                @sections={{sections}}
+                @sectionsLength={{sectionsLength}}
+                @currentSectionIndex={{currentSectionIndex}}
                 @isCurrentSection={{true}}
                 @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
               />
@@ -202,7 +214,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
                 { title: 'Grain title', type: 'activity', id: '234-abc' },
               ],
             };
-            const sections = [section];
+            const sectionsLength = [section].length;
+            const currentSectionIndex = 1;
             const handleArrowKeyNavigation = sinon.stub();
 
             //  when
@@ -210,7 +223,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               <template>
                 <NavigationButton
                   @section={{section}}
-                  @sections={{sections}}
+                  @sectionsLength={{sectionsLength}}
+                  @currentSectionIndex={{currentSectionIndex}}
                   @isCurrentSection={{true}}
                   @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
                 />
@@ -237,7 +251,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               { title: 'Grain title', type: 'activity', id: '234-abc' },
             ],
           };
-          const sections = [section];
+          const sectionsLength = [section].length;
+          const currentSectionIndex = 1;
           const handleArrowKeyNavigation = sinon.stub();
 
           //  when
@@ -245,7 +260,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             <template>
               <NavigationButton
                 @section={{section}}
-                @sections={{sections}}
+                @sectionsLength={{sectionsLength}}
+                @currentSectionIndex={{currentSectionIndex}}
                 @isCurrentSection={{true}}
                 @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
               />
@@ -269,7 +285,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
                 { title: 'Grain title', type: 'activity', id: '234-abc' },
               ],
             };
-            const sections = [section];
+            const sectionsLength = [section].length;
+            const currentSectionIndex = 1;
             const handleArrowKeyNavigation = sinon.stub();
 
             //  when
@@ -277,7 +294,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               <template>
                 <NavigationButton
                   @section={{section}}
-                  @sections={{sections}}
+                  @sectionsLength={{sectionsLength}}
+                  @currentSectionIndex={{currentSectionIndex}}
                   @isCurrentSection={{true}}
                   @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
                 />
@@ -309,7 +327,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type,
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const handleArrowKeyNavigation = sinon.stub();
 
       // when
@@ -317,7 +336,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{false}}
             @isCurrentSection={{false}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -335,7 +355,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -343,7 +364,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{false}}
               @isCurrentSection={{false}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -362,7 +384,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -370,7 +393,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{false}}
               @isCurrentSection={{true}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -389,7 +413,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
-        const sections = [section];
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
         const handleArrowKeyNavigation = sinon.stub();
 
         // when
@@ -397,7 +422,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           <template>
             <NavigationButton
               @section={{section}}
-              @sections={{sections}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
               @isPastSection={{true}}
               @isCurrentSection={{false}}
               @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -415,7 +441,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const handleArrowKeyNavigation = sinon.stub();
 
       // when
@@ -423,7 +450,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{true}}
             @isCurrentSection={{true}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -436,14 +464,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         .dom(
           screen.getByRole('button', {
             name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-              indexSection: 1,
-              totalSections: 1,
+              indexSection: currentSectionIndex,
+              totalSections: sectionsLength,
             })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
               sectionTitle: 'Se questionner',
             })}`,
           }),
         )
-        .hasAria('current', 'true');
+        .hasAria('current', 'step');
     });
   });
 
@@ -453,7 +481,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const focusAndScroll = sinon.stub();
       class ModulixAutoScrollService extends Service {
         focusAndScroll = focusAndScroll;
@@ -466,7 +495,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{false}}
             @isCurrentSection={{true}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -476,8 +506,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       await click(
         screen.getByRole('button', {
           name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-            indexSection: 1,
-            totalSections: 1,
+            indexSection: currentSectionIndex,
+            totalSections: sectionsLength,
           })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
             sectionTitle: 'Se questionner',
           })}`,
@@ -495,7 +525,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         id: 'section1',
         type: 'question-yourself',
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const trackEvent = sinon.stub();
       const handleArrowKeyNavigation = sinon.stub();
 
@@ -514,7 +545,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isCurrentSection={{true}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
@@ -523,8 +555,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       await click(
         screen.getByRole('button', {
           name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-            indexSection: 1,
-            totalSections: 1,
+            indexSection: currentSectionIndex,
+            totalSections: sectionsLength,
           })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
             sectionTitle: 'Se questionner',
           })}`,
@@ -546,7 +578,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
-      const sections = [section];
+      const sectionsLength = [section].length;
+      const currentSectionIndex = 1;
       const focusAndScroll = sinon.stub();
       const handleArrowKeyNavigation = sinon.stub();
       class ModulixAutoScrollService extends Service {
@@ -559,7 +592,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         <template>
           <NavigationButton
             @section={{section}}
-            @sections={{sections}}
+            @sectionsLength={{sectionsLength}}
+            @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{false}}
             @isCurrentSection={{false}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
@@ -569,8 +603,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       await click(
         screen.getByRole('button', {
           name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-            indexSection: 1,
-            totalSections: 1,
+            indexSection: currentSectionIndex,
+            totalSections: sectionsLength,
           })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
         }),
       );

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -24,16 +24,33 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type,
       };
+      const sections = [section];
 
       // when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isPastSection={{false}}
+            @isCurrentSection={{true}}
+          />
         </template>,
       );
 
       // then
-      assert.dom(screen.getByRole('button', { name: t(`pages.modulix.section.${type}`) })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+              indexSection: 1,
+              totalSections: 1,
+            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+              sectionTitle: 'Se questionner',
+            })}`,
+          }),
+        )
+        .exists();
       assert.dom(screen.getByRole('img', { hidden: true })).exists();
     });
 
@@ -43,11 +60,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{false}}
+              @isCurrentSection={{false}}
+            />
           </template>,
         );
 
@@ -62,11 +85,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{true}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{false}}
+              @isCurrentSection={{true}}
+            />
           </template>,
         );
 
@@ -81,11 +110,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{false}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{true}}
+              @isCurrentSection={{false}}
+            />
           </template>,
         );
 
@@ -101,13 +136,18 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           id: 'section1',
           type: 'question-yourself',
         };
+        const sections = [section];
 
         //  when
-        await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+        await render(
+          <template>
+            <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+          </template>,
+        );
 
         // then
         assert.dom('.navigation-tooltip__content').hasAttribute('aria-hidden', 'true');
-      })
+      });
 
       module('when a button is hovered', function () {
         test('should display tooltip', async function (assert) {
@@ -116,9 +156,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             id: 'section1',
             type: 'question-yourself',
           };
+          const sections = [section];
 
           //  when
-          await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+          await render(
+            <template>
+              <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+            </template>,
+          );
 
           // then
           assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
@@ -137,9 +182,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
                 { title: 'Grain title', type: 'activity', id: '234-abc' },
               ],
             };
+            const sections = [section];
 
             //  when
-            await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+            await render(
+              <template>
+                <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+              </template>,
+            );
 
             // then
             await triggerEvent('.navigation-tooltip', 'mouseenter');
@@ -161,9 +211,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               { title: 'Grain title', type: 'activity', id: '234-abc' },
             ],
           };
+          const sections = [section];
 
           //  when
-          await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+          await render(
+            <template>
+              <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+            </template>,
+          );
 
           // then
           assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
@@ -182,9 +237,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
                 { title: 'Grain title', type: 'activity', id: '234-abc' },
               ],
             };
+            const sections = [section];
 
             //  when
-            await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+            await render(
+              <template>
+                <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+              </template>,
+            );
 
             // then
             await triggerEvent('.navigation-tooltip', 'focusin');
@@ -194,7 +254,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           });
         });
       });
-    })
+    });
   });
 
   module('when screen is mobile', function (hooks) {
@@ -211,11 +271,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type,
       };
+      const sections = [section];
 
       // when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isPastSection={{false}}
+            @isCurrentSection={{false}}
+          />
         </template>,
       );
 
@@ -229,11 +295,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{false}}
+              @isCurrentSection={{false}}
+            />
           </template>,
         );
 
@@ -248,11 +320,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{true}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{false}}
+              @isCurrentSection={{true}}
+            />
           </template>,
         );
 
@@ -267,11 +345,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         const section = {
           type: 'question-yourself',
         };
+        const sections = [section];
 
         // when
         const screen = await render(
           <template>
-            <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{false}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isPastSection={{true}}
+              @isCurrentSection={{false}}
+            />
           </template>,
         );
 
@@ -285,17 +369,32 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
+      const sections = [section];
 
       // when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @isPastSection={{true}} @isCurrentSection={{true}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isPastSection={{true}}
+            @isCurrentSection={{true}}
+          />
         </template>,
       );
 
       // then
       assert
-        .dom(screen.getByRole('button', { name: t('pages.modulix.section.question-yourself') }))
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+              indexSection: 1,
+              totalSections: 1,
+            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+              sectionTitle: 'Se questionner',
+            })}`,
+          }),
+        )
         .hasAria('current', 'true');
     });
   });
@@ -306,6 +405,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
+      const sections = [section];
       const focusAndScroll = sinon.stub();
       class ModulixAutoScrollService extends Service {
         focusAndScroll = focusAndScroll;
@@ -315,10 +415,24 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       // when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{true}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isPastSection={{false}}
+            @isCurrentSection={{true}}
+          />
         </template>,
       );
-      await click(screen.getByRole('button', { name: 'Se questionner' }));
+      await click(
+        screen.getByRole('button', {
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 1,
+            totalSections: 1,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+            sectionTitle: 'Se questionner',
+          })}`,
+        }),
+      );
 
       // then
       sinon.assert.called(focusAndScroll);
@@ -331,6 +445,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         id: 'section1',
         type: 'question-yourself',
       };
+      const sections = [section];
       const trackEvent = sinon.stub();
 
       class MetricsStubService extends Service {
@@ -345,9 +460,20 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
 
       //  when
       const screen = await render(
-        <template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>,
+        <template>
+          <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+        </template>,
       );
-      await click(screen.getByRole('button', { name: 'Se questionner' }));
+      await click(
+        screen.getByRole('button', {
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 1,
+            totalSections: 1,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+            sectionTitle: 'Se questionner',
+          })}`,
+        }),
+      );
 
       // then
       sinon.assert.calledWithExactly(trackEvent, 'Clic sur le bouton de la navigation', {
@@ -364,6 +490,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       const section = {
         type: 'question-yourself',
       };
+      const sections = [section];
       const focusAndScroll = sinon.stub();
       class ModulixAutoScrollService extends Service {
         focusAndScroll = focusAndScroll;
@@ -373,10 +500,22 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       // when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @isPastSection={{false}} @isCurrentSection={{false}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isPastSection={{false}}
+            @isCurrentSection={{false}}
+          />
         </template>,
       );
-      await click(screen.getByRole('button', { name: 'Se questionner' }));
+      await click(
+        screen.getByRole('button', {
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 1,
+            totalSections: 1,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
+        }),
+      );
 
       // then
       sinon.assert.notCalled(focusAndScroll);

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -94,8 +94,8 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       });
     });
 
-    module('when a button is hovered', function () {
-      test('should display tooltip', async function (assert) {
+    module('on tooltip', function () {
+      test('should not vocalise the tooltip for screen readers', async function (assert) {
         // given
         const section = {
           id: 'section1',
@@ -106,58 +106,52 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
 
         // then
-        assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
-        await triggerEvent('.navigation-tooltip', 'mouseenter');
-        assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
-      });
+        assert.dom('.navigation-tooltip__content').hasAttribute('aria-hidden', 'true');
+      })
 
-      module('then when a button is left', function () {
-        test('should not display tooltip anymore', async function (assert) {
+      module('when a button is hovered', function () {
+        test('should display tooltip', async function (assert) {
           // given
           const section = {
             id: 'section1',
             type: 'question-yourself',
-            grains: [
-              { title: 'Grain title', type: 'discovery', id: '123-abc' },
-              { title: 'Grain title', type: 'activity', id: '234-abc' },
-            ],
           };
 
           //  when
           await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
 
           // then
+          assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
           await triggerEvent('.navigation-tooltip', 'mouseenter');
           assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
-          await triggerEvent('.navigation-tooltip', 'mouseleave');
-          assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
+        });
+
+        module('then when a button is left', function () {
+          test('should not display tooltip anymore', async function (assert) {
+            // given
+            const section = {
+              id: 'section1',
+              type: 'question-yourself',
+              grains: [
+                { title: 'Grain title', type: 'discovery', id: '123-abc' },
+                { title: 'Grain title', type: 'activity', id: '234-abc' },
+              ],
+            };
+
+            //  when
+            await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+
+            // then
+            await triggerEvent('.navigation-tooltip', 'mouseenter');
+            assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
+            await triggerEvent('.navigation-tooltip', 'mouseleave');
+            assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
+          });
         });
       });
-    });
 
-    module('when a button is focused', function () {
-      test('should display tooltip', async function (assert) {
-        // given
-        const section = {
-          id: 'section1',
-          type: 'question-yourself',
-          grains: [
-            { title: 'Grain title', type: 'discovery', id: '123-abc' },
-            { title: 'Grain title', type: 'activity', id: '234-abc' },
-          ],
-        };
-
-        //  when
-        await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
-
-        // then
-        assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
-        await triggerEvent('.navigation-tooltip', 'focusin');
-        assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
-      });
-
-      module('then when a button is not focused anymore', function () {
-        test('should not display tooltip anymore', async function (assert) {
+      module('when a button is focused', function () {
+        test('should display tooltip', async function (assert) {
           // given
           const section = {
             id: 'section1',
@@ -172,13 +166,35 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
 
           // then
+          assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
           await triggerEvent('.navigation-tooltip', 'focusin');
           assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
-          await triggerEvent('.navigation-tooltip', 'focusout');
-          assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
+        });
+
+        module('then when a button is not focused anymore', function () {
+          test('should not display tooltip anymore', async function (assert) {
+            // given
+            const section = {
+              id: 'section1',
+              type: 'question-yourself',
+              grains: [
+                { title: 'Grain title', type: 'discovery', id: '123-abc' },
+                { title: 'Grain title', type: 'activity', id: '234-abc' },
+              ],
+            };
+
+            //  when
+            await render(<template><NavigationButton @section={{section}} @isCurrentSection={{true}} /></template>);
+
+            // then
+            await triggerEvent('.navigation-tooltip', 'focusin');
+            assert.dom('.navigation-tooltip').hasClass('navigation-tooltip--visible');
+            await triggerEvent('.navigation-tooltip', 'focusout');
+            assert.dom('.navigation-tooltip').doesNotHaveClass('navigation-tooltip--visible');
+          });
         });
       });
-    });
+    })
   });
 
   module('when screen is mobile', function (hooks) {

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -25,6 +25,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         type,
       };
       const sections = [section];
+      const handleArrowKeyNavigation = sinon.stub();
 
       // when
       const screen = await render(
@@ -34,6 +35,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sections={{sections}}
             @isPastSection={{false}}
             @isCurrentSection={{true}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );
@@ -61,6 +63,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -70,6 +73,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{false}}
               @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -86,6 +90,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -95,6 +100,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{false}}
               @isCurrentSection={{true}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -111,6 +117,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -120,6 +127,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{true}}
               @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -137,11 +145,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         //  when
         await render(
           <template>
-            <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+            <NavigationButton
+              @section={{section}}
+              @sections={{sections}}
+              @isCurrentSection={{true}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
           </template>,
         );
 
@@ -157,11 +171,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             type: 'question-yourself',
           };
           const sections = [section];
+          const handleArrowKeyNavigation = sinon.stub();
 
           //  when
           await render(
             <template>
-              <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+              <NavigationButton
+                @section={{section}}
+                @sections={{sections}}
+                @isCurrentSection={{true}}
+                @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+              />
             </template>,
           );
 
@@ -183,11 +203,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               ],
             };
             const sections = [section];
+            const handleArrowKeyNavigation = sinon.stub();
 
             //  when
             await render(
               <template>
-                <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+                <NavigationButton
+                  @section={{section}}
+                  @sections={{sections}}
+                  @isCurrentSection={{true}}
+                  @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+                />
               </template>,
             );
 
@@ -212,11 +238,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             ],
           };
           const sections = [section];
+          const handleArrowKeyNavigation = sinon.stub();
 
           //  when
           await render(
             <template>
-              <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+              <NavigationButton
+                @section={{section}}
+                @sections={{sections}}
+                @isCurrentSection={{true}}
+                @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+              />
             </template>,
           );
 
@@ -238,11 +270,17 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               ],
             };
             const sections = [section];
+            const handleArrowKeyNavigation = sinon.stub();
 
             //  when
             await render(
               <template>
-                <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+                <NavigationButton
+                  @section={{section}}
+                  @sections={{sections}}
+                  @isCurrentSection={{true}}
+                  @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+                />
               </template>,
             );
 
@@ -272,6 +310,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         type,
       };
       const sections = [section];
+      const handleArrowKeyNavigation = sinon.stub();
 
       // when
       const screen = await render(
@@ -281,6 +320,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sections={{sections}}
             @isPastSection={{false}}
             @isCurrentSection={{false}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );
@@ -296,6 +336,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -305,6 +346,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{false}}
               @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -321,6 +363,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -330,6 +373,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{false}}
               @isCurrentSection={{true}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -346,6 +390,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
           type: 'question-yourself',
         };
         const sections = [section];
+        const handleArrowKeyNavigation = sinon.stub();
 
         // when
         const screen = await render(
@@ -355,6 +400,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
               @sections={{sections}}
               @isPastSection={{true}}
               @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
             />
           </template>,
         );
@@ -370,6 +416,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         type: 'question-yourself',
       };
       const sections = [section];
+      const handleArrowKeyNavigation = sinon.stub();
 
       // when
       const screen = await render(
@@ -379,6 +426,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sections={{sections}}
             @isPastSection={{true}}
             @isCurrentSection={{true}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );
@@ -411,6 +459,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         focusAndScroll = focusAndScroll;
       }
       this.owner.register('service:modulix-auto-scroll', ModulixAutoScrollService);
+      const handleArrowKeyNavigation = sinon.stub();
 
       // when
       const screen = await render(
@@ -420,6 +469,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sections={{sections}}
             @isPastSection={{false}}
             @isCurrentSection={{true}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );
@@ -447,6 +497,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       };
       const sections = [section];
       const trackEvent = sinon.stub();
+      const handleArrowKeyNavigation = sinon.stub();
 
       class MetricsStubService extends Service {
         trackEvent = trackEvent;
@@ -461,7 +512,12 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       //  when
       const screen = await render(
         <template>
-          <NavigationButton @section={{section}} @sections={{sections}} @isCurrentSection={{true}} />
+          <NavigationButton
+            @section={{section}}
+            @sections={{sections}}
+            @isCurrentSection={{true}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+          />
         </template>,
       );
       await click(
@@ -492,6 +548,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
       };
       const sections = [section];
       const focusAndScroll = sinon.stub();
+      const handleArrowKeyNavigation = sinon.stub();
       class ModulixAutoScrollService extends Service {
         focusAndScroll = focusAndScroll;
       }
@@ -505,6 +562,7 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sections={{sections}}
             @isPastSection={{false}}
             @isCurrentSection={{false}}
+            @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );

--- a/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
@@ -9,60 +9,6 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Navigation', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when current section is second section', function () {
-    test('should set aria-current attribute to the second NavigationButton element', async function (assert) {
-      // given
-      const modulixNavigationProgressService = this.owner.lookup('service:modulix-navigation-progress');
-      modulixNavigationProgressService.setCurrentSectionIndex(1);
-      const sections = [
-        {
-          type: 'question-yourself',
-        },
-        {
-          type: 'explore-to-understand',
-        },
-        {
-          type: 'retain-the-essentials',
-        },
-        {
-          type: 'practise',
-        },
-        {
-          type: 'go-further',
-        },
-      ];
-
-      // when
-      const screen = await render(<template><ModulixNavigation @sections={{sections}} /></template>);
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('button', {
-            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-              indexSection: 2,
-              totalSections: 5,
-            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
-              sectionTitle: 'Explorer pour comprendre',
-            })}`,
-          }),
-        )
-        .hasAria('current', 'true');
-      assert
-        .dom(
-          screen.getByRole('button', {
-            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-              indexSection: 1,
-              totalSections: 5,
-            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
-              sectionTitle: 'Se questionner',
-            })}`,
-          }),
-        )
-        .hasAria('current', 'false');
-    });
-  });
-
   module('handleArrowKeyNavigation', function () {
     module('when user press arrow down or right on buttons', function () {
       test('should focus on next button', async function (assert) {

--- a/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
@@ -36,10 +36,28 @@ module('Integration | Component | Module | Navigation', function (hooks) {
 
       // then
       assert
-        .dom(await screen.findByRole('button', { name: t('pages.modulix.section.explore-to-understand') }))
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+              indexSection: 2,
+              totalSections: 5,
+            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+              sectionTitle: 'Explorer pour comprendre',
+            })}`,
+          }),
+        )
         .hasAria('current', 'true');
       assert
-        .dom(screen.getByRole('button', { name: t('pages.modulix.section.question-yourself') }))
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+              indexSection: 1,
+              totalSections: 5,
+            })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+              sectionTitle: 'Se questionner',
+            })}`,
+          }),
+        )
         .hasAria('current', 'false');
     });
   });

--- a/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { triggerKeyEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixNavigation from 'mon-pix/components/module/layout/navigation';
 import { module, test } from 'qunit';
@@ -59,6 +60,92 @@ module('Integration | Component | Module | Navigation', function (hooks) {
           }),
         )
         .hasAria('current', 'false');
+    });
+  });
+
+  module('handleArrowKeyNavigation', function () {
+    module('when user press arrow down or right on buttons', function () {
+      test('should focus on next button', async function (assert) {
+        // given
+        const sections = [
+          {
+            type: 'question-yourself',
+          },
+          {
+            type: 'explore-to-understand',
+          },
+          {
+            type: 'retain-the-essentials',
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixNavigation @sections={{sections}} /></template>);
+        const button = screen.getByRole('button', {
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 1,
+            totalSections: 3,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+            sectionTitle: 'Se questionner',
+          })}`,
+        });
+        button.focus();
+        await triggerKeyEvent(button, 'keydown', 40);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+                indexSection: 2,
+                totalSections: 3,
+              })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
+            }),
+          )
+          .isFocused();
+      });
+    });
+
+    module('when user press arrow up or left on buttons', function () {
+      test('should focus on next button', async function (assert) {
+        // given
+        const sections = [
+          {
+            type: 'question-yourself',
+          },
+          {
+            type: 'explore-to-understand',
+          },
+          {
+            type: 'retain-the-essentials',
+          },
+        ];
+
+        // when
+        const screen = await render(<template><ModulixNavigation @sections={{sections}} /></template>);
+        const button = screen.getByRole('button', {
+          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+            indexSection: 2,
+            totalSections: 3,
+          })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
+        });
+        button.focus();
+        await triggerKeyEvent(button, 'keydown', 38);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+                indexSection: 1,
+                totalSections: 3,
+              })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+                sectionTitle: 'Se questionner',
+              })}`,
+            }),
+          )
+          .isFocused();
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -1560,4 +1560,34 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
   });
+
+  test('should inform user at which step it is', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const textElement = { content: 'content', type: 'text' };
+    const section = store.createRecord('section', {
+      id: 'section1',
+      type: 'blank',
+      grains: [
+        {
+          title: 'Grain title',
+          type: 'discovery',
+          id: '123-abc',
+          components: [{ type: 'element', element: textElement }],
+        },
+      ],
+    });
+    const module = store.createRecord('module', {
+      title: 'Didacticiel',
+      slug: 'module-slug',
+      sections: [section],
+    });
+    const passage = store.createRecord('passage');
+
+    //  when
+    const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+    // then
+    assert.dom(screen.getByText('Étape 1 sur 1')).exists();
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1682,7 +1682,7 @@
         "buttons": {
           "aria-label": {
             "disabled": "Not available. Complete the previous step.",
-            "enabled": "Go to {sectionTitle}",
+            "enabled": "Go to step {sectionTitle}",
             "steps": "Step {indexSection} of {totalSections}."
           }
         }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1678,6 +1678,15 @@
           "title": "Transcription"
         }
       },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "Not available. Complete the previous step.",
+            "enabled": "Go to {sectionTitle}",
+            "steps": "Step {indexSection} of {totalSections}."
+          }
+        }
+      },
       "preview": {
         "showJson": "Show JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1659,7 +1659,7 @@
           "aria-label": {
             "steps": "Paso {indexSection} de {totalSections}.",
             "disabled": "No disponible. Finalizar el paso anterior.",
-            "enabled": "Acceder a {sectionTitle}"
+            "enabled": "Acceder al paso {sectionTitle}"
           }
         }
       },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1654,6 +1654,15 @@
       "title": "Conectarse a Pix"
     },
     "modulix": {
+      "navigation" : {
+        "buttons": {
+          "aria-label": {
+            "steps": "Paso {indexSection} de {totalSections}.",
+            "disabled": "No disponible. Finalizar el paso anterior.",
+            "enabled": "Acceder a {sectionTitle}"
+          }
+        }
+      },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
       "buttons": {
         "activity": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1658,6 +1658,15 @@
       "title": "Conectarse a Pix"
     },
     "modulix": {
+      "navigation" : {
+        "buttons": {
+          "aria-label": {
+            "steps": "Paso {indexSection} de {totalSections}.",
+            "disabled": "No disponible. Finalizar el paso anterior.",
+            "enabled": "Acceder a {sectionTitle}"
+          }
+        }
+      },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
       "buttons": {
         "activity": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1663,7 +1663,7 @@
           "aria-label": {
             "steps": "Paso {indexSection} de {totalSections}.",
             "disabled": "No disponible. Finalizar el paso anterior.",
-            "enabled": "Acceder a {sectionTitle}"
+            "enabled": "Acceder al paso {sectionTitle}"
           }
         }
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1686,6 +1686,15 @@
           "title": "Transcription"
         }
       },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "Non disponible. Terminer l'étape précédente",
+            "enabled": "Accéder à {sectionTitle}",
+            "steps": "Étape {indexSection} sur {totalSections}."
+          }
+        }
+      },
       "preview": {
         "showJson": "Afficher le JSON",
         "stepper": "Preview : stepper {direction}",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1690,7 +1690,7 @@
         "buttons": {
           "aria-label": {
             "disabled": "Non disponible. Terminer l'étape précédente",
-            "enabled": "Accéder à {sectionTitle}",
+            "enabled": "Accéder à l'étape {sectionTitle}",
             "steps": "Étape {indexSection} sur {totalSections}."
           }
         }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1667,7 +1667,7 @@
           "aria-label": {
             "steps": "Stap {indexSection} van {totalSections}.",
             "disabled": "Niet beschikbaar. Vorige stap voltooien.",
-            "enabled": "Ga naar {sectionTitle}"
+            "enabled": "Ga naar stap {sectionTitle}"
           }
         }
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1662,6 +1662,15 @@
       "title": "Verbinding maken met Pix"
     },
     "modulix": {
+      "navigation" : {
+        "buttons": {
+          "aria-label": {
+            "steps": "Stap {indexSection} van {totalSections}.",
+            "disabled": "Niet beschikbaar. Vorige stap voltooien.",
+            "enabled": "Ga naar {sectionTitle}"
+          }
+        }
+      },
       "beta-banner": "Deze module is in bètaversie. In de loop van de tijd kunnen er wijzigingen worden aangebracht.",
       "buttons": {
         "activity": {


### PR DESCRIPTION
## 🍂 Problème

La navigation est complète fonctionnellement mais elle manque d'info pour faciliter la navigation clavier et pour les lecteurs d'écran.

## 🌰 Proposition

Renforcer l'accessibilité sur la navigation

## 🍁 Remarques

Pour le aria-hidden du tooltip => le tooltip n'est que décoratif, l'aria-label du bouton est suffisamment complet en terme d'info.

Pour la navigation clavier dans le menu, on s'est inspiré de cet exemple https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/ (sauf pour le menuitem et les tabindex)

## 🪵 Pour tester
https://app-pr14095.review.pix.fr/modules/bac-a-sable/details
- Naviguer au clavier sur la nav
- ouvrir VoiceOver et se laisser porter par sa douce voix
- Tester en mobile, au clic sur un bouton, le menu se ferme
