### PR TITLE
[BUGFIX] Corriger affichage barre de navigation en Mobile et avec bannière (PIX-20469)

### DIFF
--- a/mon-pix/app/components/module/layout/navigation.gjs
+++ b/mon-pix/app/components/module/layout/navigation.gjs
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
+import didInsert from '../../../modifiers/modifier-did-insert';
 import ModulixNavigationButton from './navigation-button';
 
 export default class ModulixNavigation extends Component {
@@ -52,12 +53,23 @@ export default class ModulixNavigation extends Component {
     return this.args.sections.indexOf(section) + 1;
   }
 
+  @action
+  setHTMLElementOffset(htmlElement) {
+    const bannerElement = document.getElementById('pix-layout-banner-container');
+    if (!bannerElement) return;
+    const distanceBetweenNavigationAndBanner = 8;
+    const top = bannerElement.getBoundingClientRect().height + distanceBetweenNavigationAndBanner;
+    htmlElement.style.setProperty('top', `${top}px `);
+  }
+
   <template>
     <PixNavigation
+      id="module-navigation"
       class="app-navigation module-navigation"
       @navigationAriaLabel={{t "navigation.nav-bar.aria-label"}}
       @openLabel={{t "navigation.nav-bar.open"}}
       @closeLabel={{t "navigation.nav-bar.close"}}
+      {{didInsert this.setHTMLElementOffset}}
     >
       <:brand>
         <img class="module-navigation__logo" src="/images/modulix-pix-logo.svg" alt={{t "navigation.homepage"}} />

--- a/mon-pix/app/services/modulix-auto-scroll.js
+++ b/mon-pix/app/services/modulix-auto-scroll.js
@@ -3,24 +3,52 @@ import Service, { service } from '@ember/service';
 
 export default class ModulixAutoScroll extends Service {
   @service modulixPreviewMode;
+  @service media;
 
-  #DISTANCE_BETWEEN_GRAIN_AND_PAGE_TOP_PX = 70;
+  #DISTANCE_BETWEEN_GRAIN_AND_NAVBAR_PX = 70;
+  #MOBILE_NAVBAR_HEIGHT = 72;
 
   @action
   setHTMLElementScrollOffsetCssProperty(htmlElement) {
     htmlElement.style.setProperty('--scroll-offset', `${this.#getScrollOffset()}px`);
   }
 
-  #getScrollOffset() {
-    return this.#DISTANCE_BETWEEN_GRAIN_AND_PAGE_TOP_PX;
+  get #bannerHeight() {
+    const bannerElement = document.getElementById('pix-layout-banner-container');
+    if (!bannerElement) {
+      return 0;
+    }
+
+    return bannerElement.getBoundingClientRect().height;
+  }
+
+  #getNavbar() {
+    return document.getElementById('module-navigation');
+  }
+
+  #getNavbarHeight({ getNavbar }) {
+    const navbar = getNavbar();
+    if (!navbar || this.media.isDesktop) {
+      return 0;
+    }
+
+    return this.#MOBILE_NAVBAR_HEIGHT;
+  }
+
+  #getScrollOffset({ getNavbar } = { getNavbar: this.#getNavbar }) {
+    const bannerHeight = this.#bannerHeight;
+    const distanceBetweenBannerAndNavBar = this.#bannerHeight > 0 ? 8 : 0;
+    const navbarHeight = this.#getNavbarHeight({ getNavbar }) + distanceBetweenBannerAndNavBar;
+    return bannerHeight + navbarHeight + this.#DISTANCE_BETWEEN_GRAIN_AND_NAVBAR_PX;
   }
 
   focusAndScroll(
     htmlElement,
-    { scroll, userPrefersReducedMotion, getWindowScrollY } = {
+    { scroll, userPrefersReducedMotion, getWindowScrollY, getNavbar } = {
       scroll: this.#scroll,
       userPrefersReducedMotion: this.#userPrefersReducedMotion,
       getWindowScrollY: this.#getWindowScrollY,
+      getNavbar: this.#getNavbar,
     },
   ) {
     if (this.modulixPreviewMode.isEnabled) {
@@ -31,7 +59,7 @@ export default class ModulixAutoScroll extends Service {
 
     const elementY = htmlElement.getBoundingClientRect().top + getWindowScrollY();
     scroll({
-      top: elementY - this.#getScrollOffset(),
+      top: elementY - this.#getScrollOffset({ getNavbar }),
       behavior: userPrefersReducedMotion() ? 'instant' : 'smooth',
     });
   }

--- a/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
+++ b/mon-pix/tests/integration/components/module/layout/navigation_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import { triggerKeyEvent } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
+import InformationBanners from 'mon-pix/components/information-banners';
 import ModulixNavigation from 'mon-pix/components/module/layout/navigation';
 import { module, test } from 'qunit';
 
@@ -8,6 +9,61 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Navigation', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  module('setHTMLElementOffset', function () {
+    module('when there is no banner', function () {
+      test('should place the navbar at the beginning of the page', async function (assert) {
+        // given
+        const sections = [
+          {
+            type: 'question-yourself',
+          },
+          {
+            type: 'explore-to-understand',
+          },
+        ];
+
+        // when
+        await render(<template><ModulixNavigation @sections={{sections}} /></template>);
+
+        // then
+        assert.dom('#module-navigation').doesNotHaveAttribute('style');
+      });
+    });
+
+    module('when there is a banner', function () {
+      test('should place the navbar below the banner', async function (assert) {
+        // given
+        const sections = [
+          {
+            type: 'question-yourself',
+          },
+          {
+            type: 'explore-to-understand',
+          },
+        ];
+        const banners = [
+          {
+            message: 'Une information importante',
+            severity: 'information',
+          },
+        ];
+
+        // when
+        await render(
+          <template>
+            <div id="pix-layout-banner-container">
+              <InformationBanners @banners={{banners}} />
+            </div>
+            <ModulixNavigation @sections={{sections}} />
+          </template>,
+        );
+
+        // then
+        assert.dom('#module-navigation').hasAttribute('style', 'top: 36.5px;');
+      });
+    });
+  });
 
   module('handleArrowKeyNavigation', function () {
     module('when user press arrow down or right on buttons', function () {

--- a/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
+++ b/mon-pix/tests/unit/services/modulix-auto-scroll-test.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -44,13 +45,21 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
 
       test('should scroll to given html element', function (assert) {
         // given
-        const scrollOffsetPx = 70;
         const topOfGivenElement = 150;
+        const navbarHeight = 72;
         const windowScrollY = 12;
+        const distanceBetweenNavbarAndGrain = 70;
 
+        class MediaServiceStub extends Service {
+          isDesktop = false;
+        }
+        this.owner.register('service:media', MediaServiceStub);
         const modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
         htmlElement.getBoundingClientRect = sinon.stub().returns({ top: topOfGivenElement });
+        const navbarElement = document.createElement('nav');
+        navbarElement.getBoundingClientRect = sinon.stub().returns({ height: navbarHeight });
         const scroll = sinon.stub();
+        const getNavbar = sinon.stub().returns(navbarElement);
         const getWindowScrollY = sinon.stub().returns(windowScrollY);
         const userPrefersReducedMotion = sinon.stub().returns(false);
 
@@ -59,11 +68,14 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
           scroll,
           userPrefersReducedMotion,
           getWindowScrollY,
+          getNavbar,
         });
 
         // then
+        const expectedScrollPosition =
+          topOfGivenElement + windowScrollY - (navbarHeight + distanceBetweenNavbarAndGrain);
         sinon.assert.calledWithExactly(scroll, {
-          top: topOfGivenElement + windowScrollY - scrollOffsetPx,
+          top: expectedScrollPosition,
           behavior: 'smooth',
         });
         assert.ok(true);
@@ -73,6 +85,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
         let modulixAutoScrollService;
         let scrollStub;
         let getWindowScrollYStub;
+        let getNavbarStub;
 
         hooks.beforeEach(function () {
           modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
@@ -86,6 +99,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
           const givenWindowScrollY = 5;
           getWindowScrollYStub = sinon.stub();
           getWindowScrollYStub.returns(givenWindowScrollY);
+          getNavbarStub = sinon.stub();
         });
 
         function executeFocusAndScroll(givenUserPrefersReducedMotion) {
@@ -95,6 +109,7 @@ module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
             scroll: scrollStub,
             userPrefersReducedMotion: userPrefersReducedMotionStub,
             getWindowScrollY: getWindowScrollYStub,
+            getNavbar: getNavbarStub,
           });
         }
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1696,7 +1696,7 @@
           }
         },
         "tooltip": {
-          "disabled": "A suivre : {sectionTitle}"
+          "disabled": "À suivre : {sectionTitle}"
         }
       },
       "preview": {


### PR DESCRIPTION
## 🍂 Problème

En Mobile, quand il y a une bannière des cap'tains, la barre de navigation des modules s'affiche en dessous de la bannière : https://github.com/1024pix/pix/pull/14177#issuecomment-3541985208

## 🌰 Proposition

Ajouter une condition qui décale la barre de navigation des modules sous la bannière, dans le cas où le contenu de la bannière n'est pas vide.

## 🍁 Remarques

- Désolés, on n'a pas trouvé mieux 🤷‍♀️
- En Desktop, même s'il y a une bannière, cette PR ne change pas l'espace entre la bannière et la barra de navigation qui existait au préalable. 
- On a pris en compte la bannière des cap'tains, et la hauteur de la barre de navigation en mobile, pour le scroll dans le module.
- On a corrigé le terme "A suivre" en "À suivre" dans les boutons de navigation désactivés


## 🪵 Pour tester

- Dans la barre de navigation, vérifier qu'il s'affiche "À suivre" pour les boutons désactivés

_Avec bannière_
- Ouvrir un [module](https://app-pr14184.review.pix.fr/modules/tmp-ia-premier-prompt/details)
- Se mettre en mode Mobile
- Commencer le module, et constater que la barre de navigation est bien en dessous de la bannière des captains
- Ouvrir la barre de navigation. Sélectionner une section dans la barre de navigation, et vérifier que le scroll auto se met à la hauteur du titre de la section sélectionnée

_Sans bannière_
- Récupérer la branche localement et lancer PixApp et API
- Ouvrir un module, et constater que la barre de navigation est bien positionnée
