### PR TITLE
[BUGFIX] Corriger le focusAndScroll en Mobile (PIX-20402)

### DIFF
--- a/mon-pix/app/components/module/_passage.scss
+++ b/mon-pix/app/components/module/_passage.scss
@@ -1,6 +1,16 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
+
 
 .module-passage {
+  @include breakpoints.device-is('mobile') {
+    padding-top: 0;
+
+    &--new-pattern {
+      padding-top: 70px;
+    }
+  }
+
   max-width: var(--modulix-max-content-width);
   margin: 0 auto;
   padding: 0 var(--pix-spacing-4x);

--- a/mon-pix/app/components/module/layout/_navigation.scss
+++ b/mon-pix/app/components/module/layout/_navigation.scss
@@ -8,7 +8,11 @@ img.module-navigation {
 
 .module-navigation {
   @include breakpoints.device-is('mobile') {
-    position: sticky;
+    position: fixed;
+    top: var(--pix-spacing-2x);
+    right: var(--pix-spacing-2x);
+    left: var(--pix-spacing-2x);
+    width: calc(100vw - var(--pix-spacing-4x));
     padding: 0;
   }
 

--- a/mon-pix/app/components/module/passage.gjs
+++ b/mon-pix/app/components/module/passage.gjs
@@ -32,6 +32,10 @@ export default class ModulePassage extends Component {
     });
   }
 
+  get isNewPattern() {
+    return this.args.module.isNewPattern;
+  }
+
   @action
   getSectionTypeForGrain(grain) {
     return this.enrichedSections.find((section) => section.firstGrainId === grain.id).sectionType;
@@ -251,7 +255,7 @@ export default class ModulePassage extends Component {
   <template>
     {{pageTitle @module.title}}
 
-    <main class="module-passage">
+    <main class="module-passage {{if this.isNewPattern 'module-passage--new-pattern'}}">
       {{#if @module.isBeta}}
         <BetaBanner />
       {{/if}}


### PR DESCRIPTION
## 🍂 Problème

En mobile, le scroll ne fonctionne pas correctement : le viewport n'est pas positionné au bon endroit dans la page, ou pas déplacé du tout.

Après enquête, nous avons compris que le problème est dû au fait que plusieurs évènements scroll surviennent en même au clic sur le bouton de navigation. En effet, le clic ferme le menu, et comme celui-ci est dans une div avec `position: sticky`, cela provoque un déplacement dans la page et donc un évènement scroll qui prend le pas sur le notre.

Or, le positionnement `sticky` n'est pas nécessaire ici étant donné que la barre de navigation est toujours affichée en haut de la page et que sa position ne change pas au scroll.

## 🌰 Proposition

Remplacer le positionnement `sticky` par un positionnement `fixed`.

## 🍁 Remarques

RAS

## 🪵 Pour tester

**En mobile**

1. Se rendre sur le module [bac-a-sable](https://app-pr14156.review.pix.fr/modules/bac-a-sable/details)
2. Passer les grains jusqu'à la deuxième section
3. Utiliser le menu de navigation pour naviguer entre les deux sections et constater que le viewport se positionne au bon endroit

**En desktop**

Non-régression sur la navigation de modules
