### PR TITLE
[FEATURE] Appeler /oidc/identity-providers pour récupérer les OIDC providers sur Pix Orga (PIX-20322)

### DIFF
--- a/orga/app/adapters/oidc-identity-provider.js
+++ b/orga/app/adapters/oidc-identity-provider.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class OidcIdentityProviderAdapter extends ApplicationAdapter {
+  urlForFindAll() {
+    return `${this.host}/${this.namespace}/oidc/identity-providers`;
+  }
+}

--- a/orga/app/models/oidc-identity-provider.js
+++ b/orga/app/models/oidc-identity-provider.js
@@ -1,0 +1,10 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OidcIdentityProvider extends Model {
+  @attr() code;
+  @attr() organizationName;
+  @attr() slug;
+  @attr() shouldCloseSession;
+  @attr() source;
+  @attr() isVisible;
+}

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -11,6 +11,7 @@ export default class ApplicationRoute extends Route {
   @service session;
   @service locale;
   @service intl;
+  @service oidcIdentityProviders;
   @service pixMetrics;
   @service router;
 
@@ -31,6 +32,7 @@ export default class ApplicationRoute extends Route {
     this.locale.setBestLocale({ queryParams });
     await this.session.setup();
     await this.featureToggles.load();
+    await this.oidcIdentityProviders.load().catch();
     await this.currentUser.load();
   }
 

--- a/orga/app/services/oidc-identity-providers.js
+++ b/orga/app/services/oidc-identity-providers.js
@@ -1,0 +1,16 @@
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class OidcIdentityProviders extends Service {
+  @service store;
+  @service currentDomain;
+
+  @tracked isOidcProviderAuthenticationInProgress = false;
+
+  async load() {
+    const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
+    oidcIdentityProviders.forEach((oidcIdentityProvider) => {
+      this[oidcIdentityProvider.id] = oidcIdentityProvider;
+    });
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -697,4 +697,23 @@ function routes() {
     });
     return schema.combinedCourseStatistics.find(combinedCourseId);
   });
+
+  this.get('/oidc/identity-providers', () => {
+    return {
+      data: [
+        {
+          type: 'oidc-identity-providers',
+          id: 'oidc-partner',
+          attributes: {
+            code: 'OIDC_PARTNER',
+            'organization-name': 'Partenaire OIDC',
+            slug: 'oidc-partner',
+            'should-close-session': false,
+            source: 'oidc-externe',
+            'is-visible': true,
+          },
+        },
+      ],
+    };
+  });
 }

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -10,6 +10,7 @@ module('Unit | Route | application', function (hooks) {
 
     sinon.stub(this.route.session, 'setup').resolves();
     sinon.stub(this.route.featureToggles, 'load').resolves();
+    sinon.stub(this.route.oidcIdentityProviders, 'load').resolves();
     sinon.stub(this.route.locale, 'setBestLocale').resolves();
     sinon.stub(this.route.currentUser, 'load').resolves();
   });
@@ -30,7 +31,7 @@ module('Unit | Route | application', function (hooks) {
     });
 
     test('sets up the session', async function (assert) {
-      // given // when
+      // when
       await this.route.beforeModel();
 
       // then
@@ -38,15 +39,23 @@ module('Unit | Route | application', function (hooks) {
     });
 
     test('loads feature toggles', async function (assert) {
-      // given // when
+      // when
       await this.route.beforeModel();
 
       // then
       assert.ok(this.route.featureToggles.load.called);
     });
 
+    test('loads identity providers', async function (assert) {
+      // when
+      await this.route.beforeModel();
+
+      // then
+      assert.ok(this.route.oidcIdentityProviders.load.called);
+    });
+
     test('loads current user', async function (assert) {
-      // given // when
+      // when
       await this.route.beforeModel();
 
       // then


### PR DESCRIPTION
## 🍂 Problème


Afin d’afficher les OIDC providers, nous devons les récupérer côté frontend

## 🌰 Proposition

Comme pour Pix App ou Pix Admin, au moment où l’application Pix Orga se charge faire l’appel pour récupérer la liste des oidc-providers et intégrer le service des oidc providers dans Pix Orga.

Récupérer le service et modèle de PixApp


## 🍁 Remarques

Cette PR peut être rebasée sur celle du ticket https://1024pix.atlassian.net/browse/PIX-19809

## 🪵 Pour tester

 (tests à faire sur .fr et sur .org)

- Aller sur pix.orga
- Vérifier que la route /oidc/identity-providers renvoie un tableau contenant les 5 OIDC identity-providers de test.
