### PR TITLE
[TECH] Rendre facile l’utilisation des variables d’environnement DOMAIN_PIX*** (DOMAIN_PIX_CERTIF, etc.) rapport aux tests

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -522,8 +522,9 @@ const configuration = (function () {
     config.domain.tldFr = '.fr';
     config.domain.tldOrg = '.org';
     config.domain.pix = 'https://pix';
-    config.domain.pixOrga = 'https://orga.pix';
     config.domain.pixApp = 'https://test.app.pix';
+    config.domain.pixOrga = 'https://orga.pix';
+    config.domain.pixCertif = 'https://certif.pix';
 
     config.features.dayBeforeRetrying = 4;
     config.features.dayBeforeImproving = 4;


### PR DESCRIPTION
## 🍂 Problème

Actuellement quand en local on veut mettre dans son `api/.env` tout un bloc pour définir les variables d’environnement `DOMAIN_PIX***`, comme ci-dessous, on a des erreurs lorsqu’on exécute les tests.

```shell
DOMAIN_PIX="https://pix.dev"
DOMAIN_PIX_APP="https://app.dev.pix"
DOMAIN_PIX_ORGA="https://orga.dev.pix"
DOMAIN_PIX_CERTIF="https://certif.dev.pix"
```

💡 Or mettre en place cette configuration dans son `api/.env` permet d’avoir des liens fonctionnels (dans les courriels transactionnels par exemple) sans avoir faire de pénibles remplacements manuels répétitifs sur les URL.

Or il s’agit d’un tout petit problème : la valeur pour la variable d’environnement `DOMAIN_PIX_CERTIF` n’est pas définie pour l’environnement de `test`.

## 🌰 Proposition

Définir la valeur pour la variable d’environnement `DOMAIN_PIX_CERTIF` pour l’environnement de `test`.

## 🍁 Remarques

RAS

## 🪵 Pour tester

* Vérifier que la CI passe
* En local ajouter le bloc de code suivant dans son `api/.env`, exécuter les tests (`npm t`) et constater que les tests s’exécutent sans erreur :

```shell
DOMAIN_PIX="https://pix.dev"
DOMAIN_PIX_APP="https://app.dev.pix"
DOMAIN_PIX_ORGA="https://orga.dev.pix"
DOMAIN_PIX_CERTIF="https://certif.dev.pix"
```

