### PR TITLE
[FEATURE] Repliquer la nouvelle colonne passage_count de la table organizations_cover_rates (PIX-20110)

### DIFF
--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -70,6 +70,7 @@ export const replications = [
         'max_level',
         'sum_user_max_level',
         'nb_user',
+        'passage_count',
         'nb_tubes_in_competence',
       );
     },


### PR DESCRIPTION
## 🍂 Problème

La colonne nb_user a été renommée dans la table data_pro_campaigns_kpi_aggregated de pix-datawarehouse.
Cette colonne doit être répliquée avec le même nom dans la table organizations_cover_rates.

## 🌰 Proposition

Répliquer la nouvelle colonne mais conserver la réplication de l'ancienne pour la rétro-compatibilité du calcul du taux de couverture. 

## 🪵 Pour tester

Lancer la réplication organizations_cover_rates et vérifier que la colonne passage_count contient les mêmes données que la colonne nb_user.

Positionner des données dans la table `data_pro_campaigns_kpi_aggregated` du datawarehouse d'intégration.

Créer un token avec le scope `replication` :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr14138.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer la réplication :

```
curl -X POST "https://pix-api-maddo-review-pr14138.osc-fr1.scalingo.io/api/replications/organizations_cover_rates" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```

Se connecter à la DB de Maddo (le datamart) pour s'assurer que les données ont bien été répliquée et que les valeurs des colonnes `nb_user` et `passage_count` sont identiques (les mêmes que dans `data_pro_campaigns_kpi_aggregated` a minima).

```
scalingo -a "pix-api-maddo-review-pr14138" psql-console
```
