### PR TITLE
[FEATURE] Modification des durées de certification Pix+ Pro Santé et Pix+ Droit (PIX-20358)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -17,8 +17,8 @@ const Modals = {
 };
 
 const PIX_PLUS_DURATIONS = {
-  DROIT: 45,
-  PRO_SANTE: 45,
+  DROIT: 60,
+  PRO_SANTE: 60,
   EDU: 90,
 };
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list-test.js
@@ -566,10 +566,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
   module('when calculating theoretical end time for different certification types', function () {
     module('when candidate has Pix+ Droit certification', function () {
-      test('it calculates end time using 45 minutes duration', async function (assert) {
+      test('it calculates end time using 1 hour duration', async function (assert) {
         // given
         const startTime = new Date('2022-10-19T14:30:00Z');
-        const expectedEndTime = dayjs(startTime).add(45, 'minute').format('HH:mm');
+        const expectedEndTime = dayjs(startTime).add(60, 'minute').format('HH:mm');
 
         this.candidate = store.createRecord('certification-candidate-for-supervising', {
           id: '456',
@@ -590,10 +590,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     });
 
     module('when candidate has Pix+ Pro Santé certification', function () {
-      test('it calculates end time using 45 minutes duration', async function (assert) {
+      test('it calculates end time using 1 hour duration', async function (assert) {
         // given
         const startTime = new Date('2022-10-19T10:00:00Z');
-        const expectedEndTime = dayjs(startTime).add(45, 'minute').format('HH:mm');
+        const expectedEndTime = dayjs(startTime).add(60, 'minute').format('HH:mm');
 
         this.candidate = store.createRecord('certification-candidate-for-supervising', {
           id: '456',

--- a/mon-pix/app/components/certification-instructions/steps.gjs
+++ b/mon-pix/app/components/certification-instructions/steps.gjs
@@ -16,8 +16,8 @@ import StepThree from './step-three';
 import StepTwo from './step-two';
 
 const PIX_PLUS_DURATIONS = {
-  DROIT: 45,
-  PRO_SANTE: 45,
+  DROIT: 60,
+  PRO_SANTE: 60,
   EDU: 90,
 };
 

--- a/mon-pix/tests/unit/components/certification-instructions/steps-test.js
+++ b/mon-pix/tests/unit/components/certification-instructions/steps-test.js
@@ -177,7 +177,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       assert.strictEqual(component.certificationDurationInMinutes, 105);
     });
 
-    test('should return 45 minutes for Pix+ Droit certification', function (assert) {
+    test('should return 1 hour for Pix+ Droit certification', function (assert) {
       // given
       const component = createGlimmerComponent('certification-instructions/steps');
       component.args.candidate = {
@@ -185,10 +185,10 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       };
 
       // then
-      assert.strictEqual(component.certificationDurationInMinutes, 45);
+      assert.strictEqual(component.certificationDurationInMinutes, 60);
     });
 
-    test('should return 45 minutes for Pix+ Pro Santé certification', function (assert) {
+    test('should return 1 hour for Pix+ Pro Santé certification', function (assert) {
       // given
       const component = createGlimmerComponent('certification-instructions/steps');
       component.args.candidate = {
@@ -196,7 +196,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       };
 
       // then
-      assert.strictEqual(component.certificationDurationInMinutes, 45);
+      assert.strictEqual(component.certificationDurationInMinutes, 60);
     });
 
     test('should return 90 minutes for Pix+ Édu 1er degré certification', function (assert) {
@@ -245,7 +245,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       assert.strictEqual(component.durationLegend, '1 H 45 min');
     });
 
-    test('should return "45 min" for Pix+ Droit certification', function (assert) {
+    test('should return "1 H" for Pix+ Droit certification', function (assert) {
       // given
       const component = createGlimmerComponent('certification-instructions/steps');
       component.args.candidate = {
@@ -253,7 +253,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       };
 
       // then
-      assert.strictEqual(component.durationLegend, '45 min');
+      assert.strictEqual(component.durationLegend, '1 H');
     });
 
     test('should return "1 H 30 min" for Pix+ Édu certification', function (assert) {
@@ -280,7 +280,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       assert.strictEqual(component.durationText, '1h45');
     });
 
-    test('should return "45min" for Pix+ Droit certification', function (assert) {
+    test('should return "1h" for Pix+ Droit certification', function (assert) {
       // given
       const component = createGlimmerComponent('certification-instructions/steps');
       component.args.candidate = {
@@ -288,7 +288,7 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
       };
 
       // then
-      assert.strictEqual(component.durationText, '45min');
+      assert.strictEqual(component.durationText, '1h');
     });
 
     test('should return "1h30" for Pix+ Édu certification', function (assert) {


### PR DESCRIPTION
## 🍂 Problème

Une certification de 45mins pour 32 questions a été jugée trop courte par les panels utilisateurs Pix+ Pro Santé et Pix+ Droit.

## 🌰 Proposition

Modifier la durée de la certification Pix+ Droit et Pix+ Pro Santé pour la passer de 45mins à 1h. La durée est affichée sur les page d'entrée en certif et dans l'espace surveillant.

## 🍁 Remarques

Pour rappel, les durées sont actuellement et provisoirement en dur dans le front, justement les durées des pix plus sont toujours en cours d'expérimentation (#13748 et #13618).

## 🪵 Pour tester
-  Créer une session avec des candidats inscrits enPix+ Droit et Pix+ Pro Santé
- Entrer en certif avec les différents candidats et vérifier côté surveillant que l'horaire de fin estimé est correct pour chaque
- Côté candidats, naviguer sur les écrans d'entrée de certification et vérifier que les durées sont correctement affichées 