### PR TITLE
[TECH] :broom: Réduit la « densité informationnelle » (PIX-5750)

### DIFF
--- a/certif/app/components/sessions/session-details/controls-links.gjs
+++ b/certif/app/components/sessions/session-details/controls-links.gjs
@@ -10,7 +10,6 @@ export default class ControlsLinks extends Component {
 
   <template>
     <div class='session-details__controls-links'>
-      <span class='session-details__controls-title'>{{t 'pages.sessions.detail.downloads.label'}}</span>
       <PixButtonLink
         href='{{@urlToDownloadSessionIssueReportSheet}}'
         @variant='secondary'

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -700,8 +700,7 @@
           "invigilator-kit": {
             "extra-information": "Download invigilator’s kit",
             "label": "Invigilator’s kit"
-          },
-          "label": "Downloads:"
+          }
         },
         "page-title": "Details | Session {sessionId} | Pix Certif",
         "panel-clea": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -700,8 +700,7 @@
           "invigilator-kit": {
             "extra-information": "Télécharger le kit surveillant",
             "label": "Kit surveillant"
-          },
-          "label": "Téléchargements :"
+          }
         },
         "page-title": "Détails | Session {sessionId} | Pix Certif",
         "panel-clea": {


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de l’audit design Pix Certif, il a été remonté un problème de densité informationnelle à ce niveau. En effet, la page étant déjà très riche, le label “téléchargements” constitue une surcharge.

## 🌰 Proposition

Supprimer le label "téléchargements".

## 🍁 Remarques

Le ticket évoque un lien 
> Prévoir un lien vers la doc dans la page pour aider à l'administration d'une session.

Comme il n'y a pas d'information à propos de la doc, ça sera fait dans un autre ticket.

## 🪵 Pour tester

Aller sur la page de session d'une certification
(par exemple https://certif-pr14161.review.pix.fr/sessions/7407)
Et constater qu'il n'y a plus le label « Téléchargements : »

<img width="1532" height="316" alt="image" src="https://github.com/user-attachments/assets/dea2892e-dc2f-42b7-8279-1c8fcb768963" />

