### PR TITLE
[FEATURE] Pouvoir supprimer les filtres sur la page de recherche d'organisations (PIX-20025)

### DIFF
--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -19,10 +19,6 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
   @tracked showModal = false;
   @tracked organizationToDetach;
 
-  searchedId = this.args.id;
-  searchedName = this.args.name;
-  searchedExternalId = this.args.externalId;
-
   optionType = [
     { value: 'PRO', label: 'PRO' },
     { value: 'SCO', label: 'SCO' },
@@ -60,12 +56,21 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
     this.args.triggerFiltering('hideArchived', event);
   }
 
+  get isClearFiltersButtonDisabled() {
+    return !this.args.id && !this.args.name && !this.args.type && !this.args.externalId && !this.args.hideArchived;
+  }
+
   <template>
-    <PixFilterBanner @title={{t "common.filters.title"}}>
-      <PixInput value={{this.searchedId}} oninput={{fn @triggerFiltering "id"}}>
+    <PixFilterBanner
+      @title={{t "common.filters.title"}}
+      @onClearFilters={{@onResetFilter}}
+      @clearFiltersLabel={{t "common.filters.actions.clear"}}
+      @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+    >
+      <PixInput value={{@id}} oninput={{fn @triggerFiltering "id"}} type="number" min="1">
         <:label>Identifiant</:label>
       </PixInput>
-      <PixInput value={{this.searchedName}} oninput={{fn @triggerFiltering "name"}}>
+      <PixInput value={{@name}} oninput={{fn @triggerFiltering "name"}}>
         <:label>Nom</:label>
       </PixInput>
       <PixSelect
@@ -77,7 +82,7 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
       >
         <:label>Type</:label>
       </PixSelect>
-      <PixInput value={{this.searchedExternalId}} oninput={{fn @triggerFiltering "externalId"}}>
+      <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
         <:label>Identifiant externe</:label>
       </PixInput>
       <PixToggleButton @onChange={{this.filterHideArchived}} @toggled={{@hideArchived}}>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -193,6 +193,7 @@ export default class Organizations extends Component {
         @targetProfileName={{@targetProfile.internalName}}
         @hideArchived={{@hideArchived}}
         @showDetachColumn={{this.isSuperAdminOrMetier}}
+        @onResetFilter={{@onResetFilter}}
       />
     </section>
   </template>

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -32,4 +32,13 @@ export default class ListController extends Controller {
   triggerFiltering(fieldName, event) {
     debounceTask(this, 'updateFilters', { [fieldName]: event.target.value }, this.DEBOUNCE_MS);
   }
+
+  @action
+  onResetFilter() {
+    this.id = null;
+    this.name = null;
+    this.type = null;
+    this.externalId = null;
+    this.hideArchived = false;
+  }
 }

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -63,4 +63,13 @@ export default class TargetProfileOrganizationsController extends Controller {
       return this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
     }
   }
+
+  @action
+  onResetFilter() {
+    this.id = null;
+    this.name = null;
+    this.type = null;
+    this.externalId = null;
+    this.hideArchived = false;
+  }
 }

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -22,6 +22,7 @@
       @hideArchived={{this.hideArchived}}
       @toggleArchived={{fn (mut this.hideArchived)}}
       @showDetachColumn={{false}}
+      @onResetFilter={{@controller.onResetFilter}}
     />
   </section>
 </main>

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -11,4 +11,5 @@
   @triggerFiltering={{this.triggerFiltering}}
   @goToOrganizationPage={{this.goToOrganizationPage}}
   @detachOrganizations={{this.detachOrganizations}}
+  @onResetFilter={{@controller.onResetFilter}}
 />

--- a/admin/tests/integration/components/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/organizations/list-items-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import ListItems from 'pix-admin/components/organizations/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -122,6 +122,26 @@ module('Integration | Component | ListItems', function (hooks) {
   });
 
   module('filters', () => {
+    module('internal identifier', () => {
+      test('it should not allow to search text in id input', async function (assert) {
+        const screen = await render(
+          <template>
+            <ListItems
+              @organizations={{organizations}}
+              @externalId="123"
+              @goToOrganizationPage={{goToOrganizationPage}}
+              @triggerFiltering={{triggerFiltering}}
+            />
+          </template>,
+        );
+        const input = screen.getByLabelText('Identifiant');
+
+        await fillIn(input, 'not allowed text');
+
+        assert.strictEqual(input.value, '');
+      });
+    });
+
     test('when one filter is active, clic on reset filter button should trigger onResetFilters method', async function (assert) {
       // given
       const onResetFilters = sinon.stub();
@@ -130,7 +150,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
-            @externalId={{"123"}}
+            @externalId="123"
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
             @onResetFilter={{onResetFilters}}

--- a/admin/tests/integration/components/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/organizations/list-items-test.gjs
@@ -11,6 +11,7 @@ module('Integration | Component | ListItems', function (hooks) {
   let currentUser;
 
   hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
     currentUser = this.owner.lookup('service:currentUser');
     currentUser.adminMember = { isSuperAdmin: true };
   });
@@ -117,6 +118,51 @@ module('Integration | Component | ListItems', function (hooks) {
 
       // then
       assert.true(detachOrganizations.calledWith(organizations[0].id));
+    });
+  });
+
+  module('filters', () => {
+    test('when one filter is active, clic on reset filter button should trigger onResetFilters method', async function (assert) {
+      // given
+      const onResetFilters = sinon.stub();
+
+      const screen = await render(
+        <template>
+          <ListItems
+            @organizations={{organizations}}
+            @externalId={{"123"}}
+            @goToOrganizationPage={{goToOrganizationPage}}
+            @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{onResetFilters}}
+          />
+        </template>,
+      );
+
+      // when
+      const button = screen.getByRole('button', { name: this.intl.t('common.filters.actions.clear') });
+      await click(button);
+
+      // then
+      assert.true(onResetFilters.calledOnce);
+    });
+
+    test('when no filter is active, reset filter button should be disabled', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <ListItems
+            @organizations={{organizations}}
+            @goToOrganizationPage={{goToOrganizationPage}}
+            @triggerFiltering={{triggerFiltering}}
+          />
+        </template>,
+      );
+
+      // when
+      const button = screen.getByRole('button', { name: this.intl.t('common.filters.actions.clear') });
+
+      // then
+      assert.ok(button.hasAttribute('aria-disabled'));
     });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -52,7 +52,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     const screen = await render(<template><ListItems @triggerFiltering={{triggerFiltering}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Identifiant' })).exists();
+    assert.dom(screen.getByRole('spinbutton', { name: 'Identifiant' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Type' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).exists();

--- a/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/integration/controllers/authenticated/target-profiles/target-profile/organizations-test.js
@@ -66,4 +66,25 @@ module('Integration | Controller | authenticated/target-profiles/target-profile/
       assert.true(controller.pixToast.sendErrorNotification.calledWith({ message: 'Une erreur est survenue.' }));
     });
   });
+
+  module('#onResetFilter', function () {
+    test('resets all filters', async function (assert) {
+      // given
+      controller.id = 123;
+      controller.name = 'name';
+      controller.type = 'PRO';
+      controller.externalId = 'abc';
+      controller.hideArchived = true;
+
+      // when
+      controller.onResetFilter();
+
+      // then
+      assert.strictEqual(controller.id, null);
+      assert.strictEqual(controller.name, null);
+      assert.strictEqual(controller.type, null);
+      assert.strictEqual(controller.externalId, null);
+      assert.false(controller.hideArchived);
+    });
+  });
 });

--- a/admin/tests/unit/controllers/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/list-test.js
@@ -52,4 +52,25 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
       });
     });
   });
+
+  module('#onResetFilter', function () {
+    test('resets all filters', async function (assert) {
+      // given
+      controller.id = 123;
+      controller.name = 'name';
+      controller.type = 'PRO';
+      controller.externalId = 'abc';
+      controller.hideArchived = true;
+
+      // when
+      controller.onResetFilter();
+
+      // then
+      assert.strictEqual(controller.id, null);
+      assert.strictEqual(controller.name, null);
+      assert.strictEqual(controller.type, null);
+      assert.strictEqual(controller.externalId, null);
+      assert.false(controller.hideArchived);
+    });
+  });
 });


### PR DESCRIPTION
## 🍂 Problème
Actuellement:

On peut sélectionner un filtre, mais si on veut le supprimer, on doit manuellement vider le champ
SAUF pour le champ “TYPE”: une fois sélectionné, il n’y a pas de moyen de le vider, sauf à vider dans l’URL

## 🌰 Proposition

Reprendre le même fonctionnement que pour la page utilisateurs ou profils cible, avec le bouton effacer les filtres

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Se connecter à PixAdmin
- Utiliser des filtres sur la page Organisations
- Clic sur le bouton Effacer les filtres -> Tout doit revenir à zéro
- On peut faire la même manip sur l'onglet Organisations sur un profil cible
- 🐈‍⬛ 