### PR TITLE
[BUGFIX] Stepper horizontal - Ne pas afficher le bouton "Suivant" dans les steps précédentes (PIX-19973)

### DIFF
--- a/mon-pix/app/components/module/component/step.gjs
+++ b/mon-pix/app/components/module/component/step.gjs
@@ -27,6 +27,10 @@ export default class ModulixStep extends Component {
     return this.args.isActive && this.args.shouldAppearToRight;
   }
 
+  get shouldDisplayNextButton() {
+    return this.args.shouldDisplayNextButton && this.args.currentStep === this.args.lastDisplayedStepIndex + 1;
+  }
+
   @action
   focusAndScroll(htmlElement) {
     if (!this.args.isActive || this.args.preventScrollAndFocus) {
@@ -65,7 +69,7 @@ export default class ModulixStep extends Component {
             />
           </div>
         {{/each}}
-        {{#if @shouldDisplayNextButton}}
+        {{#if this.shouldDisplayNextButton}}
           <PixButton
             aria-label="{{t 'pages.modulix.buttons.stepper.next.ariaLabel'}}"
             @variant="primary"

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -268,6 +268,7 @@ export default class ModulixStepper extends Component {
                 @shouldAppearToRight={{this.shouldAppearToRight}}
                 @updateSkipButton={{@updateSkipButton}}
                 @nextButtonName={{t "pages.modulix.buttons.stepper.next.horizontal.name"}}
+                @lastDisplayedStepIndex={{this.lastDisplayedStepIndex}}
               />
             {{/each}}
           {{/if}}
@@ -292,6 +293,7 @@ export default class ModulixStepper extends Component {
               @shouldDisplayNextButton={{this.shouldDisplayVerticalNextButton index}}
               @updateSkipButton={{@updateSkipButton}}
               @nextButtonName={{t "pages.modulix.buttons.stepper.next.vertical.name"}}
+              @lastDisplayedStepIndex={{index}}
             />
           {{/each}}
         {{/if}}

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -127,6 +127,7 @@ module('Integration | Component | Module | Step', function (hooks) {
                 @step={{step}}
                 @shouldDisplayNextButton={{true}}
                 @onNextButtonClick={{onNextButtonClickSpy}}
+                @lastDisplayedStepIndex={{0}}
               />
             </template>,
           );

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1867,7 +1867,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
               .isFocused();
           });
 
-          test('should enable next button', async function (assert) {
+          test('should enable the controls next button', async function (assert) {
             const steps = [
               {
                 elements: [
@@ -1969,6 +1969,111 @@ module('Integration | Component | Module | Stepper', function (hooks) {
                 .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.next.ariaLabel') }))
                 .isFocused();
             });
+          });
+        });
+      });
+    });
+
+    module('A Stepper with 3 steps, each step with answerable elements', function () {
+      module('On the second step', function () {
+        module('when user clicks on the verify button', function () {
+          test('should not display a next button on the previous step', async function (assert) {
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931855555c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio3' },
+                      { id: '2', content: 'radio4' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'Instruction',
+                    proposals: [
+                      { id: '1', content: 'radio5' },
+                      { id: '2', content: 'radio6' },
+                    ],
+                    isAnswerable: true,
+                    type: 'qcu',
+                  },
+                ],
+              },
+            ];
+
+            function stepperIsFinished() {}
+
+            function onStepperNextStepStub() {}
+
+            function getLastCorrectionForElementStub() {
+              return Symbol('Correction');
+            }
+            const onElementAnswerStub = sinon.stub();
+            const store = this.owner.lookup('service:store');
+            const passage = store.createRecord('passage');
+            const passageEventService = this.owner.lookup('service:passage-events');
+            sinon.stub(passageEventService, 'record');
+
+            // when
+            const screen = await render(
+              <template>
+                <ModulixStepper
+                  @direction="horizontal"
+                  @passage={{passage}}
+                  @steps={{steps}}
+                  @stepperIsFinished={{stepperIsFinished}}
+                  @onStepperNextStep={{onStepperNextStepStub}}
+                  @onElementAnswer={{onElementAnswerStub}}
+                  @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+                />
+              </template>,
+            );
+
+            // when
+            await clickByName('radio2');
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.activity.verify') }));
+            passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+            await clock.tickAsync(NEXT_STEP_BUTTON_DELAY + 100);
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }));
+
+            await clickByName('radio3');
+            await click(screen.getByRole('button', { name: t('pages.modulix.buttons.activity.verify') }));
+            await clock.tickAsync(NEXT_STEP_BUTTON_DELAY + 100);
+
+            // then
+            assert
+              .dom(screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .exists();
+
+            // when
+            await click(
+              screen.getByRole('button', { name: t('pages.modulix.buttons.stepper.controls.previous.ariaLabel') }),
+            );
+            assert
+              .dom(screen.queryByRole('button', { name: t('pages.modulix.buttons.stepper.next.ariaLabel') }))
+              .doesNotExist();
           });
         });
       });


### PR DESCRIPTION
## 🍂 Problème

Quand on parcourt les steps d’un stepper horizontal, en revenant en arrière, quand on a répondu à la dernière Step ouverte, le bouton suivant apparaît sur les steps antérieurs alors qu’il ne devrait pas.
L’utilisateur doit parcourir les étapes déjà vue en utilisant les flèches de contrôle en haut du Stepper.

## 🌰 Proposition

Stocker l'index de la dernière Step ouverte dans le stepper horizontal, et ajouter cette info comme condition pour afficher ou non le bouton "Suivant"

## 🍁 Remarques

- Dans le template de `stepper.gjs`, on déclare 2 fois le composant Step, une fois par direction. Ainsi, le nouvel argument `@lastDsplayedStepIndex`est passé dans les deux cas pour assurer une cohérence, mais la valeur diffère entre les deux directions.

## 🪵 Pour tester
Ouvrir le module [bac-a-sable](https://app-pr14149.review.pix.fr/modules/bac-a-sable/details)

**Stepper horizontal**
- Naviguer jusqu'au premier stepper horizontal
- Répondre au QCU de la première Step, et cliquer sur "Suivant"
- Répondre au QCU déclaratif de la deuxième Step
- Retourner à la première Step
- Vérifier qu'il n'y a pas de bouton "Suivant" qui s'affiche

**Stepper vertical**
- Naviguer jusqu'à un Stepper vertical (de type Leçon par exemple)
- Le bouton "Lire la Suite" doit apparaître
