### PR TITLE
[FEATURE] Ajouter une nouvelle colonne passage_count à la table organizations_cover_rates (PIX-20110)

### DIFF
--- a/api/datamart/migrations/20251112104348_add-column-passage_count-to-organizations_cover_rates.js
+++ b/api/datamart/migrations/20251112104348_add-column-passage_count-to-organizations_cover_rates.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'organizations_cover_rates';
+const COLUMN_NAME = 'passage_count';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigint(COLUMN_NAME).defaultTo(null).comment('Number of passages of the tube.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

La colonne nb_user va être renommé dans la table data_pro_campaigns_kpi_aggregated de pix-datawarehouse.
Cette colonne étant répliquée avec le même nom dans la table organizations_cover_rates, le même renommage doit y être réalisé.

## 🌰 Proposition

Ajouter une nouvelle colonne passage_count avant la suppression de la colonne nb_user dans une prochaine PR.


## 🪵 Pour tester

La colonne passage_count est ajoutée et nullable dans la table organizations_cover_rates.
