### PR TITLE
[FEATURE] Enregistrer le connectionMethodCode comme IdentityProvider quand un utilisateur se connecte (PIX-20399)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider/oidc-provider.controller.js
@@ -146,10 +146,14 @@ async function getRedirectLogoutUrl(request, h) {
   const userId = request.auth.credentials.userId;
   const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
 
+  const origin = getForwardedOrigin(request.headers);
+  const requestedApplication = RequestedApplication.fromOrigin(origin);
+
   const redirectLogoutUrl = await usecases.getRedirectLogoutUrl({
     identityProvider,
     logoutUrlUUID,
     userId,
+    requestedApplication,
   });
 
   return h.response({ redirectLogoutUrl }).code(200);

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -6,12 +6,9 @@ import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authentication-service.js';
 
 export class OidcAuthenticationServiceRegistry {
-  /** @type {OidcAuthenticationService[]|null} */
   #allOidcProviderServices = null;
-  /** @type {OidcAuthenticationService[]|null} */
-  #readyOidcProviderServices = null;
-  /** @type {OidcAuthenticationService[]|null} */
   #readyOidcProviderServicesForPixAdmin = null;
+  #readyOidcProviderServicesByRequestedApplications = {};
 
   constructor(dependencies = {}) {
     this.oidcProviderRepository = dependencies.oidcProviderRepository;
@@ -36,19 +33,20 @@ export class OidcAuthenticationServiceRegistry {
     return this.#allOidcProviderServices;
   }
 
-  getReadyOidcProviderServices() {
-    return this.#readyOidcProviderServices;
-  }
-
   getReadyOidcProviderServicesForPixAdmin() {
     return this.#readyOidcProviderServicesForPixAdmin;
   }
 
+  getReadyOidcProviderServicesByRequestedApplication(requestedApplication) {
+    return this.#readyOidcProviderServicesByRequestedApplications[
+      generateGroupByKey(requestedApplication.applicationName, requestedApplication.applicationTld)
+    ];
+  }
+
   getOidcProviderServiceByCode({ identityProviderCode, requestedApplication }) {
-    const services = requestedApplication?.isPixAdmin
-      ? this.#readyOidcProviderServicesForPixAdmin
-      : this.#readyOidcProviderServices;
-    const oidcProviderService = services.find((service) => identityProviderCode === service.code);
+    const oidcProviderService = this.#readyOidcProviderServicesByRequestedApplications[
+      generateGroupByKey(requestedApplication.applicationName, requestedApplication.applicationTld)
+    ].find((service) => identityProviderCode === service.code);
 
     if (!oidcProviderService) {
       throw new InvalidIdentityProviderError(identityProviderCode);
@@ -80,18 +78,28 @@ export class OidcAuthenticationServiceRegistry {
     }
 
     this.#allOidcProviderServices = oidcProviderServices;
-    this.#readyOidcProviderServices = this.#allOidcProviderServices.filter(
-      (oidcProviderService) => oidcProviderService.isReady,
-    );
+
     this.#readyOidcProviderServicesForPixAdmin = this.#allOidcProviderServices.filter(
       (oidcProviderService) => oidcProviderService.isReadyForPixAdmin,
     );
+
+    this.#readyOidcProviderServicesByRequestedApplications = Object.groupBy(
+      this.#allOidcProviderServices.filter(
+        (oidcProviderService) => oidcProviderService.isReady || oidcProviderService.isReadyForPixAdmin,
+      ),
+      (oidcProviderService) => generateGroupByKey(oidcProviderService.application, oidcProviderService.applicationTld),
+    );
+
     return true;
   }
 
   testOnly_reset() {
     this.#allOidcProviderServices = null;
-    this.#readyOidcProviderServices = null;
     this.#readyOidcProviderServicesForPixAdmin = null;
+    this.#readyOidcProviderServicesByRequestedApplications = {};
   }
+}
+
+function generateGroupByKey(application, applicationTld) {
+  return application + applicationTld;
 }

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -33,6 +33,7 @@ export class OidcAuthenticationService {
       claimsToStore,
       clientId,
       clientSecret,
+      connectionMethodCode,
       extraAuthorizationUrlParameters,
       enabled,
       enabledForPixAdmin,
@@ -60,6 +61,7 @@ export class OidcAuthenticationService {
     this.extraAuthorizationUrlParameters = extraAuthorizationUrlParameters;
     this.shouldCloseSession = shouldCloseSession;
     this.identityProvider = identityProvider;
+    this.connectionMethodCode = connectionMethodCode;
     this.openidClientExtraMetadata = openidClientExtraMetadata;
     this.openidConfigurationUrl = openidConfigurationUrl;
     this.organizationName = organizationName;
@@ -231,7 +233,7 @@ export class OidcAuthenticationService {
 
       const authenticationComplement = this.createAuthenticationComplement({ userInfo });
       const authenticationMethod = new AuthenticationMethod({
-        identityProvider: this.identityProvider,
+        identityProvider: this.connectionMethodCode || this.identityProvider,
         userId: createdUserId,
         externalIdentifier: externalIdentityId,
         authenticationComplement,

--- a/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-oidc-user.usecase.js
@@ -85,18 +85,32 @@ async function authenticateOidcUser({
 
   await _assertUserHasAccessToApplication({ requestedApplication, user, adminMemberRepository });
 
+  const hasConnectionMethodCode = !!oidcAuthenticationService.connectionMethodCode;
+  const preferredIdentityProviderName = hasConnectionMethodCode
+    ? oidcAuthenticationService.connectionMethodCode
+    : oidcAuthenticationService.identityProvider;
+
+  if (hasConnectionMethodCode) {
+    await _updateIdentityProviderWithConnectionMethodCodeIfNeeded({
+      userId: user.id,
+      oidcAuthenticationService,
+      authenticationMethodRepository,
+    });
+  }
+
   await _updateAuthenticationMethodWithComplement({
     userInfo,
     userId: user.id,
     sessionContent,
     oidcAuthenticationService,
+    preferredIdentityProviderName,
     authenticationMethodRepository,
   });
 
   await _updateUserLastConnection({
     user,
+    preferredIdentityProviderName,
     requestedApplication,
-    oidcAuthenticationService,
     authenticationMethodRepository,
     lastUserApplicationConnectionsRepository,
     userLoginRepository,
@@ -138,9 +152,23 @@ async function _assertUserHasAccessToApplication({ requestedApplication, user, a
   }
 }
 
+async function _updateIdentityProviderWithConnectionMethodCodeIfNeeded({
+  userId,
+  oidcAuthenticationService,
+  authenticationMethodRepository,
+}) {
+  const { identityProvider, connectionMethodCode } = oidcAuthenticationService;
+  await authenticationMethodRepository.updateIdentityProviderByUserIdAndIdentityProvider({
+    userId,
+    currentIdentityProvider: identityProvider,
+    newIdentityProvider: connectionMethodCode,
+  });
+}
+
 async function _updateAuthenticationMethodWithComplement({
   userInfo,
   userId,
+  preferredIdentityProviderName,
   sessionContent,
   oidcAuthenticationService,
   authenticationMethodRepository,
@@ -153,14 +181,14 @@ async function _updateAuthenticationMethodWithComplement({
   await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
     authenticationComplement,
     userId,
-    identityProvider: oidcAuthenticationService.identityProvider,
+    identityProvider: preferredIdentityProviderName,
   });
 }
 
 async function _updateUserLastConnection({
   user,
+  preferredIdentityProviderName,
   requestedApplication,
-  oidcAuthenticationService,
   authenticationMethodRepository,
   lastUserApplicationConnectionsRepository,
   userLoginRepository,
@@ -173,6 +201,6 @@ async function _updateUserLastConnection({
   });
   await authenticationMethodRepository.updateLastLoggedAtByIdentityProvider({
     userId: user.id,
-    identityProvider: oidcAuthenticationService.identityProvider,
+    identityProvider: preferredIdentityProviderName,
   });
 }

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -62,6 +62,7 @@ async function createOidcUser({
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
   const userId = await oidcAuthenticationService.createUserAccount({

--- a/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-oidc-user.usecase.js
@@ -39,12 +39,26 @@ async function createOidcUser({
 
   const { userInfo, sessionContent } = sessionContentAndUserInfo;
 
-  const authenticationMethod = await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
-    externalIdentifier: userInfo.externalIdentityId,
-    identityProvider,
+  await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
+  await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
+  const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
-  if (authenticationMethod) {
+  const identityProviders = [
+    oidcAuthenticationService.connectionMethodCode,
+    oidcAuthenticationService.identityProvider,
+  ].filter(Boolean);
+
+  const hasAlreadyAuthenticationMethod =
+    await authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders({
+      externalIdentifier: userInfo.externalIdentityId,
+      identityProviders,
+    });
+
+  if (hasAlreadyAuthenticationMethod) {
     throw new UserAlreadyExistsWithAuthenticationMethodError(
       'Authentication method already exists for this external identifier.',
     );
@@ -57,13 +71,10 @@ async function createOidcUser({
     lang: language,
   });
 
-  await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
-  await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
-
-  const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
-    identityProviderCode: identityProvider,
-    requestedApplication,
-  });
+  const hasConnectionMethodCode = !!oidcAuthenticationService.connectionMethodCode;
+  const preferredIdentityProviderName = hasConnectionMethodCode
+    ? oidcAuthenticationService.connectionMethodCode
+    : oidcAuthenticationService.identityProvider;
 
   const userId = await oidcAuthenticationService.createUserAccount({
     user,
@@ -76,8 +87,8 @@ async function createOidcUser({
 
   await _updateUserLastConnection({
     userId,
+    preferredIdentityProviderName,
     requestedApplication,
-    oidcAuthenticationService,
     authenticationMethodRepository,
     lastUserApplicationConnectionsRepository,
     userLoginRepository,
@@ -97,8 +108,8 @@ export { createOidcUser };
 
 async function _updateUserLastConnection({
   userId,
+  preferredIdentityProviderName,
   requestedApplication,
-  oidcAuthenticationService,
   authenticationMethodRepository,
   lastUserApplicationConnectionsRepository,
   userLoginRepository,
@@ -111,6 +122,6 @@ async function _updateUserLastConnection({
   });
   await authenticationMethodRepository.updateLastLoggedAtByIdentityProvider({
     userId,
-    identityProvider: oidcAuthenticationService.identityProvider,
+    identityProvider: preferredIdentityProviderName,
   });
 }

--- a/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
@@ -12,7 +12,7 @@ const getReadyIdentityProviders = async function ({ requestedApplication, oidcAu
     return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
   }
 
-  return oidcAuthenticationServiceRegistry.getReadyOidcProviderServices();
+  return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
 };
 
 export { getReadyIdentityProviders };

--- a/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
@@ -7,12 +7,19 @@
  * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
  * @return {Promise<string>}
  */
-async function getRedirectLogoutUrl({ identityProvider, logoutUrlUUID, userId, oidcAuthenticationServiceRegistry }) {
+async function getRedirectLogoutUrl({
+  identityProvider,
+  logoutUrlUUID,
+  userId,
+  requestedApplication,
+  oidcAuthenticationServiceRegistry,
+}) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
 
   const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    requestedApplication,
   });
 
   return oidcAuthenticationService.getRedirectLogoutUrl({

--- a/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/reconcile-oidc-user.usecase.js
@@ -47,13 +47,18 @@ export const reconcileOidcUser = async function ({
 
   const { userId, externalIdentityId } = userInfo;
 
+  const hasConnectionMethodCode = !!oidcAuthenticationService.connectionMethodCode;
+  const preferredIdentityProviderName = hasConnectionMethodCode
+    ? oidcAuthenticationService.connectionMethodCode
+    : oidcAuthenticationService.identityProvider;
+
   const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({
     userInfo,
     sessionContent,
   });
   await authenticationMethodRepository.create({
     authenticationMethod: new AuthenticationMethod({
-      identityProvider: oidcAuthenticationService.identityProvider,
+      identityProvider: preferredIdentityProviderName,
       userId,
       externalIdentifier: externalIdentityId,
       authenticationComplement,
@@ -63,7 +68,7 @@ export const reconcileOidcUser = async function ({
   await _updateUserLastConnection({
     userId,
     requestedApplication,
-    oidcAuthenticationService,
+    preferredIdentityProviderName,
     authenticationMethodRepository,
     lastUserApplicationConnectionsRepository,
     userLoginRepository,
@@ -85,7 +90,7 @@ export const reconcileOidcUser = async function ({
 async function _updateUserLastConnection({
   userId,
   requestedApplication,
-  oidcAuthenticationService,
+  preferredIdentityProviderName,
   authenticationMethodRepository,
   lastUserApplicationConnectionsRepository,
   userLoginRepository,
@@ -98,6 +103,6 @@ async function _updateUserLastConnection({
   });
   await authenticationMethodRepository.updateLastLoggedAtByIdentityProvider({
     userId,
-    identityProvider: oidcAuthenticationService.identityProvider,
+    identityProvider: preferredIdentityProviderName,
   });
 }

--- a/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/authentication-method.repository.js
@@ -93,6 +93,22 @@ const findOneByExternalIdentifierAndIdentityProvider = async function ({ externa
   return authenticationMethodDTO ? _toDomain(authenticationMethodDTO) : null;
 };
 
+const hasAuthenticationMethodForAnyOfTheseIdentityProviders = async function ({
+  externalIdentifier,
+  identityProviders,
+}) {
+  if (!identityProviders || identityProviders.length === 0) {
+    return false;
+  }
+  const result = await knex(AUTHENTICATION_METHODS_TABLE)
+    .where({ externalIdentifier })
+    .whereIn('identityProvider', identityProviders)
+    .count('* as count')
+    .first();
+
+  return result.count > 0;
+};
+
 const findByUserId = async function ({ userId }) {
   const authenticationMethodDTOs = await knex
     .select(COLUMNS)
@@ -196,6 +212,20 @@ const updateExternalIdentifierByUserIdAndIdentityProvider = async function ({
   return _toDomain(authenticationMethodDTO);
 };
 
+const updateIdentityProviderByUserIdAndIdentityProvider = async function ({
+  userId,
+  currentIdentityProvider,
+  newIdentityProvider,
+}) {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn(AUTHENTICATION_METHODS_TABLE)
+    .where({
+      userId,
+      identityProvider: currentIdentityProvider,
+    })
+    .update({ identityProvider: newIdentityProvider, updatedAt: new Date() });
+};
+
 const updateAuthenticationComplementByUserIdAndIdentityProvider = async function ({
   authenticationComplement,
   userId,
@@ -269,9 +299,11 @@ const anonymizeByUserIds = async function ({ userIds }) {
  * @property {function} getByIdAndUserId
  * @property {function} hasIdentityProviderPIX
  * @property {function} hasIdentityProviderGar
+ * @property {function} hasAuthenticationMethodForAnyOfTheseIdentityProviders
  * @property {function} removeAllAuthenticationMethodsByUserId
  * @property {function} removeByUserIdAndIdentityProvider
  * @property {function} update
+ * @property {function} updateIdentityProviderByUserIdAndIdentityProvider
  * @property {function} updateAuthenticationComplementByUserIdAndIdentityProvider
  * @property {function} updateAuthenticationMethodUserId
  * @property {function} updatePassword
@@ -286,6 +318,7 @@ export {
   findOneByExternalIdentifierAndIdentityProvider,
   findOneByUserIdAndIdentityProvider,
   getByIdAndUserId,
+  hasAuthenticationMethodForAnyOfTheseIdentityProviders,
   hasIdentityProviderGar,
   hasIdentityProviderPIX,
   removeAllAuthenticationMethodsByUserId,
@@ -294,6 +327,7 @@ export {
   updateAuthenticationComplementByUserIdAndIdentityProvider,
   updateAuthenticationMethodUserId,
   updateExternalIdentifierByUserIdAndIdentityProvider,
+  updateIdentityProviderByUserIdAndIdentityProvider,
   updateLastLoggedAtByIdentityProvider,
   updatePassword,
 };

--- a/api/src/identity-access-management/infrastructure/utils/network.js
+++ b/api/src/identity-access-management/infrastructure/utils/network.js
@@ -40,10 +40,13 @@ export function getForwardedOrigin(headers) {
 
 export class RequestedApplication {
   /**
-   * @param {string} applicationName
+   * @param {Object} params
+   * @param {string} params.applicationName
+   * @param {string} params.applicationTld
    */
-  constructor(applicationName) {
+  constructor({ applicationName, applicationTld }) {
     this.applicationName = applicationName;
+    this.applicationTld = applicationTld;
   }
 
   get isPixApp() {
@@ -82,7 +85,7 @@ export class RequestedApplication {
 
     if (url.hostname == 'localhost') {
       applicationName = localhostApplicationPortMapping[url.port];
-      return new RequestedApplication(applicationName);
+      return new RequestedApplication({ applicationName });
     }
 
     const hostnameParts = url.hostname.split('.');
@@ -91,6 +94,7 @@ export class RequestedApplication {
     }
 
     const urlFirstLabel = hostnameParts[0];
+    const applicationTld = `.${hostnameParts.at(-1)}`;
 
     const urlFirstLabelParts = urlFirstLabel.split('-');
     if (urlFirstLabelParts.length == 2) {
@@ -100,7 +104,7 @@ export class RequestedApplication {
       applicationName = urlFirstLabel;
     }
 
-    return new RequestedApplication(applicationName);
+    return new RequestedApplication({ applicationName, applicationTld });
   }
 }
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.admin.route.test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Identity Access Management | Route | Admin | oidc-provide
   let server;
 
   beforeEach(async function () {
-    await createMockedTestOidcProvider();
+    await createMockedTestOidcProvider({ application: 'admin', applicationTld: '.fr' });
     server = await createServer();
   });
 

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -149,9 +149,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           refresh_token: 'refresh_token',
         });
 
-        const headers = generateAuthenticatedUserRequestHeaders();
-        headers.cookie = cookies[0];
-
         // when
         const response = await server.inject({
           method: 'POST',
@@ -267,9 +264,6 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
             expires_in: 60,
             refresh_token: 'refresh_token',
           });
-
-          const headers = generateAuthenticatedUserRequestHeaders();
-          headers.cookie = cookies[0];
 
           // when
           const response = await server.inject({

--- a/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/oidc-authentication-service-registry.test.js
@@ -41,6 +41,8 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
     await databaseBuilder.factory.buildOidcProvider(genericDisabledOidcProviderProperties);
 
     const genericOidcProviderFoxPixAdminProperties = {
+      application: 'admin',
+      applicationTld: '.fr',
       enabledForPixAdmin: true,
       accessTokenLifespan: '7d',
       clientId: 'client',
@@ -49,7 +51,7 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
       identityProvider: 'OIDC_EXAMPLE_FOR_PIX_ADMIN',
       openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
       organizationName: 'OIDC Example',
-      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      redirectUri: 'https://admin.dev.pix.fr/connexion/oidc-example-net',
       scope: 'openid profile',
       slug: 'oidc-example-net',
       source: 'oidcexamplenet',
@@ -167,7 +169,7 @@ describe('Integration | Identity Access Management | Domain | Service | oidc-aut
     describe('when the requestedApplication is admin', function () {
       it('returns a ready OIDC provider for Pix Admin', async function () {
         // given
-        const requestedApplication = new RequestedApplication('admin');
+        const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
         await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
 
         // when

--- a/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -6,6 +6,8 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Identity Access Management | Domain | UseCases | get-ready-identity-providers', function () {
   beforeEach(async function () {
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'app',
+      applicationTld: '.org',
       identityProvider: 'OIDC_PROVIDER_FOR_APP',
       organizationName: 'OIDC Provider For App',
       slug: 'oidc-provider-for-app',
@@ -20,6 +22,8 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     });
 
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'app',
+      applicationTld: '.org',
       identityProvider: 'OIDC_PROVIDER_DISABLED',
       organizationName: 'OIDC Provider Disabled',
       slug: 'oidc-provider-disabled',
@@ -34,6 +38,8 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
     });
 
     await databaseBuilder.factory.buildOidcProvider({
+      application: 'admin',
+      applicationTld: '.fr',
       identityProvider: 'OIDC_PROVIDER_FOR_ADMIN',
       organizationName: 'OIDC Provider For Admin',
       slug: 'oidc-provider-for-admin',
@@ -43,7 +49,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
       clientSecret: 'plainTextSecret',
       accessTokenLifespan: '7d',
       openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
-      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      redirectUri: 'https://admin.dev.pix.fr/connexion/oidc-example-net',
       scope: 'openid profile',
     });
 
@@ -52,7 +58,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
 
   it('returns enabled oidc providers (excluding the PixAdmin ones)', async function () {
     // given
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.org' });
 
     // when
     const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });
@@ -69,7 +75,7 @@ describe('Integration | Identity Access Management | Domain | UseCases | get-rea
   describe('when the provided requestedApplication is Pix Admin', function () {
     it('returns enabled oidc providers for PixAdmin only', async function () {
       // given
-      const requestedApplication = new RequestedApplication('admin');
+      const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
       // when
       const identityProviders = await usecases.getReadyIdentityProviders({ requestedApplication });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/authentication-method.repository.test.js
@@ -452,6 +452,44 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     });
   });
 
+  describe('#hasAuthenticationMethodForAnyOfTheseIdentityProviders', function () {
+    it('returns true if there is at least one AuthenticationMethod for the given external id and these identity providers', async function () {
+      // given
+      const externalIdentifier = 'sub_456';
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+        id: 123,
+        identityProvider: 'firstProvider',
+        externalIdentifier,
+        userId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders({
+        externalIdentifier,
+        identityProviders: ['firstProvider', 'secondProvider'],
+      });
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('returns null if there is no AuthenticationMethods for the given external identifier and identity provider', async function () {
+      // given & when
+      const authenticationMethodsByTypeAndValue =
+        await authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider({
+          externalIdentifier: 'samlId',
+          identityProvider: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        });
+
+      // then
+      expect(authenticationMethodsByTypeAndValue).to.be.null;
+    });
+  });
+
   describe('#updateExternalIdentifierByUserIdAndIdentityProvider', function () {
     context('When authentication method exists', function () {
       let clock;
@@ -1037,6 +1075,45 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(authenticationMethodUpdated[0].userId).to.equal(targetUserId);
       expect(authenticationMethodUpdated[0].updatedAt).to.deep.equal(now);
       expect(authenticationMethodUpdated[0].lastLoggedAt).to.deep.equal(null);
+    });
+  });
+
+  describe('#updateIdentityProviderByUserIdAndIdentityProvider', function () {
+    let clock;
+    const now = new Date('2022-02-16');
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('updates identityProvider if necessary', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const currentIdentityProvider = 'currentNameForIdentityProvider';
+      const newIdentityProvider = 'newNameForIdentityProvider';
+      databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+        userId: user.id,
+        identityProvider: currentIdentityProvider,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await authenticationMethodRepository.updateIdentityProviderByUserIdAndIdentityProvider({
+        userId: user.id,
+        currentIdentityProvider,
+        newIdentityProvider,
+      });
+
+      // then
+      const authenticationMethodUpdated = await knex('authentication-methods').select();
+      expect(authenticationMethodUpdated[0].userId).to.equal(user.id);
+      expect(authenticationMethodUpdated[0].identityProvider).to.equal(newIdentityProvider);
+      expect(authenticationMethodUpdated[0].updatedAt).to.deep.equal(now);
     });
   });
 

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -15,7 +15,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
     const identityProvider = 'OIDC_EXAMPLE_NET';
     const pixAccessToken = 'pixAccessToken';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
     const locale = 'fr-FR';
 
     let request;
@@ -147,7 +147,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
         locale: 'fr-FR',
         language: 'fr',
         audience: 'https://app.pix.fr',
-        requestedApplication: new RequestedApplication('app'),
+        requestedApplication: new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' }),
       });
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal({
@@ -229,7 +229,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       //then
       expect(usecases.getAuthorizationUrl).to.have.been.calledWithExactly({
         identityProvider: 'OIDC',
-        requestedApplication: new RequestedApplication('app'),
+        requestedApplication: new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' }),
       });
       expect(request.yar.set).to.have.been.calledTwice;
       expect(request.yar.set.getCall(0)).to.have.been.calledWithExactly(
@@ -287,7 +287,7 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
           authenticationKey: '123abc',
         },
       };
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       sinon.stub(usecases, 'reconcileOidcUser').resolves({
         accessToken: 'accessToken',

--- a/api/tests/identity-access-management/unit/application/saml/saml.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/saml/saml.controller.test.js
@@ -15,7 +15,7 @@ describe('Unit | Identity Access Management | Application | Controller | Authent
       const externalUserToken = 'SamlJacksonToken';
       const expectedUserId = 1;
       const audience = 'https://app.pix.fr';
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       const request = {
         headers: {

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -46,7 +46,7 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
     const password = 'user_password';
     const source = 'pix';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
     /**
      * @see https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service-registry.test.js
@@ -4,6 +4,7 @@ import { OidcAuthenticationService } from '../../../../../src/identity-access-ma
 import { OidcAuthenticationServiceRegistry } from '../../../../../src/identity-access-management/domain/services/oidc-authentication-service-registry.js';
 import { PoleEmploiOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js';
 import { oidcProviderRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/oidc-provider-repository.js';
+import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Services | oidc-authentication-service-registry', function () {
@@ -41,16 +42,19 @@ describe('Unit | Identity Access Management | Domain | Services | oidc-authentic
         // given
         const oidcProviderServices = [
           { code: 'ONE' },
-          { code: 'OIDC', isReady: true },
+          { code: 'OIDC', application: 'app', applicationTld: '.fr', isReady: true },
           { code: 'OIDC_FOR_PIX_ADMIN', isReadyForPixAdmin: true },
         ];
+
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
         // when
         const result = await oidcAuthenticationServiceRegistry.loadOidcProviderServices(oidcProviderServices);
 
         // then
         const allOidcProviderServices = oidcAuthenticationServiceRegistry.getAllOidcProviderServices();
-        const readyOidcProviderServices = oidcAuthenticationServiceRegistry.getReadyOidcProviderServices();
+        const readyOidcProviderServices =
+          oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesByRequestedApplication(requestedApplication);
         const readyOidcProviderServicesForPixAdmin =
           oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
 

--- a/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/oidc-authentication-service.test.js
@@ -901,7 +901,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const userId = 1;
       userToCreateRepository.create.withArgs({ user }).resolves({ id: userId });
 
-      const identityProvider = 'genericOidcProviderCode';
+      const identityProvider = 'someIdp';
       const expectedAuthenticationMethod = new AuthenticationMethod({
         identityProvider,
         externalIdentifier: externalIdentityId,
@@ -914,6 +914,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         externalIdentityId,
         user,
         userInfo,
+        identityProvider,
         authenticationMethodRepository,
         userToCreateRepository,
       });
@@ -923,6 +924,48 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         authenticationMethod: expectedAuthenticationMethod,
       });
       expect(result).to.equal(userId);
+    });
+
+    context('when oidc authentication service has a connectionMethodCode', function () {
+      it('creates authentication method with connectionMethodCode as an alias for identityProvider', async function () {
+        // given
+        const externalIdentityId = '1233BBBC';
+
+        const user = new UserToCreate({
+          firstName: 'Adam',
+          lastName: 'Troisjours',
+        });
+        const userInfo = {};
+        const userId = 1;
+        userToCreateRepository.create.withArgs({ user }).resolves({ id: userId });
+
+        const identityProvider = 'genericOidcProviderCode';
+        const connectionMethodCode = 'aliasForGenericOidcProviderCode';
+
+        const oidcAuthenticationService = new OidcAuthenticationService(
+          { identityProvider, connectionMethodCode },
+          { openIdClient },
+        );
+        const expectedAuthenticationMethod = new AuthenticationMethod({
+          identityProvider: connectionMethodCode,
+          externalIdentifier: externalIdentityId,
+          userId,
+        });
+
+        // when
+        await oidcAuthenticationService.createUserAccount({
+          externalIdentityId,
+          user,
+          userInfo,
+          authenticationMethodRepository,
+          userToCreateRepository,
+        });
+
+        // then
+        expect(authenticationMethodRepository.create).to.have.been.calledWithExactly({
+          authenticationMethod: expectedAuthenticationMethod,
+        });
+      });
     });
 
     context('when claimsToStore is empty', function () {

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-for-saml.usecase.test.js
@@ -25,7 +25,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-fo
   let userRepository;
   let userLoginRepository;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     pixAuthenticationService = {

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -55,7 +55,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
 
     context('check access by requestedApplication', function () {
       context('when requestedApplication is Pix Admin', function () {
-        const requestedApplication = new RequestedApplication('admin');
+        const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
         context('when user has no role and is therefore not an admin member', function () {
           it('throws an error', async function () {
@@ -278,7 +278,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
 
           // when
-          const requestedApplication = new RequestedApplication('app');
+          const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
           await authenticateOidcUser({
             requestedApplication,
             stateReceived: 'state',
@@ -316,7 +316,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
       context('when the provider has an authentication complement', function () {
         it('updates the authentication method', async function () {
           // given
-          const requestedApplication = new RequestedApplication('app');
+          const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
           _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
           const user = domainBuilder.buildUser({ id: 10 });
           userRepository.findByExternalIdentifier.resolves(user);
@@ -373,7 +373,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     let lastUserApplicationConnectionsRepository;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
     const audience = 'https://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
     beforeEach(function () {
       oidcAuthenticationService = {
@@ -411,7 +411,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     context('when user has an account', function () {
       it('updates the authentication method', async function () {
         // given
-        const requestedApplication = new RequestedApplication('app');
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         const user = domainBuilder.buildUser({ id: 1 });
         userRepository.findByExternalIdentifier.resolves(user);
@@ -502,7 +502,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
     context('when user is logged with their pix account but also has a separate oidc account', function () {
       it('updates the oidc authentication method', async function () {
         // given
-        const requestedApplication = new RequestedApplication('app');
+        const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
         const { sessionContent } = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
         const user = domainBuilder.buildUser({ id: 10 });
         userRepository.findByExternalIdentifier
@@ -606,7 +606,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         expiredDate: new Date(),
       });
       oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
-      const requestedApplication = new RequestedApplication('app');
+      const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
       // when
       await authenticateOidcUser({

--- a/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/authenticate-oidc-user.usecase.test.js
@@ -35,8 +35,10 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
         getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
       };
       authenticationMethodRepository = {
+        findOneByUserIdAndIdentityProvider: sinon.stub(),
         updateAuthenticationComplementByUserIdAndIdentityProvider: sinon.stub(),
         updateLastLoggedAtByIdentityProvider: sinon.stub(),
+        updateIdentityProviderByUserIdAndIdentityProvider: sinon.stub(),
       };
       authenticationSessionService = {
         save: sinon.stub(),
@@ -360,9 +362,113 @@ describe('Unit | Identity Access Management | Domain | UseCase | authenticate-oi
           });
         });
       });
+
+      context('when the provider has no connection method code', function () {
+        it('does not update the identity provider and uses correct identity provider value as parameter', async function () {
+          // given
+          const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+          _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+          const user = domainBuilder.buildUser({ id: 10 });
+          userRepository.findByExternalIdentifier.resolves(user);
+          const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+            family_name: 'TITEGOUTTE',
+            given_name: 'Mélusine',
+          });
+          oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
+
+          // when
+          await authenticateOidcUser({
+            requestedApplication,
+            stateReceived: 'state',
+            stateSent: 'state',
+            locale: 'fr-FR',
+            identityProviderCode: 'OIDC_EXAMPLE_NET',
+            oidcAuthenticationServiceRegistry,
+            authenticationSessionService,
+            authenticationMethodRepository,
+            userRepository,
+            userLoginRepository,
+            lastUserApplicationConnectionsRepository,
+          });
+
+          // then
+          expect(authenticationMethodRepository.updateIdentityProviderByUserIdAndIdentityProvider).to.not.have.been
+            .called;
+          expect(
+            authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
+          ).to.have.been.calledWithExactly({
+            authenticationComplement,
+            userId: 10,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
+          expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+            userId: 10,
+            identityProvider: oidcAuthenticationService.identityProvider,
+          });
+        });
+      });
+
+      context('when the provider has a connection method code', function () {
+        context(
+          "when the connection method code is different from the authentication method's identity provider",
+          function () {
+            it('updates the authentication method and uses updated identity provider as parameter', async function () {
+              // given
+              const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+              _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
+              const user = domainBuilder.buildUser({ id: 10 });
+              userRepository.findByExternalIdentifier.resolves(user);
+              const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
+                family_name: 'TITEGOUTTE',
+                given_name: 'Mélusine',
+              });
+              oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
+              authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves({});
+
+              oidcAuthenticationService.connectionMethodCode = 'ALIAS_OIDC_EXAMPLE';
+
+              // when
+              await authenticateOidcUser({
+                requestedApplication,
+                stateReceived: 'state',
+                stateSent: 'state',
+                locale: 'fr-FR',
+                identityProviderCode: 'OIDC_EXAMPLE_NET',
+                oidcAuthenticationServiceRegistry,
+                authenticationSessionService,
+                authenticationMethodRepository,
+                userRepository,
+                userLoginRepository,
+                lastUserApplicationConnectionsRepository,
+              });
+
+              // then
+              expect(
+                authenticationMethodRepository.updateLastLoggedAtByIdentityProvider,
+              ).to.have.been.calledWithExactly({
+                userId: user.id,
+                identityProvider: oidcAuthenticationService.connectionMethodCode,
+              });
+              expect(
+                authenticationMethodRepository.updateIdentityProviderByUserIdAndIdentityProvider,
+              ).to.have.been.calledWithExactly({
+                userId: user.id,
+                currentIdentityProvider: oidcAuthenticationService.identityProvider,
+                newIdentityProvider: oidcAuthenticationService.connectionMethodCode,
+              });
+              expect(
+                authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider,
+              ).to.have.been.calledWithExactly({
+                authenticationComplement,
+                userId: 10,
+                identityProvider: oidcAuthenticationService.connectionMethodCode,
+              });
+            });
+          },
+        );
+      });
     });
   });
-
   context('when identityProvider is POLE_EMPLOI', function () {
     let oidcAuthenticationService;
     let authenticationSessionService;

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -104,7 +104,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     const idToken = 'idToken';
     const language = 'nl';
     const audience = 'htttps://app.pix.fr';
-    const requestedApplication = new RequestedApplication('app');
+    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
     authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
       sessionContent: { idToken, accessToken: 'accessToken' },
       userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },

--- a/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-oidc-user.usecase.test.js
@@ -18,7 +18,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     now = new Date(clock.now);
 
     authenticationMethodRepository = {
-      findOneByExternalIdentifierAndIdentityProvider: sinon.stub(),
+      hasAuthenticationMethodForAnyOfTheseIdentityProviders: sinon.stub(),
       updateLastLoggedAtByIdentityProvider: sinon.stub(),
     };
 
@@ -27,6 +27,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
     };
 
     oidcAuthenticationService = {
+      identityProvider: 'SOME_IDP',
       shouldCloseSession: true,
       getUserInfo: sinon.stub(),
       createUserAccount: sinon.stub(),
@@ -77,11 +78,9 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       // given
       authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
         sessionContent: { idToken: 'idToken', accessToken: 'accessToken' },
-        userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'duGAR' },
+        userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
       });
-      authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
-        .withArgs({ externalIdentifier: 'duGAR', identityProvider: 'SOME_IDP' })
-        .resolves({ userId: 'FOUND_USER_ID' });
+      authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders.resolves(true);
 
       // when
       const error = await catchErr(createOidcUser)({
@@ -94,76 +93,148 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-oidc-use
       });
 
       // then
+      const call = authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders.getCall(0);
+      const externaIdentifierParameter = call.args[0].externalIdentifier;
+      const identityProvidersParameter = call.args[0].identityProviders;
+      expect(externaIdentifierParameter).to.equal('externalId');
+      expect(identityProvidersParameter).to.have.members(['SOME_IDP']);
       expect(error).to.be.instanceOf(UserAlreadyExistsWithAuthenticationMethodError);
       expect(error.message).to.equal('Authentication method already exists for this external identifier.');
     });
   });
-
-  it('creates the user account with given language and returns an access token, the logout url uuid and update the last logged date with the existing external user id', async function () {
-    // given
+  context('successful account creation and authentication', function () {
     const idToken = 'idToken';
     const language = 'nl';
-    const audience = 'htttps://app.pix.fr';
-    const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
-    authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
-      sessionContent: { idToken, accessToken: 'accessToken' },
-      userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
-    });
-    authenticationMethodRepository.findOneByExternalIdentifierAndIdentityProvider
-      .withArgs({ externalIdentifier: 'externalId', identityProvider: 'SOME_IDP' })
-      .resolves(null);
-    oidcAuthenticationService.createUserAccount.resolves(10);
-    oidcAuthenticationService.createAccessToken
-      .withArgs({ userId: 10, audience })
-      .returns('accessTokenForExistingExternalUser');
-    oidcAuthenticationService.saveIdToken.withArgs({ idToken, userId: 10 }).resolves('logoutUrlUUID');
+    const audience = 'https://app.pix.fr';
+    let requestedApplication;
 
-    // when
-    const result = await createOidcUser({
-      identityProvider: 'SOME_IDP',
-      authenticationKey: 'AUTHENTICATION_KEY',
-      locale: 'nl-BE',
-      language,
-      audience,
-      authenticationSessionService,
-      oidcAuthenticationServiceRegistry,
-      authenticationMethodRepository,
-      userToCreateRepository,
-      userLoginRepository,
-      lastUserApplicationConnectionsRepository,
-      requestedApplication,
+    beforeEach(function () {
+      requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
+      authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
+        sessionContent: { idToken, accessToken: 'accessToken' },
+        userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
+      });
+      authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders.resolves(false);
+      oidcAuthenticationService.createUserAccount.resolves(10);
+      oidcAuthenticationService.createAccessToken
+        .withArgs({ userId: 10, audience })
+        .returns('accessTokenForExistingExternalUser');
+      oidcAuthenticationService.saveIdToken.withArgs({ idToken, userId: 10 }).resolves('logoutUrlUUID');
     });
 
-    // then
-    expect(oidcAuthenticationService.createUserAccount).to.have.been.calledWithMatch({
-      user: {
-        firstName: 'Jean',
-        lastName: 'Heymar',
+    it('creates the user account with given language and returns an access token, the logout url uuid and update the last logged date with the existing external user id', async function () {
+      // when
+      const result = await createOidcUser({
+        identityProvider: 'SOME_IDP',
+        authenticationKey: 'AUTHENTICATION_KEY',
         locale: 'nl-BE',
-        lang: 'nl',
-        cgu: true,
-        lastTermsOfServiceValidatedAt: now,
-      },
-      sessionContent: { idToken, accessToken: 'accessToken' },
-      externalIdentityId: 'externalId',
-      userToCreateRepository,
-      authenticationMethodRepository,
+        language,
+        audience,
+        authenticationSessionService,
+        oidcAuthenticationServiceRegistry,
+        authenticationMethodRepository,
+        userToCreateRepository,
+        userLoginRepository,
+        lastUserApplicationConnectionsRepository,
+        requestedApplication,
+      });
+
+      // then
+      expect(oidcAuthenticationService.createUserAccount).to.have.been.calledWithMatch({
+        user: {
+          firstName: 'Jean',
+          lastName: 'Heymar',
+          locale: 'nl-BE',
+          lang: 'nl',
+          cgu: true,
+          lastTermsOfServiceValidatedAt: now,
+        },
+        sessionContent: { idToken, accessToken: 'accessToken' },
+        externalIdentityId: 'externalId',
+        userToCreateRepository,
+        authenticationMethodRepository,
+      });
+      expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
+      expect(oidcAuthenticationService.saveIdToken).to.have.been.calledOnce;
+      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: 10 });
+      expect(result).to.deep.equal({
+        accessToken: 'accessTokenForExistingExternalUser',
+        logoutUrlUUID: 'logoutUrlUUID',
+      });
+      expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+        userId: 10,
+        identityProvider: oidcAuthenticationService.identityProvider,
+      });
+      expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
+        userId: 10,
+        application: 'app',
+        lastLoggedAt: sinon.match.instanceOf(Date),
+      });
     });
-    expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
-    expect(oidcAuthenticationService.saveIdToken).to.have.been.calledOnce;
-    expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: 10 });
-    expect(result).to.deep.equal({
-      accessToken: 'accessTokenForExistingExternalUser',
-      logoutUrlUUID: 'logoutUrlUUID',
-    });
-    expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
-      userId: 10,
-      identityProvider: oidcAuthenticationService.identityProvider,
-    });
-    expect(lastUserApplicationConnectionsRepository.upsert).to.have.been.calledWithExactly({
-      userId: 10,
-      application: 'app',
-      lastLoggedAt: sinon.match.instanceOf(Date),
+
+    context('when the authentication service has a connectionMethodCode', function () {
+      it('registers connectionMethodCode as identity provider and correctly uses it as a parameter', async function () {
+        // given
+        oidcAuthenticationService.connectionMethodCode = 'ALIAS_IDP';
+
+        // when
+        await createOidcUser({
+          identityProvider: 'SOME_IDP',
+          authenticationKey: 'AUTHENTICATION_KEY',
+          locale: 'nl-BE',
+          language,
+          audience,
+          authenticationSessionService,
+          oidcAuthenticationServiceRegistry,
+          authenticationMethodRepository,
+          userToCreateRepository,
+          userLoginRepository,
+          lastUserApplicationConnectionsRepository,
+          requestedApplication,
+        });
+
+        // then
+        expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.have.been.calledWithExactly({
+          userId: 10,
+          identityProvider: oidcAuthenticationService.connectionMethodCode,
+        });
+      });
+      context(
+        'when there is already an authentication method for this external id and this identityProvider',
+        function () {
+          it("throws an UserAlreadyExistsWithAuthenticationMethodError even if the identity provider's name to register is an alias of the already registered one", async function () {
+            // given
+            oidcAuthenticationService.connectionMethodCode = 'ALIAS_IDP';
+            oidcAuthenticationService.identityProvider = 'SOME_IDP';
+            authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
+              sessionContent: { idToken: 'idToken', accessToken: 'accessToken' },
+              userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
+            });
+            authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders.resolves(true);
+
+            // when
+            const error = await catchErr(createOidcUser)({
+              identityProvider: 'ALIAS_IDP',
+              authenticationKey: 'AUTHENTICATION_KEY',
+              authenticationSessionService,
+              oidcAuthenticationServiceRegistry,
+              authenticationMethodRepository,
+              userToCreateRepository,
+            });
+
+            // then
+            const call =
+              authenticationMethodRepository.hasAuthenticationMethodForAnyOfTheseIdentityProviders.getCall(0);
+            const externaIdentifierParameter = call.args[0].externalIdentifier;
+            const identityProvidersParameter = call.args[0].identityProviders;
+            expect(externaIdentifierParameter).to.equal('externalId');
+            expect(identityProvidersParameter).to.have.members(['SOME_IDP', 'ALIAS_IDP']);
+
+            expect(error).to.be.instanceOf(UserAlreadyExistsWithAuthenticationMethodError);
+            expect(error.message).to.equal('Authentication method already exists for this external identifier.');
+          });
+        },
+      );
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-saml-authentication-redirection-url_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
   let lastUserApplicationConnectionsRepository;
   let samlSettings;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     userRepository = {

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user-for-admin.usecase.test.js
@@ -16,7 +16,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
     oidcAuthenticationService;
   const identityProvider = 'genericOidcProviderCode';
   const audience = 'https://admin.pix.fr';
-  const requestedApplication = new RequestedApplication('admin');
+  const requestedApplication = new RequestedApplication({ applicationName: 'admin', applicationTld: '.fr' });
 
   beforeEach(function () {
     authenticationMethodRepository = {

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
@@ -10,7 +10,7 @@ import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-user', function () {
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   context('when identityProvider is generic', function () {
     let authenticationMethodRepository,

--- a/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/reconcile-oidc-user.usecase.test.js
@@ -115,87 +115,176 @@ describe('Unit | Identity Access Management | Domain | UseCase | reconcile-oidc-
         expect(error.message).to.be.equal('Les informations de compte requises sont manquantes');
       });
     });
+    context('when there is no connectionMethodCode', function () {
+      it('creates authentication method with complement', async function () {
+        // given
+        const sessionContent = { idToken: 'idToken' };
+        const externalIdentifier = 'external_id';
+        const userId = 1;
+        const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
+        authenticationSessionService.getByKey.resolves({
+          sessionContent,
+          userInfo,
+        });
 
-    it('creates authentication method with complement', async function () {
-      // given
-      const sessionContent = { idToken: 'idToken' };
-      const externalIdentifier = 'external_id';
-      const userId = 1;
-      const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
-      authenticationSessionService.getByKey.resolves({
-        sessionContent,
-        userInfo,
+        oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
+          new AuthenticationMethod.OidcAuthenticationComplement({
+            accessToken: 'accessToken',
+            expiredDate: new Date(),
+          }),
+        );
+
+        // when
+        await reconcileOidcUser({
+          authenticationKey: 'authenticationKey',
+          identityProvider,
+          audience,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          oidcAuthenticationServiceRegistry,
+          userLoginRepository,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
+        });
+
+        // then
+        expect(authenticationMethodRepository.create).to.be.calledOnce;
+        const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
+        expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
+        expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
+          AuthenticationMethod.OidcAuthenticationComplement,
+        );
       });
+      it('saves the last user connection', async function () {
+        // given
+        const sessionContent = { idToken: 'idToken' };
+        const externalIdentifier = 'external_id';
+        const userId = 1;
+        const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
+        authenticationSessionService.getByKey.resolves({
+          sessionContent,
+          userInfo,
+        });
+        oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
+          new AuthenticationMethod.OidcAuthenticationComplement({
+            accessToken: 'accessToken',
+            expiredDate: new Date(),
+          }),
+        );
 
-      oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
-        new AuthenticationMethod.OidcAuthenticationComplement({
-          accessToken: 'accessToken',
-          expiredDate: new Date(),
-        }),
-      );
+        // when
+        await reconcileOidcUser({
+          authenticationKey: 'authenticationKey',
+          identityProvider,
+          audience,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          oidcAuthenticationServiceRegistry,
+          userLoginRepository,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
+        });
 
-      // when
-      await reconcileOidcUser({
-        authenticationKey: 'authenticationKey',
-        identityProvider,
-        audience,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        oidcAuthenticationServiceRegistry,
-        userLoginRepository,
-        requestedApplication,
-        lastUserApplicationConnectionsRepository,
+        // then
+        expect(lastUserApplicationConnectionsRepository.upsert).to.be.calledWithExactly({
+          userId,
+          application: 'app',
+          lastLoggedAt: sinon.match.instanceOf(Date),
+        });
+
+        expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.be.calledWithExactly({
+          userId,
+          identityProvider,
+        });
       });
-
-      // then
-      expect(authenticationMethodRepository.create).to.be.calledOnce;
-      const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
-      expect(authenticationMethod).to.deep.contain({ identityProvider, externalIdentifier, userId });
-      expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
-        AuthenticationMethod.OidcAuthenticationComplement,
-      );
     });
+    context('when there is a connectionMethodCode', function () {
+      it('creates authentication method with complement and connectionMethodCode as identityProvider', async function () {
+        // given
+        oidcAuthenticationService.connectionMethodCode = 'aliasForGenericIdentityProvider';
+        const sessionContent = { idToken: 'idToken' };
+        const externalIdentifier = 'external_id';
+        const userId = 1;
+        const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
+        authenticationSessionService.getByKey.resolves({
+          sessionContent,
+          userInfo,
+        });
 
-    it('saves the last user connection', async function () {
-      // given
-      const sessionContent = { idToken: 'idToken' };
-      const externalIdentifier = 'external_id';
-      const userId = 1;
-      const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
-      authenticationSessionService.getByKey.resolves({
-        sessionContent,
-        userInfo,
+        oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
+          new AuthenticationMethod.OidcAuthenticationComplement({
+            accessToken: 'accessToken',
+            expiredDate: new Date(),
+          }),
+        );
+
+        // when
+        await reconcileOidcUser({
+          authenticationKey: 'authenticationKey',
+          identityProvider,
+          audience,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          oidcAuthenticationServiceRegistry,
+          userLoginRepository,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
+        });
+
+        // then
+        expect(authenticationMethodRepository.create).to.be.calledOnce;
+        const { authenticationMethod } = authenticationMethodRepository.create.firstCall.args[0];
+        expect(authenticationMethod).to.deep.contain({
+          identityProvider: 'aliasForGenericIdentityProvider',
+          externalIdentifier,
+          userId,
+        });
+        expect(authenticationMethod.authenticationComplement).to.be.instanceOf(
+          AuthenticationMethod.OidcAuthenticationComplement,
+        );
       });
-      oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
-        new AuthenticationMethod.OidcAuthenticationComplement({
-          accessToken: 'accessToken',
-          expiredDate: new Date(),
-        }),
-      );
+      it('saves the last user connection', async function () {
+        // given
+        oidcAuthenticationService.connectionMethodCode = 'aliasForGenericIdentityProvider';
+        const sessionContent = { idToken: 'idToken' };
+        const externalIdentifier = 'external_id';
+        const userId = 1;
+        const userInfo = { userId, externalIdentityId: externalIdentifier, firstName: 'Anne' };
+        authenticationSessionService.getByKey.resolves({
+          sessionContent,
+          userInfo,
+        });
+        oidcAuthenticationService.createAuthenticationComplement.withArgs({ userInfo, sessionContent }).returns(
+          new AuthenticationMethod.OidcAuthenticationComplement({
+            accessToken: 'accessToken',
+            expiredDate: new Date(),
+          }),
+        );
 
-      // when
-      await reconcileOidcUser({
-        authenticationKey: 'authenticationKey',
-        identityProvider,
-        audience,
-        authenticationSessionService,
-        authenticationMethodRepository,
-        oidcAuthenticationServiceRegistry,
-        userLoginRepository,
-        requestedApplication,
-        lastUserApplicationConnectionsRepository,
-      });
+        // when
+        await reconcileOidcUser({
+          authenticationKey: 'authenticationKey',
+          identityProvider,
+          audience,
+          authenticationSessionService,
+          authenticationMethodRepository,
+          oidcAuthenticationServiceRegistry,
+          userLoginRepository,
+          requestedApplication,
+          lastUserApplicationConnectionsRepository,
+        });
 
-      // then
-      expect(lastUserApplicationConnectionsRepository.upsert).to.be.calledWithExactly({
-        userId,
-        application: 'app',
-        lastLoggedAt: sinon.match.instanceOf(Date),
-      });
+        // then
+        expect(lastUserApplicationConnectionsRepository.upsert).to.be.calledWithExactly({
+          userId,
+          application: 'app',
+          lastLoggedAt: sinon.match.instanceOf(Date),
+        });
 
-      expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.be.calledWithExactly({
-        userId,
-        identityProvider,
+        expect(authenticationMethodRepository.updateLastLoggedAtByIdentityProvider).to.be.calledWithExactly({
+          userId,
+          identityProvider: oidcAuthenticationService.connectionMethodCode,
+        });
       });
     });
   });

--- a/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/utils/network.test.js
@@ -88,15 +88,17 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
 
   describe('RequestedApplication', function () {
     describe('constructor', function () {
-      it('initializes an applicationName property', function () {
+      it('creates an instance with properties', function () {
         // given
         const applicationName = 'orga';
+        const applicationTld = '.fr';
 
         // when
-        const requestedApplication = new RequestedApplication(applicationName);
+        const requestedApplication = new RequestedApplication({ applicationName, applicationTld });
 
         // then
         expect(requestedApplication.applicationName).to.equal('orga');
+        expect(requestedApplication.applicationTld).to.equal('.fr');
       });
     });
 
@@ -111,6 +113,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
         // then
         expect(requestedApplication).to.be.instanceOf(RequestedApplication);
         expect(requestedApplication.applicationName).to.equal('app');
+        expect(requestedApplication.applicationTld).to.equal('.org');
         expect(requestedApplication.isPixApp).to.be.true;
         expect(requestedApplication.isPixAdmin).to.be.false;
         expect(requestedApplication.isPixOrga).to.be.false;
@@ -129,6 +132,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
           // then
           expect(requestedApplication).to.be.instanceOf(RequestedApplication);
           expect(requestedApplication.applicationName).to.equal('app');
+          expect(requestedApplication.applicationTld).to.equal('.org');
           expect(requestedApplication.isPixApp).to.be.true;
           expect(requestedApplication.isPixAdmin).to.be.false;
           expect(requestedApplication.isPixOrga).to.be.false;
@@ -149,6 +153,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('app');
+            expect(requestedApplication.applicationTld).to.be.undefined;
             expect(requestedApplication.isPixApp).to.be.true;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -168,6 +173,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('orga');
+            expect(requestedApplication.applicationTld).to.be.undefined;
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.true;
@@ -187,6 +193,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('admin');
+            expect(requestedApplication.applicationTld).to.be.undefined;
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.true;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -206,6 +213,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('certif');
+            expect(requestedApplication.applicationTld).to.be.undefined;
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;
@@ -225,6 +233,7 @@ describe('Unit | Identity Access Management | Infrastructure | Utils | network',
             // then
             expect(requestedApplication).to.be.instanceOf(RequestedApplication);
             expect(requestedApplication.applicationName).to.equal('junior');
+            expect(requestedApplication.applicationTld).to.be.undefined;
             expect(requestedApplication.isPixApp).to.be.false;
             expect(requestedApplication.isPixAdmin).to.be.false;
             expect(requestedApplication.isPixOrga).to.be.false;

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -15,7 +15,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
 
   beforeEach(async function () {
     audience = 'https://app.pix.fr';
-    requestedApplication = new RequestedApplication('app');
+    requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
   });
 
   context('When the token is invalid', function () {

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let studentRepository;
   let lastUserApplicationConnectionsRepository;
   const audience = 'https://app.pix.fr';
-  const requestedApplication = new RequestedApplication('app');
+  const requestedApplication = new RequestedApplication({ applicationName: 'app', applicationTld: '.fr' });
 
   beforeEach(function () {
     userReconciliationService = {


### PR DESCRIPTION
## 🍂 Problème
Un même OIDC Provider peut être identifié par des identity-provider différents (par exemple "GENERIC_PROVIDER_ORGA" et "GENERIC_PROVIDER").
Dans ce cas la table authentication-methods ne doit ajouter ou mettre à jour qu'une méthode de connexion.

## 🌰 Proposition
<img width="2001" height="852" alt="schema_auth_method_code" src="https://github.com/user-attachments/assets/25d90233-19b1-453d-bf71-880ea0dbbdcd" />


## 🍁 Remarques

Cette PR est rebasée sur https://github.com/1024pix/pix/pull/14046. 

- Il manque la modification de api/src/identity-access-management/domain/usecases/reconcile-oidc-user-for-admin.usecase.js et de ses tests
- Il manque les tests d'acceptance

## 🪵 Pour tester

- modifier le fichier OIDC_PROVIDERS.json en local pour mettre dans certains OIDC providers un attribut connectionMethodCode différent de l'identityProvider
- Faire les parcours de connexion OIDC :
-- création de compte Pix,
--  réconciliation, 
--  connexion "simple" après création de compte ou réconciliation
  1.Pour chaque parcours, vérifier dans la table authentication-methods que l'identity provider est au nom du connectionMethodCode s'il existe, sinon de l'identityProvider.
  2. Vérifier qu'il est impossible de créer une méthode d'authentification avec un connexionMethodCode si une méthode d'authentification avec un identityProvider dont ce connexionMethodCode est l'alias existe déjà.
