### PR TITLE
[FEATURE] Ajuster la couleur du texte des boutons disabled dans la barre de navigation de modulix (PIX-20450)

### DIFF
--- a/mon-pix/app/components/module/layout/_navigation-button.scss
+++ b/mon-pix/app/components/module/layout/_navigation-button.scss
@@ -76,10 +76,9 @@
   &.pix-button[aria-disabled="true"] {
     color: var(--pix-neutral-900);
     background-color: unset;
-    opacity: 1;
 
     .pix-icon {
-      opacity: 0.5;
+      opacity: 0.3;
       fill: var(--pix-neutral-800);
     }
   }


### PR DESCRIPTION
## 🍂 Problème

En format mobile, les sections désactivées de la barre de nav de modulix ne se voient pas assez.

## 🌰 Proposition
Ajuster l'opacité du texte (comme sur le composant pix-button) à 0.5

## 🍁 Remarques

RAS

## 🪵 Pour tester

- Aller sur le module bac-a-sable et se mettre en format mobile.
- Vérifier que les sections désactivées ont maintenant la couleur adaptée.
