### PR TITLE
[FEATURE] Afficher le nombre de centres de certification dans l'onglet de navigation (PIX-20004)

### DIFF
--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -59,6 +59,10 @@ export default class User extends Model {
     return this.participations.length;
   }
 
+  get certificationCenterMembershipCount() {
+    return this.certificationCenterMemberships.length;
+  }
+
   get authenticationMethodCount() {
     return this.username && this.email ? this.authenticationMethods.length + 1 : this.authenticationMethods.length;
   }

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -39,6 +39,8 @@
       aria-label={{t "pages.user-details.navbar.certification-centers-list-aria-label"}}
     >
       {{t "pages.user-details.navbar.certification-centers-list"}}
+      ({{@model.certificationCenterMembershipCount}})
+
     </LinkTo>
 
     <LinkTo @route="authenticated.users.get.certification-courses">

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -31,6 +31,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     const expectedOrganizationMembershipsCount = 2;
     const expectedParticipationCount = 1;
     const expectedAuthenticationMethodCount = 3;
+    const expectedCertificationCenterMembershipsCount = 3;
     const connectionTabLabel = this.intl.t('pages.user-details.navbar.connections');
 
     // when
@@ -53,7 +54,9 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       .dom(
         userNavigation.getByLabelText(this.intl.t('pages.user-details.navbar.certification-centers-list-aria-label')),
       )
-      .hasText(this.intl.t('pages.user-details.navbar.certification-centers-list'));
+      .hasText(
+        `${this.intl.t('pages.user-details.navbar.certification-centers-list')} (${expectedCertificationCenterMembershipsCount})`,
+      );
     assert
       .dom(userNavigation.getByRole('link', { name: this.intl.t('pages.user-details.navbar.certification-courses') }))
       .exists();

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1371,7 +1371,7 @@
     },
     "user-details": {
       "navbar": {
-        "certification-centers-list": "Certification centers",
+        "certification-centers-list": "Pix Certif",
         "certification-centers-list-aria-label": "Lists of certifications held by the user and the certification centres to which he/she belongs",
         "certification-courses": "Certifications",
         "cgu": "Terms of service",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1372,7 +1372,7 @@
     },
     "user-details": {
       "navbar": {
-        "certification-centers-list": "Centres de certif",
+        "certification-centers-list": "Pix Certif",
         "certification-centers-list-aria-label": "Listes des certifications passées par l'utilisateur et des centres de certifs auxquels il/elle appartient",
         "certification-courses": "Certifications",
         "cgu": "CGU",


### PR DESCRIPTION
## 🍂 Problème

Actuellement sur Pix Admin, sur la page d'un utilisateur, le nombre de centres de certification dont cet utilisateur est membre n'est pas affiché.

## 🌰 Proposition

S'aligner sur ce qui est affiché pour les organisations: renommer l'onglet de navigation en _Pix Certif_ et indiquer le nombre entre parenthèses.

## 🍁 Remarques

RAS

## 🪵 Pour tester

Sur Pix Admin
- aller sur la page d'un utilisateur (par exemple le 7100 est membre de plusieurs centres de certif)
- constater le nouveau nom de l'onglet pour voir les centres de certif, et le nombre entre parenthèses
<img width="1156" height="520" alt="image" src="https://github.com/user-attachments/assets/9a7712bc-3778-46ab-9d53-fe6326c42796" />

