### PR TITLE
[FEATURE] Afficher le pays dans la page de détail d'une organisation (PIX-20137)

### DIFF
--- a/admin/app/components/organizations/information-section-view.gjs
+++ b/admin/app/components/organizations/information-section-view.gjs
@@ -66,6 +66,21 @@ class OrganizationDescription extends Component {
     return identityProviderName || this.intl.t('common.words.none');
   }
 
+  get country() {
+    //TODO: remove condition based on countryCode when it becomes not nullable at the end of Epix
+    if (!this.args.organization.countryCode && !this.args.organization.countryName) {
+      return this.intl.t('common.not-specified');
+    }
+
+    if (this.args.organization.countryCode && !this.args.organization.countryName) {
+      return this.intl.t('components.organizations.information-section-view.country.not-found', {
+        countryCode: this.args.organization.countryCode,
+      });
+    }
+
+    return `${this.args.organization.countryName} (${this.args.organization.countryCode})`;
+  }
+
   <template>
     <DescriptionList>
       <DescriptionList.Divider />
@@ -90,6 +105,10 @@ class OrganizationDescription extends Component {
           {{@organization.provinceCode}}
         </DescriptionList.Item>
       {{/if}}
+
+      <DescriptionList.Item @label={{t "components.organizations.information-section-view.country.label"}}>
+        {{this.country}}
+      </DescriptionList.Item>
 
       <DescriptionList.Divider />
 

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -28,9 +28,10 @@ export default class Organization extends Model {
   @attr('nullable-string') code;
   @attr() parentOrganizationId;
   @attr('nullable-string') parentOrganizationName;
-  //TODO REMOVE nullable-string BEFORE THE END OF EPIX
   @attr() administrationTeamId;
-  @attr('nullable-string') administrationTeamName;
+  @attr('string') administrationTeamName;
+  @attr('number') countryCode;
+  @attr('string') countryName;
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;
 

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -48,6 +48,8 @@ module('Integration | Component | organizations/information-section-view', funct
         dataProtectionOfficerFullName: 'Justin Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
         administrationTeamName: 'team Rocket',
+        countryCode: 99100,
+        countryName: 'France',
       };
 
       // when
@@ -69,6 +71,11 @@ module('Integration | Component | organizations/information-section-view', funct
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.created-at')).nextElementSibling)
         .hasText('02/09/2022');
+
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.country.label')).nextElementSibling)
+        .hasText('France (99100)');
+
       assert
         .dom(
           screen.getByText(t('components.organizations.information-section-view.administration-team'))
@@ -124,6 +131,49 @@ module('Integration | Component | organizations/information-section-view', funct
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.sso')).nextElementSibling)
         .hasText('GAR');
+    });
+
+    module('country information', function () {
+      test('it renders Not specified value if no country code', async function (assert) {
+        // given
+        const organization = {
+          name: 'Orga with no country code',
+          countryCode: null,
+        };
+
+        // when
+        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(t('components.organizations.information-section-view.country.label')).nextElementSibling,
+          )
+          .hasText(t('common.not-specified'));
+      });
+
+      test('it renders country not found message if no country name', async function (assert) {
+        // given
+        const organization = {
+          name: 'Orga with country code but no country name',
+          countryCode: 1234,
+          countryName: undefined,
+        };
+
+        // when
+        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(t('components.organizations.information-section-view.country.label')).nextElementSibling,
+          )
+          .hasText(
+            t('components.organizations.information-section-view.country.not-found', {
+              countryCode: organization.countryCode,
+            }),
+          );
+      });
     });
 
     module('data protection officer information', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -599,6 +599,10 @@
         "archive-organization": "Archive organization",
         "child-organization": "Child organization of",
         "code": "Code",
+        "country": {
+          "label": "Country (INSEE code)",
+          "not-found": "Country not found for code {countryCode}"
+        },
         "created-at": "Created on",
         "created-by": "Created by",
         "credits": "Credits",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -600,6 +600,10 @@
         "archive-organization": "Archiver l'organisation",
         "child-organization": "Organisation fille de",
         "code": "Code",
+        "country": {
+          "label": "Pays (code INSEE)",
+          "not-found": "Pays non trouvé pour le code {countryCode}"
+        },
         "created-at": "Créée le",
         "created-by": "Créée par",
         "credits": "Crédits",


### PR DESCRIPTION
## 🍂 Problème

Suite à cette PR https://github.com/1024pix/pix/pull/14118 on récupère maintenant le pays dans la page de détail d'une organisation.

## 🌰 Proposition

Afficher ce pays et son code Insee dans les informations générales.

## 🍁 Remarques

Si l'orga n'a pas de country code, on affiche "Non spécifié".
Si l'orga a un country code mais aucun pays n'est rattaché à ce code, on affiche "Pays non trouvé pour le code ..."

## 🪵 Pour tester

Sur Pix Admin:
- aller sur la page de détail d'une organisation
- constater la présence d'une nouvelle ligne Pays dans les informations