### PR TITLE
[FEATURE] Cacher l'édition d'un candidat si le scope n'est pas accessible (PIX-20360).

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -81,4 +81,10 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
   },
+  isPixPlusCandidateA11yEnabled: {
+    type: 'boolean',
+    description: 'Enable candidate accessibility adjustment for Pix+ certifications',
+    defaultValue: false,
+    tags: ['frontend', 'a11y', 'team-certif', 'pix-certif'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -30,6 +30,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-text-to-speech-button-enabled': true,
             'use-pix-orga-new-auth-design': false,
             'is-modulix-nav-enabled': false,
+            'is-pix-plus-candidate-a11y-enabled': false,
           },
         },
       };

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -315,6 +315,13 @@ export default class EnrolledCandidates extends Component {
 
     return subscriptionLabels.join(', ');
   };
+
+  @action
+  isAccessibilityAdjustmentEnabled(subscriptionType) {
+    if (subscriptionType === SUBSCRIPTION_TYPES.CORE) return true;
+    return this.featureToggles.featureToggles?.isPixPlusCandidateA11yEnabled;
+  }
+
   <template>
     <header class='panel-header'>
       <h3 class='panel-header__title'>
@@ -429,30 +436,32 @@ export default class EnrolledCandidates extends Component {
                     {{t 'pages.sessions.detail.candidates.list.actions.details.label'}}
                   </PixButton>
                 {{/unless}}
-                {{#if candidate.isLinked}}
-                  <PixTooltip @position='left' @isInline={{true}} @id='tooltip-edit-student-button'>
-                    <:triggerElement>
-                      <PixIconButton
-                        @iconName='edit'
-                        @plainIcon={{true}}
-                        @ariaLabel='{{t
-                          "pages.sessions.detail.candidates.list.actions.edit.extra-information"
-                        }} {{candidate.firstName}} {{candidate.lastName}}'
-                        disabled
-                        aria-describedby='tooltip-edit-student-button'
-                      />
-                    </:triggerElement>
-                    <:tooltip>{{t 'pages.sessions.detail.candidates.list.actions.edit.tooltip'}}</:tooltip>
-                  </PixTooltip>
-                {{else}}
-                  <PixIconButton
-                    @iconName='edit'
-                    @plainIcon={{true}}
-                    {{on 'click' (fn this.openEditCertificationCandidateDetailsModal candidate)}}
-                    @ariaLabel='{{t
-                      "pages.sessions.detail.candidates.list.actions.edit.extra-information"
-                    }} {{candidate.firstName}} {{candidate.lastName}}'
-                  />
+                {{#if (this.isAccessibilityAdjustmentEnabled candidate.subscriptionType)}}
+                  {{#if candidate.isLinked}}
+                    <PixTooltip @position='left' @isInline={{true}} @id='tooltip-edit-student-button'>
+                      <:triggerElement>
+                        <PixIconButton
+                          @iconName='edit'
+                          @plainIcon={{true}}
+                          @ariaLabel='{{t
+                            "pages.sessions.detail.candidates.list.actions.edit.extra-information"
+                          }} {{candidate.firstName}} {{candidate.lastName}}'
+                          disabled
+                          aria-describedby='tooltip-edit-student-button'
+                        />
+                      </:triggerElement>
+                      <:tooltip>{{t 'pages.sessions.detail.candidates.list.actions.edit.tooltip'}}</:tooltip>
+                    </PixTooltip>
+                  {{else}}
+                    <PixIconButton
+                      @iconName='edit'
+                      @plainIcon={{true}}
+                      {{on 'click' (fn this.openEditCertificationCandidateDetailsModal candidate)}}
+                      @ariaLabel='{{t
+                        "pages.sessions.detail.candidates.list.actions.edit.extra-information"
+                      }} {{candidate.firstName}} {{candidate.lastName}}'
+                    />
+                  {{/if}}
                 {{/if}}
                 {{#if candidate.isLinked}}
                   <PixTooltip @position='left' @isInline={{true}} @id='tooltip-delete-student-button'>

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -1,6 +1,8 @@
 import { service } from '@ember/service';
 import Model, { attr, hasMany } from '@ember-data/model';
 
+import { SUBSCRIPTION_TYPES } from './subscription';
+
 export default class CertificationCandidate extends Model {
   @service intl;
   @attr('string') firstName;
@@ -51,6 +53,13 @@ export default class CertificationCandidate extends Model {
     }
 
     return '-';
+  }
+
+  get subscriptionType() {
+    if (this.subscriptions.some((sub) => sub.isCore)) {
+      return SUBSCRIPTION_TYPES.CORE;
+    }
+    return SUBSCRIPTION_TYPES.COMPLEMENTARY;
   }
 
   hasDualCertificationSubscriptionCoreClea(centerHabilitations) {

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isPixPlusCandidateA11yEnabled;
+}

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -183,6 +183,11 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         let session;
 
         hooks.beforeEach(async () => {
+          server.create('feature-toggle', {
+            id: 0,
+            isPixPlusCandidateA11yEnabled: false,
+          });
+
           allowedCertificationCenterAccess = server.create('allowed-certification-center-access');
           certificationPointOfContact = server.create('certification-point-of-contact', {
             firstName: 'Lena',

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/index-test.gjs
@@ -12,10 +12,16 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let store;
+  let store, coreSubscription, complementarySubscription;
 
   hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
+
+    class FeatureTogglesStub extends Service {
+      featureToggles = { isPixPlusCandidateA11yEnabled: false };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesStub);
+
     const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
       id: '123',
       name: 'Center',
@@ -31,11 +37,21 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     }
 
     this.owner.register('service:current-user', CurrentUserStub);
+
+    coreSubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.CORE,
+      complementaryCertificationKey: null,
+    });
+
+    complementarySubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+      complementaryCertificationKey: 'DROIT',
+    });
   });
 
   test('it should have an accessible table description', async function (assert) {
-    //given
-    const candidate = _buildCertificationCandidate({ subscriptions: [] });
+    // given
+    const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
 
     const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
     const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
@@ -63,14 +79,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
   test('it should display candidate information', async function (assert) {
     // given
-    const coreSubscription = store.createRecord('subscription', {
-      type: SUBSCRIPTION_TYPES.CORE,
-      complementaryCertificationKey: null,
-    });
-    const complementarySubscription = store.createRecord('subscription', {
-      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-      complementaryCertificationKey: 'DROIT',
-    });
     const candidate = _buildCertificationCandidate({
       accessibilityAdjustmentNeeded: true,
       subscriptions: [coreSubscription, complementarySubscription],
@@ -113,7 +121,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
   test('it should display details button', async function (assert) {
     // given
-    const candidate = _buildCertificationCandidate({ subscriptions: [] });
+    const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
     const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
     const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -138,7 +146,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
   test('it should display details modal', async function (assert) {
     // given
-    const candidate = _buildCertificationCandidate({ subscriptions: [] });
+    const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
     const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
     const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -168,9 +176,19 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     test('it should be possible to delete the candidate', async function (assert) {
       // given
       const certificationCandidates = [
-        _buildCertificationCandidate({ id: '1' }),
-        _buildCertificationCandidate({ id: '2', firstName: 'Lara', lastName: 'Pafromage' }),
-        _buildCertificationCandidate({ id: '3', firstName: 'Jean', lastName: 'Registre' }),
+        _buildCertificationCandidate({ id: '1', subscriptions: [coreSubscription] }),
+        _buildCertificationCandidate({
+          id: '2',
+          firstName: 'Lara',
+          lastName: 'Pafromage',
+          subscriptions: [coreSubscription],
+        }),
+        _buildCertificationCandidate({
+          id: '3',
+          firstName: 'Jean',
+          lastName: 'Registre',
+          subscriptions: [coreSubscription],
+        }),
       ].map((candidateData) => store.createRecord('certification-candidate', candidateData));
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -203,9 +221,20 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     test('it display candidates with delete button disabled', async function (assert) {
       // given
       const certificationCandidates = [
-        _buildCertificationCandidate({ id: '1' }),
-        _buildCertificationCandidate({ id: '2', firstName: 'Lara', lastName: 'Pafromage', isLinked: true }),
-        _buildCertificationCandidate({ id: '3', firstName: 'Jean', lastName: 'Registre' }),
+        _buildCertificationCandidate({ id: '1', subscriptions: [coreSubscription] }),
+        _buildCertificationCandidate({
+          id: '2',
+          firstName: 'Lara',
+          lastName: 'Pafromage',
+          isLinked: true,
+          subscriptions: [coreSubscription],
+        }),
+        _buildCertificationCandidate({
+          id: '3',
+          firstName: 'Jean',
+          lastName: 'Registre',
+          subscriptions: [coreSubscription],
+        }),
       ].map((candidateData) => store.createRecord('certification-candidate', candidateData));
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -245,9 +274,20 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     test('it display candidates with an edit button', async function (assert) {
       // given
       const certificationCandidates = [
-        _buildCertificationCandidate({ id: '1' }),
-        _buildCertificationCandidate({ id: '2', firstName: 'Lara', lastName: 'Pafromage', isLinked: true }),
-        _buildCertificationCandidate({ id: '3', firstName: 'Jean', lastName: 'Registre' }),
+        _buildCertificationCandidate({ id: '1', subscriptions: [coreSubscription] }),
+        _buildCertificationCandidate({
+          id: '2',
+          firstName: 'Lara',
+          lastName: 'Pafromage',
+          isLinked: true,
+          subscriptions: [coreSubscription],
+        }),
+        _buildCertificationCandidate({
+          id: '3',
+          firstName: 'Jean',
+          lastName: 'Registre',
+          subscriptions: [coreSubscription],
+        }),
       ].map((candidateData) => store.createRecord('certification-candidate', candidateData));
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -263,8 +303,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
       );
 
       // then
-
-      // then
       assert.dom(screen.getByRole('button', { name: 'Editer le candidat Eddy Taurial' })).isNotDisabled();
       assert.dom(screen.getByRole('button', { name: 'Editer le candidat Lara Pafromage' })).isDisabled();
       assert.dom(screen.getByRole('button', { name: 'Editer le candidat Jean Registre' })).isNotDisabled();
@@ -278,6 +316,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
       // given
       const candidate = _buildCertificationCandidate({
         accessibilityAdjustmentNeeded: true,
+        subscriptions: [coreSubscription],
       });
 
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
@@ -305,6 +344,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
       // given
       const candidate = _buildCertificationCandidate({
         accessibilityAdjustmentNeeded: false,
+        subscriptions: [coreSubscription],
       });
 
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
@@ -331,10 +371,6 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
     test('it displays specific subscription text', async function (assert) {
       // given
       const cleaCertificationId = 2;
-      const coreSubscription = store.createRecord('subscription', {
-        type: SUBSCRIPTION_TYPES.CORE,
-        complementaryCertificationKey: null,
-      });
       const complementarySubscription = store.createRecord('subscription', {
         type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
         complementaryCertificationKey: COMPLEMENTARY_KEYS.CLEA,
@@ -395,9 +431,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
     test('it hides externalId and email column', async function (assert) {
       // given
-      const candidate = _buildCertificationCandidate({
-        subscriptions: [],
-      });
+      const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
       const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -444,9 +478,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
     test('it shows email columns', async function (assert) {
       // given
-      const candidate = _buildCertificationCandidate({
-        subscriptions: [],
-      });
+      const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
       const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
       const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
 
@@ -469,9 +501,7 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
   test('it should NOT display tooltip in the header of selected certification column', async function (assert) {
     //given
-    const candidate = _buildCertificationCandidate({
-      subscriptions: [],
-    });
+    const candidate = _buildCertificationCandidate({ subscriptions: [coreSubscription] });
 
     const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
     const countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
@@ -489,6 +519,109 @@ module('Integration | Component | Sessions | SessionDetails | EnrolledCandidates
 
     // then
     assert.dom(screen.queryByLabelText("Informations concernant l'inscription en certification.")).doesNotExist();
+  });
+
+  module('candidate edition', function (hooks) {
+    let certificationCandidates, countries;
+
+    hooks.beforeEach(function () {
+      const coreSubscription = store.createRecord('subscription', {
+        type: SUBSCRIPTION_TYPES.CORE,
+      });
+      const complementarySubscription = store.createRecord('subscription', {
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+        complementaryCertificationKey: 'DROIT',
+      });
+      const otherComplementarySubscription = store.createRecord('subscription', {
+        type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+        complementaryCertificationKey: 'EDU',
+      });
+
+      const coreCandidate = _buildCertificationCandidate({
+        id: 1,
+        subscriptions: [coreSubscription],
+        isLinked: false,
+        firstName: 'Bob',
+      });
+      const droitCandidate = _buildCertificationCandidate({
+        id: 2,
+        subscriptions: [complementarySubscription],
+        isLinked: false,
+        firstName: 'Lana',
+      });
+      const eduCandidate = _buildCertificationCandidate({
+        id: 3,
+        subscriptions: [otherComplementarySubscription],
+        isLinked: false,
+        firstName: 'Dummy',
+      });
+
+      certificationCandidates = [
+        store.createRecord('certification-candidate', coreCandidate),
+        store.createRecord('certification-candidate', droitCandidate),
+        store.createRecord('certification-candidate', eduCandidate),
+      ];
+
+      countries = [store.createRecord('country', { name: 'CANADA', code: 99401 })];
+    });
+
+    module('when feature toggle disables Pix+ candidate edition', function () {
+      test('it should display edit button only for CORE candidates when feature is disabled', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isPixPlusCandidateA11yEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        const localCertificationCandidates = certificationCandidates;
+        const localCountries = countries;
+
+        // when
+        const screen = await render(
+          <template>
+            <EnrolledCandidates
+              @sessionId='1'
+              @certificationCandidates={{localCertificationCandidates}}
+              @countries={{localCountries}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Editer le candidat Bob Taurial' })).exists();
+        assert.dom(screen.queryByRole('button', { name: 'Editer le candidat Lana Taurial' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Editer le candidat Dummy Taurial' })).doesNotExist();
+      });
+    });
+
+    module('when feature toggle enables Pix+ candidate edition', function () {
+      test('it should display edit button for all candidates when feature is enabled', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isPixPlusCandidateA11yEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        const localCertificationCandidates = certificationCandidates;
+        const localCountries = countries;
+
+        // when
+        const screen = await render(
+          <template>
+            <EnrolledCandidates
+              @sessionId='1'
+              @certificationCandidates={{localCertificationCandidates}}
+              @countries={{localCountries}}
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Editer le candidat Bob Taurial' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Editer le candidat Lana Taurial' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Editer le candidat Dummy Taurial' })).exists();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de la réouverture des Pix+ prévue à partir du 17/11 en version MVP, aucun aménagement de l’algo n’a pas été étudié ni proposé.

En revanche, la case dans l’interface Pix Certif existe encore pour les candidats Pix+ ce qui peut induire l’utilisateur en erreur.

## 🌰 Proposition

- Mise en place d’un feature-toggle qui décrète si on permet d'ajouter l'ajustement d'accessibilité pour les Pix+ (par défaut `false`).
- Supprimer l’icône de modification du candidat pour les candidats Pix qui n'ont pas de souscription ayant un de ces scopes accessibles.

## 🪵 Pour tester

- Ajouter un candidat avec un souscription autre que "CORE"
- Sur sa ligne, le bouton d'édition ne devrait pas être présent. 

<img width="437" height="137" alt="image" src="https://github.com/user-attachments/assets/1b0fa4a7-42b5-4900-abd4-c4cf38c601e2" />
