### PR TITLE
[TECH] Ajouter une fonction pour lister, au bon format, les modules (slug et id) pour Metabase (PIX-20356)

### DIFF
--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -6,14 +6,28 @@ import moduleDatasource from '../../src/devcomp/infrastructure/datasources/learn
  */
 async function listModulesForDBReplication() {
   const imports = await moduleDatasource.list();
+  console.log('--- List of modules for DB replication ---');
   const moduleInformation = imports.map((module) => {
     return { id: module.id, slug: module.slug, title: module.title };
   });
   console.log(JSON.stringify(moduleInformation, null, 2).replace(/"([^"]+)": "([^"]+)"/g, "$1: '$2'"));
 }
 
+/*
+ * List all modules for Metabase filter with id, slug
+ * @returns {Promise<void>}
+ */
+async function listModulesForMetabaseFilter() {
+  const imports = await moduleDatasource.list();
+  console.log('--- List of modules for Metabase filter ---');
+  imports.map((module) => {
+    console.log(`${module.id}, ${module.slug}`);
+  });
+}
+
 async function main() {
   await listModulesForDBReplication();
+  await listModulesForMetabaseFilter();
 }
 
 await main();


### PR DESCRIPTION
## 🍂 Problème
On ne peut pas automatiser la liste des modules dans le filtre [Metabase du dashboard Modulix](https://metabase.pix.fr/dashboard/1277-modulix-par-modules?intervalle_de_dates=2025-09-01~2026-04-30&module)

## 🌰 Proposition
Ajouter une fonction dans un script devcomp pour au moins générer automatiquement la liste des modules, avec slug et id, au bon format pour le filtre Metabase.
La liste générée sera à ajouter dans le filtre Metabase (ici doc sur le sujet : https://1024pix.atlassian.net/wiki/x/BgCZRgE)

## 🍁 Remarques
On espère faire mieux plus tard ! 

## 🍄Pour tester
- Récupérer la branche localement
- Aller dans `api/scripts/modulix` 
- Lancer la commande `node list-modules-for-db-replication.js`
- Vérifier la sortie dans la console