### PR TITLE
[TECH] Modifier l'url listant les logos des contenu formatif sur Pix Admin (PIX-20455).

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -197,6 +197,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
                 href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/contenu-formatif/editeur"
                 target="_blank"
                 rel="noopener noreferrer"
+                class="training__logo-url-link"
               >
                 Voir la liste des logos éditeur
               </a>

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -194,7 +194,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
             </PixInput>
             <small>
               <a
-                href="https://1024pix.github.io/pix-images-list/viewer.html?directory=contenu-formatif/editeur/"
+                href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/contenu-formatif/editeur"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/admin/app/styles/components/trainings/create-or-update-training-form.scss
+++ b/admin/app/styles/components/trainings/create-or-update-training-form.scss
@@ -24,3 +24,8 @@
     width: 6.25rem;
   }
 }
+
+.training__logo-url-link {
+  color: var(--pix-primary-700);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## 🍂 Problème

Actuellement sur Pix Admin, [lorsqu’on crée un nouveau contenu formatif](https://admin.integration.pix.fr/trainings/new), on a un lien permettant de voir la liste des logos existants, enregistrés sur pix-images-list. Mais celui-ci ne fonctionne plus suite à une action Captain.

## 🌰 Proposition

- Modifier le lien pour pointer vers les logos enregistrés sur Pix Assets.
- On en profitera pour améliorer visuellement ce lien qui ne se repère pas comme tel.

## 🪵 Pour tester

- Se rendre ici https://admin-pr14181.review.pix.fr/trainings/new
- Voir que le lien ressemble à un vrai lien (iso à celui des badges)
- Cliquer dessus et être renvoyé vers Pix Assets > Contenu formatif > editeur
<img width="304" height="101" alt="Capture d’écran 2025-11-17 à 16 06 27" src="https://github.com/user-attachments/assets/e899ef40-d327-4c49-beb2-eacd0cb171fa" />

