### PR TITLE
[FEATURE] Envoyer les évènements Plausible dans l'élément ShortVideo (PIX-20365)

### DIFF
--- a/mon-pix/app/components/module/component/element.gjs
+++ b/mon-pix/app/components/module/component/element.gjs
@@ -36,7 +36,7 @@ export default class ModulixElement extends Component {
     {{else if (eq @element.type "video")}}
       <VideoElement @video={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
     {{else if (eq @element.type "short-video")}}
-      <ShortVideoElement @element={{@element}} @onTranscriptionOpen={{@onVideoTranscriptionOpen}} />
+      <ShortVideoElement @element={{@element}} />
     {{else if (eq @element.type "download")}}
       <DownloadElement @download={{@element}} @onDownload={{@onFileDownload}} />
     {{else if (eq @element.type "embed")}}

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -11,6 +11,7 @@ import ModuleElement from './module-element';
 export default class ModulixShortVideoElement extends ModuleElement {
   @tracked modalIsOpen = false;
   @service passageEvents;
+  @service pixMetrics;
 
   @action
   showModal() {
@@ -22,6 +23,11 @@ export default class ModulixShortVideoElement extends ModuleElement {
       data: {
         elementId: this.args.element.id,
       },
+    });
+
+    this.pixMetrics.trackEvent('Clic sur le bouton transcription d’une vidéo courte', {
+      category: 'Modulix',
+      elementId: this.args.element.id,
     });
   }
 

--- a/mon-pix/app/components/module/element/short-video.gjs
+++ b/mon-pix/app/components/module/element/short-video.gjs
@@ -16,7 +16,6 @@ export default class ModulixShortVideoElement extends ModuleElement {
   @action
   showModal() {
     this.modalIsOpen = true;
-    this.args.onTranscriptionOpen(this.args.element.id);
 
     this.passageEvents.record({
       type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -47,6 +47,9 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     const passageEventService = this.owner.lookup('service:passageEvents');
     const passageEventRecordStub = sinon.stub(passageEventService, 'record');
 
+    const metricsService = this.owner.lookup('service:pix-metrics');
+    const trackEventStub = sinon.stub(metricsService, 'trackEvent');
+
     //  when
     const screen = await render(
       <template>
@@ -64,6 +67,10 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
       data: {
         elementId: shortVideoElement.id,
       },
+    });
+    sinon.assert.calledWithExactly(trackEventStub, 'Clic sur le bouton transcription d’une vidéo courte', {
+      category: 'Modulix',
+      elementId: shortVideoId,
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/element/short-video_test.gjs
+++ b/mon-pix/tests/integration/components/module/element/short-video_test.gjs
@@ -42,7 +42,6 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
       title: 'title',
       transcription: 'transcription',
     };
-    const onShortVideoTranscriptionOpenStub = sinon.stub();
 
     const passageEventService = this.owner.lookup('service:passageEvents');
     const passageEventRecordStub = sinon.stub(passageEventService, 'record');
@@ -51,17 +50,12 @@ module('Integration | Component | Module | ShortVideo', function (hooks) {
     const trackEventStub = sinon.stub(metricsService, 'trackEvent');
 
     //  when
-    const screen = await render(
-      <template>
-        <ModulixShortVideo @element={{shortVideoElement}} @onTranscriptionOpen={{onShortVideoTranscriptionOpenStub}} />
-      </template>,
-    );
+    const screen = await render(<template><ModulixShortVideo @element={{shortVideoElement}} /></template>);
 
     // then
     await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
     assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText('transcription'));
-    assert.ok(onShortVideoTranscriptionOpenStub.calledOnceWith(shortVideoId));
     sinon.assert.calledWithExactly(passageEventRecordStub, {
       type: 'SHORT_VIDEO_TRANSCRIPTION_OPENED',
       data: {


### PR DESCRIPTION
## 🍂 Problème

Clément a oublié d'envoyer l'élément Plausible dans la PR #14107.

## 🌰 Proposition

Clément répare ses bêtises.

## 🍁 Remarques

Je propose de supprimer l'argument `onTranscriptionOpen` qui ne sera pas utilisé. En effet, on préfère désormais appeler le service `pixMetrics` directement dans l'élément concerné pour éviter le "prop drilling".

## 🪵 Pour tester

1. Se rendre dans le module [bac à sable](https://app-pr14115.review.pix.fr/modules/bac-a-sable)
2. Ouvrir la transcription d'une vidéo courte
3. Constater que l'évènement apparaît côté Plausible
