### PR TITLE
[FEATURE] Amélioration du responsive sur l'écran de présentation du parcours combiné (PIX-20327)

### DIFF
--- a/mon-pix/app/components/combined-course/combined-course-item.gjs
+++ b/mon-pix/app/components/combined-course/combined-course-item.gjs
@@ -13,7 +13,8 @@ const Content = <template>
     class="combined-course-item
       {{if @hasYellowBorder 'combined-course-item--yellow-border'}}
       {{if @hasWhiteBackground 'combined-course-item--white'}}
-      {{if @isCurrentItem 'combined-course-item--current'}}"
+      {{if @isCurrentItem 'combined-course-item--current'}}
+      {{if @isCampaignType 'combined-course-item--isCampaignType'}}"
     ...attributes
   >
     <div class="combined-course-item__content">
@@ -42,36 +43,47 @@ const Content = <template>
     {{/if}}
     {{#if @isCompleted}}
       <div
-        class="combined-course-item__indicator--completed
-          {{if @hasYellowBorder 'combined-course-item__indicator--yellow'}}"
+        class="combined-course-item__indicator"
         aria-label={{if
           @isCampaignType
           (t "pages.combined-courses.items.aria-label-completed-campaign" value=@masteryRate)
         }}
       >
-        {{#if @isCampaignType}}
-          <span>{{t "common.display.percentage" value=@masteryRate}}</span>
-          {{#if @hasStagesStars}}
-            <PixStars
-              @count={{@validatedStagesCount}}
-              @total={{@totalStagesCount}}
-              @alt={{t
-                "pages.combined-courses.items.aria-label-completed-campaign-with-stages"
-                acquired=@validatedStagesCount
-                total=@totalStagesCount
-              }}
-              class="combined-course-item__stars"
-            />
-          {{/if}}
-        {{/if}}
-        <span class="combined-course-item__completion-field">{{t "pages.combined-courses.items.completed"}}</span>
-        <PixIcon
-          @name="checkCircle"
-          @plainIcon={{true}}
-          class="combined-course-item__icon {{if @hasYellowBorder 'combined-course-item__icon--yellow'}}"
-          @ariaHidden={{true}}
-        />
+        <div>
+        </div>
+        <div
+          class="combined-course-item__indicator--completed
+            {{if @hasYellowBorder 'combined-course-item__indicator--yellow'}}"
+        >
+          <span class="combined-course-item__completion-field">{{t "pages.combined-courses.items.completed"}}</span>
+          <PixIcon
+            @name="checkCircle"
+            @plainIcon={{true}}
+            class="combined-course-item__icon {{if @hasYellowBorder 'combined-course-item__icon--yellow'}}"
+            @ariaHidden={{true}}
+          />
+        </div>
       </div>
+      {{#if @isCampaignType}}
+        <div class="combined-course-item__campaign-indicators">
+
+          <span class="combined-course-item--campaign">{{t "common.display.percentage" value=@masteryRate}}
+            {{#if @hasStagesStars}}
+              <PixStars
+                @count={{@validatedStagesCount}}
+                @total={{@totalStagesCount}}
+                @alt={{t
+                  "pages.combined-courses.items.aria-label-completed-campaign-with-stages"
+                  acquired=@validatedStagesCount
+                  total=@totalStagesCount
+                }}
+                class="combined-course-item__stars"
+              />
+            {{/if}}
+
+          </span>
+        </div>
+      {{/if}}
     {{/if}}
     {{#if (has-block "blockEnd")}}
       {{yield to="blockEnd"}}

--- a/mon-pix/app/styles/components/_combined-courses.scss
+++ b/mon-pix/app/styles/components/_combined-courses.scss
@@ -1,5 +1,6 @@
 @use 'pix-design-tokens/typography';
 @use 'pix-design-tokens/breakpoints';
+@use '../globals/a11y' as *;
 
 .combined-course {
   padding: var(--pix-spacing-4x);
@@ -71,9 +72,10 @@
       color: var(--pix-secondary-900);
 
       &__title {
-        @extend %pix-title-s;
+            margin-bottom: var(--pix-spacing-2x);
+            font-size: 18px;
 
-        margin-bottom: var(--pix-spacing-2x);
+            @extend %pix-title-l;
       }
 
       &__description {
@@ -110,11 +112,26 @@
   gap: var(--pix-spacing-4x);
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   margin-bottom: var(--pix-spacing-4x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-6x);
   background: rgb(var(--pix-primary-100-inline), 0.2);
   border: 1px solid var(--pix-primary-100);
   border-radius: var(--pix-spacing-4x);
+
+  &--isCampaignType {
+    flex-wrap: wrap;
+
+    &__indicator--completed{
+      order: 1;
+    }
+
+     @include breakpoints.device-is('tablet') {
+      flex-basis: none;
+      flex-wrap: nowrap;
+    }
+
+  }
 
   &--formation {
     background: color-mix(in srgb, var(--pix-primary-100) 20%, transparent);
@@ -130,6 +147,7 @@
 
   &__content {
     display: flex;
+    flex-basis: auto;
     gap: var(--pix-spacing-4x);
     align-items: center;
   }
@@ -138,6 +156,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
+     &--yellow {
+          color: var(--pix-secondary-500);
+    }
   }
 
   &__title {
@@ -154,10 +176,42 @@
   }
 
   &__completion-field {
-    width: max-content;
+    @extend .sr-only;
+
+     @include breakpoints.device-is('tablet') {
+      position: static;
+      display: flex;
+      width: max-content;
+      width: auto;
+      width:100%;
+      height: auto;
+      margin: 0;
+      overflow: visible;
+      clip: auto;
+    }
   }
 
+  &--campaign {
+   display:flex;
+  }
+
+  &__campaign-indicators {
+    flex-basis: 100%;
+    order: 2;
+    color: var(--pix-primary-500);
+    font-weight: var(--pix-font-bold);
+
+    @include breakpoints.device-is('tablet') {
+        flex-basis: auto;
+        order: 1;
+        margin-left: auto;
+     }
+  }
+
+
   &__indicator {
+    order: 2;
+
     &--locked {
       display: flex;
       justify-content: center;
@@ -180,12 +234,15 @@
       font-weight: var(--pix-font-bold);
 
       .combined-course-item__icon {
-        width: var(--pix-spacing-8x);
+         @include breakpoints.device-is('tablet') {
+       width: var(--pix-spacing-8x);
         height: var(--pix-spacing-8x);
 
         &--yellow {
           color: var(--pix-secondary-500);
         }
+    }
+
       }
     }
 
@@ -195,7 +252,15 @@
   }
 
   &--current {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
     border: 6px solid var(--pix-primary-300);
+
+    @include breakpoints.device-is('tablet') {
+    flex-direction: row;
+    align-items: center;
+  }
 
     .combined-course-item__tag {
       display: flex;

--- a/mon-pix/tests/integration/components/combined-course/combined-course-item-test.gjs
+++ b/mon-pix/tests/integration/components/combined-course/combined-course-item-test.gjs
@@ -1,4 +1,4 @@
-import { getDefaultNormalizer, render } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import { t } from 'ember-intl/test-support';
 import CombinedCourseItem from 'mon-pix/components/combined-course/combined-course-item';
 import { module, test } from 'qunit';
@@ -184,11 +184,7 @@ module('Integration | Component | combined course item', function (hooks) {
       );
 
       //then
-      assert.ok(
-        screen.getByText(t('common.display.percentage', { value: 0.15 }), {
-          normalizer: getDefaultNormalizer({ trim: false, collapseWhitespace: false }),
-        }),
-      );
+      assert.ok(screen.getByText('15 %'));
 
       assert.ok(
         screen.getByText(


### PR DESCRIPTION
## 🍂 Problème
Un gros travail sur le responsive de ces écrans avait déjà été fait par @xav-car. 
On a juste ajusté le design par rapport :
- au taux de réussite / aux paliers acquis à la fin du parcours de diagnostic
- le tag "Vous en êtes là" 

## 🌰 Proposition

En mobile : 
On masque le texte du "Complété".
On utilise la propriété order en css pour pouvoir afficher la coche du "Complété" au niveau du titre de l'item.
On utilise flex-wrap pour faire passer le bloc taux de réussite / paliers acquis (les étoiles) pour faire passer le bloc en-dessous du titre.
On fait passer le tag "Vous en êtes là" en dessous du titre.

## 🪵 Pour tester

Se connecter sur attestation-blank@example.net avec comme mdp pix123
"J'ai un code" -> remplir par MAXICOMBI
Passer la campagne de diagnostic et basculer sur la vue mobile du navigateur pour vérifier le responsive
Partager ses résultats
Ecran de chargement : basculer sur la vue mobile du navigateur pour vérifier le responsive
Compléter le parcours et vérifier que tout s'affiche correctement en responsive à ce moment-là aussi