### PR TITLE
[FEATURE]  Ajouter un validateur pour le modèle CombinedCourseTemplate (PIX-20014)

### DIFF
--- a/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
@@ -3,9 +3,119 @@ import { CombinedCourseTemplate } from '../../../../../src/quest/domain/models/C
 import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/domain/models/CriterionProperty.js';
 import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import { COMPARISONS as COMPARISONS_REQUIREMENT, TYPES } from '../../../../../src/quest/domain/models/Requirement.js';
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () {
+  describe('#validate', function () {
+    let successRequirements;
+    beforeEach(function () {
+      successRequirements = [
+        {
+          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: COMPARISONS_REQUIREMENT.ALL,
+          data: {
+            targetProfileId: {
+              data: 123,
+              comparison: COMPARISONS_CRITERION.EQUAL,
+            },
+          },
+        },
+        {
+          requirement_type: TYPES.OBJECT.PASSAGES,
+          comparison: COMPARISONS_REQUIREMENT.ALL,
+          data: {
+            moduleId: {
+              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+              comparison: COMPARISONS_CRITERION.EQUAL,
+            },
+          },
+        },
+      ];
+    });
+
+    it('should throw if name is not provided', function () {
+      // when
+      const createCombineCourse = () =>
+        new CombinedCourseTemplate({
+          successRequirements,
+          description: 'bla bla bla',
+          illustration: 'illu.svg',
+        });
+
+      // then
+      expect(createCombineCourse).to.throw(EntityValidationError);
+    });
+
+    it('should throw if successRequirement is not provided', function () {
+      // when
+      const createCombineCourse = () =>
+        new CombinedCourseTemplate({
+          name: 'combinix',
+          description: 'description',
+          illustration: 'illu.svg',
+        });
+
+      // then
+      expect(createCombineCourse).to.throw(EntityValidationError);
+    });
+
+    it('should throw if successRequirement does not pass validation', function () {
+      // when
+      const successRequirements = [
+        {
+          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: COMPARISONS_REQUIREMENT.ALL,
+          data: {
+            moduleId: {
+              data: 1,
+              comparison: COMPARISONS_CRITERION.EQUAL,
+            },
+          },
+        },
+      ];
+
+      // then
+      expect(
+        () =>
+          new CombinedCourseTemplate({
+            name: 'combinix',
+            successRequirements,
+            description: 'description',
+            illustration: 'illu.svg',
+          }),
+      ).to.throw(EntityValidationError);
+    });
+
+    it('should throw when a target profile id in success requirement is a string', async function () {
+      //given
+
+      const targetProfileId = 12;
+
+      const successRequirements = [
+        {
+          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          comparison: COMPARISONS_REQUIREMENT.ALL,
+          data: {
+            targetProfileId: {
+              data: targetProfileId.toString(),
+              comparison: COMPARISONS_CRITERION.EQUAL,
+            },
+          },
+        },
+      ];
+      // then
+      expect(
+        () =>
+          new CombinedCourseTemplate({
+            name: 'combinix',
+            successRequirements,
+            description: 'description',
+            illustration: 'illu.svg',
+          }),
+      ).to.throw(EntityValidationError);
+    });
+  });
   describe('#getTargetProfileIds', function () {
     it('should return target profile ids from campaignParticipations success requirements', async function () {
       const successRequirements = [
@@ -31,6 +141,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
+        name: 'combinix',
         successRequirements,
       });
       expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([1, 8]);
@@ -49,6 +160,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
+        name: 'combinix',
         successRequirements,
       });
       expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([]);
@@ -90,6 +202,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
+        name: 'combinix',
         successRequirements,
       });
       expect(combinedCourseTemplate.moduleIds).to.deep.equal(['abcdef-555', 'abcdef-777']);
@@ -109,11 +222,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
+        name: 'combinix',
         successRequirements,
       });
       expect(combinedCourseTemplate.moduleIds).to.deep.equal([]);
     });
   });
+
   describe('#toCombinedCourse', function () {
     it('should create combined course from template and given organization data ', async function () {
       // given

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -904,6 +904,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'Combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -951,6 +952,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -998,6 +1000,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1044,13 +1047,14 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const recommendedModuleIdsForUser = [];
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
                 comparison: COMPARISONS_REQUIREMENT.ALL,
                 data: {
                   moduleId: {
-                    data: 7,
+                    data: 'abcdefgh1',
                     comparison: COMPARISONS_CRITERION.EQUAL,
                   },
                 },
@@ -1062,7 +1066,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             new CombinedCourse({ id, organizationId, name, code, questId }),
             combinedCourseQuestFormat,
           );
-          const module = new Module({ id: 7, title: 'module', duration: 10 });
+          const module = new Module({ id: 'abcdefgh1', title: 'module', duration: 10 });
           const dataForQuest = new DataForQuest({
             eligibility: new Eligibility({
               passages: [
@@ -1103,6 +1107,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const recommendableModuleIds = [{ moduleId: module.id, targetProfileIds: [campaign.targetProfileId] }];
           const recommendedModuleIdsForUser = [];
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1170,12 +1175,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         it('should return module if it in quest, recommandable and recommended for user', function () {
           // given
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-          const module = new Module({ id: 1, title: 'module' });
+          const module = new Module({ id: 'ebcde1', title: 'module' });
           const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
           const recommendableModuleIds = [{ moduleId: module.id, targetProfileIds: [campaign.targetProfileId] }];
           const recommendedModuleIdsForUser = [{ moduleId: module.id }];
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1256,8 +1262,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           it('should return a campaign participation item and a formation item', function () {
             // given
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-            const firstModule = new Module({ id: 1, title: 'module' });
-            const secondModule = new Module({ id: 2, title: 'module' });
+            const firstModule = new Module({ id: 'abcdef1', title: 'module' });
+            const secondModule = new Module({ id: 'abcdef2', title: 'module' });
             const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
@@ -1266,6 +1272,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ];
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
+              name: 'combinix',
               successRequirements: [
                 {
                   requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1353,8 +1360,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           it('should return two campaign participation items and two formation items', function () {
             // given
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-            const firstModule = new Module({ id: 1, title: 'module' });
-            const secondModule = new Module({ id: 2, title: 'module' });
+            const firstModule = new Module({ id: 'abcdef1', title: 'module' });
+            const secondModule = new Module({ id: 'abcdef2', title: 'module' });
             const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
             const secondCampaign = domainBuilder.buildCampaign({ id: 999, targetProfileId: 101 });
 
@@ -1364,6 +1371,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ];
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
+              name: 'combinix',
               successRequirements: [
                 {
                   requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1481,8 +1489,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           it('should return a combined course item even if data for quest is empty', function () {
             // given
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-            const firstModule = new Module({ id: 1, title: 'module' });
-            const secondModule = new Module({ id: 2, title: 'module' });
+            const firstModule = new Module({ id: 'abcdef1', title: 'module' });
+            const secondModule = new Module({ id: 'abcdef2', title: 'module' });
             const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
@@ -1491,6 +1499,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ];
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
+              name: 'combinix',
               successRequirements: [
                 {
                   requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1563,8 +1572,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           it('should return formation block for each target profile in the right order', function () {
             // given
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-            const module = new Module({ id: 1, title: 'module' });
-            const module2 = new Module({ id: 2, title: 'module2' });
+            const module = new Module({ id: 'abcdef1', title: 'module' });
+            const module2 = new Module({ id: 'abcdef3', title: 'module2' });
             const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888, code: 'campaign123' });
             const campaign2 = domainBuilder.buildCampaign({ id: 333, targetProfileId: 666, code: 'campaign456' });
 
@@ -1574,6 +1583,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ];
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
+              name: 'combinix',
               successRequirements: [
                 {
                   requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1691,8 +1701,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           it('should return a formation item and a quest item', function () {
             // given
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
-            const moduleFromTargetProfile = new Module({ id: 1, title: 'module' });
-            const moduleFromQuest = new Module({ id: 2, title: 'module from quest' });
+            const moduleFromTargetProfile = new Module({ id: 'abcdefgh1', title: 'module' });
+            const moduleFromQuest = new Module({ id: 'abcdefgh3', title: 'module from quest' });
             const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
@@ -1700,6 +1710,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             ];
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
+              name: 'combinix',
               successRequirements: [
                 {
                   requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1801,6 +1812,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', title: 'diagnostique2' });
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
+          name: 'combinix',
           successRequirements: [
             {
               requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1848,9 +1860,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         // given
         const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 888 });
         const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', title: 'diagnostique2', targetProfileId: 999 });
-        const module = new Module({ id: 7, title: 'title', slug: 'abcdef' });
+        const module = new Module({ id: 'abc2de', title: 'title', slug: 'abcdef' });
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
+          name: 'combinix',
           successRequirements: [
             {
               requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -1944,9 +1957,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
       });
       it('should evaluates if module is completed', function () {
         // given
-        const module = new Module({ id: 7, title: 'title', slug: 'abcdef' });
+        const module = new Module({ id: 'abc2de', title: 'title', slug: 'abcdef' });
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
+          name: 'combinix',
           successRequirements: [
             {
               requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
@@ -1989,6 +2003,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 888 });
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -2033,6 +2048,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 888 });
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
+            name: 'combinix',
             successRequirements: [
               {
                 requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
@@ -2077,12 +2093,13 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         // given
         const campaign1 = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 888 });
         const campaign2 = new Campaign({ id: 3, code: 'ABCDIAG2', title: 'diagnostique2', targetProfileId: 999 });
-        const module1 = new Module({ id: 7, title: 'module diag 1', slug: 'module-abcdef-1' });
-        const module11 = new Module({ id: 8, title: 'module diag 1.1', slug: 'module-azerty-1.1' });
-        const module2 = new Module({ id: 9, title: 'module diag 2', slug: 'module-querty-2' });
-        const module22 = new Module({ id: 10, title: 'module diag 2.2', slug: 'module-osef-2-2' });
+        const module1 = new Module({ id: 'abcde1', title: 'module diag 1', slug: 'module-abcdef-1' });
+        const module11 = new Module({ id: 'abcde2', title: 'module diag 1.1', slug: 'module-azerty-1.1' });
+        const module2 = new Module({ id: 'abcde3', title: 'module diag 2', slug: 'module-querty-2' });
+        const module22 = new Module({ id: 'abcde4', title: 'module diag 2.2', slug: 'module-osef-2-2' });
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
+          name: 'combinix',
           successRequirements: [
             {
               requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,


### PR DESCRIPTION
## 🍂 Problème

Il arrive que l'utilisateur upload une configuration de parcours combinés qui ne respecte pas le schéma de donnée et qui génère un erreur 500 en prod. 

## 🌰 Proposition

Ajouter un validateur Joi pour éviter les erreurs 500 (celle ci seront traduites en erreurs du domaine)

## 🍁 Remarques

on récupère la valeur du schéma pour la passer à la quête afin de bénéficier des transformations qu'offre Joi ('123' -> 123)

## 🪵 Pour tester

- Tester la création de parcours combinés avec des schémas erronnés et s'assurer qu'on remonte bien l'erreur avec un code 4xx (ex: fournir un moduleId au lieu d'un targetProfileId, ne pas donner de nom, ...)
