### PR TITLE
[BUGFIX] Corriger le problème du formulaire de récupération d'espace Pix Orga lorsqu’il est soumis par clavier (PIX-20420)

### DIFF
--- a/orga/app/components/authentication/join-request-form.gjs
+++ b/orga/app/components/authentication/join-request-form.gjs
@@ -83,7 +83,7 @@ export default class JoinRequestForm extends Component {
             @id="uai"
             name="uai"
             type="text"
-            {{on "focusout" this.validateUai}}
+            {{on "change" this.validateUai}}
             @errorMessage={{this.uaiValidationMessage}}
             @validationStatus={{if this.uaiValidationMessage "error" "default"}}
             required={{true}}
@@ -100,7 +100,7 @@ export default class JoinRequestForm extends Component {
             @id="firstName"
             name="firstName"
             type="firstName"
-            {{on "focusout" this.validateFirstName}}
+            {{on "change" this.validateFirstName}}
             @errorMessage={{this.firstNameValidationMessage}}
             @validationStatus={{if this.firstNameValidationMessage "error" "default"}}
             required={{true}}
@@ -116,7 +116,7 @@ export default class JoinRequestForm extends Component {
             @id="lastName"
             name="lastName"
             type="lastName"
-            {{on "focusout" this.validateLastName}}
+            {{on "change" this.validateLastName}}
             @errorMessage={{this.lastNameValidationMessage}}
             @validationStatus={{if this.lastNameValidationMessage "error" "default"}}
             required={{true}}


### PR DESCRIPTION
## 🍂 Problème

Les valeurs des champs du formulaire sont enregistrées pour envoi à l’API sur l’événement `focusout`. Et lorsqu’on soumet le formulaire au clavier avec la touche _« Entrée »_ il n’y a pas d’événement `focusout` émis.

### Pour reproduire

Après avoir rempli le dernier champ _« Votre nom »_, ne pas utiliser le pointeur pour cliquer sur le bouton _« Confirmer »_, mais appuyer directement sur la touche _« Entrée »_ pour soumettre le formulaire.

## 🌰 Proposition

Remplacer les événements `focusout` par `change`, de manière à ce que dans le formulaire soit toujours enregistrée la valeur courante de chaque champ.

C’est un correctif minimaliste. Une meilleure manière de faire serait de ne pas enregistrer les valeurs des champs du formulaire et les récupérer uniquement lors du submit pour l’envoi des valeurs à l’API.

## 🍁 Remarques

RAS

## 🪵 Pour tester

1. Aller sur le formulaire https://orga-pr14159.review.pix.fr/demande-administration-sco
2. Remplir le champ _«  UAI/RNE de l'établissement »_ avec l’identifiant d’une organisation que l’on peut récupérer, par exemple `ACCESS_SCO_BAUDELAIRE`
3. Après avoir rempli le dernier champ _« Votre nom »_, ne pas utiliser le pointeur pour cliquer sur le bouton _« Confirmer »_, mais appuyer directement sur la touche _« Entrée »_ pour soumettre le formulaire.
4. Constater l’affichage du message de succès : _« Un e-mail contenant la démarche à suivre a été envoyé à l'adresse e-mail de votre établissement. »_