### PR TITLE
[FEATURE] :lipstick: Expliciter le traitement immédiat des signalements par le surveillant dans l'ES (PIX-16647)

### DIFF
--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -602,7 +602,11 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               .hasAttribute('aria-disabled');
             assert.dom(screen.getByText('Les actions sont mises en pause en attendant le surveillant')).exists();
             assert
-              .dom(screen.getByText("Prévenez votre surveillant afin qu'il puisse constater votre problème."))
+              .dom(
+                screen.getByText(
+                  "Prévenez votre surveillant afin qu'il puisse constater votre problème et le gérer en direct dans son interface « Espace Surveillant ».",
+                ),
+              )
               .exists();
           });
         });

--- a/mon-pix/tests/acceptance/challenge-item-test.js
+++ b/mon-pix/tests/acceptance/challenge-item-test.js
@@ -921,7 +921,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                   assert
                     .dom(
                       screen.getByText(
-                        "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                        "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler en direct de son « Espace Surveillant ».",
                       ),
                     )
                     .exists();
@@ -961,7 +961,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                   assert
                     .dom(
                       screen.getByText(
-                        "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                        "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler en direct de son « Espace Surveillant ».",
                       ),
                     )
                     .exists();

--- a/mon-pix/tests/integration/components/certification-feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/certification-feedback-panel-test.js
@@ -71,7 +71,11 @@ module('Integration | Component | certification-feedback-panel', function (hooks
           // then
           assert.dom(screen.getByText('En attente du surveillant...')).exists();
           assert
-            .dom(screen.getByText("Prévenez votre surveillant afin qu'il puisse constater votre problème."))
+            .dom(
+              screen.getByText(
+                "Prévenez votre surveillant afin qu'il puisse constater votre problème et le gérer en direct dans son interface « Espace Surveillant ».",
+              ),
+            )
             .exists();
         });
 

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | challenge actions', function (hooks) {
             assert
               .dom(
                 screen.getByText(
-                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler en direct de son « Espace Surveillant ».",
                 ),
               )
               .exists();
@@ -178,7 +178,7 @@ module('Integration | Component | challenge actions', function (hooks) {
             assert
               .dom(
                 screen.queryByText(
-                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.",
+                  "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler en direct de son « Espace Surveillant ».",
                 ),
               )
               .doesNotExist();

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1086,7 +1086,7 @@
         "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
         "default": "Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.",
         "v3-accessible-certification": "Nous avons détecté un changement de page. Si vous avez été contraint de changer de page pour utiliser un outil d’accessibilité numérique (tel qu'un lecteur d'écran ou un clavier virtuel), répondez tout de même à la question.",
-        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler en direct de son « Espace Surveillant »."
       },
       "illustration": {
         "placeholder": "Chargement de l'image en cours"
@@ -1100,7 +1100,7 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Prévenez votre surveillant afin qu'il puisse constater votre problème."
+          "message": "Prévenez votre surveillant afin qu'il puisse constater votre problème et le gérer en direct dans son interface « Espace Surveillant »."
         },
         "companion": {
           "message": "Merci de contacter votre surveillant afin qu’il confirme la présence de l’extension."


### PR DESCRIPTION
## 🍂 Problème

Certains surveillants ne se rendent pas compte qu'un signalement a eu lieu et cela mène à des signalements qui ne peuvent pas être pris en compte à posteriori ou pire une certification qui ne peut être terminée par le candidat qui reste bloqué en l’absence de traitement de son signalement dans l’ES.

## 🌰 Proposition

Modifier le wording pour rendre le côté immédiat du traitement des signalements par le surveillant plus clair :

- pour le message dé-focus : "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, cliquez ci-dessous sur le bouton "signaler un problème avec la question”, puis prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant. en direct dans son interface "Espace Surveillant". (mis à jour 19/08 [suite discussions Slack](https://1024pix.slack.com/archives/C06AQ1DDRUM/p1739963053076179))

- pour le message du signalement en attente de traitement : "Prévenez votre surveillant afin qu'il puisse constater votre problème et le gérer en direct dans son interface "Espace Surveillant"."

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Connexion avec certif-success@example.net ;
- Réconciliation avec Max Lagagne 30/10/2000 ;
- Lancer une certification ;
- Atteindre une épreuve Focus ;
- Faire un dé-focus ;
- **Constater le 1ᵉʳ changement dans le message** ;
- Continuer la certification ;
- Faire un signalement ;
- **Constater le 2e changement dans le message** ; 