### PR TITLE
[FEATURE] Enregistrer les traces d'apprentissage pour l'élément ShortVideo (PIX-20287)

### DIFF
--- a/api/src/devcomp/domain/factories/passage-event-factory.js
+++ b/api/src/devcomp/domain/factories/passage-event-factory.js
@@ -12,6 +12,7 @@ import {
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
+  ShortVideoTranscriptionOpenedEvent,
   VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
 } from '../models/passage-events/events.js';
@@ -74,6 +75,8 @@ class PassageEventFactory {
         return new QCUDeclarativeAnsweredEvent(eventData);
       case 'QCU_DISCOVERY_ANSWERED':
         return new QCUDiscoveryAnsweredEvent(eventData);
+      case 'SHORT_VIDEO_TRANSCRIPTION_OPENED':
+        return new ShortVideoTranscriptionOpenedEvent(eventData);
       case 'VIDEO_TRANSCRIPTION_OPENED':
         return new VideoTranscriptionOpenedEvent(eventData);
       case 'VIDEO_PLAYED':

--- a/api/src/devcomp/domain/models/passage-events/events.js
+++ b/api/src/devcomp/domain/models/passage-events/events.js
@@ -63,6 +63,27 @@ class ImageAlternativeTextOpenedEvent extends PassageEventWithElement {
 }
 
 /**
+ * @class ShortVideoTranscriptionOpenedEvent
+ * See PassageEventWithElement for more info.
+ *
+ * This event is generated when the user opens the transcription of a short video.
+ *
+ * */
+class ShortVideoTranscriptionOpenedEvent extends PassageEventWithElement {
+  constructor({ id, occurredAt, createdAt, passageId, sequenceNumber, elementId }) {
+    super({
+      type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',
+      id,
+      occurredAt,
+      createdAt,
+      passageId,
+      sequenceNumber,
+      elementId,
+    });
+  }
+}
+
+/**
  * @class VideoTranscriptionOpenedEvent
  * See PassageEventWithElement for more info.
  *
@@ -129,6 +150,7 @@ export {
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
+  ShortVideoTranscriptionOpenedEvent,
   VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
 };

--- a/api/tests/devcomp/integration/domain/models/passage-events/events_test.js
+++ b/api/tests/devcomp/integration/domain/models/passage-events/events_test.js
@@ -1,0 +1,34 @@
+import { ShortVideoTranscriptionOpenedEvent } from '../../../../../../src/devcomp/domain/models/passage-events/events.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Integration | Devcomp | Domain | Models | passage-events | events', function () {
+  describe('#ShortVideoTranscriptionOpenedEvent', function () {
+    it('should init and keep attributes', function () {
+      // given
+      const id = Symbol('id');
+      const occurredAt = new Date();
+      const createdAt = Symbol('date');
+      const passageId = 1234;
+      const sequenceNumber = 2;
+      const elementId = 'f46f8a14-a4d2-400a-95a3-2c8033b30f4e';
+
+      // when
+      const event = new ShortVideoTranscriptionOpenedEvent({
+        id,
+        occurredAt,
+        createdAt,
+        passageId,
+        sequenceNumber,
+        elementId,
+      });
+
+      // then
+      expect(event.id).to.equal(id);
+      expect(event.type).to.equal('SHORT_VIDEO_TRANSCRIPTION_OPENED');
+      expect(event.occurredAt).to.equal(occurredAt);
+      expect(event.createdAt).to.equal(createdAt);
+      expect(event.passageId).to.equal(passageId);
+      expect(event.data).to.deep.equal({ elementId });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
+++ b/api/tests/devcomp/unit/domain/factories/passage-event-factory_test.js
@@ -14,6 +14,7 @@ import {
   ExpandOpenedEvent,
   FileDownloadedEvent,
   ImageAlternativeTextOpenedEvent,
+  ShortVideoTranscriptionOpenedEvent,
   VideoPlayedEvent,
   VideoTranscriptionOpenedEvent,
 } from '../../../../../src/devcomp/domain/models/passage-events/events.js';
@@ -443,6 +444,24 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
         // then
         expect(builtEvent).to.be.instanceOf(ImageAlternativeTextOpenedEvent);
+      });
+    });
+
+    describe('when given an SHORT_VIDEO_TRANSCRIPTION_OPENED event', function () {
+      it('should return a ShortVideoTranscriptionOpened instance', function () {
+        // given
+        const rawEvent = {
+          occurredAt: new Date(),
+          passageId: 2,
+          sequenceNumber: 3,
+          elementId: 'c505e7c9-327e-4be5-9c62-ce4627b85f44',
+          type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',
+        };
+        // when
+        const builtEvent = PassageEventFactory.build(rawEvent);
+
+        // then
+        expect(builtEvent).to.be.instanceOf(ShortVideoTranscriptionOpenedEvent);
       });
     });
 

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
@@ -9,11 +10,19 @@ import ModuleElement from './module-element';
 
 export default class ModulixShortVideoElement extends ModuleElement {
   @tracked modalIsOpen = false;
+  @service passageEvents;
 
   @action
   showModal() {
     this.modalIsOpen = true;
     this.args.onTranscriptionOpen(this.args.element.id);
+
+    this.passageEvents.record({
+      type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',
+      data: {
+        elementId: this.args.element.id,
+      },
+    });
   }
 
   @action

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -44,6 +44,9 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     };
     const onShortVideoTranscriptionOpenStub = sinon.stub();
 
+    const passageEventService = this.owner.lookup('service:passageEvents');
+    const passageEventRecordStub = sinon.stub(passageEventService, 'record');
+
     //  when
     const screen = await render(
       <template>
@@ -56,5 +59,11 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText('transcription'));
     assert.ok(onShortVideoTranscriptionOpenStub.calledOnceWith(shortVideoId));
+    sinon.assert.calledWithExactly(passageEventRecordStub, {
+      type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',
+      data: {
+        elementId: shortVideoElement.id,
+      },
+    });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Les traces d'apprentissage pour l'élément ShortVideo ne sont pas enregistrés.

## 🌰 Proposition

Enregistrer les traces d'apprentissage pour l'élément ShortVideo.

## 🍁 Remarques

Je propose (dans le dernier commit) de retirer l'argument `onTranscriptionOpen` qui ne sera pas utilisé.

## 🪵 Pour tester

1. Se rendre sur module [bac-a-sable](https://app-pr14107.review.pix.fr/modules/bac-a-sable)
2. Ouvrir la transcription d'une vidéo courte
3. Constater l'enregistrement d'une trace d'apprentissage dans la table `passage-events` 
