### PR TITLE
[BUGFIX] Réparer le generateItems (PIX-20336)

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -231,7 +231,7 @@ export class CombinedCourseDetails extends CombinedCourse {
         const isCompleted = dataForQuest ? requirement.isFulfilled(dataForQuest) : false;
 
         const associatedParticipation = dataForQuest?.campaignParticipations?.find(
-          (campaignParticipation) => (campaignParticipation.campaignId = requirement.data.campaignId.data),
+          (campaignParticipation) => campaignParticipation.campaignId === requirement.data.campaignId.data,
         );
 
         const doesCampaignRecommendModules =


### PR DESCRIPTION
## 🍂 Problème

Une image valant mille mots....
<img width="720" height="536" alt="image" src="https://github.com/user-attachments/assets/4994e1dd-3dca-4b1f-b914-14d9d9ceb0d9" /> 


## 🌰 Proposition

fixer le bug

## 🍁 Remarques

On a quand même écrit un test parce qu'on pas des cochons

## 🪵 Pour tester

BON COURAGE !!!!
parce qu'il faut créer un parcours combiné avec 2 campagnes qui ont des contenus formatifs rattaché à leur PC et dont certains CF sont sur les deux PC 
Ensuite 
- faire la premiere campagne de diag 
- faire les 2 modules recommandés
- faire la 2 deuxième campagne
- Voir le 2 module recommandés 
- Ne pas voir de bloc formations
- voir que la campagne est débloqué et le troisième module est aussi débloqué.

🍿 