### PR TITLE
[FEATURE] Utiliser la nouvelle colonne passage_count pour le calcul du taux de couverture

### DIFF
--- a/api/datamart/datamart-builder/factory/build-organizations-cover-rates.js
+++ b/api/datamart/datamart-builder/factory/build-organizations-cover-rates.js
@@ -13,7 +13,7 @@ const buildOrganizationsCoverRates = function ({
   extraction_date,
   max_level,
   sum_user_max_level,
-  nb_user,
+  passage_count,
   nb_tubes_in_competence,
 } = {}) {
   const values = {
@@ -29,7 +29,7 @@ const buildOrganizationsCoverRates = function ({
     extraction_date,
     max_level,
     sum_user_max_level,
-    nb_user,
+    passage_count,
     nb_tubes_in_competence,
   };
 

--- a/api/datamart/seeds/populate-organization-cover-rates-datamart.js
+++ b/api/datamart/seeds/populate-organization-cover-rates-datamart.js
@@ -21,7 +21,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '3.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -37,7 +37,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '4.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 1,
   },
   {
@@ -53,7 +53,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '5.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -69,7 +69,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '2.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 1,
   },
   {
@@ -85,7 +85,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '2.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -101,7 +101,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '1.3',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -117,7 +117,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '1.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 1,
   },
   {
@@ -133,7 +133,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '5.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 1,
   },
   {
@@ -149,7 +149,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '4.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -165,7 +165,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '1.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -181,7 +181,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '3.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -197,7 +197,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '5.2',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 3,
   },
   {
@@ -213,7 +213,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '3.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 2,
   },
   {
@@ -229,7 +229,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '1.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 3,
   },
   {
@@ -245,7 +245,7 @@ const organizationCoverRates = [
     extraction_date: '2025-05-04',
     tag_name: 'PRO',
     competence_code: '2.1',
-    nb_user: 42,
+    passage_count: 42,
     max_level: 3,
   },
 ];

--- a/api/src/maddo/infrastructure/repositories/replication-repository.js
+++ b/api/src/maddo/infrastructure/repositories/replication-repository.js
@@ -69,7 +69,6 @@ export const replications = [
         'extraction_date',
         'max_level',
         'sum_user_max_level',
-        'nb_user',
         'passage_count',
         'nb_tubes_in_competence',
       );

--- a/api/src/prescription/organization-learner/infrastructure/repositories/analysis-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/analysis-repository.js
@@ -8,9 +8,11 @@ async function findByTubes({ organizationId }) {
       'competence_code',
       'competence_name as competence',
       'tube_practical_title as sujet',
-      knex.raw('sum(sum_user_max_level) / sum(nb_user) as niveau_par_user'),
-      knex.raw('sum(max_level * nb_user) / sum(nb_user) as niveau_par_sujet'),
-      knex.raw('(sum(sum_user_max_level) / sum(nb_user)) / (sum(max_level * nb_user) / sum(nb_user)) as couverture'),
+      knex.raw('sum(sum_user_max_level) / sum(passage_count) as niveau_par_user'),
+      knex.raw('sum(max_level * passage_count) / sum(passage_count) as niveau_par_sujet'),
+      knex.raw(
+        '(sum(sum_user_max_level) / sum(passage_count)) / (sum(max_level * passage_count) / sum(passage_count)) as couverture',
+      ),
     )
     .where('orga_id', organizationId)
     .groupBy('extraction_date', 'domain_name', 'competence_code', 'competence_name', 'tube_id', 'tube_practical_title')

--- a/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
+++ b/api/tests/prescription/organization-learner/acceptance/application/organization-learners-route_test.js
@@ -217,7 +217,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
           extraction_date: '2025-01-01',
           max_level: 5,
           sum_user_max_level: 2,
-          nb_user: 2,
+          passage_count: 2,
           nb_tubes_in_competence: 1,
         });
         datamartBuilder.factory.buildOrganizationsCoverRates({
@@ -231,7 +231,7 @@ describe('Prescription | Organization Learner | Acceptance | Application | Organ
           extraction_date: '2025-01-01',
           max_level: 7,
           sum_user_max_level: 6,
-          nb_user: 2,
+          passage_count: 2,
           nb_tubes_in_competence: 1,
         });
         await datamartBuilder.commit();

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/analysis-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/analysis-repository_test.js
@@ -22,7 +22,7 @@ describe('Integration | Infrastructure | Repository | Analysis', function () {
         extraction_date: '2025-01-01',
         max_level: 5,
         sum_user_max_level: 2,
-        nb_user: 2,
+        passage_count: 2,
         nb_tubes_in_competence: 1,
       });
       datamartBuilder.factory.buildOrganizationsCoverRates({
@@ -36,7 +36,7 @@ describe('Integration | Infrastructure | Repository | Analysis', function () {
         extraction_date: '2025-01-01',
         max_level: 7,
         sum_user_max_level: 6,
-        nb_user: 2,
+        passage_count: 2,
         nb_tubes_in_competence: 1,
       });
 
@@ -53,7 +53,7 @@ describe('Integration | Infrastructure | Repository | Analysis', function () {
         extraction_date: '2025-01-01',
         max_level: 5,
         sum_user_max_level: 2,
-        nb_user: 2,
+        passage_count: 2,
         nb_tubes_in_competence: 1,
       });
 


### PR DESCRIPTION
## 🍂 Problème

La colonne `nb_user` a été renommée dans la table `data_pro_campaigns_kpi_aggregated` de `pix-datawarehouse`.
La nouvelle colonne `passage_count` est maintenant répliquée dans la table `organizations_cover_rates`. C'est cette nouvelle colonne qui doit être utilisée en remplacement de `nb_user` pour le calcul du taux de couverture.

## 🌰 Proposition

Mettre à jour le calcul du taux de couverture pour utiliser la colonne `passage_count`.

## 🍁 Remarques

* Les seeds du datamart concernant le taux de couverture sont également mise à jour par cette PR.
* La réplication de l'ancienne colonne `nb_user` est supprimée.

## 🪵 Pour tester

Le taux de couverture apparait bien pour l'orga "PRO Classic".