### PR TITLE
[FEATURE] Permettre au support de supprimer les prescrit lié aux utilisateurs (Pix-20225)

### DIFF
--- a/.vscode/sample.launch.json
+++ b/.vscode/sample.launch.json
@@ -5,6 +5,8 @@
       "type": "node",
       "request": "launch",
       "name": "api start",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start"],
       "outputCapture": "std",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/api",

--- a/admin/app/adapters/organization-learner.js
+++ b/admin/app/adapters/organization-learner.js
@@ -3,7 +3,12 @@ import ApplicationAdapter from './application';
 export default class OrganizationLearnerAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForDeleteRecord(id) {
-    return `${this.host}/${this.namespace}/organization-learners/${id}/association`;
+  urlForDeleteRecord(id, _, snapshot) {
+    return `${this.host}/${this.namespace}/organizations/${snapshot.attr('organizationId')}/organization-learners/${id}`;
+  }
+
+  dissociate(id) {
+    const url = `${this.host}/${this.namespace}/organization-learners/${id}/association`;
+    return this.ajax(url, 'DELETE');
   }
 }

--- a/admin/app/components/ui/deletion-modal.gjs
+++ b/admin/app/components/ui/deletion-modal.gjs
@@ -1,0 +1,50 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
+
+export default class DeletionModal extends Component {
+  @tracked allowDeletion = false;
+
+  get canDelete() {
+    return this.allowDeletion;
+  }
+
+  @action
+  toggleDeletionPermission() {
+    this.allowDeletion = !this.allowDeletion;
+  }
+
+  <template>
+    <PixModal @title={{@title}} @showModal={{@showModal}} @onCloseButtonClick={{@onCloseModal}}>
+      <:content>
+        {{yield to="content"}}
+        <PixCheckbox
+          {{on "click" this.toggleDeletionPermission}}
+          @size="small"
+          @checked={{this.allowDeletion}}
+          @class="deletion-modal__permission-checkbox"
+        >
+          <:label>
+            <strong>
+              {{t "common.actions.are-you-sure"}}
+            </strong>
+          </:label>
+        </PixCheckbox>
+      </:content>
+      <:footer>
+        <PixButton @variant="secondary" @triggerAction={{@onCloseModal}}>
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @variant="error" @triggerAction={{@onTriggerAction}} @isDisabled={{not this.canDelete}}>
+          {{t "common.actions.confirm-deletion"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  </template>
+}

--- a/admin/app/components/ui/deletion-modal.scss
+++ b/admin/app/components/ui/deletion-modal.scss
@@ -1,0 +1,5 @@
+.deletion-modal {
+  &__permission-checkbox {
+    margin-top: var(--pix-spacing-3x);
+  }
+}

--- a/admin/app/components/users/user-detail-personal-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information.gjs
@@ -2,6 +2,8 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+import DeletionModal from 'pix-admin/components/ui/deletion-modal';
 
 import ConfirmPopup from '../confirm-popup';
 import OrganizationLearnerInformation from './user-detail-personal-information/organization-learner-information';
@@ -10,23 +12,45 @@ const DISSOCIATE_SUCCESS_NOTIFICATION_MESSAGE = 'La dissociation a bien été ef
 
 export default class UserDetailPersonalInformationComponent extends Component {
   @tracked displayDissociateModal = false;
+  @tracked displayDeletionLearnerModal = false;
   @tracked isLoading = false;
 
   @service pixToast;
+  @service store;
+  @service intl;
 
   organizationLearnerToDissociate = null;
+  organizationLearnerToDelete = null;
 
   @action
   toggleDisplayDissociateModal(organizationLearner) {
-    this.organizationLearnerToDissociate = organizationLearner;
+    this.organizationLearnerToDissociate = !this.displayDissociateModal ? organizationLearner : null;
     this.displayDissociateModal = !this.displayDissociateModal;
+  }
+
+  @action
+  toggleDisplayDeletionLearnerModal(organizationLearner) {
+    this.organizationLearnerToDelete = !this.displayDeletionLearnerModal ? organizationLearner : null;
+    this.displayDeletionLearnerModal = !this.displayDeletionLearnerModal;
+  }
+
+  get deletionWarningMessage() {
+    if (!this.displayDeletionLearnerModal) return null;
+
+    return this.intl.t('components.organization-learner-information.deletion-modal.warning-message', {
+      firstName: this.organizationLearnerToDelete.firstName,
+      lastName: this.organizationLearnerToDelete.lastName,
+      organizationName: this.organizationLearnerToDelete.organizationName,
+    });
   }
 
   @action
   async dissociate() {
     this.isLoading = true;
     try {
-      await this.organizationLearnerToDissociate.destroyRecord();
+      const adapter = this.store.adapterFor('organization-learner');
+      await adapter.dissociate(this.organizationLearnerToDissociate.id);
+      await this.args.user.reload();
       this.pixToast.sendSuccessNotification({ message: DISSOCIATE_SUCCESS_NOTIFICATION_MESSAGE });
     } catch {
       const errorMessage = 'Une erreur est survenue !';
@@ -37,13 +61,40 @@ export default class UserDetailPersonalInformationComponent extends Component {
     }
   }
 
+  @action
+  async delete() {
+    this.isLoading = true;
+    try {
+      await this.organizationLearnerToDelete.destroyRecord();
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.organization-learner-information.deletion-modal.success-message'),
+      });
+    } catch {
+      const errorMessage = 'Une erreur est survenue !';
+      this.pixToast.sendErrorNotification({ message: errorMessage });
+    } finally {
+      this.displayDeletionLearnerModal = false;
+      this.isLoading = false;
+    }
+  }
+
   <template>
     <section class="page-section">
       <OrganizationLearnerInformation
         @user={{@user}}
         @toggleDisplayDissociateModal={{this.toggleDisplayDissociateModal}}
+        @toggleDisplayDeletionLearnerModal={{this.toggleDisplayDeletionLearnerModal}}
       />
     </section>
+
+    <DeletionModal
+      @title={{t "components.organization-learner-information.deletion-modal.title"}}
+      @onCloseModal={{this.toggleDisplayDeletionLearnerModal}}
+      @showModal={{this.displayDeletionLearnerModal}}
+      @onTriggerAction={{this.delete}}
+    >
+      <:content><p>{{this.deletionWarningMessage}}</p></:content>
+    </DeletionModal>
 
     <ConfirmPopup
       @message="Êtes-vous sûr de vouloir dissocier ce prescrit ?"

--- a/admin/app/components/users/user-detail-personal-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information.gjs
@@ -53,7 +53,7 @@ export default class UserDetailPersonalInformationComponent extends Component {
       await this.args.user.reload();
       this.pixToast.sendSuccessNotification({ message: DISSOCIATE_SUCCESS_NOTIFICATION_MESSAGE });
     } catch {
-      const errorMessage = 'Une erreur est survenue !';
+      const errorMessage = this.intl.t('common.api-error-messages.internal-server-error');
       this.pixToast.sendErrorNotification({ message: errorMessage });
     } finally {
       this.displayDissociateModal = false;
@@ -70,7 +70,7 @@ export default class UserDetailPersonalInformationComponent extends Component {
         message: this.intl.t('components.organization-learner-information.deletion-modal.success-message'),
       });
     } catch {
-      const errorMessage = 'Une erreur est survenue !';
+      const errorMessage = this.intl.t('common.api-error-messages.internal-server-error');
       this.pixToast.sendErrorNotification({ message: errorMessage });
     } finally {
       this.displayDeletionLearnerModal = false;

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -14,19 +14,19 @@ export default class OrganizationLearnerInformation extends Component {
 
   <template>
     <header class="page-section__header">
-      <h2 class="page-section__title">Informations prescrit</h2>
+      <h2 class="page-section__title">{{t "components.organization-learner-information.title"}}</h2>
     </header>
 
     {{#if @user.organizationLearners}}
       <PixTable
         @variant="admin"
-        @caption={{t "components.users.organization-learner-information.table.caption"}}
+        @caption={{t "components.organization-learner-information.table.caption"}}
         @data={{@user.organizationLearners}}
       >
         <:columns as |organizationLearner context|>
           <PixTableColumn @context={{context}} class="break-word">
             <:header>
-              Prénom
+              {{t "components.organization-learner-information.table.columns.firstName"}}
             </:header>
             <:cell>
               {{organizationLearner.firstName}}
@@ -34,7 +34,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}} class="break-word">
             <:header>
-              Nom
+              {{t "components.organization-learner-information.table.columns.lastName"}}
             </:header>
             <:cell>
               {{organizationLearner.lastName}}
@@ -42,7 +42,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
-              DDN
+              {{t "components.organization-learner-information.table.columns.birthdate"}}
             </:header>
             <:cell>
               {{#if organizationLearner.birthdate}}
@@ -52,7 +52,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
-              Classe / Groupe
+              {{t "components.organization-learner-information.table.columns.division-group"}}
             </:header>
             <:cell>
               {{if organizationLearner.division organizationLearner.division}}
@@ -61,7 +61,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}} class="break-word">
             <:header>
-              Organisation
+              {{t "components.organization-learner-information.table.columns.organization"}}
             </:header>
             <:cell>
               <LinkTo @route="authenticated.organizations.get" @model={{organizationLearner.organizationId}}>
@@ -71,7 +71,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
-              Création
+              {{t "components.organization-learner-information.table.columns.createdAt"}}
             </:header>
             <:cell>
               {{formatDate organizationLearner.createdAt}}
@@ -79,7 +79,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}}>
             <:header>
-              Dernière MAJ
+              {{t "components.organization-learner-information.table.columns.updatedAt"}}
             </:header>
             <:cell>
               {{formatDate organizationLearner.updatedAt}}
@@ -87,7 +87,7 @@ export default class OrganizationLearnerInformation extends Component {
           </PixTableColumn>
           <PixTableColumn @context={{context}} class="table-admin-organization-learners-status">
             <:header>
-              Actif
+              {{t "components.organization-learner-information.table.columns.active"}}
             </:header>
             <:cell>
               {{#if organizationLearner.isDisabled}}
@@ -95,7 +95,7 @@ export default class OrganizationLearnerInformation extends Component {
                   @name="cancel"
                   @plainIcon={{true}}
                   @ariaHidden={{false}}
-                  aria-label="Inscription désactivée"
+                  aria-label={{t "components.organization-learner-information.table.active.false"}}
                   class="organization-learners-table__status--isDisabled"
                 />
               {{else}}
@@ -103,7 +103,7 @@ export default class OrganizationLearnerInformation extends Component {
                   @name="checkCircle"
                   @plainIcon={{true}}
                   @ariaHidden={{false}}
-                  aria-label="Inscription activée"
+                  aria-label={{t "components.organization-learner-information.table.active.true"}}
                   class="organization-learners-table__status--isEnabled"
                 />
               {{/if}}
@@ -112,7 +112,7 @@ export default class OrganizationLearnerInformation extends Component {
           {{#if this.accessControl.hasAccessToUsersActionsScope}}
             <PixTableColumn @context={{context}}>
               <:header>
-                Actions
+                {{t "components.organization-learner-information.table.columns.actions"}}
               </:header>
               <:cell>
                 {{#if organizationLearner.canBeDissociated}}
@@ -121,7 +121,7 @@ export default class OrganizationLearnerInformation extends Component {
                     @size="small"
                     @variant="error"
                   >
-                    Dissocier
+                    {{t "components.organization-learner-information.table.actions.dissociate"}}
                   </PixButton>
                 {{/if}}
               </:cell>

--- a/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
+++ b/admin/app/components/users/user-detail-personal-information/organization-learner-information.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { fn } from '@ember/helper';
@@ -123,6 +124,14 @@ export default class OrganizationLearnerInformation extends Component {
                   >
                     {{t "components.organization-learner-information.table.actions.dissociate"}}
                   </PixButton>
+                {{/if}}
+
+                {{#if this.accessControl.hasAccessToDeleteOrganizationLearnerScope}}
+                  <PixIconButton
+                    @triggerAction={{fn @toggleDisplayDeletionLearnerModal organizationLearner}}
+                    @ariaLabel={{t "components.organization-learner-information.table.actions.delete"}}
+                    @iconName="delete"
+                  />
                 {{/if}}
               </:cell>
             </PixTableColumn>

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -10,7 +10,7 @@ export default class AccessControlService extends Service {
   }
 
   get hasAccessToDeleteOrganizationLearnerScope() {
-    return this.currentUser.adminMember.isSupport || false;
+    return Boolean(this.currentUser.adminMember.isSupport || this.currentUser.adminMember.isSuperAdmin);
   }
 
   get hasAccessToTargetProfilesActionsScope() {

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -9,6 +9,10 @@ export default class AccessControlService extends Service {
     return !!(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isSupport);
   }
 
+  get hasAccessToDeleteOrganizationLearnerScope() {
+    return this.currentUser.adminMember.isSupport || false;
+  }
+
   get hasAccessToTargetProfilesActionsScope() {
     return !!(
       this.currentUser.adminMember.isSuperAdmin ||

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -105,7 +105,6 @@
 
 /* App/Components */
 @use 'ui/deletion-modal' as *;
-
 @use 'certifications/certification/details-v3' as *;
 @use 'certification-centers/certification-center-form' as *;
 @use 'certification-centers/information' as *;

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -104,6 +104,8 @@
 @use 'display/footer-modal' as *;
 
 /* App/Components */
+@use 'ui/deletion-modal' as *;
+
 @use 'certifications/certification/details-v3' as *;
 @use 'certification-centers/certification-center-form' as *;
 @use 'certification-centers/information' as *;

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -223,33 +223,6 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     });
   });
 
-  module('when administrator click on dissociate button', function () {
-    test('not displays registration any more', async function (assert) {
-      // given
-      const user = await _buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
-      const organizationName = 'Organisation_to_dissociate_of';
-      const organizationLearnerToDissociate = this.server.create('organization-learner', {
-        id: 10,
-        organizationName,
-        canBeDissociated: true,
-      });
-      user.organizationLearners.models.push(organizationLearnerToDissociate);
-      user.save();
-
-      const screen = await visit(`/users/${user.id}`);
-      await click(screen.getByRole('button', { name: 'Dissocier' }));
-
-      await screen.findByRole('dialog');
-
-      // when
-      await clickByName('Oui, je dissocie');
-
-      // then
-      assert.deepEqual(currentURL(), `/users/${user.id}`);
-      assert.dom(screen.queryByText('Organisation_to_dissociate_of')).doesNotExist();
-    });
-  });
-
   module('when administrator click on remove authentication method button', function () {
     test('not displays remove link and display unchecked icon', async function (assert) {
       // given

--- a/admin/tests/integration/components/ui/deletion-modal-test.gjs
+++ b/admin/tests/integration/components/ui/deletion-modal-test.gjs
@@ -1,0 +1,109 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import UiDeletionModal from 'pix-admin/components/ui/deletion-modal';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Ui::DeletionModal', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('Nominal case', function () {
+    test('it should display title, content and action buttons', async function (assert) {
+      //given
+      const noop = () => {};
+      const title = 'Coucou';
+      const content = 'Juste du texte';
+
+      // when
+      const screen = await render(
+        <template>
+          <UiDeletionModal
+            @title={{title}}
+            @showModal={{true}}
+            @count={{0}}
+            @onTriggerAction={{noop}}
+            @onCloseModal={{noop}}
+          ><:content>
+              {{content}}</:content></UiDeletionModal>
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText(content));
+      assert.ok(screen.getByText(title));
+      assert.ok(screen.getByRole('checkbox', { name: t('common.actions.are-you-sure') }));
+      assert.ok(screen.getByRole('button', { name: t('common.actions.cancel') }));
+      assert.ok(screen.getByRole('button', { name: t('common.actions.confirm-deletion') }));
+    });
+
+    test('it should call onTriggerAction after confirmation when click on confirm', async function (assert) {
+      //given
+      const triggerActionStub = sinon.stub();
+      const onCloseModalStub = sinon.stub();
+      const title = 'Coucou';
+      const content = 'Juste du texte';
+
+      // when
+      const screen = await render(
+        <template>
+          <UiDeletionModal
+            @title={{title}}
+            @showModal={{true}}
+            @onTriggerAction={{triggerActionStub}}
+            @onCloseModal={{onCloseModalStub}}
+          ><:content>
+              {{content}}</:content></UiDeletionModal>
+        </template>,
+      );
+
+      const confirmationCheckbox = screen.getByRole('checkbox', {
+        name: t('common.actions.are-you-sure'),
+      });
+
+      await click(confirmationCheckbox);
+
+      const confirmButton = screen.getByRole('button', {
+        name: t('common.actions.confirm-deletion'),
+      });
+
+      await click(confirmButton);
+
+      // then
+      assert.ok(triggerActionStub.called);
+    });
+
+    test('it should call onCloseModal when click on cancel button', async function (assert) {
+      //given
+      const triggerActionStub = sinon.stub();
+      const onCloseModalStub = sinon.stub();
+      const title = 'Coucou';
+      const content = 'Juste du texte';
+
+      // when
+      const screen = await render(
+        <template>
+          <UiDeletionModal
+            @title={{title}}
+            @showModal={{true}}
+            @count={{1}}
+            @onTriggerAction={{triggerActionStub}}
+            @onCloseModal={{onCloseModalStub}}
+          ><:content>
+              {{content}}</:content></UiDeletionModal>
+        </template>,
+      );
+
+      const cancelButton = screen.getByRole('button', {
+        name: t('common.actions.cancel'),
+      });
+
+      await click(cancelButton);
+
+      // then
+      assert.ok(onCloseModalStub.called);
+    });
+  });
+});

--- a/admin/tests/integration/components/users/user-detail-personal-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information-test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import UserDetailPersonalInformation from 'pix-admin/components/users/user-detail-personal-information';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -13,6 +14,7 @@ module('Integration | Component | users | user-detail-personal-information', fun
 
   class AccessControlStub extends Service {
     hasAccessToUsersActionsScope = true;
+    hasAccessToDeleteOrganizationLearnerScope = true;
   }
 
   module('when the admin member click on dissociate button', function () {
@@ -65,7 +67,9 @@ module('Integration | Component | users | user-detail-personal-information', fun
         organizationLearners: [organizationLearner],
         authenticationMethods: [{ identityProvider: 'PIX' }],
       });
-
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('organization-learner');
+      const dissociateAdapterStub = sinon.stub(adapter, 'dissociate');
       this.owner.register('service:access-control', AccessControlStub);
 
       const screen = await render(<template><UserDetailPersonalInformation @user={{user}} /></template>);
@@ -79,10 +83,82 @@ module('Integration | Component | users | user-detail-personal-information', fun
       // then
       // TODO Add Aria-hidden to PixUI before fix this test
       //assert.dom(screen.queryByRole('heading', { name: 'Confirmer la dissociation' })).doesNotExist();
-      assert.ok(destroyRecordStub.notCalled);
+      assert.ok(dissociateAdapterStub.notCalled);
     });
 
-    test('should call destroyRecord on click on confirm button', async function (assert) {
+    test('should call dissociate action on click on confirm button', async function (assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const organizationLearner = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        canBeDissociated: true,
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        organizationLearners: [organizationLearner],
+        authenticationMethods: [{ identityProvider: 'PIX' }],
+      });
+
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('organization-learner');
+      const dissociateAdapterStub = sinon.stub(adapter, 'dissociate');
+
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const screen = await render(<template><UserDetailPersonalInformation @user={{user}} /></template>);
+      await click(screen.getByRole('button', { name: 'Dissocier' }));
+
+      await screen.findByRole('dialog');
+
+      // when
+      await click(screen.getByRole('button', { name: 'Oui, je dissocie' }));
+
+      // then
+      assert.ok(dissociateAdapterStub.called);
+    });
+  });
+
+  module('when the admin member click on delete button', function () {
+    test('should display deletion confirm modal', async function (assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const organizationLearner = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        canBeDissociated: true,
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        organizationLearners: [organizationLearner],
+        authenticationMethods: [{ identityProvider: 'PIX' }],
+      });
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const screen = await render(<template><UserDetailPersonalInformation @user={{user}} /></template>);
+
+      // when
+      await click(
+        screen.getByRole('button', { name: t('components.organization-learner-information.table.actions.delete') }),
+      );
+
+      await screen.findByRole('dialog');
+
+      // then
+      assert.dom(screen.getByText(t('components.organization-learner-information.deletion-modal.title'))).exists();
+    });
+
+    test('should close the modal on click on cancel button', async function (assert) {
       // given
       const destroyRecordStub = sinon.stub();
       const organizationLearner = EmberObject.create({
@@ -104,12 +180,52 @@ module('Integration | Component | users | user-detail-personal-information', fun
       this.owner.register('service:access-control', AccessControlStub);
 
       const screen = await render(<template><UserDetailPersonalInformation @user={{user}} /></template>);
-      await click(screen.getByRole('button', { name: 'Dissocier' }));
+      await click(
+        screen.getByRole('button', { name: t('components.organization-learner-information.table.actions.delete') }),
+      );
 
       await screen.findByRole('dialog');
 
       // when
-      await click(screen.getByRole('button', { name: 'Oui, je dissocie' }));
+      await click(screen.getByRole('button', { name: t('common.actions.cancel') }));
+
+      // then
+      // TODO Add Aria-hidden to PixUI before fix this test
+      //assert.dom(screen.queryByRole('heading', { name: 'Confirmer la dissociation' })).doesNotExist();
+      assert.ok(destroyRecordStub.notCalled);
+    });
+
+    test('should call delete action on click on confirm button', async function (assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const organizationLearner = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        canBeDissociated: true,
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        organizationLearners: [organizationLearner],
+        authenticationMethods: [{ identityProvider: 'PIX' }],
+      });
+
+      this.owner.register('service:access-control', AccessControlStub);
+
+      const screen = await render(<template><UserDetailPersonalInformation @user={{user}} /></template>);
+      await click(
+        screen.getByRole('button', { name: t('components.organization-learner-information.table.actions.delete') }),
+      );
+
+      await screen.findByRole('dialog');
+
+      // when
+      await click(screen.getByRole('checkbox', { name: t('common.actions.are-you-sure') }));
+      await click(screen.getByRole('button', { name: t('common.actions.confirm-deletion') }));
 
       // then
       assert.ok(destroyRecordStub.called);

--- a/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
@@ -320,7 +320,9 @@ module(
         );
 
         // then
-        assert.dom(screen.queryByText(t('components.organization-learner-information.table.actions.dissociate')).doesNotExist();
+        assert
+          .dom(screen.queryByText(t('components.organization-learner-information.table.actions.dissociate')))
+          .doesNotExist();
       });
     });
 

--- a/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
+++ b/admin/tests/integration/components/users/user-detail-personal-information/organization-learner-information-test.gjs
@@ -272,8 +272,7 @@ module(
         );
 
         // then
-        sinon.assert.called(toggleDisplayDeletionLearnerModal);
-        assert.ok(true);
+        assert.ok(toggleDisplayDeletionLearnerModal.calledOnce);
       });
 
       test('should be able to dissociate user if it is enabled', async function (assert) {

--- a/admin/tests/unit/adapters/organization-learner-test.js
+++ b/admin/tests/unit/adapters/organization-learner-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapter | organization-learner', function (hooks) {
   setupTest(hooks);
@@ -9,19 +10,38 @@ module('Unit | Adapter | organization-learner', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:organization-learner');
+    adapter.ajax = sinon.stub();
   });
 
-  module('#urlForDeleteRecord', function () {
+  module('#dissociate', function () {
     test('it performs the request to dissociate user from organization learner', async function (assert) {
       // given
       const organizationLearner = { id: 12345 };
       const expectedUrl = `${ENV.APP.API_HOST}/api/admin/organization-learners/${organizationLearner.id}/association`;
 
       // when
-      const url = adapter.urlForDeleteRecord(organizationLearner.id);
+      adapter.dissociate(organizationLearner.id);
 
       // then
-      assert.strictEqual(url, expectedUrl);
+      assert.ok(adapter.ajax.calledWith(expectedUrl, 'DELETE'));
+    });
+  });
+
+  module('#urlForDeleteRecord', function () {
+    test('should build url to delete record', async function (assert) {
+      // given
+      const attrStub = (name) => {
+        if (name === 'organizationId') return 777;
+      };
+      const snapshot = {
+        attr: attrStub,
+      };
+
+      // when
+      const url = await adapter.urlForDeleteRecord(123, 'organization-learner', snapshot);
+
+      // then
+      assert.true(url.endsWith('/organizations/777/organization-learners/123'), url);
     });
   });
 });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -67,7 +67,7 @@ module('Unit | Service | access-control', function (hooks) {
 
   module('#hasAccessToDeleteOrganizationLearnerScope', function () {
     [
-      { role: 'isSuperAdmin', hasAccess: false },
+      { role: 'isSuperAdmin', hasAccess: true },
       { role: 'isSupport', hasAccess: true },
       { role: 'isMetier', hasAccess: false },
       { role: 'isCertif', hasAccess: false },

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -65,6 +65,26 @@ module('Unit | Service | access-control', function (hooks) {
     });
   });
 
+  module('#hasAccessToDeleteOrganizationLearnerScope', function () {
+    [
+      { role: 'isSuperAdmin', hasAccess: false },
+      { role: 'isSupport', hasAccess: true },
+      { role: 'isMetier', hasAccess: false },
+      { role: 'isCertif', hasAccess: false },
+    ].forEach(function ({ role, hasAccess }) {
+      test(`should be ${hasAccess} if current admin member is ${role}`, async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { [role]: true };
+
+        const service = this.owner.lookup('service:access-control');
+
+        // when / then
+        assert.deepEqual(service.hasAccessToDeleteOrganizationLearnerScope, hasAccess);
+      });
+    });
+  });
+
   module('#hasAccessToTargetProfilesActionsScope', function () {
     [
       { role: 'isSuperAdmin', hasAccess: true },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -103,6 +103,31 @@
     }
   },
   "components": {
+    "organisation-learner-information": {
+      "table": {
+        "actions": {
+          "delete": "Delete",
+          "dissociate": "Dissociate"
+        },
+        "active": {
+          "false": "Registration deactivated",
+          "true": "Registration activated"
+        },
+        "caption": "List of information about a prescribed person and the different organisations to which they belong. In the case of an organisation with import, it is possible to dissociate the user via the action column.",
+        "columns": {
+          "actions": "Actions",
+          "active": "Active",
+          "birthdate": "Date of birth",
+          "createdAt": "Created on",
+          "division-group": "Class/Group",
+          "firstName": "First name",
+          "lastName": "Surname",
+          "organisation": "Organisation",
+          "updatedAt": "Updated on"
+        }
+      },
+      "title": "Prescribed information"
+    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Trying to enable already existing features on organizations would produce an error.",
@@ -294,7 +319,7 @@
           "label": "Quel profil cible voulez-vous associer à ce parcours autonome ?",
           "placeholder": "Choisir un profil cible",
           "search-label": "Recherchez un profil cible",
-          "sub-label": "Le profil cible doit être en accès simplifié et relié à l’organisation \"Organisation pour les parcours autonomes\""
+          "sub-label": "Le profil cible doit être en accès simplifié et relié à l'organisation \"Organisation pour les parcours autonomes\""
         },
         "technical-informations": {
           "label": "Nom interne",
@@ -730,9 +755,23 @@
           "caption": "Liste des utilisateurs. Contient le prénom, le nom, l'adresse e-mail et l'identifiant."
         }
       },
-      "organization-learner-information": {
+      "organisation-learner-information": {
+        "title": "Prescribed information",
         "table": {
-          "caption": "Liste des informations d'un prescrit. Contient le prénom, le nom, la date de naissance, sa classe ou groupe, le nom de l'organisation auquel prescrit est rattaché, la date de création, la dernière date de mise à jour de ses informations, son état (actif ou inactif). Une action permet le dissocier le prescrit de l'organisation auquel il est rattaché.."
+          "caption": "List of information about a prescribed person and the different organisations to which they belong. In the case of an organisation with import, it is possible to dissociate the user via the action column.",
+          "columns": {
+            "firstName": "First name",
+            "lastName": "Surname",
+            "birthdate": "Date of birth",
+            "organisation": "Organisation",
+            "division-group": "Class/Group",
+            "createdAt": "Created on",
+            "updatedAt": "Updated on",
+            "active": "Active",
+            "actions": "Actions"
+          },
+          "actions": { "dissociate": "Dissociate" },
+          "active": { "true": "Registration activated", "false": "Registration deactivated" }
         }
       },
       "organizations": {
@@ -795,7 +834,7 @@
             "maximumAssessmentLength": "Nombre de questions",
             "variationPercent": "Capage de la capacité (en % )"
           },
-          "title": "Configuration de l’algorithme de déroulé du test"
+          "title": "Configuration de l'algorithme de déroulé du test"
         },
         "competence-scoring-configuration": {
           "form": {
@@ -954,7 +993,7 @@
             },
             "completion-date-tooltip": {
               "ended-by-supervisor": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
-              "ended-due-to-finalization": "Date et heure d’affichage de la dernière question proposée au candidat."
+              "ended-due-to-finalization": "Date et heure d'affichage de la dernière question proposée au candidat."
             },
             "general-informations": {
               "labels": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -777,7 +777,7 @@
             "active": "Active",
             "actions": "Actions"
           },
-          "actions": { "dissociate": "Dissociate" },
+          "actions": { "dissociate": "Dissociate", "delete": "Delete" },
           "active": { "true": "Registration activated", "false": "Registration deactivated" }
         }
       },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -542,8 +542,8 @@
     "organization-learner-information": {
       "deletion-modal": {
         "success-message": "The user has been successfully removed from the organisation.",
-        "warning-message": "You are about to remove {firstName} {lastName} from the organisation {organisationName}. This action cannot be undone.",
-        "title": "Confirm learner deletion"
+        "title": "Confirm learner deletion",
+        "warning-message": "You are about to remove {firstName} {lastName} from the organisation {organisationName}. This action cannot be undone."
       },
       "table": {
         "actions": {
@@ -760,25 +760,6 @@
       "list-items": {
         "table": {
           "caption": "Liste des utilisateurs. Contient le prénom, le nom, l'adresse e-mail et l'identifiant."
-        }
-      },
-      "organisation-learner-information": {
-        "title": "Prescribed information",
-        "table": {
-          "caption": "List of information about a prescribed person and the different organisations to which they belong. In the case of an organisation with import, it is possible to dissociate the user via the action column.",
-          "columns": {
-            "firstName": "First name",
-            "lastName": "Surname",
-            "birthdate": "Date of birth",
-            "organisation": "Organisation",
-            "division-group": "Class/Group",
-            "createdAt": "Created on",
-            "updatedAt": "Updated on",
-            "active": "Active",
-            "actions": "Actions"
-          },
-          "actions": { "dissociate": "Dissociate", "delete": "Delete" },
-          "active": { "true": "Registration activated", "false": "Registration deactivated" }
         }
       },
       "organizations": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -3,9 +3,11 @@
     "actions": {
       "add": "Add",
       "archive": "Archive",
+      "are-you-sure": "By ticking this box, you confirm that you have the right to perform this action.",
       "cancel": "Cancel",
       "close": "Close",
       "confirm": "Confirm",
+      "confirm-deletion": "Yes, delete",
       "confirm-title": "Please confirm",
       "deactivate": "Deactivate",
       "download-template": "Download template",
@@ -103,31 +105,6 @@
     }
   },
   "components": {
-    "organisation-learner-information": {
-      "table": {
-        "actions": {
-          "delete": "Delete",
-          "dissociate": "Dissociate"
-        },
-        "active": {
-          "false": "Registration deactivated",
-          "true": "Registration activated"
-        },
-        "caption": "List of information about a prescribed person and the different organisations to which they belong. In the case of an organisation with import, it is possible to dissociate the user via the action column.",
-        "columns": {
-          "actions": "Actions",
-          "active": "Active",
-          "birthdate": "Date of birth",
-          "createdAt": "Created on",
-          "division-group": "Class/Group",
-          "firstName": "First name",
-          "lastName": "Surname",
-          "organisation": "Organisation",
-          "updatedAt": "Updated on"
-        }
-      },
-      "title": "Prescribed information"
-    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Trying to enable already existing features on organizations would produce an error.",
@@ -561,6 +538,36 @@
       "table": {
         "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
+    },
+    "organization-learner-information": {
+      "deletion-modal": {
+        "success-message": "The user has been successfully removed from the organisation.",
+        "warning-message": "You are about to remove {firstName} {lastName} from the organisation {organisationName}. This action cannot be undone.",
+        "title": "Confirm learner deletion"
+      },
+      "table": {
+        "actions": {
+          "delete": "Delete",
+          "dissociate": "Dissociate"
+        },
+        "active": {
+          "false": "Registration deactivated",
+          "true": "Registration activated"
+        },
+        "caption": "List of information about a prescribed person and the different organisations to which they belong. In the case of an organisation with import, it is possible to dissociate the user via the action column.",
+        "columns": {
+          "actions": "Actions",
+          "active": "Active",
+          "birthdate": "Date of birth",
+          "createdAt": "Created on",
+          "division-group": "Class/Group",
+          "firstName": "First name",
+          "lastName": "Surname",
+          "organization": "Organisation",
+          "updatedAt": "Updated on"
+        }
+      },
+      "title": "Prescribed information"
     },
     "organizations": {
       "all-tags": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -103,6 +103,30 @@
     }
   },
   "components": {
+    "organization-learner-information": {
+      "title": "Informations prescrit",
+      "table": {
+        "caption": "Liste des informations d'un prescrit sur les différentes organisations auxquels il appartient. Dans le cas d'une organisation avec import, il est possible de dissocier l'utilisateur via la colonne action.",
+        "columns": {
+          "firstName": "Prénom",
+          "lastName": "Nom",
+          "birthdate": "Date de naissance",
+          "organization": "Organisation",
+          "division-group": "Classe/Groupe",
+          "createdAt": "Créé le",
+          "updatedAt": "Mise à jour le",
+          "active": "Actif",
+          "actions": "Actions"
+        },
+        "actions": {
+          "dissociate": "Dissocier"
+        },
+        "active": {
+          "true": "Inscription activée",
+          "false": "Inscription désactivée"
+        }
+      }
+    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Chercher à activer à nouveau des fonctionnalités déjà existantes sur une organisation renverrait une erreur.",
@@ -729,11 +753,6 @@
       "list-items": {
         "table": {
           "caption": "Liste des utilisateurs. Contient le prénom, le nom, l'adresse e-mail et l'identifiant."
-        }
-      },
-      "organization-learner-information": {
-        "table": {
-          "caption": "Liste des informations d'un prescrit. Contient le prénom, le nom, la date de naissance, sa classe ou groupe, le nom de l'organisation auquel prescrit est rattaché, la date de création, la dernière date de mise à jour de ses informations, son état (actif ou inactif). Une action permet le dissocier le prescrit de l'organisation auquel il est rattaché.."
         }
       },
       "organizations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -3,9 +3,11 @@
     "actions": {
       "add": "Ajouter",
       "archive": "Archiver",
+      "are-you-sure": "En cochant cette case vous affirmer avoir les droits d'effectuer cette action.",
       "cancel": "Annuler",
       "close": "Fermer",
       "confirm": "Confirmer",
+      "confirm-deletion": "Oui, je supprime",
       "confirm-title": "Merci de confirmer",
       "deactivate": "Désactiver",
       "download-template": "Télécharger le template",
@@ -103,30 +105,6 @@
     }
   },
   "components": {
-    "organization-learner-information": {
-      "title": "Informations prescrit",
-      "table": {
-        "caption": "Liste des informations d'un prescrit sur les différentes organisations auxquels il appartient. Dans le cas d'une organisation avec import, il est possible de dissocier l'utilisateur via la colonne action.",
-        "columns": {
-          "firstName": "Prénom",
-          "lastName": "Nom",
-          "birthdate": "Date de naissance",
-          "organization": "Organisation",
-          "division-group": "Classe/Groupe",
-          "createdAt": "Créé le",
-          "updatedAt": "Mise à jour le",
-          "active": "Actif",
-          "actions": "Actions"
-        },
-        "actions": {
-          "dissociate": "Dissocier"
-        },
-        "active": {
-          "true": "Inscription activée",
-          "false": "Inscription désactivée"
-        }
-      }
-    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Chercher à activer à nouveau des fonctionnalités déjà existantes sur une organisation renverrait une erreur.",
@@ -561,6 +539,36 @@
       "table": {
         "caption": "Liste des membres appartenant au centre de certification. Contient son identifiant, nom et prénom, son adresse e-mail, son rôle, son dernier accès et sa date de rattachement à l'espace de certification. Des actions permettent de modifier son rôle ou de le supprimer du centre."
       }
+    },
+    "organization-learner-information": {
+      "deletion-modal": {
+        "warning-message": "Vous êtes sur le point de supprimer {firstName} {lastName} de l'organisation {organizationName}. Cette action est irréversible.",
+        "success-message": "l'utilisateur a bien été supprimé de l'organisation.",
+        "title": "Confirmer la suppression du prescrit"
+      },
+      "table": {
+        "actions": {
+          "delete": "Supprimer",
+          "dissociate": "Dissocier"
+        },
+        "active": {
+          "false": "Inscription désactivée",
+          "true": "Inscription activée"
+        },
+        "caption": "Liste des informations d'un prescrit sur les différentes organisations auxquels il appartient. Dans le cas d'une organisation avec import, il est possible de dissocier l'utilisateur via la colonne action.",
+        "columns": {
+          "actions": "Actions",
+          "active": "Actif",
+          "birthdate": "Date de naissance",
+          "createdAt": "Créé le",
+          "division-group": "Classe/Groupe",
+          "firstName": "Prénom",
+          "lastName": "Nom",
+          "organization": "Organisation",
+          "updatedAt": "Mise à jour le"
+        }
+      },
+      "title": "Informations prescrit"
     },
     "organizations": {
       "all-tags": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -105,6 +105,31 @@
     }
   },
   "components": {
+    "organization-learner-information": {
+      "title": "Informations prescrit",
+      "table": {
+        "caption": "Liste des informations d'un prescrit sur les différentes organisations auxquels il appartient. Dans le cas d'une organisation avec import, il est possible de dissocier l'utilisateur via la colonne action.",
+        "columns": {
+          "firstName": "Prénom",
+          "lastName": "Nom",
+          "birthdate": "Date de naissance",
+          "organization": "Organisation",
+          "division-group": "Classe/Groupe",
+          "createdAt": "Créé le",
+          "updatedAt": "Mise à jour le",
+          "active": "Actif",
+          "actions": "Actions"
+        },
+        "actions": {
+          "dissociate": "Dissocier",
+          "delete": "Supprimer"
+        },
+        "active": {
+          "true": "Inscription activée",
+          "false": "Inscription désactivée"
+        }
+      }
+    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Chercher à activer à nouveau des fonctionnalités déjà existantes sur une organisation renverrait une erreur.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -105,31 +105,6 @@
     }
   },
   "components": {
-    "organization-learner-information": {
-      "title": "Informations prescrit",
-      "table": {
-        "caption": "Liste des informations d'un prescrit sur les différentes organisations auxquels il appartient. Dans le cas d'une organisation avec import, il est possible de dissocier l'utilisateur via la colonne action.",
-        "columns": {
-          "firstName": "Prénom",
-          "lastName": "Nom",
-          "birthdate": "Date de naissance",
-          "organization": "Organisation",
-          "division-group": "Classe/Groupe",
-          "createdAt": "Créé le",
-          "updatedAt": "Mise à jour le",
-          "active": "Actif",
-          "actions": "Actions"
-        },
-        "actions": {
-          "dissociate": "Dissocier",
-          "delete": "Supprimer"
-        },
-        "active": {
-          "true": "Inscription activée",
-          "false": "Inscription désactivée"
-        }
-      }
-    },
     "administration": {
       "add-organization-features-in-batch": {
         "description": "Note: Chercher à activer à nouveau des fonctionnalités déjà existantes sur une organisation renverrait une erreur.",
@@ -567,9 +542,9 @@
     },
     "organization-learner-information": {
       "deletion-modal": {
-        "warning-message": "Vous êtes sur le point de supprimer {firstName} {lastName} de l'organisation {organizationName}. Cette action est irréversible.",
         "success-message": "l'utilisateur a bien été supprimé de l'organisation.",
-        "title": "Confirmer la suppression du prescrit"
+        "title": "Confirmer la suppression du prescrit",
+        "warning-message": "Vous êtes sur le point de supprimer {firstName} {lastName} de l'organisation {organizationName}. Cette action est irréversible."
       },
       "table": {
         "actions": {

--- a/api/src/authorization/domain/constants.js
+++ b/api/src/authorization/domain/constants.js
@@ -11,6 +11,14 @@ const PIX_ADMIN = {
 const PIX_ORGA = {
   NOT_LINKED_ORGANIZATION_MSG:
     "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
+  ROLES: {
+    ADMIN: 'ORGA_ADMIN',
+  },
 };
 
-export { PIX_ADMIN, PIX_ORGA };
+const CLIENT = {
+  PIX_ADMIN: 'PIX_ADMIN',
+  PIX_ORGA: 'PIX_ORGA',
+};
+
+export { CLIENT, PIX_ADMIN, PIX_ORGA };

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,3 +1,4 @@
+import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
@@ -7,14 +8,12 @@ const deleteOrganizationLearners = async function (request, h) {
   const listLearners = request.payload.listLearners;
   const organizationId = request.params.organizationId;
 
-  await DomainTransaction.execute(async () => {
-    await usecases.deleteOrganizationLearners({
-      organizationLearnerIds: listLearners,
-      userId: authenticatedUserId,
-      organizationId,
-      userRole: 'ORGA_ADMIN',
-      client: 'PIX_ORGA',
-    });
+  await usecases.deleteOrganizationLearners({
+    organizationLearnerIds: listLearners,
+    userId: authenticatedUserId,
+    organizationId,
+    userRole: 'ORGA_ADMIN',
+    client: 'PIX_ORGA',
   });
   return h.response().code(200);
 };

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,5 +1,4 @@
-import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
-import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { CLIENT, PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as scoOrganizationLearnerSerializer from '../infrastructure/serializers/jsonapi/sco-organization-learner-serializer.js';
 
@@ -12,9 +11,25 @@ const deleteOrganizationLearners = async function (request, h) {
     organizationLearnerIds: listLearners,
     userId: authenticatedUserId,
     organizationId,
-    userRole: 'ORGA_ADMIN',
-    client: 'PIX_ORGA',
+    userRole: PIX_ORGA.ROLES.ADMIN,
+    client: CLIENT.PIX_ORGA,
   });
+  return h.response().code(200);
+};
+
+const deleteOrganizationLearnerFromAdmin = async function (request, h) {
+  const authenticatedUserId = request.auth.credentials.userId;
+  const organizationLearnerId = request.params.organizationLearnerId;
+  const organizationId = request.params.organizationId;
+
+  await usecases.deleteOrganizationLearners({
+    organizationLearnerIds: [organizationLearnerId],
+    userId: authenticatedUserId,
+    organizationId,
+    userRole: PIX_ADMIN.ROLES.SUPPORT,
+    client: CLIENT.PIX_ADMIN,
+  });
+
   return h.response().code(200);
 };
 
@@ -78,6 +93,7 @@ const updateOrganizationLearnerName = async function (request, h) {
 const organizationLearnersController = {
   reconcileCommonOrganizationLearner,
   deleteOrganizationLearners,
+  deleteOrganizationLearnerFromAdmin,
   importOrganizationLearnerFromFeature,
   dissociate,
   reconcileScoOrganizationLearnerAutomatically,

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -49,8 +49,11 @@ const register = async (server) => {
             assign: 'organizationLearnerBelongsToOrganization',
           },
           {
-            method: securityPreHandlers.checkAdminMemberHasRoleSupport,
-            assign: 'checkAdminMemberHasRoleSupport',
+            method: securityPreHandlers.hasAtLeastOneAccessOf([
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            ]),
+            assign: 'hasAtLeastOneAccessOf',
           },
         ],
         validate: {

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -40,6 +40,34 @@ const register = async (server) => {
       },
     },
     {
+      method: 'DELETE',
+      path: '/api/admin/organizations/{organizationId}/organization-learners/{organizationLearnerId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkOrganizationLearnerBelongsToOrganization,
+            assign: 'organizationLearnerBelongsToOrganization',
+          },
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSupport,
+            assign: 'checkAdminMemberHasRoleSupport',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+            organizationLearnerId: identifiersType.organizationLearnerId,
+          }),
+        },
+        handler: organizationLearnersController.deleteOrganizationLearnerFromAdmin,
+        notes: [
+          '- **This is a restricted endpoint to ADMIN_SUPPORT member from Administration back office**\n' +
+            '- it allows to delete an organization learner belonging to an organization',
+        ],
+        tags: ['api', 'admin', 'organization-learners'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/organizations/{organizationId}/organization-learners/{organizationLearnerId}',
       config: {

--- a/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-learners-route_test.js
@@ -1,3 +1,4 @@
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { IMPORT_KEY_FIELD } from '../../../../../src/prescription/learner-management/domain/constants.js';
 import { getLastByOrganizationId } from '../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
@@ -40,7 +41,7 @@ describe('Acceptance | Prescription | learner management | Application | organiz
     });
   });
 
-  describe('DELETE /organizations/{id}/organization-learners', function () {
+  describe('DELETE /organizations/{organizationId}/organization-learners', function () {
     let options;
 
     it('should return a 200 status after having successfully deleted organization learners', async function () {
@@ -59,6 +60,30 @@ describe('Acceptance | Prescription | learner management | Application | organiz
         payload: {
           listLearners: [firstOrganizationLearnerId, secondOrganizationLearnerId],
         },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('DELETE /admin/organizations/{organizationId}/organization-learners/{organizationLearnerId}', function () {
+    let options;
+
+    it('should return a 200 status after having successfully deleted organization learners', async function () {
+      // given
+      const { id: organizationLearnerId, organizationId } = databaseBuilder.factory.buildOrganizationLearner();
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPPORT }).id;
+
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'DELETE',
+        url: `/api/admin/organizations/${organizationId}/organization-learners/${organizationLearnerId}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
       };
 
       // when

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-controller_test.js
@@ -1,3 +1,4 @@
+import { CLIENT, PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 import { organizationLearnersController } from '../../../../../src/prescription/learner-management/application/organization-learners-controller.js';
 import { usecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
@@ -57,6 +58,42 @@ describe('Unit | Prescription | Learner Management | Application | organization-
         'reconcileCommonOrganizationLearner',
       ).to.be.true;
       expect(response.statusCode).to.be.equal(204);
+    });
+  });
+
+  describe('#deleteOrganizationLearnerFromAdmin', function () {
+    let deleteOrganizationLearnersStub;
+
+    beforeEach(function () {
+      deleteOrganizationLearnersStub = sinon.stub(usecases, 'deleteOrganizationLearners');
+    });
+
+    it('called usecases with correct parameters', async function () {
+      const userId = Symbol('userId');
+      const organizationLearnerId = Symbol('organizationLearnerId');
+      const organizationId = Symbol('organizationId');
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: {
+          organizationLearnerId,
+          organizationId,
+        },
+      };
+
+      const response = await organizationLearnersController.deleteOrganizationLearnerFromAdmin(request, hFake);
+
+      expect(
+        deleteOrganizationLearnersStub.calledWithExactly({
+          userId,
+          organizationLearnerIds: [organizationLearnerId],
+          organizationId,
+          userRole: PIX_ADMIN.ROLES.SUPPORT,
+          client: CLIENT.PIX_ADMIN,
+        }),
+        'deleteOrganizationLearners',
+      ).to.be.true;
+      expect(response.statusCode).to.be.equal(200);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
@@ -14,8 +14,18 @@ describe('Unit | Prescription | learner management | Application | Router | orga
         .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
         .callsFake((request, h) => h.response().code(200));
       sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response().code(200));
+      sinon
         .stub(organizationLearnersController, 'deleteOrganizationLearnerFromAdmin')
         .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        ])
+        .returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -24,7 +34,7 @@ describe('Unit | Prescription | learner management | Application | Router | orga
 
       // then
       sinon.assert.calledOnce(securityPreHandlers.checkOrganizationLearnerBelongsToOrganization);
-      sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+      sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
       sinon.assert.calledOnce(organizationLearnersController.deleteOrganizationLearnerFromAdmin);
     });
   });

--- a/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-learners-route_test.js
@@ -4,6 +4,31 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { expect, generateAuthenticatedUserRequestHeaders, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Prescription | learner management | Application | Router | organization-learner-router', function () {
+  describe('DELETE /api/admin/organizations/{organizationId}/organization-learners/{organizationLearnerId}', function () {
+    it('should call right handler before calling controller', async function () {
+      // given
+      sinon
+        .stub(securityPreHandlers, 'checkOrganizationLearnerBelongsToOrganization')
+        .callsFake((request, h) => h.response().code(200));
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+        .callsFake((request, h) => h.response().code(200));
+      sinon
+        .stub(organizationLearnersController, 'deleteOrganizationLearnerFromAdmin')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('DELETE', '/api/admin/organizations/1/organization-learners/2');
+
+      // then
+      sinon.assert.calledOnce(securityPreHandlers.checkOrganizationLearnerBelongsToOrganization);
+      sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+      sinon.assert.calledOnce(organizationLearnersController.deleteOrganizationLearnerFromAdmin);
+    });
+  });
+
   describe('DELETE /api/admin/organization-learners/{id}/association', function () {
     it('should return a HTTP status code 204 when user role is "SUPER_ADMIN"', async function () {
       // given


### PR DESCRIPTION
## 🍂 Problème

Pour supprimer un utilisateur, même après voir reçu l'accord du DPO de l'organization c'est toujours un script à jouer.

## 🌰 Proposition

Permettre au fonction support de supprimer le learner associé à l'utilisateur si l'accord leur a été remonté

## 🍁 Remarques

Une modal plus une checkbox a été ajouté afin de validé la validation de la suppression définitive de l'apprenant

## 🪵 Pour tester

Aller sur PixAdmin : 

Se connecter avec `supportadmin@example.net`
Se rendre sur Sarah Croche
Voir la liste des prescrit associé
cliquer sur la poubelle. 
Ne plus voir la ligne. 

Vérifier enBDD que sarah croche n'est plus associé a cette organization