### PR TITLE
[FEATURE] Supprimer la colonne nb_user de la table organizations_cover_rates (PIX-20110)

### DIFF
--- a/api/datamart/migrations/20251112111614_remove-column-nb_user-from-organizations_cover_rates.js
+++ b/api/datamart/migrations/20251112111614_remove-column-nb_user-from-organizations_cover_rates.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'organizations_cover_rates';
+const COLUMN_NAME = 'nb_user';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigint('COLUMN_NAME');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

La colonne nb_user a été renommée dans la table data_pro_campaigns_kpi_aggregated de pix-datawarehouse.
La nouvelle colonne passage_count est maintenant utilisée partout et la colonne nb_user n'est plus alimentée (via la réplication), ni utilisée.

## 🌰 Proposition

Supprimer la colonne `nb_user` qui est maintenant obsolète.

## 🪵 Pour tester

* Lancer une réplication. Celle-ci se déroule sans erreur.

Positionner des données dans la table data_pro_campaigns_kpi_aggregated du datawarehouse d'intégration.

Créer un token avec le scope replication :

```
ACCESS_TOKEN=$(curl -X 'POST' \
  'https://pix-api-maddo-review-pr14155.osc-fr1.scalingo.io/api/application/token' \
  -s -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=pixData&client_secret=pixdatasecret&scope=replication' | jq -r .access_token)
```

Lancer la réplication :

```
curl -X POST "https://pix-api-maddo-review-pr14155.osc-fr1.scalingo.io/api/replications/organizations_cover_rates" -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN"
```

Se connecter à la DB de Maddo (le datamart) pour s'assurer que les données ont bien été répliquée et que les valeurs des colonnes nb_user et passage_count sont identiques (les mêmes que dans data_pro_campaigns_kpi_aggregated a minima).

```
scalingo -a "pix-api-maddo-review-pr14155" psql-console
```

* Accéder au taux de couverture de l'orga "PRO Classic" dans Pix Orga.
