### PR TITLE
[TECH] Ne plus utiliser l'historySize de la configuration LLM (PIX-20338)

### DIFF
--- a/api/db/database-builder/factory/build-chat.js
+++ b/api/db/database-builder/factory/build-chat.js
@@ -12,7 +12,6 @@ const buildChat = function ({
   configId = null,
   configContent = {
     llm: {
-      outputMaxToken: 1,
       historySize: 2,
     },
     challenge: {

--- a/api/db/database-builder/factory/build-chat.js
+++ b/api/db/database-builder/factory/build-chat.js
@@ -11,9 +11,6 @@ const buildChat = function ({
   challengeId = null,
   configId = null,
   configContent = {
-    llm: {
-      historySize: 2,
-    },
     challenge: {
       victoryConditions: {
         expectations: [

--- a/api/src/llm/application/llm-preview-route.js
+++ b/api/src/llm/application/llm-preview-route.js
@@ -19,11 +19,6 @@ export async function register(server) {
         validate: {
           payload: Joi.object({
             configuration: Joi.object({
-              llm: Joi.object({
-                historySize: Joi.number().required(),
-              })
-                .required()
-                .unknown(true),
               challenge: Joi.object({
                 inputMaxChars: Joi.number().required(),
                 inputMaxPrompts: Joi.number().required(),

--- a/api/src/llm/domain/models/Chat.js
+++ b/api/src/llm/domain/models/Chat.js
@@ -50,10 +50,7 @@ export class Chat {
   }
 
   get messagesToForwardToLLM() {
-    return this.messages
-      .filter((message) => message.shouldBeForwardedToLLM)
-      .slice(-this.configuration.historySize)
-      .map((message) => message.toLLMHistory());
+    return this.messages.filter((message) => message.shouldBeForwardedToLLM).map((message) => message.toLLMHistory());
   }
 
   get isPreview() {

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -9,10 +9,6 @@ export class Configuration {
     this.#dto = configurationDTO;
   }
 
-  get historySize() {
-    return this.#dto.llm.historySize;
-  }
-
   get inputMaxChars() {
     return this.#dto.challenge.inputMaxChars;
   }
@@ -55,8 +51,6 @@ export class Configuration {
 
 /**
  * @typedef {object} ConfigurationDTO
- * @property {object} llm
- * @property {number} llm.historySize
  * @property {string} name
  * @property {object} challenge
  * @property {string[]} challenge.tools

--- a/api/src/llm/domain/models/Configuration.js
+++ b/api/src/llm/domain/models/Configuration.js
@@ -56,12 +56,7 @@ export class Configuration {
 /**
  * @typedef {object} ConfigurationDTO
  * @property {object} llm
- * @property {string} llm.model
- * @property {string} llm.environment
  * @property {number} llm.historySize
- * @property {number} llm.temperature
- * @property {number} llm.outputMaxToken
- * @property {string} llm.moderationModel
  * @property {string} name
  * @property {object} challenge
  * @property {string[]} challenge.tools

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -251,9 +251,6 @@ describe('Acceptance | Controller | passage-controller', function () {
         it('should start a new chat', async function () {
           // given
           const config = {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
@@ -370,9 +367,6 @@ describe('Acceptance | Controller | passage-controller', function () {
             userId: user.id,
             configurationId: 'uneConfigQuiExist',
             configuration: new Configuration({
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxChars: 999,
                 inputMaxPrompts: 999,
@@ -396,9 +390,6 @@ describe('Acceptance | Controller | passage-controller', function () {
           const promptLlmScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxChars: 999,
                   inputMaxPrompts: 999,

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -741,9 +741,6 @@ describe('Acceptance | Controller | assessment-controller', function () {
         it('should start a new chat', async function () {
           // given
           const config = {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,
@@ -860,9 +857,6 @@ describe('Acceptance | Controller | assessment-controller', function () {
             userId: user.id,
             configurationId: 'uneConfigQuiExist',
             configuration: new Configuration({
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxChars: 999,
                 inputMaxPrompts: 999,
@@ -887,9 +881,6 @@ describe('Acceptance | Controller | assessment-controller', function () {
           const promptLlmScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxChars: 999,
                   inputMaxPrompts: 999,

--- a/api/tests/llm/acceptance/application/llm-preview-route_test.js
+++ b/api/tests/llm/acceptance/application/llm-preview-route_test.js
@@ -68,7 +68,7 @@ describe('Acceptance | Route | llm-preview', function () {
             configuration: {
               name: 'Config de test',
               challenge: {
-                inputMaxChars: 1024,
+                inputMaxChars: 'coucou maman',
                 inputMaxPrompts: 5,
               },
             },
@@ -99,9 +99,6 @@ describe('Acceptance | Route | llm-preview', function () {
           payload: {
             configuration: {
               name: 'Config de test',
-              llm: {
-                historySize: 10,
-              },
               challenge: {
                 inputMaxChars: 1024,
                 inputMaxPrompts: 5,
@@ -129,9 +126,6 @@ describe('Acceptance | Route | llm-preview', function () {
         payload: {
           configuration: {
             name: 'Config de test',
-            llm: {
-              historySize: 10,
-            },
             challenge: {
               inputMaxChars: 1024,
               inputMaxPrompts: 5,
@@ -168,9 +162,6 @@ describe('Acceptance | Route | llm-preview', function () {
       expect(chat).to.deep.contain({
         configContent: {
           name: 'Config de test',
-          llm: {
-            historySize: 10,
-          },
           challenge: {
             inputMaxChars: 1024,
             inputMaxPrompts: 5,
@@ -225,9 +216,6 @@ describe('Acceptance | Route | llm-preview', function () {
           userId: 123,
           configId: 'some-config-id',
           configContent: {
-            llm: {
-              historySize: 10,
-            },
             challenge: {
               inputMaxChars: 500,
               inputMaxPrompts: 4,
@@ -320,9 +308,6 @@ describe('Acceptance | Route | llm-preview', function () {
       const chat = {
         id: chatId,
         configContent: {
-          llm: {
-            historySize: 10,
-          },
           challenge: {
             inputMaxChars: 500,
             inputMaxPrompts: 4,
@@ -432,9 +417,6 @@ describe('Acceptance | Route | llm-preview', function () {
           userId: 123,
           configId: 'some-config-id',
           configContent: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxChars: 999,
               inputMaxPrompts: 999,
@@ -463,9 +445,6 @@ describe('Acceptance | Route | llm-preview', function () {
         userId: null,
         configId: 'some-config-id',
         configContent: {
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxChars: 999,
             inputMaxPrompts: 999,
@@ -482,9 +461,6 @@ describe('Acceptance | Route | llm-preview', function () {
       const promptLlmScope = nock('https://llm-test.pix.fr/api')
         .post('/chat', {
           configuration: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxChars: 999,
               inputMaxPrompts: 999,

--- a/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/prompt-chat_test.js
@@ -246,18 +246,12 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
 
     beforeEach(function () {
       configuration = new Configuration({
-        llm: {
-          historySize: 123,
-        },
         challenge: {
           inputMaxPrompts: 100,
           inputMaxChars: 255,
         },
       });
       configurationWithAttachment = new Configuration({
-        llm: {
-          historySize: 123,
-        },
         challenge: {
           inputMaxPrompts: 100,
           inputMaxChars: 255,
@@ -285,9 +279,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxPrompts: 100,
                   inputMaxChars: 255,
@@ -334,9 +325,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             userId: 123,
             configId: 'uneConfigQuiExist',
             configContent: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -420,9 +408,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxPrompts: 100,
                   inputMaxChars: 255,
@@ -471,9 +456,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             userId: 123,
             configId: 'uneConfigQuiExist',
             configContent: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -650,9 +632,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
                   .post('/chat', {
                     configuration: {
-                      llm: {
-                        historySize: 123,
-                      },
                       challenge: {
                         inputMaxPrompts: 100,
                         inputMaxChars: 255,
@@ -717,9 +696,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   userId: 123,
                   configId: 'uneConfigQuiExist',
                   configContent: {
-                    llm: {
-                      historySize: 123,
-                    },
                     challenge: {
                       inputMaxPrompts: 100,
                       inputMaxChars: 255,
@@ -905,9 +881,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 userId: 123,
                 configId: 'uneConfigQuiExist',
                 configContent: {
-                  llm: {
-                    historySize: 123,
-                  },
                   challenge: {
                     inputMaxPrompts: 100,
                     inputMaxChars: 255,
@@ -1025,9 +998,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
                   .post('/chat', {
                     configuration: {
-                      llm: {
-                        historySize: 123,
-                      },
                       challenge: {
                         inputMaxPrompts: 100,
                         inputMaxChars: 255,
@@ -1092,9 +1062,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   userId: 123,
                   configId: 'uneConfigQuiExist',
                   configContent: {
-                    llm: {
-                      historySize: 123,
-                    },
                     challenge: {
                       inputMaxPrompts: 100,
                       inputMaxChars: 255,
@@ -1259,9 +1226,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
                   .post('/chat', {
                     configuration: {
-                      llm: {
-                        historySize: 123,
-                      },
                       challenge: {
                         inputMaxPrompts: 100,
                         inputMaxChars: 255,
@@ -1324,9 +1288,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   userId: 123,
                   configId: 'uneConfigQuiExist',
                   configContent: {
-                    llm: {
-                      historySize: 123,
-                    },
                     challenge: {
                       inputMaxPrompts: 100,
                       inputMaxChars: 255,
@@ -1559,9 +1520,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 userId: 123,
                 configId: 'uneConfigQuiExist',
                 configContent: {
-                  llm: {
-                    historySize: 123,
-                  },
                   challenge: {
                     inputMaxPrompts: 100,
                     inputMaxChars: 255,
@@ -1716,9 +1674,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                 userId: 123,
                 configId: 'uneConfigQuiExist',
                 configContent: {
-                  llm: {
-                    historySize: 123,
-                  },
                   challenge: {
                     inputMaxPrompts: 100,
                     inputMaxChars: 255,
@@ -1844,9 +1799,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   userId: 123,
                   configId: 'uneConfigQuiExist',
                   configContent: {
-                    llm: {
-                      historySize: 123,
-                    },
                     challenge: {
                       inputMaxPrompts: 100,
                       inputMaxChars: 255,
@@ -2004,9 +1956,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
                   userId: 123,
                   configId: 'uneConfigQuiExist',
                   configContent: {
-                    llm: {
-                      historySize: 123,
-                    },
                     challenge: {
                       inputMaxPrompts: 100,
                       inputMaxChars: 255,
@@ -2100,9 +2049,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
         const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
           .post('/chat', {
             configuration: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -2150,9 +2096,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           userId: 123,
           configId: 'uneConfigQuiExist',
           configContent: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxPrompts: 100,
               inputMaxChars: 255,
@@ -2239,9 +2182,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
         const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
           .post('/chat', {
             configuration: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -2289,9 +2229,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           userId: 123,
           configId: 'uneConfigQuiExist',
           configContent: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxPrompts: 100,
               inputMaxChars: 255,
@@ -2376,9 +2313,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
         const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
           .post('/chat', {
             configuration: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -2416,9 +2350,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           userId: 123,
           configId: 'uneConfigQuiExist',
           configContent: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxPrompts: 100,
               inputMaxChars: 255,
@@ -2491,9 +2422,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxPrompts: 100,
                   inputMaxChars: 255,
@@ -2539,9 +2467,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             id: chatId,
             configId: 'uneConfigQuiExist',
             configContent: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -2629,9 +2554,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
           const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
             .post('/chat', {
               configuration: {
-                llm: {
-                  historySize: 123,
-                },
                 challenge: {
                   inputMaxPrompts: 100,
                   inputMaxChars: 255,
@@ -2678,9 +2600,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
             userId: 123,
             configId: 'uneConfigQuiExist',
             configContent: {
-              llm: {
-                historySize: 123,
-              },
               challenge: {
                 inputMaxPrompts: 100,
                 inputMaxChars: 255,
@@ -2760,9 +2679,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
 
     beforeEach(function () {
       configuration = new Configuration({
-        llm: {
-          historySize: 123,
-        },
         challenge: {
           inputMaxPrompts: 100,
           inputMaxChars: 255,
@@ -2784,9 +2700,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
       const llmPostPromptScope = nock('https://llm-test.pix.fr/api')
         .post('/chat', {
           configuration: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxPrompts: 100,
               inputMaxChars: 255,
@@ -2832,9 +2745,6 @@ describe('LLM | Integration | Domain | UseCases | prompt-chat', function () {
         userId: 123,
         configId: 'uneConfigQuiExist',
         configContent: {
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxPrompts: 100,
             inputMaxChars: 255,

--- a/api/tests/llm/integration/domain/usecases/start-chat_test.js
+++ b/api/tests/llm/integration/domain/usecases/start-chat_test.js
@@ -17,9 +17,6 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
 
       beforeEach(function () {
         configuration = new Configuration({
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxChars: 456,
             inputMaxPrompts: 789,
@@ -55,9 +52,6 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
         configurationId = 'uneConfigQuiExist';
         userId = 123456;
         config = {
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxChars: 456,
             inputMaxPrompts: 789,
@@ -115,9 +109,6 @@ describe('LLM | Integration | Domain | UseCases | start-chat', function () {
           passageId: 22,
           configId: 'uneConfigQuiExist',
           configContent: {
-            llm: {
-              historySize: 123,
-            },
             challenge: {
               inputMaxChars: 456,
               inputMaxPrompts: 789,

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -266,7 +266,6 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         configId: 'someConfigId',
         configContent: {
           llm: {
-            outputMaxToken: 10,
             historySize: 20,
           },
           challenge: {
@@ -334,7 +333,6 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           configurationId: 'someConfigId',
           configuration: new Configuration({
             llm: {
-              outputMaxToken: 10,
               historySize: 20,
             },
             challenge: {

--- a/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/chat-repository_test.js
@@ -29,9 +29,6 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           moduleId,
           configurationId: 'some-config-id',
           configuration: new Configuration({
-            llm: {
-              historySize: 10,
-            },
             challenge: {
               inputMaxChars: 500,
               inputMaxPrompts: 4,
@@ -265,9 +262,6 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
         challengeId: 'recCHallengeA',
         configId: 'someConfigId',
         configContent: {
-          llm: {
-            historySize: 20,
-          },
           challenge: {
             victoryConditions: {
               expectations: [
@@ -332,9 +326,6 @@ describe('LLM | Integration | Infrastructure | Repositories | chat', function ()
           moduleId: null,
           configurationId: 'someConfigId',
           configuration: new Configuration({
-            llm: {
-              historySize: 20,
-            },
             challenge: {
               victoryConditions: {
                 expectations: [

--- a/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
+++ b/api/tests/llm/integration/infrastructure/repositories/configuration-repository_test.js
@@ -59,7 +59,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
         const llmApiScope = nock('https://llm-test.pix.fr/api')
           .get('/configurations/unIdDeConfiguration')
           .reply(200, {
-            llm: { historySize: 1 },
             challenge: { inputMaxChars: 2, inputMaxPrompts: 4 },
             attachment: { name: 'some_attachment_name', context: 'some attachment context' },
           });
@@ -69,7 +68,6 @@ describe('LLM | Integration | Infrastructure | Repositories | configuration', fu
 
         // then
         expect(configuration).to.contain({
-          historySize: 1,
           inputMaxChars: 2,
           inputMaxPrompts: 3,
           attachmentName: 'some_attachment_name',

--- a/api/tests/llm/unit/domain/models/Chat_test.js
+++ b/api/tests/llm/unit/domain/models/Chat_test.js
@@ -1125,7 +1125,6 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           id: 'some-chat-id',
           configuration: new Configuration({
             id: 'some-config-id',
-            historySize: 10,
             inputMaxChars: 500,
             inputMaxPrompts: 4,
             attachmentName: 'test.csv',
@@ -1242,51 +1241,13 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
         // given
         const chat = new Chat({
           id: 'some-chat-id',
-          configuration: new Configuration({ id: 'some-config-id', llm: { historySize: 45 } }),
+          configuration: new Configuration({ id: 'some-config-id' }),
           hasAttachmentContextBeenAdded: false,
           messages: [],
         });
 
         // then
         expect(chat.messagesToForwardToLLM).to.deep.equal([]);
-      });
-    });
-    context('history size', function () {
-      it('returns the N latest messages according to configuration history size', function () {
-        // given
-        const chat = new Chat({
-          id: 'some-chat-id',
-          configuration: new Configuration({ id: 'some-config-id', llm: { historySize: 4 } }),
-          hasAttachmentContextBeenAdded: false,
-          messages: [
-            new Message({ index: 0, content: 'first message', isFromUser: true, shouldBeForwardedToLLM: true }),
-            new Message({ index: 1, content: 'second message', isFromUser: false, shouldBeForwardedToLLM: true }),
-            new Message({ index: 2, content: 'third message', isFromUser: true, shouldBeForwardedToLLM: true }),
-            new Message({ index: 3, content: 'fourth message', isFromUser: false, shouldBeForwardedToLLM: true }),
-            new Message({ index: 4, content: 'fifth message', isFromUser: true, shouldBeForwardedToLLM: true }),
-            new Message({ index: 5, content: 'sixth message', isFromUser: false, shouldBeForwardedToLLM: true }),
-          ],
-        });
-
-        // then
-        expect(chat.messagesToForwardToLLM).to.deep.equal([
-          {
-            content: 'third message',
-            role: 'user',
-          },
-          {
-            content: 'fourth message',
-            role: 'assistant',
-          },
-          {
-            content: 'fifth message',
-            role: 'user',
-          },
-          {
-            content: 'sixth message',
-            role: 'assistant',
-          },
-        ]);
       });
     });
     context('attachments', function () {
@@ -1296,7 +1257,6 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           id: 'some-chat-id',
           configuration: new Configuration({
             id: 'some-config-id',
-            llm: { historySize: 4 },
             attachment: { name: 'file.txt', context: "Ceci n'est pas une pipe." },
           }),
           hasAttachmentContextBeenAdded: true,
@@ -1344,7 +1304,6 @@ describe('LLM | Unit | Domain | Models | Chat', function () {
           id: 'some-chat-id',
           configuration: new Configuration({
             id: 'some-config-id',
-            llm: { historySize: 4 },
             attachment: { name: 'file.txt', context: "Ceci n'est pas une pipe." },
           }),
           hasAttachmentContextBeenAdded: true,

--- a/api/tests/llm/unit/domain/models/Configuration_test.js
+++ b/api/tests/llm/unit/domain/models/Configuration_test.js
@@ -35,9 +35,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
       it('return property values', function () {
         // given
         const configuration = new Configuration({
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxChars: 456,
             inputMaxPrompts: 789,
@@ -51,7 +48,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
 
         // then
         expect(configuration).to.contain({
-          historySize: 123,
           inputMaxChars: 456,
           inputMaxPrompts: 788,
           hasAttachment: true,
@@ -66,9 +62,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
       it('returns undefined for attachment properties', function () {
         // given
         const configuration = new Configuration({
-          llm: {
-            historySize: 123,
-          },
           challenge: {
             inputMaxChars: 456,
             inputMaxPrompts: 789,
@@ -77,7 +70,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
 
         // then
         expect(configuration).to.contain({
-          historySize: 123,
           inputMaxChars: 456,
           inputMaxPrompts: 789,
           hasAttachment: false,
@@ -107,9 +99,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
     it('returns Configuration model', function () {
       // given
       const dto = {
-        llm: {
-          historySize: 123,
-        },
         challenge: {
           inputMaxChars: 456,
           inputMaxPrompts: 789,
@@ -127,7 +116,6 @@ describe('LLM | Unit | Domain | Models | Configuration', function () {
       // then
       expect(configuration).to.be.instanceOf(Configuration);
       expect(configuration).to.contain({
-        historySize: 123,
         inputMaxChars: 456,
         inputMaxPrompts: 788,
         hasAttachment: true,


### PR DESCRIPTION
## 🍂 Problème

Côté configuration LLM, on va retirer le paramètre "historySize' qui est en fait redondant voire inutile avec le paramètre "maxUserPrompts"

## 🌰 Proposition

Décommissionner l'usage de ce paramètre sur l'API de Pix
retirer aussi les paramètres déjà inutilisés

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Tests autos OK
