### PR TITLE
[FEATURE] Page de détails d'une participation à un parcours (PIX-20270)

### DIFF
--- a/api/src/quest/application/combined-course-controller.js
+++ b/api/src/quest/application/combined-course-controller.js
@@ -5,6 +5,7 @@ import { extractUserIdFromRequest } from '../../shared/infrastructure/utils/requ
 import { usecases } from '../domain/usecases/index.js';
 import * as combinedCourseDetailsSerializer from '../infrastructure/serializers/combined-course-details-serializer.js';
 import * as combinedCourseListSerializer from '../infrastructure/serializers/combined-course-list-serializer.js';
+import * as combinedCourseParticipationDetailSerializer from '../infrastructure/serializers/combined-course-participation-detail-serializer.js';
 import * as combinedCourseParticipationSerializer from '../infrastructure/serializers/combined-course-participation-serializer.js';
 import * as combinedCourseSerializer from '../infrastructure/serializers/combined-course-serializer.js';
 import * as combinedCourseStatisticsSerializer from '../infrastructure/serializers/combined-course-statistics-serializer.js';
@@ -37,6 +38,16 @@ const getStatistics = async (request, _, dependencies = { combinedCourseStatisti
   const combinedCourseId = request.params.combinedCourseId;
   const combinedCourseStatistics = await usecases.getCombinedCourseStatistics({ combinedCourseId });
   return dependencies.combinedCourseStatisticsSerializer.serialize(combinedCourseStatistics);
+};
+
+const getCombinedCourseParticipationById = async function (
+  request,
+  _,
+  dependencies = { combinedCourseParticipationDetailSerializer },
+) {
+  const participationId = request.params.participationId;
+  const combinedCourseParticipation = await usecases.getCombinedCourseParticipationById({ participationId });
+  return dependencies.combinedCourseParticipationDetailSerializer.serialize(combinedCourseParticipation);
 };
 
 const findParticipations = async (request, _, dependencies = { combinedCourseParticipationSerializer }) => {
@@ -88,6 +99,7 @@ const combinedCourseController = {
   getById,
   getByOrganizationId,
   getStatistics,
+  getCombinedCourseParticipationById,
   findParticipations,
   start,
   reassessStatus,

--- a/api/src/quest/application/combined-course-route.js
+++ b/api/src/quest/application/combined-course-route.js
@@ -77,7 +77,7 @@ const register = async function (server) {
           }),
         },
         notes: [
-          "- Récupération du parcours combiné dont l'id de la quête est passé en paramètre," +
+          "- Récupération du parcours combiné dont l'id est passé en paramètre," +
             " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
         ],
         tags: ['api', 'combined-course', 'orga'],
@@ -99,7 +99,7 @@ const register = async function (server) {
           }),
         },
         notes: [
-          "- Récupération des statistiques de participations d'un parcours combiné dont l'id de la quête est passé en paramètre,\n" +
+          "- Récupération des statistiques de participations du parcours combiné dont l'id est passé en paramètre,\n" +
             " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
         ],
         tags: ['api', 'combined-course', 'orga'],
@@ -138,7 +138,33 @@ const register = async function (server) {
           }),
         },
         notes: [
-          "- Récupération des participations d'un parcours combiné dont l'id de la quête est passé en paramètre,\n" +
+          "- Récupération des participations du parcours combiné dont l'id est passé en paramètre,\n" +
+            " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
+        ],
+        tags: ['api', 'combined-course', 'orga'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/combined-courses/{combinedCourseId}/participations/{participationId}',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserCanManageCombinedCourse,
+          },
+          {
+            method: securityPreHandlers.checkParticipationBelongsToCombinedCourse,
+          },
+        ],
+        handler: combinedCourseController.getCombinedCourseParticipationById,
+        validate: {
+          params: Joi.object({
+            combinedCourseId: identifiersType.combinedCourseId,
+            participationId: identifiersType.participationId,
+          }),
+        },
+        notes: [
+          "- Récupération de la participation dont l'id est passée en paramètre,\n" +
             " Nécessite que l'utilisateur soit membre de l'organisation propriétaire du parcours combiné",
         ],
         tags: ['api', 'combined-course', 'orga'],

--- a/api/src/quest/application/usecases/check-participation-belongs-to-combined-course.js
+++ b/api/src/quest/application/usecases/check-participation-belongs-to-combined-course.js
@@ -1,0 +1,8 @@
+import * as combinedCourseParticipationRepository from '../../infrastructure/repositories/combined-course-participation-repository.js';
+
+export const execute = async function ({ combinedCourseId, participationId }) {
+  return await combinedCourseParticipationRepository.isParticipationOnCombinedCourse({
+    combinedCourseId,
+    participationId,
+  });
+};

--- a/api/src/quest/domain/usecases/get-combined-course-participation-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-participation-by-id.js
@@ -1,0 +1,14 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+export const getCombinedCourseParticipationById = async ({
+  participationId,
+  combinedCourseParticipationRepository,
+}) => {
+  const participation = await combinedCourseParticipationRepository.findById({ participationId });
+
+  if (participation === null) {
+    throw new NotFoundError(`CombinedCourseParticipation introuvable à l'id ${participationId}`);
+  }
+
+  return participation;
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -47,6 +47,7 @@ import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by
 import { findCombinedCourseParticipations } from './find-combined-course-participations.js';
 import { getCombinedCourseByCode } from './get-combined-course-by-code.js';
 import getCombinedCourseById from './get-combined-course-by-id.js';
+import { getCombinedCourseParticipationById } from './get-combined-course-participation-by-id.js';
 import { getCombinedCourseStatistics } from './get-combined-course-statistics.js';
 import getCombinedCoursesByOrganizationId from './get-combined-courses-by-organization-id.js';
 import { getQuestResultsForCampaignParticipation } from './get-quest-results-for-campaign-participation.js';
@@ -63,6 +64,7 @@ const usecasesWithoutInjectedDependencies = {
   getCombinedCourseByCode,
   getCombinedCourseStatistics,
   getCombinedCourseById,
+  getCombinedCourseParticipationById,
   findCombinedCourseParticipations,
   getCombinedCoursesByOrganizationId,
   getQuestResultsForCampaignParticipation,

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -1,3 +1,4 @@
+import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { filterByFullName } from '../../../shared/infrastructure/utils/filter-utils.js';
@@ -53,6 +54,24 @@ export const findById = async function ({ participationId }) {
     .first();
   if (!combinedCourseParticipation) return null;
   return new CombinedCourseParticipation(combinedCourseParticipation);
+};
+
+/**
+ * @param {number} combinedCourseId
+ * @param {number} participationId
+ * @returns {Promise<boolean>}
+ */
+export const isParticipationOnCombinedCourse = async function ({ combinedCourseId, participationId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const { count } = await knexConnection('organization_learner_participations')
+    .select(knex.raw('count(1)'))
+    .where({
+      referenceId: combinedCourseId.toString(),
+      'organization_learner_participations.id': participationId,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+    })
+    .first();
+  return Boolean(count);
 };
 
 export const getByUserId = async function ({ userId, combinedCourseId }) {

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -32,6 +32,29 @@ export const save = async function ({ organizationLearnerId, combinedCourseId })
     .returning('id');
 };
 
+/**
+ * @param {number} participationId
+ * @returns {Promise<CombinedCourseParticipation | null>}
+ */
+export const findById = async function ({ participationId }) {
+  const knexConnection = DomainTransaction.getConnection();
+  const combinedCourseParticipation = await knexConnection('organization_learner_participations')
+    .select('organization_learner_participations.id', 'firstName', 'lastName')
+    .join(
+      'view-active-organization-learners',
+      'view-active-organization-learners.id',
+      'organization_learner_participations.organizationLearnerId',
+    )
+    .where({
+      'organization_learner_participations.id': participationId,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+    })
+    .whereNull('organization_learner_participations.deletedAt')
+    .first();
+  if (!combinedCourseParticipation) return null;
+  return new CombinedCourseParticipation(combinedCourseParticipation);
+};
+
 export const getByUserId = async function ({ userId, combinedCourseId }) {
   const knexConnection = DomainTransaction.getConnection();
 

--- a/api/src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (combinedCourseParticipation) {
+  return new Serializer('combined-course-participation-details', {
+    attributes: ['firstName', 'lastName'],
+  }).serialize(combinedCourseParticipation);
+};
+
+export { serialize };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -67,6 +67,7 @@ const typesPositiveInteger32bits = [
   'organizationInvitationId',
   'organizationLearnerId',
   'ownerId',
+  'participationId',
   'passageId',
   'placeId',
   'profileRewardId',

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -350,6 +350,48 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
     });
   });
 
+  describe('GET /api/combined-courses/{combinedCourseId}/participations/{participationId}', function () {
+    context('when user has membership in the combined course organization', function () {
+      it('should return the participation detail page', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+          name: 'Mon parcours combiné',
+          code: 'PARCOURS123',
+          organizationId,
+          successRequirements: [],
+        });
+        const learner = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          firstName: 'Paul',
+          lastName: 'Azerty',
+        });
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+        const participationId = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+          type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+          status: OrganizationLearnerParticipationStatuses.STARTED,
+          organizationLearnerId: learner.id,
+          combinedCourseId,
+        }).id;
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/combined-courses/${combinedCourseId}/participations/${participationId}`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.equal('combined-course-participation-details');
+      });
+    });
+  });
+
   describe('GET /api/organizations/{organizationId}/combined-courses', function () {
     context('when user belongs to the organization', function () {
       it('should return the list of combined courses for the organization', async function () {

--- a/api/tests/quest/integration/application/usecases/check-participation-belongs-to-combined-course_test.js
+++ b/api/tests/quest/integration/application/usecases/check-participation-belongs-to-combined-course_test.js
@@ -1,0 +1,41 @@
+import * as checkParticipationBelongsToCombinedCourse from '../../../../../src/quest/application/usecases/check-participation-belongs-to-combined-course.js';
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Application | Usecases | checkParticipationBelongsToCombinedCourse', function () {
+  it('should return true when participation is in combined course', async function () {
+    // given
+    const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+    const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      combinedCourseId,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.STARTED,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const authorized = await checkParticipationBelongsToCombinedCourse.execute({ combinedCourseId, participationId });
+
+    // then
+    expect(authorized).true;
+  });
+
+  it('should return false when participation is not in combined course', async function () {
+    // given
+    const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+    const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      status: OrganizationLearnerParticipationStatuses.STARTED,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const authorized = await checkParticipationBelongsToCombinedCourse.execute({ combinedCourseId, participationId });
+
+    // then
+    expect(authorized).false;
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-participation-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-participation-by-id_test.js
@@ -1,0 +1,40 @@
+import {
+  OrganizationLearnerParticipationStatuses,
+  OrganizationLearnerParticipationTypes,
+} from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Domain | Usecases | getCombinedCourseParticipationById', function () {
+  it('should return a participation with given id', async function () {
+    // given
+    const { id: organizationLearnerId, firstName, lastName } = databaseBuilder.factory.buildOrganizationLearner();
+    const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      organizationLearnerId,
+      status: OrganizationLearnerParticipationStatuses.STARTED,
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getCombinedCourseParticipationById({ participationId });
+
+    // then
+    expect(result.id).equal(participationId);
+    expect(result.firstName).equal(firstName);
+    expect(result.lastName).equal(lastName);
+  });
+
+  it('should throw when no participation found', async function () {
+    // given
+    const participationId = 12;
+
+    // when
+    const error = await catchErr(usecases.getCombinedCourseParticipationById)({ participationId });
+
+    // then
+    expect(error).to.be.instanceof(NotFoundError);
+    expect(error.message).to.equal(`CombinedCourseParticipation introuvable à l'id ${participationId}`);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -164,6 +164,68 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
+  describe('#isParticipationOnCombinedCourse', function () {
+    it('should return true if participation is on combined course', async function () {
+      // given
+      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        combinedCourseId,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.isParticipationOnCombinedCourse({
+        combinedCourseId,
+        participationId,
+      });
+
+      // then
+      expect(result).true;
+    });
+
+    it('should return false if participation is not on combined course', async function () {
+      // given
+      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        combinedCourseId: '123',
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.isParticipationOnCombinedCourse({
+        combinedCourseId,
+        participationId,
+      });
+
+      // then
+      expect(result).false;
+    });
+
+    it('should return false if participation is not of COMBINED_COURSE type', async function () {
+      // given
+      const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        combinedCourseId,
+        type: OrganizationLearnerParticipationTypes.PASSAGE,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.isParticipationOnCombinedCourse({
+        combinedCourseId,
+        participationId,
+      });
+
+      // then
+      expect(result).false;
+    });
+  });
+
   describe('#getByUserId', function () {
     it('should return combinedCourse participation for given user and combinedCourse ids', async function () {
       // given

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-participation-repository_test.js
@@ -78,8 +78,94 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
     });
   });
 
+  describe('#findById', function () {
+    it('should return combined course participation for given participationId', async function () {
+      // given
+      const { id: organizationLearnerId, firstName, lastName } = databaseBuilder.factory.buildOrganizationLearner();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.findById({ participationId });
+
+      // then
+      expect(result.id).equal(participationId);
+      expect(result.firstName).equal(firstName);
+      expect(result.lastName).equal(lastName);
+    });
+
+    it('should return null when participation does not have combined course type', async function () {
+      // given
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+        type: OrganizationLearnerParticipationTypes.PASSAGE,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.findById({ participationId });
+
+      // then
+      expect(result).null;
+    });
+
+    it('should return null when organization learner is deleted', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
+        deletedAt: new Date(),
+        deletedBy: userId,
+      });
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await combinedCourseParticipationRepository.findById({ participationId });
+
+      // then
+      expect(result).null;
+    });
+
+    it('should return null when participation has been deleted', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner();
+      const { id: participationId } = databaseBuilder.factory.buildOrganizationLearnerParticipation({
+        organizationLearnerId,
+        status: OrganizationLearnerParticipationStatuses.STARTED,
+        type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+        deletedAt: new Date(),
+        deletedBy: userId,
+      });
+
+      // when
+      const result = await combinedCourseParticipationRepository.findById({ participationId });
+
+      // then
+      expect(result).null;
+    });
+
+    it('should return null when participation does not exist', async function () {
+      // when
+      const result = await combinedCourseParticipationRepository.findById({ participationId: 12 });
+
+      // then
+      expect(result).null;
+    });
+  });
+
   describe('#getByUserId', function () {
-    it('should return quest participation for given user and quest', async function () {
+    it('should return combinedCourse participation for given user and combinedCourse ids', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const {
@@ -100,7 +186,6 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       const result = await combinedCourseParticipationRepository.getByUserId({ userId, combinedCourseId });
 
       // then
-      expect(result.id).to.be.finite;
       expect(result.combinedCourseId).to.deep.equal(combinedCourseId);
       expect(result.organizationLearnerId).to.deep.equal(organizationLearnerId);
       expect(result.firstName).equal(firstName);
@@ -108,7 +193,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(result.status).to.deep.equal(OrganizationLearnerParticipationStatuses.COMPLETED);
     });
 
-    it('should throw NotFound error when quest participation does not exist for given user and quest', async function () {
+    it('should throw NotFound error when combinedCourse participation does not exist for given user and combinedCourse ids', async function () {
       // given
       const userId = 1;
       const combinedCourseId = 2;
@@ -192,7 +277,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       await databaseBuilder.commit();
     });
 
-    it('should return user ids only for given quest id', async function () {
+    it('should return user ids only for given combinedCourse id', async function () {
       // when
       const { userIds } = await combinedCourseParticipationRepository.findPaginatedCombinedCourseParticipationById({
         combinedCourseId,
@@ -322,7 +407,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
   });
 
   describe('#findByCombinedCourseIds', function () {
-    it('should return a paginated list of participations for given quest IDs', async function () {
+    it('should return a paginated list of participations for given combinedCourse ids', async function () {
       // given
       const { id: combinedCourseId1, organizationId } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBI1',
@@ -413,7 +498,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       ]);
     });
 
-    it('should return empty array when no participations match the quest IDs', async function () {
+    it('should return empty array when no participations match the combinedCourse ids', async function () {
       // given
       const { id: combinedCourseId1 } = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI1' });
       const { id: combinedCourseId2 } = databaseBuilder.factory.buildCombinedCourse({ code: 'COMBI2' });
@@ -430,7 +515,7 @@ describe('Quest | Integration | Infrastructure | repositories | Combined-Course-
       expect(combinedCourseParticipations).to.deep.equal([]);
     });
 
-    it('should return the second page of participations for a given questId', async function () {
+    it('should return the second page of participations for a given combinedCourse id', async function () {
       // given
       const { id: combinedCourseId1, organizationId } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBI1',

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -27,6 +27,39 @@ describe('Unit | Quest | Application | Controller | CombinedCourse', function ()
     });
   });
 
+  describe('#getCombinedCourseParticipationById', function () {
+    it('should call getCombinedCourseParticipationById usecase with participationId', async function () {
+      // given
+      const participationId = Symbol('participationId');
+      const combinedCourseParticipation = Symbol('combinedCourseParticipation');
+      const serializedCombinedCourseParticipation = Symbol('serializedCombinedCourseParticipation');
+      const request = {
+        params: { participationId },
+      };
+
+      sinon
+        .stub(usecases, 'getCombinedCourseParticipationById')
+        .withArgs({ participationId })
+        .resolves(combinedCourseParticipation);
+
+      const combinedCourseParticipationDetailSerializer = { serialize: sinon.stub() };
+      combinedCourseParticipationDetailSerializer.serialize
+        .withArgs(combinedCourseParticipation)
+        .returns(serializedCombinedCourseParticipation);
+
+      // when
+      const result = await combinedCourseController.getCombinedCourseParticipationById(request, null, {
+        combinedCourseParticipationDetailSerializer,
+      });
+
+      // then
+      expect(combinedCourseParticipationDetailSerializer.serialize).to.have.been.calledOnceWithExactly(
+        combinedCourseParticipation,
+      );
+      expect(result).to.equal(serializedCombinedCourseParticipation);
+    });
+  });
+
   describe('#findParticipations', function () {
     it('should call findCombinedCourseParticipation usecase with combinedCourseId', async function () {
       // given

--- a/api/tests/quest/unit/application/combined-course-controller_test.js
+++ b/api/tests/quest/unit/application/combined-course-controller_test.js
@@ -4,7 +4,7 @@ import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Quest | Application | Controller | CombinedCourse', function () {
   describe('#getById', function () {
-    it('should call getCombinedCourseByQuestId usecase with questId', async function () {
+    it('should call getCombinedCourseById usecase with combinedCourseId', async function () {
       // given
       const combinedCourseId = 'combinedCourseId123';
       const combinedCourse = Symbol('combinedCourse');
@@ -26,8 +26,9 @@ describe('Unit | Quest | Application | Controller | CombinedCourse', function ()
       expect(result).to.equal(serializedCombinedCourse);
     });
   });
+
   describe('#findParticipations', function () {
-    it('should call findCombinedCourseParticipation usecase with questId', async function () {
+    it('should call findCombinedCourseParticipation usecase with combinedCourseId', async function () {
       // given
       const combinedCourseId = 'combinedCourseId123';
       const combinedCourseParticipations = Symbol('combinedCourseParticipations');
@@ -58,8 +59,9 @@ describe('Unit | Quest | Application | Controller | CombinedCourse', function ()
       expect(result).to.equal(serializedCombinedCourseParticipations);
     });
   });
+
   describe('#getStatistics', function () {
-    it('should call getCombinedCourseStatistics usecase with questId', async function () {
+    it('should call getCombinedCourseStatistics usecase with combinedCourseId', async function () {
       // given
       const combinedCourseId = 'combinedCourseId123';
       const combinedCourseStatistics = Symbol('combinedCourseStatistics');

--- a/api/tests/quest/unit/application/combined-course-route_test.js
+++ b/api/tests/quest/unit/application/combined-course-route_test.js
@@ -72,6 +72,27 @@ describe('Quest | Unit | Routes | combined-course-route', function () {
     });
   });
 
+  describe('GET /api/combined-courses/{combinedCourseId}/participations/{participationId}', function () {
+    it('should call prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserCanManageCombinedCourse').returns(() => true);
+      sinon.stub(securityPreHandlers, 'checkParticipationBelongsToCombinedCourse').returns(() => true);
+      sinon
+        .stub(combinedCourseController, 'getCombinedCourseParticipationById')
+        .callsFake((request, h) => h.response());
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(combinedCourseRoute);
+
+      // when
+      await httpTestServer.request('GET', '/api/combined-courses/123/participations/456');
+
+      // then
+      expect(securityPreHandlers.checkUserCanManageCombinedCourse).to.have.been.called;
+      expect(securityPreHandlers.checkParticipationBelongsToCombinedCourse).to.have.been.called;
+    });
+  });
+
   describe('PUT /api/combined-course/{code}/start', function () {
     it('should call prehandler', async function () {
       // given

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-detail-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-participation-detail-serializer_test.js
@@ -1,0 +1,30 @@
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
+import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
+import { serialize } from '../../../../../src/quest/infrastructure/serializers/combined-course-participation-detail-serializer.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('CombinedCourseParticipationSerializer', function () {
+  it('should serialize a CombinedCourseParticipationDetail', function () {
+    const combinedCourseParticipation = new CombinedCourseParticipation({
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      status: CombinedCourseParticipationStatuses.COMPLETED,
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: new Date('2023-01-02T00:00:00Z'),
+    });
+
+    const serialized = serialize(combinedCourseParticipation);
+
+    expect(serialized).to.deep.equal({
+      data: {
+        type: 'combined-course-participation-details',
+        id: '1',
+        attributes: {
+          'first-name': 'John',
+          'last-name': 'Doe',
+        },
+      },
+    });
+  });
+});

--- a/orga/app/adapters/combined-course-participation-detail.js
+++ b/orga/app/adapters/combined-course-participation-detail.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class CombinedCourseParticipationDetailAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const combinedCourseId = query.combinedCourseId;
+    const participationId = query.participationId;
+    delete query.combinedCourseId;
+    delete query.participationId;
+    return `${this.host}/${this.namespace}/combined-courses/${combinedCourseId}/participations/${participationId}`;
+  }
+}

--- a/orga/app/components/combined-course/participation-detail.gjs
+++ b/orga/app/components/combined-course/participation-detail.gjs
@@ -1,0 +1,41 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import Breadcrumb from 'pix-orga/components/ui/breadcrumb';
+import PageTitle from 'pix-orga/components/ui/page-title';
+
+export default class ParticipationDetail extends Component {
+  @service intl;
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.campaigns.list.my-campaigns',
+        label: this.intl.t('navigation.main.campaigns'),
+      },
+      {
+        route: 'authenticated.campaigns.combined-courses',
+        label: this.intl.t('navigation.main.combined-courses'),
+      },
+      {
+        route: 'authenticated.combined-course',
+        label: this.args.combinedCourse.name,
+        model: this.args.combinedCourse.id,
+      },
+      {
+        label: `Participation de ${this.args.participation.firstName} ${this.args.participation.lastName}`,
+      },
+    ];
+  }
+
+  <template>
+    <PageTitle>
+      <:breadcrumb>
+        <Breadcrumb @links={{this.breadcrumbLinks}} class="campaign-header-title__breadcrumb" />
+      </:breadcrumb>
+      <:title>
+        {{@participation.firstName}}
+        {{@participation.lastName}}
+      </:title>
+    </PageTitle>
+  </template>
+}

--- a/orga/app/models/combined-course-participation-detail.js
+++ b/orga/app/models/combined-course-participation-detail.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CombinedCourseParticipationDetails extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+}

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -98,6 +98,7 @@ Router.map(function () {
     this.route('statistics', { path: '/statistiques' });
     this.route('combined-course', { path: '/parcours/:combined_course_id' }, function () {
       this.route('participations', { path: '/' });
+      this.route('participation-detail', { path: '/participations/:participation_id' });
     });
   });
 

--- a/orga/app/routes/authenticated/combined-course/participation-detail.js
+++ b/orga/app/routes/authenticated/combined-course/participation-detail.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class CombinedCourseParticipationDetailsRoute extends Route {
+  @service store;
+  @service currentUser;
+  @service router;
+
+  beforeModel() {
+    if (!this.currentUser.canAccessCampaignsPage) {
+      return this.router.replaceWith('authenticated.index');
+    }
+  }
+
+  async model(params) {
+    const combinedCourse = this.modelFor('authenticated.combined-course');
+    const combinedCourseParticipation = await this.store
+      .queryRecord('combined-course-participation-detail', {
+        combinedCourseId: combinedCourse.id,
+        participationId: params.participation_id,
+      })
+      .catch((error) => {
+        console.error(error);
+        this.router.replaceWith('not-found');
+      });
+    return { combinedCourse, combinedCourseParticipation };
+  }
+}

--- a/orga/app/templates/authenticated/combined-course.gjs
+++ b/orga/app/templates/authenticated/combined-course.gjs
@@ -1,12 +1,1 @@
-import CombinedCourseHeader from 'pix-orga/components/combined-course/header';
-
-<template>
-  <CombinedCourseHeader
-    @code={{@model.code}}
-    @name={{@model.name}}
-    @campaignIds={{@model.campaignIds}}
-    @participationsCount={{@model.combinedCourseStatistics.participationsCount}}
-    @completedParticipationsCount={{@model.combinedCourseStatistics.completedParticipationsCount}}
-  />
-  {{outlet}}
-</template>
+<template>{{outlet}}</template>

--- a/orga/app/templates/authenticated/combined-course/participation-detail.gjs
+++ b/orga/app/templates/authenticated/combined-course/participation-detail.gjs
@@ -1,0 +1,8 @@
+import ParticipationDetail from 'pix-orga/components/combined-course/participation-detail';
+
+<template>
+  <ParticipationDetail
+    @combinedCourse={{@model.combinedCourse}}
+    @participation={{@model.combinedCourseParticipation}}
+  />
+</template>

--- a/orga/app/templates/authenticated/combined-course/participations.gjs
+++ b/orga/app/templates/authenticated/combined-course/participations.gjs
@@ -1,6 +1,14 @@
+import CombinedCourseHeader from 'pix-orga/components/combined-course/header';
 import CombinedCourseParticipations from 'pix-orga/components/combined-course/participations';
 
 <template>
+  <CombinedCourseHeader
+    @code={{@model.combinedCourse.code}}
+    @name={{@model.combinedCourse.name}}
+    @campaignIds={{@model.combinedCourse.campaignIds}}
+    @participationsCount={{@model.combinedCourse.combinedCourseStatistics.participationsCount}}
+    @completedParticipationsCount={{@model.combinedCourse.combinedCourseStatistics.completedParticipationsCount}}
+  />
   <CombinedCourseParticipations
     @hasCampaigns={{@model.combinedCourse.hasCampaigns}}
     @hasModules={{@model.combinedCourse.hasModules}}

--- a/orga/tests/integration/components/combined-course/participation-detail-test.gjs
+++ b/orga/tests/integration/components/combined-course/participation-detail-test.gjs
@@ -1,0 +1,48 @@
+import { render } from '@1024pix/ember-testing-library';
+import ParticipationDetail from 'pix-orga/components/combined-course/participation-detail';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | combined-course/participation-detail', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders title', async function (assert) {
+    const participation = {
+      firstName: 'Jean',
+      lastName: 'Bon',
+      combinedCourseId: 123,
+    };
+    const combinedCourse = {
+      id: 123,
+      name: 'Combinix',
+    };
+
+    const screen = await render(
+      <template><ParticipationDetail @participation={{participation}} @combinedCourse={{combinedCourse}} /></template>,
+    );
+
+    assert.ok(screen.getByRole('heading', { name: 'Jean Bon', level: 1 }));
+  });
+
+  test('it renders breadcrumb', async function (assert) {
+    const participation = {
+      firstName: 'Jean',
+      lastName: 'Bon',
+      combinedCourseId: 123,
+    };
+    const combinedCourse = {
+      id: 123,
+      name: 'Combinix',
+    };
+
+    const screen = await render(
+      <template><ParticipationDetail @participation={{participation}} @combinedCourse={{combinedCourse}} /></template>,
+    );
+
+    assert.ok(screen.getByRole('link', { name: 'Campagnes' }));
+    assert.ok(screen.getByRole('link', { name: 'Parcours apprenants' }));
+    assert.ok(screen.getByRole('link', { name: 'Combinix' }));
+    assert.ok(screen.getByText('Participation de Jean Bon'));
+  });
+});

--- a/orga/tests/integration/templates/authenticated/combined-course/participation-detail-test.gjs
+++ b/orga/tests/integration/templates/authenticated/combined-course/participation-detail-test.gjs
@@ -1,0 +1,31 @@
+import { render } from '@1024pix/ember-testing-library';
+import ParticipationDetail from 'pix-orga/templates/authenticated/combined-course/participation-detail';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | combined-course/participation-detail', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders template', async function (assert) {
+    const model = {
+      combinedCourseParticipation: {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      },
+      combinedCourse: {
+        id: 123,
+        name: 'Combinix',
+      },
+    };
+
+    const screen = await render(<template><ParticipationDetail @model={{model}} /></template>);
+
+    assert.ok(screen.getByRole('heading', { name: 'Jean Bon', level: 1 }));
+    assert.ok(screen.getByRole('link', { name: 'Campagnes' }));
+    assert.ok(screen.getByRole('link', { name: 'Parcours apprenants' }));
+    assert.ok(screen.getByRole('link', { name: 'Combinix' }));
+    assert.ok(screen.getByText('Participation de Jean Bon'));
+  });
+});

--- a/orga/tests/unit/adapters/combined-course-participation-detail-test.js
+++ b/orga/tests/unit/adapters/combined-course-participation-detail-test.js
@@ -1,0 +1,27 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapters | combined-course-participation-detail', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:combined-course-participation-detail');
+    adapter.ajax = sinon.stub().resolves();
+  });
+
+  module('#urlForQueryRecord', () => {
+    test('should build query record url', async function (assert) {
+      const combinedCourseId = 123;
+      const participationId = 456;
+      const query = { combinedCourseId, participationId };
+      const url = await adapter.urlForQueryRecord(query);
+
+      assert.ok(url.endsWith(`api/combined-courses/${combinedCourseId}/participations/${participationId}`));
+      assert.strictEqual(query.combinedCourseId, undefined);
+      assert.strictEqual(query.participationId, undefined);
+    });
+  });
+});

--- a/orga/tests/unit/adapters/combined-course-participation-test.js
+++ b/orga/tests/unit/adapters/combined-course-participation-test.js
@@ -2,7 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | combined-course-participations', function (hooks) {
+module('Unit | Adapters | combined-course-participation', function (hooks) {
   setupTest(hooks);
 
   let adapter;

--- a/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
@@ -1,0 +1,74 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/combined-course', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+  module('beforeModel', function () {
+    test('user is redirected to index when he has no access', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const router = this.owner.lookup('service:router');
+      const currentUser = this.owner.lookup('service:current-user');
+
+      const replaceWithStub = sinon.stub(router, 'replaceWith');
+      sinon.stub(currentUser, 'canAccessCampaignsPage').value(false);
+
+      // when
+      await route.beforeModel();
+
+      // then
+      assert.ok(replaceWithStub.calledWithExactly('authenticated.index'));
+    });
+  });
+  module('model', function () {
+    test('fetch a combined course participation detail', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourseId = Symbol('combinedCourseId');
+      const combinedCourse = { id: combinedCourseId };
+      sinon.stub(route, 'modelFor').returns(combinedCourse);
+
+      const participationId = Symbol('participationId');
+      const participationDetail = Symbol('participationDetail');
+
+      sinon
+        .stub(store, 'queryRecord')
+        .withArgs('combined-course-participation-detail', { combinedCourseId, participationId })
+        .resolves(participationDetail);
+
+      // when
+      const result = await route.model({ participation_id: participationId });
+
+      // then
+      assert.deepEqual(result, { combinedCourse, combinedCourseParticipation: participationDetail });
+    });
+
+    test('replace route with not-found route when queryRecord throws', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const router = this.owner.lookup('service:router');
+      const store = this.owner.lookup('service:store');
+
+      const combinedCourseId = Symbol('combinedCourseId');
+      const combinedCourse = { id: combinedCourseId };
+      sinon.stub(route, 'modelFor').returns(combinedCourse);
+
+      const replaceWithStub = sinon.stub(router, 'replaceWith');
+      sinon.stub(store, 'queryRecord').rejects(new Error('olala'));
+      sinon.stub(console, 'error');
+
+      // when
+      await route.model({});
+
+      // then
+      assert.ok(replaceWithStub.calledWithExactly('not-found'));
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Actuellement, nous n'avons pas de vue détaillée de la participation d'un apprenant à un parcours.

## 🌰 Proposition

Ajouter une page permettant de voir le détail d'une participation à un parcours.

## 🪵 Pour tester

Se connecter à Pix Orga
Sélectionner l'organisation Pro Classic
Aller dans Campagnes > Parcours apprenants
Sélectionner le COMBINIX1 (Parcours apprenant complet)
Ajouter au chemin d'url `participations/107892`
Voir que la page de détails d'une participation s'affiche avec le nom `Kiana BEDNAR` (en titre et dans le fil d'ariane)