### PR TITLE
[FEATURE] Traiter les retours design sur la barre de navigation des modules (PIX-20375)

### DIFF
--- a/mon-pix/app/components/module/layout/_navigation-button.scss
+++ b/mon-pix/app/components/module/layout/_navigation-button.scss
@@ -118,11 +118,11 @@
 
     &--current {
       color: var(--pix-neutral-0);
-      background-color: rgb(var(--pix-primary-700-inline), 0.6);
+      background: linear-gradient(0deg, rgb(var(--pix-primary-700-inline), 0.6) 0%, rgb(var(--pix-primary-700-inline), 0.6) 100%), var(--pix-neutral-0);
     }
 
     &--enabled {
-      background-color: rgb(var(--pix-primary-700-inline), 0.2);
+      background: linear-gradient(0deg, rgb(var(--pix-primary-700-inline), 0.2) 0%, rgb(var(--pix-primary-700-inline), 0.2) 100%), var(--pix-neutral-0);
     }
 
     &--disabled {

--- a/mon-pix/app/components/module/layout/_navigation-button.scss
+++ b/mon-pix/app/components/module/layout/_navigation-button.scss
@@ -19,7 +19,6 @@
   }
 
   &--enabled {
-
     &.pix-icon-button:not([aria-disabled="true"]){
       &:focus, &:hover{
         color:var(--pix-neutral-800);
@@ -63,6 +62,10 @@
 
   &--enabled {
     color: var(--pix-neutral-900);
+
+    &:hover, &:focus, &:active {
+      color: var(--pix-neutral-0);
+    }
   }
 
   &--current {

--- a/mon-pix/app/components/module/layout/_navigation-button.scss
+++ b/mon-pix/app/components/module/layout/_navigation-button.scss
@@ -81,6 +81,11 @@
     }
   }
 
+  &__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .pix-button__icon {
    width: 1.5rem;
    height: 1.5rem;

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -126,7 +126,7 @@ export default class ModulixNavigationButton extends Component {
         @isDisabled={{this.isDisabled}}
         aria-label={{this.ariaLabelButton}}
         aria-current="{{this.isCurrentSection}}"
-      >{{this.sectionTitle @section.type}}</PixButton>
+      ><span class="module-navigation-mobile-button__text">{{this.mobileSectionTitle @section.type}}</span></PixButton>
     {{else}}
       <div
         class="navigation-tooltip {{if this.isTooltipVisible 'navigation-tooltip--visible' ''}}"

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -26,6 +26,19 @@ export default class ModulixNavigationButton extends Component {
     return SECTION_TITLE_ICONS[type];
   }
 
+  @action
+  tooltipText(type) {
+    const sectionTitle = this.intl.t(`pages.modulix.section.${type}`);
+
+    if (this.args.isCurrentSection || this.args.isPastSection) {
+      return sectionTitle;
+    }
+
+    return this.intl.t('pages.modulix.navigation.tooltip.disabled', {
+      sectionTitle,
+    });
+  }
+
   get buttonClass() {
     if (this.args.isCurrentSection) {
       return '--current';
@@ -133,7 +146,7 @@ export default class ModulixNavigationButton extends Component {
           class="navigation-tooltip__content navigation-tooltip__content{{this.buttonClass}}"
           aria-hidden="true"
         >
-          {{this.sectionTitle @section.type}}
+          {{this.tooltipText @section.type}}
         </span>
       </div>
     {{/if}}

--- a/mon-pix/app/components/module/layout/navigation-button.gjs
+++ b/mon-pix/app/components/module/layout/navigation-button.gjs
@@ -17,6 +17,11 @@ export default class ModulixNavigationButton extends Component {
   @tracked isTooltipVisible = false;
 
   @action
+  mobileSectionTitle(type) {
+    return this.tooltipText(type);
+  }
+
+  @action
   sectionTitle(type) {
     return this.intl.t(`pages.modulix.section.${type}`);
   }

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -427,14 +427,14 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
             @sectionsLength={{sectionsLength}}
             @currentSectionIndex={{currentSectionIndex}}
             @isPastSection={{false}}
-            @isCurrentSection={{false}}
+            @isCurrentSection={{true}}
             @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
           />
         </template>,
       );
 
       // then
-      assert.dom(screen.getByRole('button', { href: '#question-yourself' })).exists();
+      assert.dom(screen.getByRole('button')).hasText(t('pages.modulix.section.question-yourself'));
     });
 
     module('when isCurrentSection and isPastSection arguments are false', function () {
@@ -463,6 +463,36 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('button')).hasAria('disabled', 'true');
+      });
+
+      test('should display a button with a specific text', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{false}}
+              @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const buttonText = t('pages.modulix.navigation.tooltip.disabled', {
+          sectionTitle: t('pages.modulix.section.question-yourself'),
+        });
+        assert.dom(screen.getByRole('button')).hasText(buttonText);
       });
     });
 
@@ -493,9 +523,37 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         // then
         assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
       });
+
+      test('should display a button with section title as text', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{false}}
+              @isCurrentSection={{true}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const buttonText = t('pages.modulix.section.question-yourself');
+        assert.dom(screen.getByRole('button')).hasText(buttonText);
+      });
     });
 
-    module('when isPactSection argument is true', function () {
+    module('when isPastSection argument is true', function () {
       test('should enable the navigation link', async function (assert) {
         // given
         const section = {
@@ -521,6 +579,34 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
+      });
+
+      test('should display a button with section title as text', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{true}}
+              @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const buttonText = t('pages.modulix.section.question-yourself');
+        assert.dom(screen.getByRole('button')).hasText(buttonText);
       });
     });
 

--- a/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation-button_test.gjs
@@ -85,6 +85,36 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         // then
         assert.dom(screen.getByRole('button')).hasAttribute('aria-disabled', 'true');
       });
+
+      test('should display a specific tooltip message', async function (assert) {
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{false}}
+              @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const tooltip = screen.getByRole('tooltip', { hidden: true });
+        const tooltipText = t('pages.modulix.navigation.tooltip.disabled', {
+          sectionTitle: t('pages.modulix.section.question-yourself'),
+        });
+        assert.dom(tooltip).hasText(tooltipText);
+      });
     });
 
     module('when isCurrentSection argument is true', function () {
@@ -114,9 +144,38 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
         // then
         assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
       });
+
+      test('should display section title as tooltip message', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{false}}
+              @isCurrentSection={{true}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const tooltip = screen.getByRole('tooltip', { hidden: true });
+        const tooltipText = t('pages.modulix.section.question-yourself');
+        assert.dom(tooltip).hasText(tooltipText);
+      });
     });
 
-    module('when isPactSection argument is true', function () {
+    module('when isPastSection argument is true', function () {
       test('should enable the navigation button', async function (assert) {
         // given
         const section = {
@@ -142,6 +201,35 @@ module('Integration | Component | Module | NavigationButton', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('button')).hasNoAttribute('aria-disabled');
+      });
+
+      test('should display section title as tooltip message', async function (assert) {
+        // given
+        const section = {
+          type: 'question-yourself',
+        };
+        const sectionsLength = [section].length;
+        const currentSectionIndex = 1;
+        const handleArrowKeyNavigation = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <NavigationButton
+              @section={{section}}
+              @sectionsLength={{sectionsLength}}
+              @currentSectionIndex={{currentSectionIndex}}
+              @isPastSection={{true}}
+              @isCurrentSection={{false}}
+              @handleArrowKeyNavigation={{handleArrowKeyNavigation}}
+            />
+          </template>,
+        );
+
+        // then
+        const tooltip = screen.getByRole('tooltip', { hidden: true });
+        const tooltipText = t('pages.modulix.section.question-yourself');
+        assert.dom(tooltip).hasText(tooltipText);
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1686,6 +1686,9 @@
             "enabled": "Go to step {sectionTitle}",
             "steps": "Step {indexSection} of {totalSections}."
           }
+        },
+        "tooltip": {
+          "disabled": "Next: {sectionTitle}"
         }
       },
       "preview": {

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1662,6 +1662,9 @@
             "disabled": "No disponible. Finalizar el paso anterior.",
             "enabled": "Acceder al paso {sectionTitle}"
           }
+        },
+        "tooltip": {
+          "disabled": "A continuación: {sectionTitle}"
         }
       },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1666,6 +1666,9 @@
             "disabled": "No disponible. Finalizar el paso anterior.",
             "enabled": "Acceder al paso {sectionTitle}"
           }
+        },
+        "tooltip": {
+          "disabled": "A continuación: {sectionTitle}"
         }
       },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1694,6 +1694,9 @@
             "enabled": "Accéder à l'étape {sectionTitle}",
             "steps": "Étape {indexSection} sur {totalSections}."
           }
+        },
+        "tooltip": {
+          "disabled": "A suivre : {sectionTitle}"
         }
       },
       "preview": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1670,6 +1670,9 @@
             "disabled": "Niet beschikbaar. Vorige stap voltooien.",
             "enabled": "Ga naar stap {sectionTitle}"
           }
+        },
+        "tooltip": {
+          "disabled": "Te volgen: {sectionTitle}"
         }
       },
       "beta-banner": "Deze module is in bètaversie. In de loop van de tijd kunnen er wijzigingen worden aangebracht.",


### PR DESCRIPTION
## 🍂 Problème

Des retours nous ont été faits sur la barre de navigation par l'équipe Design.

## 🌰 Proposition

Les traiter. 

La liste des changements : 
- Ajout d'un fond blanc sur les tooltip `en cours` et `précédent`
- Ajout d'une mention `A suivre` sur les tooltip avec l'état `A suivre` et sur les boutons mobile
- En format mobile, cela tronque si le texte de chaque bouton / étape est trop long
- En format mobile, la couleur des texte change en --pix-neutral-0 lorsque le bouton est à l'état focus, hover ou active

## 🍁 Remarques
La correction de la scrollbar sera faite dans une autre PR. Nous nous sommes aperçus qu'il y a aussi le problème en desktop

## 🪵 Pour tester
- Se mettre sur le module [bac-a-sable](https://app-pr14140.review.pix.fr/modules/bac-a-sable/passage) et commencer le module
- Vérifier que les sections non commencées contiennent bien la mention  => A suivre : titre de la section que ce soit côté desktop / mobile.
- Vérifier que le fond des tooltips s'affiche bien dans tous les cas 😄 
