### PR TITLE
[FEATURE] Afficher le besoin d'a11y dans la modale de détail d'un candidat (PIX-13681).

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-details-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-details-modal.gjs
@@ -78,6 +78,13 @@ export default class CandidateDetailsModal extends Component {
     return transform(value) || value || '-';
   }
 
+  @action
+  getAccessibilityAdjustmentNeeded() {
+    return this.args.candidate['accessibilityAdjustmentNeeded']
+      ? this.intl.t('common.labels.candidate.accessibility-adjusted-certification-needed')
+      : '-';
+  }
+
   computeSubscriptionsText = (candidate) => {
     const complementaryCertificationList = this.args.complementaryCertifications ?? [];
     const subscriptionLabels = [];
@@ -115,6 +122,10 @@ export default class CandidateDetailsModal extends Component {
               @value={{this.getRowValue field.value field.transform}}
             />
           {{/each}}
+          <CandidateDetailsModalRow
+            @label={{this.getRowLabel 'forms.certification-labels.accessibility'}}
+            @value={{this.getAccessibilityAdjustmentNeeded}}
+          />
           {{#if @shouldDisplayPaymentOptions}}
             <CandidateDetailsModalRow
               @label={{this.getRowLabel 'forms.certification-labels.pricing'}}

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-details-modal-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-details-modal-test.gjs
@@ -32,6 +32,7 @@ module(
         birthInseeCode: 76255,
         birthPostalCode: 76260,
         sex: 'F',
+        accessibilityAdjustmentNeeded: true,
         subscriptions: [pixEduSubscription],
       });
 
@@ -67,6 +68,7 @@ module(
       assert.dom(screen.getByText('12345')).exists();
       assert.dom(screen.getByText('25/12/2000')).exists();
       assert.dom(screen.getByText('10 %')).exists();
+      assert.dom(screen.getByText('Oui')).exists();
       assert.dom(screen.getByText('Pix+Edu')).exists();
     });
 
@@ -150,7 +152,7 @@ module(
         );
 
         // then
-        assert.strictEqual(screen.getAllByText('-').length, 12);
+        assert.strictEqual(screen.getAllByText('-').length, 13);
       });
     });
 
@@ -175,6 +177,7 @@ module(
           birthInseeCode: 76255,
           birthPostalCode: 76260,
           sex: 'F',
+          accessibilityAdjustmentNeeded: false,
           billingMode: 'PREPAID',
           prepaymentCode: 'prep123',
           subscriptions: [coreSubscription],
@@ -207,6 +210,7 @@ module(
         assert.dom(screen.getByText('12345')).exists();
         assert.dom(screen.getByText('25/12/2000')).exists();
         assert.dom(screen.getByText('10 %')).exists();
+        assert.dom(screen.getByText('-')).exists();
         assert.dom(screen.getByText('Prépayée')).exists();
         assert.dom(screen.getByText('prep123')).exists();
       });


### PR DESCRIPTION
## 🍂 Problème

Si ce champ a été ajouté en base de donnée, il n’est actuellement pas visualisable pour le centre de certification depuis la page de détails d’un candidat dans Pix Certif.

## 🌰 Proposition

Permettre aux utilisateurs Pix certif de visualiser l’information concernant un besoin d’aménagement pour un candidat depuis sa page de détails.

Sur la page de détails du candidat (accessible depuis la liste des candidats, bouton “Voir le détail”) :
- ajouter un champ “Accessibilité” - Oui / Non
- à placer après le champ “Temps majoré (%)”

<img width="427" height="134" alt="image" src="https://github.com/user-attachments/assets/bb7e3b47-1f8a-440a-9885-8ccc89f67760" />

## 🪵 Pour tester

✅  Visualiser en RA
