### PR TITLE
[BUGFIX] Donner les bons liens anglais de documentation (PIX-20441).

### DIFF
--- a/certif/app/components/layout/sidebar.gjs
+++ b/certif/app/components/layout/sidebar.gjs
@@ -8,19 +8,10 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
-const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
-const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
-
 export default class Sidebar extends Component {
+  @service url;
   @service currentUser;
   @service router;
-
-  get documentationLink() {
-    if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
-      return LINK_SCO;
-    }
-    return LINK_OTHER;
-  }
 
   get showLinkToSessions() {
     return !this.currentUser.currentAllowedCertificationCenterAccess.isAccessRestricted;
@@ -97,7 +88,7 @@ export default class Sidebar extends Component {
           </li>
           <li>
             <PixNavigationButton
-              href={{this.documentationLink}}
+              href={{this.url.documentationUrl}}
               @icon='book'
               @title='Documentation'
               @target='_blank'

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import UrlBaseService from './url-base.js';
 
 export default class Url extends UrlBaseService {
+  @service currentUser;
   @service intl;
   @service locale;
 
@@ -32,6 +33,13 @@ export default class Url extends UrlBaseService {
     }
 
     return 'https://cloud.pix.fr/s/JmBn2q5rpzgrjxN/download';
+  }
+
+  get documentationUrl() {
+    if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
+      return this.intl.t('common.urls.documentation.sco-managing-students');
+    }
+    return this.intl.t('common.urls.documentation.other');
   }
 
   get urlToDownloadSessionIssueReportSheet() {

--- a/certif/tests/integration/components/layout/sidebar_test.gjs
+++ b/certif/tests/integration/components/layout/sidebar_test.gjs
@@ -8,9 +8,6 @@ import sinon from 'sinon';
 
 import setupRenderingIntlTest from '../../../helpers/setup-intl-rendering';
 
-const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
-const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
-
 module('Integration | Component | Layout | Sidebar', function (hooks) {
   setupRenderingIntlTest(hooks);
 
@@ -248,7 +245,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
         // then
         assert
           .dom(screen.getByRole('link', { name: t('navigation.sidebar.documentation') }))
-          .hasAttribute('href', LINK_SCO);
+          .hasAttribute('href', t('common.urls.documentation.sco-managing-students'));
       });
     });
 
@@ -280,7 +277,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
         // then
         assert
           .dom(screen.getByRole('link', { name: t('navigation.sidebar.documentation') }))
-          .hasAttribute('href', LINK_OTHER);
+          .hasAttribute('href', t('common.urls.documentation.other'));
       });
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -188,6 +188,10 @@
       "invigilator": "Invigilator"
     },
     "urls": {
+      "documentation": {
+        "other": "https://cloud.pix.fr/s/WPcbosgLjnWLQJ4",
+        "sco-managing-students": "https://cloud.pix.fr/s/WPcbosgLjnWLQJ4"
+      },
       "fraud": "https://cloud.pix.fr/s/9A598pR5ksp6jss/download",
       "session-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download",
       "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/ro7jHtsZZbY5SCX/download"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -188,6 +188,10 @@
       "invigilator": "Surveillant"
     },
     "urls": {
+      "documentation": {
+        "other": "https://cloud.pix.fr/s/fLSG4mYCcX7GDRF",
+        "sco-managing-students": "https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
+      },
       "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download",
       "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",
       "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download"


### PR DESCRIPTION
## 🍂 Problème

Sur PixCertif, lorsque la langue est en anglais, le lien d’accès à la documentation dans la navigation n’est pas le bon.

## 🌰 Proposition

Utiliser le lien anglophone sur PixCertif en anglais.

## 🍁 Remarques

Il y a 2 liens différents en FR (SCO vs autres)

## 🪵 Pour tester

Tester les 2 cas en RA
