### PR TITLE
[FEATURE] Ajouter un champ shortId aux modules (PIX-20382)

### DIFF
--- a/api/scripts/modulix/add-short-id-for-modules.js
+++ b/api/scripts/modulix/add-short-id-for-modules.js
@@ -1,0 +1,18 @@
+import { randomBytes } from 'node:crypto';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as url from 'node:url';
+
+const modulesPath = url.fileURLToPath(
+  new URL('../../../api/src/devcomp/infrastructure/datasources/learning-content/modules', import.meta.url),
+);
+const moduleNames = readdirSync(modulesPath);
+moduleNames.forEach((moduleName) => {
+  const fileData = readFileSync(`${modulesPath}/${moduleName}`, 'utf8');
+  const jsonParsed = JSON.parse(fileData);
+  if (!Object.keys(jsonParsed).includes('shortId')) {
+    const moduleWithShortId = { id: jsonParsed.id, shortId: randomBytes(4).toString('hex') };
+    delete jsonParsed['id'];
+    const finalModule = { ...moduleWithShortId, ...jsonParsed };
+    writeFileSync(`${modulesPath}/${moduleName}`, JSON.stringify(finalModule, null, 2));
+  }
+});

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,8 +1,9 @@
 import { assertIsArray, assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class Module {
-  constructor({ id, slug, title, isBeta, sections, details, version }) {
+  constructor({ id, shortId, slug, title, isBeta, sections, details, version }) {
     assertNotNullOrUndefined(id, 'The id is required for a module');
+    assertNotNullOrUndefined(shortId, 'The shortId is required for a module');
     assertNotNullOrUndefined(slug, 'The slug is required for a module');
     assertNotNullOrUndefined(title, 'The title is required for a module');
     assertNotNullOrUndefined(isBeta, 'isBeta value is required for a module');
@@ -10,6 +11,7 @@ class Module {
     assertNotNullOrUndefined(details, 'The details are required for a module');
 
     this.id = id;
+    this.shortId = shortId;
     this.slug = slug;
     this.title = title;
     this.isBeta = isBeta;

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "93c4a755-7576-47b7-b2f0-9001ca9c2e57",
+  "shortId": "09afbfa2",
   "slug": "tmp-cyber-proteger-mdp",
   "title": "Protéger ses mots de passe",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "fbde0db0-344a-4b98-a9b4-68f74f358629",
+  "shortId": "0389ba82",
   "slug": "tmp-cyber-mdp-fort",
   "title": "Un mot de passe fort, c’est quoi ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -1,5 +1,6 @@
 {
   "id": "f924b0e8-0b2b-4b8e-b7fe-f1b14e9b8094",
+  "shortId": "4fb0e2cd",
   "slug": "tmp-cyber-ingenierie-sociale",
   "title": "Cyberattaques : quand l’ingénierie sociale s’en mêle !",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -1,5 +1,6 @@
 {
   "id": "70813abe-7423-426d-80c8-b1f0271ae0b4",
+  "shortId": "82920553",
   "slug": "tmp-anatomie-message-arnaque",
   "title": "Anatomie d’un message d’arnaque",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "d86262d1-bf99-41d3-abc5-ef39c7d05288",
+  "shortId": "975d25d1",
   "slug": "cyber-message-arnaque",
   "title": "Vous avez un nouveau message ✉️ : attention aux arnaques",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -1,5 +1,6 @@
 {
   "id": "bc6d164f-26bd-4f58-9925-8cf5365e2ca6",
+  "shortId": "43e420e6",
   "slug": "tmp-ia-def-ind",
   "title": "Une IA apprentie botaniste : un cas d'un apprentissage supervisé.",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "40ab5711-4025-4052-a269-00fd0448d60a",
+  "shortId": "cc0cbab7",
   "slug": "tmp-ia-dit-ia",
   "title": "IA, vous avez dit IA ? ",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -1,5 +1,6 @@
 {
   "id": "ccad60a8-6c48-4d91-84cb-d717a1ea4918",
+  "shortId": "5bb2f995",
   "slug": "tmp-iagenbiais-avance",
   "title": "IA génératives : Qui programme la morale ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -1,5 +1,6 @@
 {
   "id": "a1eea948-2125-488f-8006-9f85e646830d",
+  "shortId": "163b520e",
   "slug": "tmp-ia-bias-ind",
   "title": "Les biais des IA génératives",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "c8607621-09ab-4601-be7d-68ed9c914c30",
+  "shortId": "9be9cfae",
   "slug": "tmp-ia-hallu",
   "title": "Elles hallucinent, ces IA génératives ! ",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -1,5 +1,6 @@
 {
   "id": "178e7bb5-9d0a-43e6-b0a1-c7039bd7e2a8",
+  "shortId": "e5019e0e",
   "slug": "tmp-ia-biais-ind-alt",
   "title": "Les biais des lA",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "8266f923-4255-46ba-97c5-61cbdbe18986",
+  "shortId": "e71a9bdd",
   "slug": "tmp-iagenethique",
   "title": "Ce qu’il vaut mieux ne pas dire à une IA générative.",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -1,5 +1,6 @@
 {
   "id": "d03cef94-74af-463d-8901-c886b48d6e0b",
+  "shortId": "76961c86",
   "slug": "tmp-ia-fonctionnement-ind",
   "title": "Comment l’IA générative apprend-elle à discuter avec vous ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "71618929-fcc9-415e-a3f3-9582545d7a78",
+  "shortId": "797ea8fb",
   "slug": "tmp-ia-fonctionnement-debut",
   "title": "Comment font les IA génératives pour répondre à nos demandes ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "8343e9c1-5b46-4500-ab85-54061e0c4712",
+  "shortId": "6bf111e0",
   "slug": "les-ia-generatives-consomment",
   "title": "L‘IA générative, ça consomme !",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -1,5 +1,6 @@
 {
   "id": "7a38c90d-9937-4497-bee3-fe58541af420",
+  "shortId": "4eacd0c3",
   "slug": "tmp-prompt-intermediaire",
   "title": "J’améliore mes prompts !",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "cf183961-e85a-421d-a316-05870191ff82",
+  "shortId": "4920d56c",
   "slug": "tmp-ia-premier-prompt",
   "title": "Mon premier prompt !",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -1,5 +1,6 @@
 {
   "id": "8aa17e6d-3470-479d-838d-ff6923de6686",
+  "shortId": "05b24fee",
   "slug": "tmp-ia-deepfakes",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -1,5 +1,6 @@
 {
   "id": "5df14039-803b-4db4-9778-67e4b84afbbd",
+  "shortId": "ecc13f55",
   "slug": "adresse-ip-publique-et-vous",
   "title": "L'adresse IP publique : ce qu'elle révèle sur vous !",
   "isBeta": true,
@@ -210,7 +211,7 @@
                     "id": "1",
                     "content": "C'est l'adresse qui permet d'identifier un appareil informatique connecté à internet.",
                     "feedback": {
-                      "state": "Bonne réponse \uD83D\uDCAB",
+                      "state": "Bonne réponse 💫",
                       "diagnosis": "<p>L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>"
                     }
                   },
@@ -438,8 +439,13 @@
                     "placeholder": "",
                     "ariaLabel": "Nom du pays :",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["Japon", "Tokyo"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "Japon",
+                      "Tokyo"
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/au-dela-des-mots-de-passe.json
@@ -1,5 +1,6 @@
 {
   "id": "9beb922f-4d8e-495d-9c85-0e7265ca78d6",
+  "shortId": "e074af34",
   "slug": "au-dela-des-mots-de-passe",
   "title": "Au-delà des mots de passe : comment s’authentifier ?",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -1,5 +1,6 @@
 {
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
+  "shortId": "6a68bf32",
   "slug": "bac-a-sable",
   "title": "Bac à sable",
   "isBeta": true,
@@ -9,7 +10,9 @@
     "duration": 5,
     "level": "novice",
     "tabletSupport": "inconvenient",
-    "objectives": ["Non régression fonctionnelle"]
+    "objectives": [
+      "Non régression fonctionnelle"
+    ]
   },
   "sections": [
     {
@@ -125,7 +128,11 @@
                           "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                         }
                       },
-                      "solutions": ["1", "3", "4"]
+                      "solutions": [
+                        "1",
+                        "3",
+                        "4"
+                      ]
                     }
                   ]
                 },
@@ -411,8 +418,14 @@
                 "id": "901ccbaa-f4e6-4322-b863-8e8eab08a33a",
                 "type": "download",
                 "files": [
-                  { "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx", "format": ".xlsx" },
-                  { "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods", "format": ".ods" }
+                  {
+                    "url": "https://dl.pix.fr/1641899675462/Pix_velos.xlsx",
+                    "format": ".xlsx"
+                  },
+                  {
+                    "url": "https://dl.pix.fr/1641899675463/Pix_velos.ods",
+                    "format": ".ods"
+                  }
                 ]
               }
             },
@@ -928,7 +941,11 @@
                     "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                   }
                 },
-                "solutions": ["1", "3", "4"]
+                "solutions": [
+                  "1",
+                  "3",
+                  "4"
+                ]
               }
             }
           ]
@@ -1015,8 +1032,13 @@
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
                     "defaultValue": "",
-                    "tolerances": ["t1", "t3"],
-                    "solutions": ["Groupement"]
+                    "tolerances": [
+                      "t1",
+                      "t3"
+                    ],
+                    "solutions": [
+                      "Groupement"
+                    ]
                   },
                   {
                     "type": "text",
@@ -1032,7 +1054,9 @@
                     "ariaLabel": "Année à trouver",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": [2016]
+                    "solutions": [
+                      2016
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -1086,8 +1110,14 @@
                     "placeholder": "",
                     "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
                     "defaultValue": "",
-                    "tolerances": ["t1", "t2", "t3"],
-                    "solutions": ["Katie"]
+                    "tolerances": [
+                      "t1",
+                      "t2",
+                      "t3"
+                    ],
+                    "solutions": [
+                      "Katie"
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -1160,8 +1190,12 @@
                     "placeholder": "",
                     "ariaLabel": "Nom de ce produit",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["Modulix"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "Modulix"
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-1.json
@@ -1,5 +1,6 @@
 {
   "id": "654c44dc-0560-4acc-9860-4a67c923577f",
+  "shortId": "740d5aa9",
   "slug": "bases-clavier-1",
   "title": "Les bases du clavier sur ordinateur 1/2",
   "isBeta": true,
@@ -293,7 +294,9 @@
                           "ariaLabel": "Cliquer ici",
                           "defaultValue": "",
                           "tolerances": [],
-                          "solutions": ["cornichons"]
+                          "solutions": [
+                            "cornichons"
+                          ]
                         },
                         {
                           "type": "text",
@@ -309,7 +312,9 @@
                           "ariaLabel": "Cliquer ici",
                           "defaultValue": "",
                           "tolerances": [],
-                          "solutions": ["vide"]
+                          "solutions": [
+                            "vide"
+                          ]
                         },
                         {
                           "type": "text",
@@ -322,7 +327,7 @@
                           "diagnosis": "<p>Bravo ! Vous avez bien complété la phrase.</p>"
                         },
                         "invalid": {
-                          "state": "Mauvaise réponse. \uD83C\uDF7D\uFE0F",
+                          "state": "Mauvaise réponse. 🍽️",
                           "diagnosis": "<p> Bien tenté ! Mais la phrase n’est pas identique. Réessayez !</p>"
                         }
                       }
@@ -615,7 +620,9 @@
                           "ariaLabel": "Cliquer ici",
                           "defaultValue": "",
                           "tolerances": [],
-                          "solutions": ["céleri"]
+                          "solutions": [
+                            "céleri"
+                          ]
                         }
                       ],
                       "feedbacks": {
@@ -648,7 +655,9 @@
                           "ariaLabel": "Cliquer ici",
                           "defaultValue": "",
                           "tolerances": [],
-                          "solutions": ["pastèque"]
+                          "solutions": [
+                            "pastèque"
+                          ]
                         }
                       ],
                       "feedbacks": {
@@ -681,7 +690,9 @@
                           "ariaLabel": "Cliquer ici",
                           "defaultValue": "",
                           "tolerances": [],
-                          "solutions": ["bac à glaçons"]
+                          "solutions": [
+                            "bac à glaçons"
+                          ]
                         }
                       ],
                       "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bases-clavier-ordinateur-2.json
@@ -1,5 +1,6 @@
 {
   "id": "bb0a4ed3-1b49-4782-b867-05ade0868c4f",
+  "shortId": "31ca924a",
   "slug": "bases-clavier-2",
   "title": "Les bases du clavier sur ordinateur 2/2",
   "isBeta": true,
@@ -65,7 +66,10 @@
                     "ariaLabel": "zone de saisie",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": ["voilà le zèbre déçu", "« voilà le zèbre déçu »"]
+                    "solutions": [
+                      "voilà le zèbre déçu",
+                      "« voilà le zèbre déçu »"
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -319,7 +323,6 @@
             }
           ]
         },
-
         {
           "id": "d310a45d-b3e1-4875-9c8e-55d39368d039",
           "type": "activity",
@@ -353,17 +356,21 @@
                     "placeholder": "recopiez la phrase ",
                     "ariaLabel": "zone de saisie",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["Coucou, peux-tu mettre ces 3 pommes à cet endroit ?"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "Coucou, peux-tu mettre ces 3 pommes à cet endroit ?"
+                    ]
                   }
                 ],
                 "feedbacks": {
                   "valid": {
-                    "state": "Bonne réponse ! \uD83C\uDF4F\uD83C\uDF4F\uD83C\uDF4F",
+                    "state": "Bonne réponse ! 🍏🍏🍏",
                     "diagnosis": "<p>Bravo, vous maîtrisez la touche majuscule ⇧.</p>"
                   },
                   "invalid": {
-                    "state": "Mauvaise réponse. \uD83C\uDF4E\uD83C\uDF4E\uD83C\uDF4E",
+                    "state": "Mauvaise réponse. 🍎🍎🍎",
                     "diagnosis": "<p>Pour taper les caractères spéciaux, faites bien attention à leur position sur la touche. Elle vous indique si vous avez besoin d’utiliser la touche majuscule ⇧.</p>"
                   }
                 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -1,5 +1,6 @@
 {
   "id": "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d",
+  "shortId": "9d4dcab8",
   "slug": "bien-ecrire-son-adresse-mail",
   "title": "Bien écrire une adresse mail",
   "isBeta": true,
@@ -233,8 +234,12 @@
                           "placeholder": "",
                           "ariaLabel": "Réponse 1 sur 1",
                           "defaultValue": "",
-                          "tolerances": ["t1"],
-                          "solutions": ["@"]
+                          "tolerances": [
+                            "t1"
+                          ],
+                          "solutions": [
+                            "@"
+                          ]
                         }
                       ],
                       "feedbacks": {
@@ -288,7 +293,9 @@
                               "content": "le fournisseur d'adresse mail"
                             }
                           ],
-                          "solutions": ["1"]
+                          "solutions": [
+                            "1"
+                          ]
                         },
                         {
                           "type": "text",
@@ -316,7 +323,9 @@
                               "content": "le fournisseur d'adresse mail"
                             }
                           ],
-                          "solutions": ["2"]
+                          "solutions": [
+                            "2"
+                          ]
                         }
                       ],
                       "feedbacks": {
@@ -523,13 +532,18 @@
                     "placeholder": "",
                     "ariaLabel": "Adresse mail de Naomi",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["naomizao457@yahoo.com", "naomizao457@yahoo.fr"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "naomizao457@yahoo.com",
+                      "naomizao457@yahoo.fr"
+                    ]
                   }
                 ],
                 "feedbacks": {
                   "valid": {
-                    "state": "Bravo !&nbsp;\uD83D\uDCAB",
+                    "state": "Bravo !&nbsp;💫",
                     "diagnosis": "<p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>"
                   },
                   "invalid": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/chatgpt-vraiment-neutre.json
@@ -1,5 +1,6 @@
 {
   "id": "01151659-77c1-41cc-8724-89091357af3d",
+  "shortId": "e67ec5d0",
   "slug": "chatgpt-vraiment-neutre",
   "title": "ChatGPT est-il vraiment neutre ?",
   "isBeta": true,
@@ -195,7 +196,11 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Regardez bien la vidéo précédente et réessayez&nbsp;!</p>"
                   }
                 },
-                "solutions": ["1", "3", "5"]
+                "solutions": [
+                  "1",
+                  "3",
+                  "5"
+                ]
               }
             }
           ]
@@ -596,7 +601,7 @@
                     "id": "1",
                     "content": "oui",
                     "feedback": {
-                      "state": "Bravo&nbsp;! \uD83D\uDCAB",
+                      "state": "Bravo&nbsp;! 💫",
                       "diagnosis": ""
                     }
                   },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/comment-envoyer-un-mail.json
@@ -1,5 +1,6 @@
 {
   "id": "d4c4a2b2-0046-471d-ad9c-15f9cfc8f1f6",
+  "shortId": "7762efcb",
   "slug": "comment-envoyer-un-mail",
   "title": "Comment envoyer un mail ? ",
   "isBeta": true,
@@ -407,7 +408,9 @@
                         "content": "Rayan"
                       }
                     ],
-                    "solutions": ["1"]
+                    "solutions": [
+                      "1"
+                    ]
                   },
                   {
                     "type": "text",
@@ -439,7 +442,9 @@
                         "content": "Jennifer, Marine, Clément, Rayan"
                       }
                     ],
-                    "solutions": ["3"]
+                    "solutions": [
+                      "3"
+                    ]
                   },
                   {
                     "type": "text",
@@ -471,7 +476,9 @@
                         "content": "Costumes pour le 27 octobre"
                       }
                     ],
-                    "solutions": ["4"]
+                    "solutions": [
+                      "4"
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/controle-parental.json
@@ -1,5 +1,6 @@
 {
   "id": "a9e7dda1-fbcc-43a0-a9b4-90056548a4ae",
+  "shortId": "15894c06",
   "slug": "controle-parental",
   "title": "Le contrôle parental",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/decouverte-de-l-ent.json
@@ -1,5 +1,6 @@
 {
   "id": "1c765240-c790-4f32-8ec0-bc9945bcc5ce",
+  "shortId": "c6437577",
   "slug": "decouverte-de-l-ent",
   "title": "À la découverte de l’ENT",
   "isBeta": true,
@@ -196,7 +197,10 @@
                     "diagnosis": "<p>Pas tout à fait ! Grâce à l'ENT, Martin peut consulter des informations qui concernent sa fille&nbsp;: ses notes, son emploi du temps, ses devoirs. Par contre, il ne peut pas modifier l'emploi du temps de la classe.</p>"
                   }
                 },
-                "solutions": ["1", "2"]
+                "solutions": [
+                  "1",
+                  "2"
+                ]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-1.json
@@ -1,5 +1,6 @@
 {
   "id": "eeeb4951-6f38-4467-a4ba-0c85ed71321a",
+  "shortId": "27d6ca4f",
   "slug": "demo-combinix-1",
   "title": "Demo combinix 1",
   "isBeta": true,
@@ -9,7 +10,9 @@
     "duration": 1,
     "level": "novice",
     "tabletSupport": "inconvenient",
-    "objectives": ["Test parcours combiné"]
+    "objectives": [
+      "Test parcours combiné"
+    ]
   },
   "sections": [
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-combinix-2.json
@@ -1,5 +1,6 @@
 {
   "id": "f32a2238-4f65-4698-b486-15d51935d335",
+  "shortId": "df82ec66",
   "slug": "demo-combinix-2",
   "title": "Demo combinix 2",
   "isBeta": true,
@@ -9,7 +10,9 @@
     "duration": 1,
     "level": "novice",
     "tabletSupport": "inconvenient",
-    "objectives": ["Test parcours combiné 2"]
+    "objectives": [
+      "Test parcours combiné 2"
+    ]
   },
   "sections": [
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -1,5 +1,6 @@
 {
   "id": "235c680e-cbd2-4c56-bef6-80d3ed4d417a",
+  "shortId": "0aefd71f",
   "slug": "demo-epreuves-components",
   "title": "Démonstration des composants Pix Épreuves",
   "isBeta": true,
@@ -8,7 +9,9 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement tous les composants Pix Épreuves.</p>",
     "duration": 2,
     "level": "novice",
-    "objectives": ["<p>Non régression sur les composants Pix Épreuves.</p>"],
+    "objectives": [
+      "<p>Non régression sur les composants Pix Épreuves.</p>"
+    ],
     "tabletSupport": "comfortable"
   },
   "sections": [
@@ -101,33 +104,63 @@
                   "areas": [
                     {
                       "shape": "rect",
-                      "coords": { "x1": 390, "y1": 120, "x2": 842, "y2": 400 },
+                      "coords": {
+                        "x1": 390,
+                        "y1": 120,
+                        "x2": 842,
+                        "y2": 400
+                      },
                       "info": "Pixvidéo : Vous avez aimé « Les chroniques de Flundertown », vous aimerez sûrement « Autant en emporte les fleurs »."
                     },
                     {
                       "shape": "rect",
-                      "coords": { "x1": 510, "y1": 588, "x2": 702, "y2": 635 },
+                      "coords": {
+                        "x1": 510,
+                        "y1": 588,
+                        "x2": 702,
+                        "y2": 635
+                      },
                       "info": "Jeu vidéo : Kart Party, le jeu s’adapte en fonction du niveau du joueur"
                     },
                     {
                       "shape": "rect",
-                      "coords": { "x1": 248, "y1": 398, "x2": 325, "y2": 492 },
+                      "coords": {
+                        "x1": 248,
+                        "y1": 398,
+                        "x2": 325,
+                        "y2": 492
+                      },
                       "info": "Enceinte connectée : Paramètre activé « Reconnaissance vocale »"
                     },
                     {
                       "shape": "rect",
-                      "coords": { "x1": 828, "y1": 560, "x2": 1042, "y2": 725 },
+                      "coords": {
+                        "x1": 828,
+                        "y1": 560,
+                        "x2": 1042,
+                        "y2": 725
+                      },
                       "info": "ChatPix : « Que puis-je faire pour toi aujourd’hui ? »",
                       "tooltipPosition": "bottom"
                     },
                     {
                       "shape": "rect",
-                      "coords": { "x1": 122, "y1": 796, "x2": 318, "y2": 916 },
+                      "coords": {
+                        "x1": 122,
+                        "y1": 796,
+                        "x2": 318,
+                        "y2": 916
+                      },
                       "info": "Robot aspirateur : Paramètre activé « Détection automatique des obstacles et adaptation du parcours »"
                     },
                     {
                       "shape": "rect",
-                      "coords": { "x1": 986, "y1": 148, "x2": 1100, "y2": 230 },
+                      "coords": {
+                        "x1": 986,
+                        "y1": 148,
+                        "x2": 1100,
+                        "y2": 230
+                      },
                       "info": "Thermostat mural : Paramètre activé « Température idéale et économie d’énergie »",
                       "tooltipPosition": "bottom"
                     }
@@ -243,7 +276,11 @@
                   ],
                   "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                   "llmMessage": "On peut mettre du ",
-                  "wordsToAdd": ["beurre", "et", "du ?"]
+                  "wordsToAdd": [
+                    "beurre",
+                    "et",
+                    "du ?"
+                  ]
                 }
               }
             }
@@ -913,7 +950,7 @@
                 "tagName": "pix-article",
                 "props": {
                   "titleLevel": 2,
-                  "title": "\uD83D\uDD34 Une vidéo de la maire de la capitale crée la polémique",
+                  "title": "🔴 Une vidéo de la maire de la capitale crée la polémique",
                   "author": "Rédaction Locale",
                   "date": "14 mai 2025",
                   "paragraphs": [
@@ -1039,15 +1076,24 @@
                   "options": [
                     {
                       "label": "Bon",
-                      "feedback": { "type": "good", "text": "OUI, ÇA SENT LA PATATE ! 🎉" }
+                      "feedback": {
+                        "type": "good",
+                        "text": "OUI, ÇA SENT LA PATATE ! 🎉"
+                      }
                     },
                     {
                       "label": "Presque",
-                      "feedback": { "type": "close", "text": "PATATE 🥔" }
+                      "feedback": {
+                        "type": "close",
+                        "text": "PATATE 🥔"
+                      }
                     },
                     {
                       "label": "Neutre",
-                      "feedback": { "type": "neutral", "text": "Ça souffle dis donc 💨" }
+                      "feedback": {
+                        "type": "neutral",
+                        "text": "Ça souffle dis donc 💨"
+                      }
                     },
                     {
                       "label": "Incorrect",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-llm.json
@@ -1,5 +1,6 @@
 {
   "id": "ab82925d-4775-4bca-b513-4c3009ec5886",
+  "shortId": "f2eeb056",
   "slug": "demo-llm",
   "title": "Démo LLM",
   "isBeta": true,
@@ -8,7 +9,9 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient un exemple d’intégration de ChatPix.</p>",
     "duration": 2,
     "level": "novice",
-    "objectives": ["<p>Démonstration</p>"],
+    "objectives": [
+      "<p>Démonstration</p>"
+    ],
     "tabletSupport": "inconvenient"
   },
   "sections": [

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -1,5 +1,6 @@
 {
   "id": "65b761ab-3ebd-44a9-84b7-8b5e151aee76",
+  "shortId": "00832162",
   "slug": "distinguer-vrai-faux-sur-internet",
   "title": "Les informations sur internet : distinguer le vrai du faux",
   "isBeta": true,
@@ -521,7 +522,11 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>!</p>"
                   }
                 },
-                "solutions": ["2", "3", "5"]
+                "solutions": [
+                  "2",
+                  "3",
+                  "5"
+                ]
               }
             }
           ]
@@ -793,7 +798,10 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Essayez à nouveau, en appliquant la méthode « Qui ? Quand ? D'où ? ». Si vous avez un doute sur ces informations, il faut être prudent.</p>"
                   }
                 },
-                "solutions": ["2", "3"]
+                "solutions": [
+                  "2",
+                  "3"
+                ]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/galerie.json
@@ -1,5 +1,6 @@
 {
   "id": "1b33d6ab-ebfe-49fa-8568-8c40471b4baa",
+  "shortId": "b9414fc3",
   "slug": "galerie",
   "title": "Galerie Modulix",
   "isBeta": true,
@@ -8,7 +9,9 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il permet de visualiser tous les modules existants.</p>",
     "duration": 0,
     "level": "novice",
-    "objectives": ["<p>Découvrir les éléments de la galerie Modulix</p>"],
+    "objectives": [
+      "<p>Découvrir les éléments de la galerie Modulix</p>"
+    ],
     "tabletSupport": "comfortable"
   },
   "sections": [
@@ -16,7 +19,6 @@
       "id": "06f70348-a80b-4ae5-9b04-5efd55f770cd",
       "type": "question-yourself",
       "grains": [
-
         {
           "id": "9f7af22d-8cd2-45e0-b2d0-611e9903300e",
           "type": "transition",
@@ -539,7 +541,11 @@
                     "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                   }
                 },
-                "solutions": ["1", "3", "4"]
+                "solutions": [
+                  "1",
+                  "3",
+                  "4"
+                ]
               }
             }
           ]
@@ -577,8 +583,13 @@
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
                     "defaultValue": "",
-                    "tolerances": ["t1", "t3"],
-                    "solutions": ["Groupement"]
+                    "tolerances": [
+                      "t1",
+                      "t3"
+                    ],
+                    "solutions": [
+                      "Groupement"
+                    ]
                   },
                   {
                     "type": "text",
@@ -594,7 +605,9 @@
                     "ariaLabel": "Année à trouver",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": [2016]
+                    "solutions": [
+                      2016
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-cadre-usage-educ-nov.json
@@ -1,5 +1,6 @@
 {
   "id": "bbc48a68-6bef-4261-89f0-86459413c10c",
+  "shortId": "0426c3c5",
   "slug": "ia-cadre-usage-educ-nov",
   "title": "IA et éducation, découverte du cadre d’usage",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -1,5 +1,6 @@
 {
   "id": "c7fe268a-9371-4eec-8a8a-df79c7479a46",
+  "shortId": "a23e9d63",
   "slug": "tmp-ia-deepfakes-alt",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
@@ -698,7 +699,10 @@
                           "diagnosis": "<p>La création d'un deepfake ne demande pas beaucoup de matériel ni de compétences.</p>"
                         }
                       },
-                      "solutions": ["1", "3"]
+                      "solutions": [
+                        "1",
+                        "3"
+                      ]
                     }
                   ]
                 },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/jeux-video-enfant.json
@@ -1,5 +1,6 @@
 {
   "id": "875df1ff-27c1-4b41-a0a8-5ff46013f35e",
+  "shortId": "87edbdda",
   "slug": "jeux-video-enfant",
   "title": "Choisir un jeu vidéo adapté à son enfant",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -1,5 +1,6 @@
 {
   "id": "8bdec793-7508-41b4-9df2-e1cf96969680",
+  "shortId": "3e5fa7fc",
   "slug": "mots-de-passe-securises",
   "title": "Des mots de passe solides",
   "isBeta": true,
@@ -56,7 +57,9 @@
                     "placeholder": "",
                     "ariaLabel": "Mot de passe",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
+                    "tolerances": [
+                      "t1"
+                    ],
                     "solutions": [
                       "123456",
                       "123456789",
@@ -189,7 +192,9 @@
                     "placeholder": "",
                     "ariaLabel": "Mot de passe d'Austin",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
+                    "tolerances": [
+                      "t1"
+                    ],
                     "solutions": [
                       "Bill15111984",
                       "15111984Bill",
@@ -553,7 +558,10 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
                   }
                 },
-                "solutions": ["1", "4"]
+                "solutions": [
+                  "1",
+                  "4"
+                ]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -1,5 +1,6 @@
 {
   "id": "e2b42968-4797-46e7-b9ca-11d0d0dfa978",
+  "shortId": "dc38a091",
   "slug": "metaux-eau-reemploi",
   "title": "Le numérique : pourquoi privilégier le réemploi ?",
   "isBeta": false,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -1,5 +1,6 @@
 {
   "id": "12cd102f-9831-4264-8d5e-15a8f177594a",
+  "shortId": "4af95e9a",
   "slug": "ports-connexions-essentiels",
   "title": "Les ports de connexion d’un ordinateur",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -1,5 +1,6 @@
 {
   "id": "a64d1ca8-5222-464a-ae0c-e8bbdf949e18",
+  "shortId": "8c6d595b",
   "slug": "principes-fondateurs-wikipedia",
   "title": "Les principes fondateurs de Wikipédia",
   "isBeta": true,
@@ -92,7 +93,10 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p> La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
                   }
                 },
-                "solutions": ["1", "4"]
+                "solutions": [
+                  "1",
+                  "4"
+                ]
               }
             }
           ]
@@ -249,7 +253,11 @@
                     "diagnosis": "<p>Certaines bonnes réponses n'ont peut-être pas été sélectionnées.</p><p>Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span></p>"
                   }
                 },
-                "solutions": ["1", "3", "4"]
+                "solutions": [
+                  "1",
+                  "3",
+                  "4"
+                ]
               }
             }
           ]
@@ -458,8 +466,12 @@
                     "placeholder": "",
                     "ariaLabel": "Remplir le nom de la cinquième section du sommaire de l'article Wikipédia proposé",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["Honneur"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "Honneur"
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -502,8 +514,12 @@
                     "placeholder": "",
                     "ariaLabel": "Remplir avec le nombre de notes et références",
                     "defaultValue": "",
-                    "tolerances": ["t1"],
-                    "solutions": ["1"]
+                    "tolerances": [
+                      "t1"
+                    ],
+                    "solutions": [
+                      "1"
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -559,7 +575,9 @@
                         "content": "Non renseigné"
                       }
                     ],
-                    "solutions": ["2"]
+                    "solutions": [
+                      "2"
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -1,5 +1,6 @@
 {
   "id": "68f92c57-9e66-4258-a2f4-b71fad7ab004",
+  "shortId": "9434a1a4",
   "slug": "sources-informations",
   "title": "Les sources d'information",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tmp08ef.json
@@ -1,5 +1,6 @@
 {
   "id": "08ef1a47-b691-4138-b899-39f3512fa152",
+  "shortId": "f0506561",
   "slug": "tmp08ef",
   "title": "Derrière le prompt : comment fonctionnent les IA génératives ?",
   "isBeta": true,
@@ -373,7 +374,9 @@
                         "content": "code"
                       }
                     ],
-                    "solutions": ["1"]
+                    "solutions": [
+                      "1"
+                    ]
                   },
                   {
                     "type": "text",
@@ -401,7 +404,9 @@
                         "content": "superviser"
                       }
                     ],
-                    "solutions": ["4"]
+                    "solutions": [
+                      "4"
+                    ]
                   },
                   {
                     "type": "text",
@@ -429,7 +434,9 @@
                         "content": "tergiversation"
                       }
                     ],
-                    "solutions": ["8"]
+                    "solutions": [
+                      "8"
+                    ]
                   },
                   {
                     "type": "text",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/tri-multicritere-tableau.json
@@ -1,5 +1,6 @@
 {
   "id": "19468565-a56b-4aa5-9bf0-369e94bc85ea",
+  "shortId": "ed36b111",
   "slug": "tri-multicritere-tableau",
   "title": "Trier un tableau selon plusieurs critères",
   "isBeta": true,
@@ -337,8 +338,12 @@
                     "placeholder": "prénom",
                     "ariaLabel": "écrivez le prénom ici",
                     "defaultValue": "",
-                    "tolerances": ["t3"],
-                    "solutions": ["emma"]
+                    "tolerances": [
+                      "t3"
+                    ],
+                    "solutions": [
+                      "emma"
+                    ]
                   },
                   {
                     "type": "text",
@@ -353,8 +358,13 @@
                     "placeholder": "lot",
                     "ariaLabel": "écrivez le lot ici",
                     "defaultValue": "",
-                    "tolerances": ["t3"],
-                    "solutions": ["glace", "glaces"]
+                    "tolerances": [
+                      "t3"
+                    ],
+                    "solutions": [
+                      "glace",
+                      "glaces"
+                    ]
                   }
                 ],
                 "feedbacks": {
@@ -531,8 +541,12 @@
                     "placeholder": "prénom",
                     "ariaLabel": "écrivez ici le prénom",
                     "defaultValue": "",
-                    "tolerances": ["t3"],
-                    "solutions": ["inès"]
+                    "tolerances": [
+                      "t3"
+                    ],
+                    "solutions": [
+                      "inès"
+                    ]
                   },
                   {
                     "type": "text",
@@ -547,8 +561,13 @@
                     "placeholder": "trésor",
                     "ariaLabel": "écrivez ici le contenu du trésor",
                     "defaultValue": "",
-                    "tolerances": ["t3"],
-                    "solutions": ["des bonbons", "bonbons"]
+                    "tolerances": [
+                      "t3"
+                    ],
+                    "solutions": [
+                      "des bonbons",
+                      "bonbons"
+                    ]
                   }
                 ],
                 "feedbacks": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-1.json
@@ -1,5 +1,6 @@
 {
   "id": "e8cee13e-1d4d-47eb-bd26-d7ea6a10b1e6",
+  "shortId": "3858d191",
   "slug": "utiliser-souris-ordinateur-1",
   "title": "Utiliser une souris d'ordinateur - 1",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/utiliser-souris-ordinateur-2.json
@@ -1,5 +1,6 @@
 {
   "id": "1f425bc6-7a35-4ceb-9634-a25da1e36233",
+  "shortId": "f59200bf",
   "slug": "utiliser-souris-ordinateur-2",
   "title": "Utiliser une souris d'ordinateur - 2",
   "isBeta": true,

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -39,6 +39,7 @@ export class ModuleFactory {
     try {
       return new Module({
         id: moduleData.id,
+        shortId: moduleData.shortId,
         slug: moduleData.slug,
         title: moduleData.title,
         version: moduleData.version,

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -7,6 +7,7 @@ function serialize(module) {
     transform(module) {
       const transformedModule = {
         id: module.id,
+        shortId: module.shortId,
         slug: module.slug,
         title: module.title,
         isBeta: module.isBeta,
@@ -27,7 +28,7 @@ function serialize(module) {
 
       return transformedModule;
     },
-    attributes: ['slug', 'title', 'isBeta', 'version', 'sections', 'details', 'redirectionUrl'],
+    attributes: ['shortId', 'slug', 'title', 'isBeta', 'version', 'sections', 'details', 'redirectionUrl'],
     sections: {
       ref: 'id',
       includes: true,

--- a/api/tests/devcomp/acceptance/scripts/test-module.json
+++ b/api/tests/devcomp/acceptance/scripts/test-module.json
@@ -1,5 +1,6 @@
 {
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
+  "shortId": "greou88fe",
   "slug": "bac-a-sable",
   "title": "Bac à sable",
   "isBeta": true,

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -33,6 +33,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            shortId: 'giedjc7f3',
             slug: 'title',
             title: 'title',
             isBeta: true,
@@ -88,6 +89,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            shortId: 'giedjc7f3',
             slug: 'title',
             title: 'title',
             isBeta: true,
@@ -143,6 +145,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           // given
           const moduleData = {
             id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            shortId: 'giedjc7f3',
             slug: 'title',
             title: 'title',
             isBeta: true,
@@ -207,6 +210,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
       const version = Symbol('version');
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'giedjc7f3',
         slug: 'title',
         title: 'title',
         version,
@@ -264,6 +268,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -362,6 +367,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -413,6 +419,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -464,6 +471,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -515,6 +523,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -562,6 +571,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -623,6 +633,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '256900b7-4c4f-4f1c-8326-ebec85a694c2',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -680,6 +691,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -732,6 +744,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -782,6 +795,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -843,6 +857,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -913,6 +928,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -995,6 +1011,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1070,6 +1087,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1161,6 +1179,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         nock('https://assets.pix.org').head('/modulix/didacticiel/ordi-spatial.svg').reply(200, {});
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1231,6 +1250,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const givenData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1287,6 +1307,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1365,6 +1386,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1422,6 +1444,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1476,6 +1499,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1532,6 +1556,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1591,6 +1616,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: 'effc5154-bc45-4eb1-b4ec-84036a574161',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1648,6 +1674,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1708,6 +1735,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1767,6 +1795,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1837,6 +1866,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1915,6 +1945,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -1998,6 +2029,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -2095,6 +2127,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           .reply(200, { width: 100, height: 100, type: 'vector' });
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -2171,6 +2204,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -2233,6 +2267,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -2297,6 +2332,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          shortId: 'giedjc7f3',
           slug: 'title',
           title: 'title',
           isBeta: true,
@@ -2352,6 +2388,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'giedjc7f3',
         slug: 'title',
         title: 'title',
         isBeta: true,
@@ -2410,6 +2447,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'giedjc7f3',
         slug: 'title',
         title: 'title',
         isBeta: true,

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -35,6 +35,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       };
       moduleDatasourceStub.getById.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'gbsri73s',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
         isBeta: true,
@@ -126,6 +127,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       };
       moduleDatasourceStub.getById.withArgs(moduleId).resolves({
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'gbsri73s',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
         isBeta: true,
@@ -262,6 +264,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'gbsri73s',
         slug: 'bac-a-sable',
         title: 'Bac à sable',
         isBeta: true,

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -15,6 +15,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       const modulesIds = ['f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d', '6282925d-4775-4bca-b513-4c3009ec5886'];
       const firstModule = {
         id: modulesIds[0],
+        shortId: 'gbsri73s',
         slug: 'getAllByIdsModuleSlug1',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
@@ -58,6 +59,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       };
       const secondModule = {
         id: modulesIds[1],
+        shortId: '1bdri73s',
         slug: 'getAllByIdsModuleSlug2',
         title: 'Bac à sable',
         isBeta: true,
@@ -223,6 +225,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       const existingModuleId = 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d';
       const expectedFoundModule = {
         id: existingModuleId,
+        shortId: 'gbsri73s',
         slug: 'existingModuleSlug',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
@@ -337,6 +340,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
       const expectedFoundModule = {
         id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        shortId: 'gbsri73s',
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
         isBeta: true,
@@ -485,6 +489,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
       const expectedFoundModule = {
         id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        shortId: 'gbsri73s',
         slug: existingModuleSlug,
         title: 'Bien écrire son adresse mail',
         isBeta: true,

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -7,6 +7,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
     it('should create a module and keep attributes', function () {
       // given
       const id = 1;
+      const shortId = 'e074af34';
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
@@ -15,10 +16,11 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const version = Symbol('version');
 
       // when
-      const module = new Module({ id, slug, title, isBeta, sections, details, version });
+      const module = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
 
       // then
       expect(module.id).to.equal(id);
+      expect(module.shortId).to.equal(shortId);
       expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
       expect(module.isBeta).to.equal(isBeta);
@@ -38,10 +40,21 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       });
     });
 
-    describe('if a module does not have a slug', function () {
+    describe('if a module does not have a shortId', function () {
       it('should throw an error', function () {
         // when
         const error = catchErrSync(() => new Module({ id: 1 }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The shortId is required for a module');
+      });
+    });
+
+    describe('if a module does not have a slug', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new Module({ id: 1, shortId: 'e074af34' }))();
 
         // then
         expect(error).to.be.instanceOf(DomainError);
@@ -52,7 +65,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
     describe('if a module does not have a title', function () {
       it('should throw an error', function () {
         // when
-        const error = catchErrSync(() => new Module({ id: 1, slug: 'my-slug' }))();
+        const error = catchErrSync(() => new Module({ id: 1, shortId: 'e074af34', slug: 'my-slug' }))();
 
         // then
         expect(error).to.be.instanceOf(DomainError);
@@ -67,6 +80,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           () =>
             new Module({
               id: 'id_module_1',
+              shortId: 'e074af34',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
             }),
@@ -85,6 +99,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           () =>
             new Module({
               id: 'id_module_1',
+              shortId: 'e074af34',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
               isBeta: true,
@@ -104,6 +119,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           () =>
             new Module({
               id: 'id_module_1',
+              shortId: 'e074af34',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
               isBeta: true,
@@ -124,6 +140,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           () =>
             new Module({
               id: 'id_module_1',
+              shortId: 'e074af34',
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
               isBeta: true,
@@ -143,6 +160,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
 
     beforeEach(function () {
       const id = 1;
+      const shortId = 'e074af34';
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
@@ -150,7 +168,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       const details = Symbol('details');
       const version = Symbol('version');
 
-      module = new Module({ id, slug, title, isBeta, sections, details, version });
+      module = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
     });
 
     it('should set redirectionUrl', function () {

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -58,6 +58,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   it('should save the passage', async function () {
     // given
     const moduleId = Symbol('moduleId');
+    const moduleShortId = 'bds87bds';
     const moduleSlug = 'les-adresses-email';
     const passageId = 1234;
     const userId = Symbol('userId');
@@ -69,6 +70,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     const version = Symbol('version');
     const module = new Module({
       id: moduleId,
+      shortId: moduleShortId,
       slug: moduleSlug,
       title,
       isBeta,

--- a/api/tests/devcomp/unit/domain/usecases/get-module_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module_test.js
@@ -25,6 +25,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
     it('should get and return a Module with a redirection url', async function () {
       // given
       const id = 1;
+      const shortId = 'f9f8bk1d';
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const isBeta = false;
@@ -32,7 +33,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module', function () {
       const details = Symbol('details');
       const version = Symbol('version');
 
-      const expectedModule = new Module({ id, slug, title, isBeta, sections, details, version });
+      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
       const moduleRepository = {
         getBySlug: sinon.stub(),
       };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-schema.js
@@ -122,6 +122,7 @@ const moduleSectionSchema = Joi.object({
 
 const moduleSchema = Joi.object({
   id: uuidSchema,
+  shortId: Joi.string().length(8).required(),
   slug: Joi.string()
     .regex(/^[a-z0-9-]+$/)
     .required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -656,6 +656,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       // given
       const invalidModule = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'gle9d3fz',
         slug: 'bac-a-sable',
         title: '<h1>Bac à sable</h1>',
         isBeta: true,

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -25,6 +25,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
     it('should serialize with redirectionUrl', function () {
       // given
       const id = 'id';
+      const shortId = 'glzovn7d';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const redirectionUrl = 'https://app.pix.fr/parcours/COMBINIX1';
@@ -42,7 +43,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           'Comprendre les fonctions des parties d’une adresse mail',
         ],
       };
-      const moduleFromDomain = new Module({ id, details, slug, title, sections: [], isBeta, version });
+      const moduleFromDomain = new Module({ id, shortId, details, slug, title, sections: [], isBeta, version });
       moduleFromDomain.setRedirectionUrl(redirectionUrl);
       const expectedJson = {
         data: {
@@ -50,6 +51,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           id,
           attributes: {
             'redirection-url': redirectionUrl,
+            'short-id': shortId,
             slug,
             title,
             'is-beta': isBeta,
@@ -74,6 +76,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
     it('should serialize with empty sections list', function () {
       // given
       const id = 'id';
+      const shortId = 'glzovn7d';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
@@ -92,6 +95,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       };
       const moduleFromDomain = new Module({
         id,
+        shortId,
         details,
         slug,
         title,
@@ -104,6 +108,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           type: 'modules',
           id,
           attributes: {
+            'short-id': shortId,
             slug,
             title,
             'is-beta': isBeta,
@@ -128,6 +133,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
     it('should serialize with empty grains list', function () {
       // given
       const id = 'id';
+      const shortId = 'glzovn7d';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
@@ -146,6 +152,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       };
       const moduleFromDomain = new Module({
         id,
+        shortId,
         details,
         slug,
         title,
@@ -158,6 +165,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           type: 'modules',
           id,
           attributes: {
+            'short-id': shortId,
             slug,
             title,
             'is-beta': isBeta,
@@ -197,6 +205,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
     it('should serialize with grains list of components', function () {
       // given
       const id = 'id';
+      const shortId = 'glzovn7d';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
       const isBeta = true;
@@ -215,6 +224,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       };
       const moduleFromDomain = new Module({
         id,
+        shortId,
         slug,
         title,
         isBeta,
@@ -243,6 +253,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const expectedJson = {
         data: {
           attributes: {
+            'short-id': shortId,
             slug,
             title: 'Bien écrire son adresse mail',
             'is-beta': isBeta,

--- a/mon-pix/app/models/module.js
+++ b/mon-pix/app/models/module.js
@@ -1,6 +1,7 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Module extends Model {
+  @attr('string') shortId;
   @attr('string') slug;
   @attr('string') title;
   @attr('boolean') isBeta;


### PR DESCRIPTION
## 🍂 Problème
On doit ajouter un champs shortId aux modules pour ne plus se baser sur le slug pour les indetifier.

## 🌰 Proposition
Ajouter ce champs au schéma du module, et mettre à jour les modules existants avec un shortId unique

## 🍁 Remarques
j'ai fait un script (jetable et non testé) pour ajouter le shortId à tous les modules existants, ça a un peut reformatter les json, il faudra voir si c'est dérangeant ou non. Sinon on pourra rollback et faire à la main.

## 🪵 Pour tester

- aller sur le[ RA](https://app-pr14174.review.pix.fr/modules/bac-a-sable)
- vérfier qu'on récupère bien les shortId dans l'appel à la route `api/modules/bac-a-sable`
