### PR TITLE
[FEATURE] Ajouter un job lorsqu'un module est terminé (pix-19076)

### DIFF
--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -2,6 +2,7 @@ import * as userRepository from '../../../identity-access-management/infrastruct
 import * as llmApi from '../../../llm/application/api/llm-api.js';
 import * as campaignRepository from '../../../prescription/campaign/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { saveOrganizationLearnerPassageForUserJobRepository } from '../../../prescription/organization-learner/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository.js';
 import * as targetProfileRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileSummaryForAdminRepository from '../../../prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js';
 import * as knowledgeElementRepository from '../../../shared/infrastructure/repositories/knowledge-element-repository.js';
@@ -24,6 +25,7 @@ const dependencies = {
   tubeRepository,
   targetProfileTrainingRepository,
   targetProfileTrainingOrganizationRepository,
+  saveOrganizationLearnerPassageForUserJobRepository,
   skillRepository,
   userRepository,
   llmApi,

--- a/api/src/prescription/organization-learner/application/jobs/save-organization-learner-passage-for-user-job-controller.js
+++ b/api/src/prescription/organization-learner/application/jobs/save-organization-learner-passage-for-user-job-controller.js
@@ -1,0 +1,16 @@
+import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import { SaveOrganizationLearnerPassageForUserJob } from '../../domain/models/SaveOrganizationLearnerPassageForUserJob.js';
+
+class SaveOrganizationLearnerPassageJobController extends JobController {
+  constructor() {
+    super(SaveOrganizationLearnerPassageForUserJob.name);
+  }
+  async handle({ data }) {
+    const { userId, moduleId } = data;
+
+    // eslint-disable-next-line no-console
+    console.log(`Saving passage for user ${userId} and module ${moduleId}`);
+  }
+}
+
+export { SaveOrganizationLearnerPassageJobController };

--- a/api/src/prescription/organization-learner/domain/models/SaveOrganizationLearnerPassageForUserJob.js
+++ b/api/src/prescription/organization-learner/domain/models/SaveOrganizationLearnerPassageForUserJob.js
@@ -1,0 +1,6 @@
+export class SaveOrganizationLearnerPassageForUserJob {
+  constructor({ userId, moduleId }) {
+    this.userId = userId;
+    this.moduleId = moduleId;
+  }
+}

--- a/api/src/prescription/organization-learner/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository.js
@@ -1,0 +1,13 @@
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { SaveOrganizationLearnerPassageForUserJob } from '../../../domain/models/SaveOrganizationLearnerPassageForUserJob.js';
+
+class SaveOrganizationLearnerPassageForUserJobRepository extends JobRepository {
+  constructor() {
+    super({
+      name: SaveOrganizationLearnerPassageForUserJob.name,
+    });
+  }
+}
+
+export const saveOrganizationLearnerPassageForUserJobRepository =
+  new SaveOrganizationLearnerPassageForUserJobRepository();

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository_test.js
@@ -1,0 +1,24 @@
+import { SaveOrganizationLearnerPassageForUserJob } from '../../../../../../../src/prescription/organization-learner/domain/models/SaveOrganizationLearnerPassageForUserJob.js';
+import { saveOrganizationLearnerPassageForUserJobRepository } from '../../../../../../../src/prescription/organization-learner/infrastructure/repositories/jobs/save-organization-learner-passage-for-user-job-repository.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Integration | Prescription | Application | Jobs | saveOrganizationLearnerPassageForUserJobRepository', function () {
+  describe('#performAsync', function () {
+    it('publish a job', async function () {
+      // given
+      const userId = 4123132;
+      const moduleId = 'module-1';
+
+      // when
+      await saveOrganizationLearnerPassageForUserJobRepository.performAsync({ userId, moduleId });
+
+      // then
+      await expect(SaveOrganizationLearnerPassageForUserJob.name).to.have.been.performed.withJob({
+        retrylimit: 0,
+        retrydelay: 0,
+        retrybackoff: false,
+        data: { userId, moduleId },
+      });
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/jobs/save-organization-learner-passage-for-user-job-controller_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/jobs/save-organization-learner-passage-for-user-job-controller_test.js
@@ -1,0 +1,24 @@
+import { SaveOrganizationLearnerPassageJobController } from '../../../../../../src/prescription/organization-learner/application/jobs/save-organization-learner-passage-for-user-job-controller.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Prescription | Application | Jobs | SaveOrganizationLearnerPassageForUserJobController', function () {
+  describe('#handle', function () {
+    it('should log a message', async function () {
+      sinon.stub(console, 'log');
+      // given
+      const handler = new SaveOrganizationLearnerPassageJobController();
+      const userId = 123;
+      const moduleId = 'abc';
+      const data = { userId, moduleId };
+
+      // when
+      await handler.handle({ data });
+
+      // then
+      // eslint-disable-next-line no-console
+      expect(console.log).to.have.been.calledOnce;
+      // eslint-disable-next-line no-console
+      expect(console.log).to.have.been.calledWithExactly(`Saving passage for user ${userId} and module ${moduleId}`);
+    });
+  });
+});


### PR DESCRIPTION

## 🍂 Problème

Actuellement on n'enregistre pas les passage de module dans la table organization-learner-participations ce qui fait qu'un utilisateur peut passer un module et celui-ci ne sera pas marqué comme fait dans le parcours combiné

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌰 Proposition

Lancer un job asynchrone lorsqu'on termine un module. Pour l'instant le job ne fait rien (on va rajouter un usecase qui peuple la table organization-learner-participations dans un autre ticket)
## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Passer un module
Se connecter à pg et lister les derniers job 
Voir le job SaveOrganizationLearnerParticipationForUser 
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
