### PR TITLE
[TECH] Supprimer le feature toggle isModulixNavEnabled (PIX-20352)(PIX-20034)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -74,13 +74,6 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-acces', 'pix-orga'],
   },
-  isModulixNavEnabled: {
-    type: 'boolean',
-    description: 'Enables navigation for modules',
-    defaultValue: false,
-    devDefaultValues: { test: false, reviewApp: true },
-    tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
-  },
   isPixPlusCandidateA11yEnabled: {
     type: 'boolean',
     description: 'Enable candidate accessibility adjustment for Pix+ certifications',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -29,7 +29,6 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-self-account-deletion-enabled': true,
             'is-text-to-speech-button-enabled': true,
             'use-pix-orga-new-auth-design': false,
-            'is-modulix-nav-enabled': false,
             'is-pix-plus-candidate-a11y-enabled': false,
             'are-module-short-id-urls-enabled': false,
           },

--- a/mon-pix/app/components/global/modulix-app-layout.gjs
+++ b/mon-pix/app/components/global/modulix-app-layout.gjs
@@ -26,7 +26,7 @@ export default class ModulixAppLayout extends Component {
   }
 
   get shouldDisplayNavigation() {
-    return this.featureToggles.featureToggles?.isModulixNavEnabled && this.args.isModulixPassage && this.isNewPattern;
+    return this.args.isModulixPassage && this.isNewPattern;
   }
 
   <template>

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -5,6 +5,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isQuestEnabled;
   @attr('boolean') isAutoShareEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
-  @attr('boolean') isModulixNavEnabled;
   @attr('boolean') areModuleShortIdUrlsEnabled;
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -4,7 +4,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (hooks) {
   setupApplicationTest(hooks);
@@ -142,57 +141,53 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
     });
   });
 
-  module('when FT isModulixNavEnabled is enabled', function () {
-    module('when the user moves on to the next section', function () {
-      test('should change the state of navigation section buttons', async function (assert) {
-        // given
-        const featureToggles = this.owner.lookup('service:featureToggles');
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixNavEnabled: true });
-        const sections = _createSections(server);
+  module('when the user moves on to the next section', function () {
+    test('should change the state of navigation section buttons', async function (assert) {
+      // given
+      const sections = _createSections(server);
 
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          sections,
-        });
-
-        // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-        const navigation = screen.getByRole('navigation', { name: t('navigation.nav-bar.aria-label') });
-        const firstSectionButton = within(navigation).getByRole('button', {
-          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-            indexSection: 1,
-            totalSections: 2,
-          })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
-            sectionTitle: 'Explorer pour comprendre',
-          })}`,
-        });
-        const secondSectionButton = within(navigation).getByRole('button', {
-          name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
-            indexSection: 2,
-            totalSections: 2,
-          })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
-        });
-
-        // then
-        assert.dom(firstSectionButton).hasAttribute('aria-current', 'step');
-        assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
-
-        assert.dom(secondSectionButton).hasAttribute('aria-current', 'false');
-        assert.dom(secondSectionButton).hasAttribute('aria-disabled', 'true');
-
-        //when
-        await click(screen.getByRole('button', { name: 'Continuer' }));
-        await click(screen.getByRole('button', { name: 'Continuer' }));
-
-        // then
-        assert.dom(firstSectionButton).hasAttribute('aria-current', 'false');
-        assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
-
-        assert.dom(secondSectionButton).hasAttribute('aria-current', 'step');
-        assert.dom(secondSectionButton).hasNoAttribute('aria-disabled');
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        sections,
       });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const navigation = screen.getByRole('navigation', { name: t('navigation.nav-bar.aria-label') });
+      const firstSectionButton = within(navigation).getByRole('button', {
+        name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+          indexSection: 1,
+          totalSections: 2,
+        })} ${t('pages.modulix.navigation.buttons.aria-label.enabled', {
+          sectionTitle: 'Explorer pour comprendre',
+        })}`,
+      });
+      const secondSectionButton = within(navigation).getByRole('button', {
+        name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {
+          indexSection: 2,
+          totalSections: 2,
+        })} ${t('pages.modulix.navigation.buttons.aria-label.disabled')}`,
+      });
+
+      // then
+      assert.dom(firstSectionButton).hasAttribute('aria-current', 'step');
+      assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
+
+      assert.dom(secondSectionButton).hasAttribute('aria-current', 'false');
+      assert.dom(secondSectionButton).hasAttribute('aria-disabled', 'true');
+
+      //when
+      await click(screen.getByRole('button', { name: 'Continuer' }));
+      await click(screen.getByRole('button', { name: 'Continuer' }));
+
+      // then
+      assert.dom(firstSectionButton).hasAttribute('aria-current', 'false');
+      assert.dom(firstSectionButton).hasNoAttribute('aria-disabled');
+
+      assert.dom(secondSectionButton).hasAttribute('aria-current', 'step');
+      assert.dom(secondSectionButton).hasNoAttribute('aria-disabled');
     });
   });
 });

--- a/mon-pix/tests/integration/components/global/module-app-layout-test.gjs
+++ b/mon-pix/tests/integration/components/global/module-app-layout-test.gjs
@@ -10,80 +10,41 @@ module('Integration | Component | Global | Module App Layout', function (hooks) 
 
   module('navigation', function (hooks) {
     let store;
-    let featureToggles;
     let routerService;
 
     hooks.beforeEach(function () {
       store = this.owner.lookup('service:store');
-      featureToggles = this.owner.lookup('service:featureToggles');
       routerService = this.owner.lookup('service:router');
     });
     module('When route is ‘passage‘', function () {
       module('When module has multiple sections', function () {
-        module('when isModulixNavEnabled feature toggle is enabled', function () {
-          test('it should display a navbar', async function (assert) {
-            // given
-            const currentRoute = {
-              name: 'module.passage',
-              params: {},
-              parent: {
-                name: 'module',
-                params: {
-                  slug: 'mon-slug',
-                },
+        test('it should display a navbar', async function (assert) {
+          // given
+          const currentRoute = {
+            name: 'module.passage',
+            params: {},
+            parent: {
+              name: 'module',
+              params: {
+                slug: 'mon-slug',
               },
-            };
-            sinon.stub(routerService, 'currentRoute').value(currentRoute);
+            },
+          };
+          sinon.stub(routerService, 'currentRoute').value(currentRoute);
 
-            sinon.stub(featureToggles, 'featureToggles').value({ isModulixNavEnabled: true });
+          const section = store.createRecord('section', { type: 'question-yourself', grains: [] });
+          const anotherSection = store.createRecord('section', { type: 'explore-to-understand', grains: [] });
 
-            const section = store.createRecord('section', { type: 'question-yourself', grains: [] });
-            const anotherSection = store.createRecord('section', { type: 'explore-to-understand', grains: [] });
-
-            store.createRecord('module', {
-              slug: 'mon-slug',
-              sections: [section, anotherSection],
-            });
-
-            // when
-            const screen = await render(<template><ModulixAppLayout @isModulixPassage={{true}} /></template>);
-
-            // then
-            assert.dom(screen.getByRole('navigation')).exists();
+          store.createRecord('module', {
+            slug: 'mon-slug',
+            sections: [section, anotherSection],
           });
-        });
 
-        module('when isModulixNavEnabled feature toggle is disabled', function () {
-          test('it should not display a navbar', async function (assert) {
-            // given
-            const currentRoute = {
-              name: 'module.passage',
-              params: {},
-              parent: {
-                name: 'module',
-                params: {
-                  slug: 'mon-slug',
-                },
-              },
-            };
-            sinon.stub(routerService, 'currentRoute').value(currentRoute);
+          // when
+          const screen = await render(<template><ModulixAppLayout @isModulixPassage={{true}} /></template>);
 
-            sinon.stub(featureToggles, 'featureToggles').value({ isModulixNavEnabled: false });
-
-            const section = store.createRecord('section', { type: 'question-yourself', grains: [] });
-            const anotherSection = store.createRecord('section', { type: 'explore-to-understand', grains: [] });
-
-            store.createRecord('module', {
-              slug: 'mon-slug',
-              sections: [section, anotherSection],
-            });
-
-            // when
-            const screen = await render(<template><ModulixAppLayout @isModulixPassage={{true}} /></template>);
-
-            // then
-            assert.dom(screen.queryByRole('navigation')).doesNotExist();
-          });
+          // then
+          assert.dom(screen.getByRole('navigation')).exists();
         });
       });
 
@@ -101,8 +62,6 @@ module('Integration | Component | Global | Module App Layout', function (hooks) 
             },
           };
           sinon.stub(routerService, 'currentRoute').value(currentRoute);
-
-          sinon.stub(featureToggles, 'featureToggles').value({ isModulixNavEnabled: true });
 
           const section = store.createRecord('section', { type: 'blank', grains: [] });
 
@@ -134,8 +93,6 @@ module('Integration | Component | Global | Module App Layout', function (hooks) 
           },
         };
         sinon.stub(routerService, 'currentRoute').value(currentRoute);
-
-        sinon.stub(featureToggles, 'featureToggles').value({ isModulixNavEnabled: true });
 
         const section = store.createRecord('section', { type: 'question-yourself', grains: [] });
         const anotherSection = store.createRecord('section', { type: 'explore-to-understand', grains: [] });


### PR DESCRIPTION
## 🍂 Problème

Nous n'avons plus besoin du feature toggle `isModulixNavEnabled` maintenant que la nouvelle barre de navigation est activée en prod.

## 🌰 Proposition

Le supprimer.

## 🍁 Remarques

RAS

## 🪵 Pour tester

1. Vérifier que le featureToggle `isModulixNavEnabled` n'est plus dans la liste des featureToggles de l'environnement (RA) : `scalingo -a pix-api-review-pr14163 run "npm run toggles -- --list"`
2. Se rendre sur un module à plusieurs sections (par exemple [bac-a-sable](https://app-pr14163.review.pix.fr/modules/bac-a-sable))
3. Constater que la barre de navigation apparaît
4. Se rendre sur un module à une section (par exemple [galerie](https://app-pr14163.review.pix.fr/modules/galerie))
5. Constater que la barre de navigation n'apparaît pas
