### PR TITLE
[FEATURE] Ajouter un feature toggle areModuleShortIdUrlsEnabled (PIX-20381)

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -87,4 +87,11 @@ export default {
     defaultValue: false,
     tags: ['frontend', 'a11y', 'team-certif', 'pix-certif'],
   },
+  areModuleShortIdUrlsEnabled: {
+    type: 'boolean',
+    description: 'Enable module urls using short ID before slug',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
+    tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
+  },
 };

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -31,6 +31,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'use-pix-orga-new-auth-design': false,
             'is-modulix-nav-enabled': false,
             'is-pix-plus-candidate-a11y-enabled': false,
+            'are-module-short-id-urls-enabled': false,
           },
         },
       };

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -6,4 +6,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isAutoShareEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') isModulixNavEnabled;
+  @attr('boolean') areModuleShortIdUrlsEnabled;
 }


### PR DESCRIPTION
## 🌰 Proposition

Créer un feature toggle pour l'implémentation des urls des modules qui utiliseront un short-id et le slug. 
On l'appelle `areModuleShortIdUrlsEnabled`.

## 🍁 Remarques

RAS

## 🪵 Pour tester

- Ouvrir le [bac-a-sable](https://app-pr14169.review.pix.fr/modules/bac-a-sable)
- Vérifier, grâce à la console dev, que la requête vers l'API `feature-toggles` renvoie bien `areModuleShortIdUrlsEnabled`à `false`
