### PR TITLE
[FEATURE] Ajouter une contrainte d'unicité sur module pour la table organization-learner-participation (pix-20406)

### DIFF
--- a/api/db/migrations/20251112170629_add-organization-learner-participations-unique-constraint.js
+++ b/api/db/migrations/20251112170629_add-organization-learner-participations-unique-constraint.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'organization_learner_participations';
+const CONSTRAINT_NAME = 'one_module_by_organization_learner';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table
+      .unique(['organizationLearnerId', 'referenceId'], {
+        indexName: CONSTRAINT_NAME,
+        // Using a raw predicate because partial indexes do not support parameterized queries.
+        // The value 'PASSAGE' corresponds to OrganizationLearnerParticipationTypes.PASSAGE.
+        predicate: knex.whereRaw(`"type" = 'PASSAGE'`),
+      })
+      .comment('Add unicity constraint for organizationLearnerId, referenceId for type `PASSAGE`');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.raw(`DROP INDEX :name:;`, { name: CONSTRAINT_NAME });
+};
+
+export { down, up };


### PR DESCRIPTION
### Description

Cette PR ajoute une contrainte d'unicité sur la table `organization_learner_participations` via un nouveau fichier de migration.

La contrainte garantit qu'un apprenant (identifié par `organizationLearnerId`) ne peut avoir qu'une seule participation de type `PASSAGE` pour un module donné (identifié par `referenceId`).

### Comment tester

1.  Lancer la migration pour appliquer la nouvelle contrainte :
    ```bash
    npm run db:migrate
    ```

2.  Vérifier que la contrainte fonctionne comme attendu :
    *   Se connecter à la base de données.
    *   Essayer d'insérer deux enregistrements dans `organization_learner_participations` avec le même `organizationLearnerId`, le même `referenceId` et le type `'PASSAGE'`. **La deuxième insertion doit échouer** avec une erreur de violation de contrainte unique.
    *   Essayer d'insérer un enregistrement avec le type `'PASSAGE'` et un autre avec un type différent pour le même `organizationLearnerId` et `referenceId`. **Les deux insertions doivent réussir**.

3.  Vérifier que la migration peut être annulée :
    ```bash
    npm run db:rollback:latest
    ```
    La commande doit s'exécuter sans erreur, et la contrainte doit être supprimée de la table.