### PR TITLE
[TECH] Ajout d'un index pour chercher les challenges de certification (PIX-20244).

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,98 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# Possible personal data
+*.json
+*.csv
+
+# compiled output
+**/dist
+**/tmp
+**/coverage
+**/pix.log.*
+**/test-results
+
+# misc
+**/.eslintcache
+**/.sass-cache
+**/npm-debug.log
+**/testem.log
+**/out.log
+**/*.log
+**/*.log.*
+
+# IDE
+**/.fleet
+**/.idea
+!.idea/runConfigurations/*.xml
+*.iml
+*.code-workspace
+
+# system
+.DS_Store
+
+**/.env
+
+# CircleCI
+*.circle-cache-key
+
+# ember-try
+**/.node_modules.ember-try/
+**/bower.json.ember-try
+**/package.json.ember-try
+
+api/.vscode/*
+api/.vscode
+.vscode/*
+!.vscode/sample.launch.json
+!.vscode/sample.settings.json
+!.vscode/extensions.json
+.history
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try
+
+# cypress
+high-level-tests/e2e/cypress/screenshots/*
+high-level-tests/e2e/cypress/screenshots
+high-level-tests/e2e/cypress/videos/*
+high-level-tests/e2e/cypress/videos
+
+# Heap files
+*.heapsnapshot
+*.heapprofile
+
+# Artillery.io
+high-level-tests/load-testing/report/*.json
+high-level-tests/load-testing/report/*.html
+
+# Dependency violations script
+api/dependencies-violations.json
+api/dependencies-violations.md
+
+# Answers extracts
+api/scripts/extractions
+
+# Visual regression snapshots
+high-level-tests/e2e/cypress/snapshots/actual/**
+
+# Pipe viewer
+**/pv*.out
+
+# Docker-compose config
+docker/data/
+
+# Claude Code documentation
+CLAUDE.md
+.claude/
+
+# Allow JSON files in translations directories
+!**/translations/*.json
+
+# Allow package.json and package-lock.json
+!package.json
+!package-lock.json
+
+# Allow JSON files in learning-content/modules directory
+!learning-content/modules/*.json

--- a/api/db/migrations/20251107105401_add_index_to_certification_frameworks_challenges.js
+++ b/api/db/migrations/20251107105401_add_index_to_certification_frameworks_challenges.js
@@ -1,0 +1,33 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.raw(
+    'CREATE INDEX certification_frameworks_challenges_version_index ON "certification-frameworks-challenges" ("versionId") WHERE "discriminant" is not null and "difficulty" is not null;',
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.raw('DROP INDEX certification_frameworks_challenges_version_index;');
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Lors des tests utilisateurs Pix+ une requete SQL a attire mon attention en monitorant les performances de la BDD, a savoir un mean time bien au dessus des autres requetes.

Cette requete est une des + appelees de certif  c’est la requete de selection du prochain challenge.

```sql
/* path: /api/assessments/{id} */ select * from "certification-frameworks-challenges" where "versionId" = $1 and "discriminant" is not null and "difficulty" is not null
```

Nos captains ont fait une etude et propose un changement pour ameliorer les perfs !

## 🌰 Proposition

* Appliquer le changement propose par les captains

```sql
CREATE INDEX certification_frameworks_challenges_version_index ON "certification-frameworks-challenges" ("versionId")
WHERE "discriminant" is not null and "difficulty" is not null
```

## 🍁 Remarques

* Demande des captains de faire du knex.raw

## 🪵 Pour tester

* Verifier que migrate up et migrate down se font bien (ajout / rolback de l'index)
* Tests au vert et API qui se deploie
