### PR TITLE
[FEATURE] Renseigner les champs `challengeId`, `assessmentId`, `moduleId` et `passageId` dans la table `chats` (PIX-20357)

### DIFF
--- a/api/src/llm/application/api/llm-api.js
+++ b/api/src/llm/application/api/llm-api.js
@@ -6,13 +6,24 @@ import { LLMChatDTO } from './models/LLMChatDTO.js';
  * @param {Object} params
  * @param {string} params.configId
  * @param {string} params.userId
+ * @param {string|undefined} params.challengeId
+ * @param {number|undefined} params.assessmentId
+ * @param {string|undefined} params.moduleId
+ * @param {number|undefined} params.passageId
  * @returns {Promise<LLMChatDTO>}
  */
-export async function startChat({ configId, userId }) {
+export async function startChat({ configId, userId, challengeId, assessmentId, moduleId, passageId }) {
   if (!userId) {
     throw new NoUserIdProvidedError();
   }
-  const { id, configuration } = await usecases.startChat({ configurationId: configId, userId });
+  const { id, configuration } = await usecases.startChat({
+    configurationId: configId,
+    userId,
+    challengeId,
+    assessmentId,
+    moduleId,
+    passageId,
+  });
 
   return new LLMChatDTO({
     id,

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -221,11 +221,15 @@ describe('Acceptance | Controller | passage-controller', function () {
   });
 
   describe('POST /api/passages/{passageId}/embed/llm/chats', function () {
-    let user;
+    let user, passage;
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildPassage({ id: 111, userId: user.id }).id;
+      passage = databaseBuilder.factory.buildPassage({
+        id: 111,
+        userId: user.id,
+        moduleId: 'c47ffa11-5785-434b-9ea8-8d70c877715b',
+      });
       await databaseBuilder.commit();
     });
 
@@ -287,6 +291,9 @@ describe('Acceptance | Controller | passage-controller', function () {
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
+          const chat = await knex('chats').first();
+          expect(chat.passageId).to.equal(passage.id);
+          expect(chat.moduleId).to.equal(passage.moduleId);
         });
       });
 

--- a/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/assessments/assessment-controller_test.js
@@ -711,11 +711,11 @@ describe('Acceptance | Controller | assessment-controller', function () {
   });
 
   describe('POST /api/assessments/{assessmentId}/embed/llm/chats', function () {
-    let user;
+    let user, assessment;
 
     beforeEach(async function () {
       user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildAssessment({ id: 111, userId: user.id });
+      assessment = databaseBuilder.factory.buildAssessment({ id: 111, userId: user.id, lastChallengeId: '222' });
       await databaseBuilder.commit();
     });
 
@@ -777,6 +777,9 @@ describe('Acceptance | Controller | assessment-controller', function () {
           });
           expect(response.result).to.have.property('id').that.is.a('string').and.not.empty;
           expect(llmApiScope.isDone()).to.be.true;
+          const createdChat = await knex('chats').first();
+          expect(createdChat.assessmentId).to.equal(assessment.id);
+          expect(createdChat.challengeId).to.equal(assessment.lastChallengeId);
         });
       });
 

--- a/api/tests/llm/unit/application/api/llm-api_test.js
+++ b/api/tests/llm/unit/application/api/llm-api_test.js
@@ -46,9 +46,20 @@ describe('LLM | Unit | Application | API | llm', function () {
       it('returns the newly created chat', async function () {
         const configId = 'abc123';
         const userId = 123;
+        const challengeId = undefined;
+        const assessmentId = undefined;
+        const moduleId = undefined;
+        const passageId = undefined;
 
         // when
-        const chat = await llmApi.startChat({ configId, userId });
+        const chat = await llmApi.startChat({
+          configId,
+          userId,
+          challengeId,
+          assessmentId,
+          moduleId,
+          passageId,
+        });
         // then
         expect(chat).to.deepEqualInstance(
           new LLMChatDTO({
@@ -60,7 +71,80 @@ describe('LLM | Unit | Application | API | llm', function () {
             context: newChat.configuration.context,
           }),
         );
-        expect(startChat).to.have.been.calledOnceWithExactly({ configurationId: configId, userId });
+        expect(startChat).to.have.been.calledOnceWithExactly({
+          configurationId: configId,
+          userId,
+          challengeId,
+          assessmentId,
+          moduleId,
+          passageId,
+        });
+      });
+
+      context('when challenge id, assessment id are provided', function () {
+        it('returns the newly created chat', async function () {
+          const configId = 'abc123';
+          const userId = 123;
+          const challengeId = 'fakeChallengeId';
+          const assessmentId = 1;
+          const moduleId = undefined;
+          const passageId = undefined;
+
+          // when
+          const chat = await llmApi.startChat({ configId, userId, challengeId, assessmentId, moduleId, passageId });
+          // then
+          expect(chat).to.deepEqualInstance(
+            new LLMChatDTO({
+              id: newChat.id,
+              attachmentName: newChat.configuration.attachmentName,
+              inputMaxChars: newChat.configuration.inputMaxChars,
+              inputMaxPrompts: newChat.configuration.inputMaxPrompts,
+              hasVictoryConditions: newChat.hasVictoryConditions,
+              context: newChat.configuration.context,
+            }),
+          );
+          expect(startChat).to.have.been.calledOnceWithExactly({
+            configurationId: configId,
+            userId,
+            challengeId,
+            assessmentId,
+            moduleId,
+            passageId,
+          });
+        });
+      });
+
+      context('when passage id, module id are provided', function () {
+        it('returns the newly created chat', async function () {
+          const configId = 'abc123';
+          const userId = 123;
+          const challengeId = undefined;
+          const assessmentId = undefined;
+          const moduleId = '550e8400-e29b-41d4-a716-446655440000';
+          const passageId = 1;
+
+          // when
+          const chat = await llmApi.startChat({ configId, userId, challengeId, assessmentId, moduleId, passageId });
+          // then
+          expect(chat).to.deepEqualInstance(
+            new LLMChatDTO({
+              id: newChat.id,
+              attachmentName: newChat.configuration.attachmentName,
+              inputMaxChars: newChat.configuration.inputMaxChars,
+              inputMaxPrompts: newChat.configuration.inputMaxPrompts,
+              hasVictoryConditions: newChat.hasVictoryConditions,
+              context: newChat.configuration.context,
+            }),
+          );
+          expect(startChat).to.have.been.calledOnceWithExactly({
+            configurationId: configId,
+            userId,
+            challengeId,
+            assessmentId,
+            moduleId,
+            passageId,
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Dans la table `chats`, les champs `challengeId`, `assessmentId`, `moduleId` et `passageId` ne sont jamais renseignés, même si on est censés les connaître dans les usecases.

## 🌰 Proposition

Utiliser les paramètres déjà fournis mais inutilisés dans la fonction `startChat`.

## 🍁 Remarques

Les chats de prévisualisation ne devraient pas être impactés. Si aucune de ces valeurs n'est fournie, ces champs resteront vides, comme ce qui est fait actuellement.

## 🪵 Pour tester

- CI OK ✅