### PR TITLE
[TECH] Simplifier les fonctions de récupération des parcours combinés (PIX-20442)

### DIFF
--- a/api/src/quest/domain/usecases/get-combined-course-statistics.js
+++ b/api/src/quest/domain/usecases/get-combined-course-statistics.js
@@ -1,9 +1,8 @@
 import { CombinedCourseStatistics } from '../models/CombinedCourseStatistics.js';
 
 export const getCombinedCourseStatistics = async ({ combinedCourseId, combinedCourseParticipationRepository }) => {
-  const allCombinedCourseParticipations = await getAllCombinedCourseParticipations({
+  const allCombinedCourseParticipations = await combinedCourseParticipationRepository.findByCombinedCourseIds({
     combinedCourseIds: [combinedCourseId],
-    combinedCourseParticipationRepository,
   });
 
   const completedParticipations = allCombinedCourseParticipations.filter((participation) =>
@@ -16,20 +15,3 @@ export const getCombinedCourseStatistics = async ({ combinedCourseId, combinedCo
     completedParticipationsCount: completedParticipations.length,
   });
 };
-
-async function getAllCombinedCourseParticipations({ combinedCourseIds, combinedCourseParticipationRepository }) {
-  let results,
-    allCombinedCourseParticipations = [];
-  const page = { number: 1, size: 100 };
-
-  do {
-    results = await combinedCourseParticipationRepository.findByCombinedCourseIds({
-      combinedCourseIds,
-      page,
-    });
-    allCombinedCourseParticipations = allCombinedCourseParticipations.concat(results.combinedCourseParticipations);
-    page.number += 1;
-  } while (results.combinedCourseParticipations.length > 0);
-
-  return allCombinedCourseParticipations;
-}

--- a/api/src/quest/domain/usecases/get-combined-courses-by-organization-id.js
+++ b/api/src/quest/domain/usecases/get-combined-courses-by-organization-id.js
@@ -11,9 +11,8 @@ export default async ({ organizationId, page, combinedCourseRepository, combined
 
   const combinedCourseIds = combinedCourses.map((combinedCourse) => combinedCourse.id);
 
-  const allCombinedCourseParticipations = await getAllCombinedCourseParticipations({
+  const allCombinedCourseParticipations = await combinedCourseParticipationRepository.findByCombinedCourseIds({
     combinedCourseIds,
-    combinedCourseParticipationRepository,
   });
 
   const combinedCoursesWithParticipations = combinedCourses.map((combinedCourse) => {
@@ -25,20 +24,3 @@ export default async ({ organizationId, page, combinedCourseRepository, combined
 
   return { combinedCourses: combinedCoursesWithParticipations, meta };
 };
-
-async function getAllCombinedCourseParticipations({ combinedCourseIds, combinedCourseParticipationRepository }) {
-  let results,
-    allCombinedCourseParticipations = [];
-  const page = { number: 1, size: 100 };
-
-  do {
-    results = await combinedCourseParticipationRepository.findByCombinedCourseIds({
-      combinedCourseIds,
-      page,
-    });
-    allCombinedCourseParticipations = allCombinedCourseParticipations.concat(results.combinedCourseParticipations);
-    page.number += 1;
-  } while (results.combinedCourseParticipations.length > 0);
-
-  return allCombinedCourseParticipations;
-}

--- a/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-participation-repository.js
@@ -154,24 +154,12 @@ export const update = async function ({ id, ...updateFields }) {
 
 /**
  * @param {[number]} combinedCourseIds
- * @param {number} page
  * @returns {Promise<[CombinedCourseParticipation]>}
  */
-export const findByCombinedCourseIds = async ({ combinedCourseIds, page }) => {
+export const findByCombinedCourseIds = async ({ combinedCourseIds }) => {
   const knexConnection = DomainTransaction.getConnection();
-  const queryBuilder = knexConnection('organization_learner_participations')
-    .select(
-      'organization_learner_participations.id',
-      'view-active-organization-learners.firstName',
-      'view-active-organization-learners.lastName',
-      'view-active-organization-learners.division',
-      'view-active-organization-learners.group',
-      'organization_learner_participations.status',
-      'organizationLearnerId',
-      'organization_learner_participations.createdAt',
-      'organization_learner_participations.updatedAt',
-      'organization_learner_participations.referenceId',
-    )
+  const results = await knexConnection('organization_learner_participations')
+    .select('organization_learner_participations.status', 'organization_learner_participations.referenceId')
     .join(
       'view-active-organization-learners',
       'view-active-organization-learners.id',
@@ -181,14 +169,7 @@ export const findByCombinedCourseIds = async ({ combinedCourseIds, page }) => {
       'organization_learner_participations.referenceId',
       combinedCourseIds.map((combinedCourseId) => combinedCourseId.toString()),
     )
-    .where('organization_learner_participations.type', OrganizationLearnerParticipationTypes.COMBINED_COURSE)
-    .orderBy([
-      { column: 'lastName', order: 'asc' },
-      { column: 'firstName', order: 'asc' },
-    ]);
-  const { results, pagination } = await fetchPage({ queryBuilder, paginationParams: page });
-  return {
-    combinedCourseParticipations: results.map((participation) => new CombinedCourseParticipation(participation)),
-    meta: { ...pagination },
-  };
+    .where('organization_learner_participations.type', OrganizationLearnerParticipationTypes.COMBINED_COURSE);
+
+  return results.map((participation) => new CombinedCourseParticipation(participation));
 };

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-statistics_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-statistics_test.js
@@ -60,4 +60,51 @@ describe('Quest | Integration | Domain | Usecases | getCombinedCourseStatistics'
       completedParticipationsCount: 1,
     });
   });
+
+  it('should not include statistics from deleted organization learners', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const deletedByUserId = databaseBuilder.factory.buildUser().id;
+    const activeLearner = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      firstName: 'Active',
+      lastName: 'Learner',
+    });
+    const deletedLearner = databaseBuilder.factory.buildOrganizationLearner({
+      organizationId,
+      firstName: 'Deleted',
+      lastName: 'Learner',
+      deletedAt: new Date('2024-01-01'),
+      deletedBy: deletedByUserId,
+    });
+    const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
+      code: 'COMBI3',
+      organizationId,
+    });
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      organizationLearnerId: activeLearner.id,
+      combinedCourseId,
+      status: OrganizationLearnerParticipationStatuses.COMPLETED,
+    });
+    databaseBuilder.factory.buildOrganizationLearnerParticipation({
+      type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
+      organizationLearnerId: deletedLearner.id,
+      combinedCourseId,
+      status: OrganizationLearnerParticipationStatuses.STARTED,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.getCombinedCourseStatistics({ combinedCourseId });
+
+    // then
+    expect(result).instanceOf(CombinedCourseStatistics);
+    expect(result).deep.equal({
+      id: combinedCourseId,
+      participationsCount: 1,
+      completedParticipationsCount: 1,
+    });
+  });
 });

--- a/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-courses-by-organization-id_test.js
@@ -80,17 +80,17 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     expect(firstCourse.name).to.equal('First Combined Course');
     expect(firstCourse.participations).to.have.lengthOf(2);
     expect(firstCourse.participations[0]).to.be.an.instanceof(CombinedCourseParticipation);
-    expect(firstCourse.participations[0].firstName).to.equal('Alice');
-    expect(firstCourse.participations[0].lastName).to.equal('Anderson');
-    expect(firstCourse.participations[1].firstName).to.equal('Bob');
-    expect(firstCourse.participations[1].lastName).to.equal('Brown');
+    expect(firstCourse.participations[0].status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
+    expect(firstCourse.participations[0].combinedCourseId).to.equal(combinedCourseId1);
+    expect(firstCourse.participations[1].status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
+    expect(firstCourse.participations[1].combinedCourseId).to.equal(combinedCourseId1);
 
     expect(secondCourse.code).to.equal('COURSE2');
     expect(secondCourse.name).to.equal('Second Combined Course');
     expect(secondCourse.participations).to.have.lengthOf(1);
     expect(secondCourse.participations[0]).to.be.an.instanceof(CombinedCourseParticipation);
-    expect(secondCourse.participations[0].firstName).to.equal('Charlie');
-    expect(secondCourse.participations[0].lastName).to.equal('Clark');
+    expect(secondCourse.participations[0].status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
+    expect(secondCourse.participations[0].combinedCourseId).to.equal(combinedCourseId2);
   });
 
   it('should return combined courses with empty participations when no participations exist', async function () {
@@ -197,9 +197,11 @@ describe('Integration | Quest | Domain | UseCases | get-combined-courses-by-orga
     const secondCourse = result.combinedCourses.find((course) => course.id === combinedCourseId2);
 
     expect(firstCourse.participations).to.have.lengthOf(1);
-    expect(firstCourse.participations[0].firstName).to.equal('Alice');
+    expect(firstCourse.participations[0].combinedCourseId).to.equal(combinedCourseId1);
+    expect(firstCourse.participations[0].status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
 
     expect(secondCourse.participations).to.have.lengthOf(1);
-    expect(secondCourse.participations[0].firstName).to.equal('Bob');
+    expect(secondCourse.participations[0].combinedCourseId).to.equal(combinedCourseId2);
+    expect(secondCourse.participations[0].status).to.equal(OrganizationLearnerParticipationStatuses.STARTED);
   });
 });


### PR DESCRIPTION
## 🍂 Problème

La fonction `findByCombinedCourseIds` dans le repository `combined-course-participation-repository` utilisait la pagination et récupérait des champs non nécessaires, ce qui complexifiait le code sans apporter de valeur.

## 🌰 Proposition

Refactoring des fonctions du repository `combined-course-participation-repository` :
- Suppression de la pagination dans `findByCombinedCourseIds`
- Retrait des champs inutiles dans les requêtes
- Simplification des use cases `get-combined-course-statistics` et `get-combined-courses-by-organization-id`
- Mise à jour des tests associés

## 🍁 Remarques

Ce refactoring améliore la lisibilité du code sans modifier le comportement fonctionnel.

## 🪵 Pour tester 
- Les tests passent 
- Les pages Orga des parcours combinés fonctionnent