### PR TITLE
[FEATURE] Enregistrer le code pays lors de la modification d'une orga (PIX-20294)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -4,6 +4,7 @@ import {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
   ArchiveOrganizationsInBatchError,
+  CountryNotFoundError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,
@@ -58,6 +59,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: AdministrationTeamNotFound.name,
     httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: CountryNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message, error.code, error.meta),
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -35,6 +35,13 @@ class ArchiveOrganizationsInBatchError extends DomainError {
   }
 }
 
+class CountryNotFoundError extends DomainError {
+  constructor({ code = 'COUNTRY_NOT_FOUND', message = 'Country not found', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
 class DpoEmailInvalid extends DomainError {
   constructor({ code = 'DPO_EMAIL_INVALID', message = 'DPO email invalid', meta } = {}) {
     super(message);
@@ -98,6 +105,7 @@ export {
   AdministrationTeamNotFound,
   ArchiveCertificationCentersInBatchError,
   ArchiveOrganizationsInBatchError,
+  CountryNotFoundError,
   DpoEmailInvalid,
   FeatureNotFound,
   FeatureParamsNotProcessable,

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -228,6 +228,7 @@ class OrganizationForAdmin {
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     if (organization.administrationTeamId) this.administrationTeamId = organization.administrationTeamId;
+    if (organization.countryCode) this.countryCode = organization.countryCode;
   }
 
   setCountryName(countryName) {

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -247,6 +247,7 @@ const update = async function ({ organization }) {
     'showSkills',
     'type',
     'administrationTeamId',
+    'countryCode',
   ]);
 
   await _enableFeatures(knexConn, organization.features, organization.id);

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -122,8 +122,8 @@ const deserialize = function (json) {
     parentOrganizationId: attributes['parent-organization-id'] ? parseInt(attributes['parent-organization-id']) : null,
     features: attributes.features,
     tagIds,
+    countryCode: attributes['country-code'] && parseInt(attributes['country-code']),
   });
-
   return organization;
 };
 

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -676,6 +676,12 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       // given
       const administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
 
+      const country = databaseBuilder.factory.buildCertificationCpfCountry({
+        code: '99102',
+        commonName: 'Islande',
+        originalName: 'Islande',
+      });
+
       const organizationAttributes = {
         externalId: '0446758F',
         provinceCode: '044',
@@ -696,6 +702,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
             email: organizationAttributes.email,
             credit: organizationAttributes.credit,
             'administration-team-id': administrationTeamId,
+            'country-code': country.code,
           },
         },
       };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1173,17 +1173,24 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     it('updates organization detail', async function () {
       // given
       const parentOrganizationId = databaseBuilder.factory.buildOrganization({ name: 'Parent Organization' }).id;
-      const childOrganization = databaseBuilder.factory.buildOrganization({ name: 'Child Organization' });
+      const childOrganization = databaseBuilder.factory.buildOrganization({
+        name: 'Child Organization',
+        countryCode: 99100,
+      });
       await databaseBuilder.commit();
-      const childOrganizationForAdmin = new OrganizationForAdmin(childOrganization);
+      const childOrganizationForAdmin = new OrganizationForAdmin({
+        ...childOrganization,
+        parentOrganizationId,
+        countryCode: 99243,
+      });
 
       // when
-      childOrganizationForAdmin.parentOrganizationId = parentOrganizationId;
       await repositories.organizationForAdminRepository.update({ organization: childOrganizationForAdmin });
 
       // then
       const updatedOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
       expect(updatedOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+      expect(updatedOrganization.countryCode).to.equal(99243);
       expect(updatedOrganization.updatedAt).to.deep.equal(new Date('2022-02-02'));
     });
 

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -1,5 +1,6 @@
 import { organizationalEntitiesDomainErrorMappingConfiguration } from '../../../../src/organizational-entities/application/http-error-mapper-configuration.js';
 import {
+  CountryNotFoundError,
   TagNotFoundError,
   UnableToDetachParentOrganizationFromChildOrganization,
 } from '../../../../src/organizational-entities/domain/errors.js';
@@ -50,6 +51,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
       expect(error.message).to.equal('Unable to detach parent organization from child organization');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "CountryNotFoundError"', function () {
+    it('should return a Not found Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CountryNotFoundError.name,
+      );
+
+      const meta = { countryCode: 123456 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new CountryNotFoundError({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(HttpErrors.NotFoundError);
+      expect(error.message).to.equal('Country not found');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -347,6 +347,34 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organization.administrationTeamId).to.equal(initialAdministrationTeamId);
     });
 
+    it('updates country code', async function () {
+      // given
+      const initialCountryCode = Symbol('initial country code');
+      const newCountryCode = Symbol('new country code');
+
+      const organization = new OrganizationForAdmin({ countryCode: initialCountryCode });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({ countryCode: newCountryCode, features });
+
+      // then
+      expect(organization.countryCode).to.equal(newCountryCode);
+    });
+
+    it('does not update country code to empty value', async function () {
+      // given
+      const initialCountryCode = Symbol('initial country code');
+      const newCountryCode = null;
+
+      const organization = new OrganizationForAdmin({ countryCode: initialCountryCode });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({ countryCode: newCountryCode, features });
+
+      // then
+      expect(organization.countryCode).to.equal(initialCountryCode);
+    });
+
     context('updates organization isManagingStudents', function () {
       it('updates organization isManagingStudents when LEARNER_IMPORT feature does not exist', function () {
         // given

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -175,6 +175,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
           [ORGANIZATION_FEATURE.IS_MANAGING_STUDENTS.key]: { active: true },
           [ORGANIZATION_FEATURE.SHOW_SKILLS.key]: { active: true },
         },
+        countryCode: '99100',
       };
 
       // when
@@ -198,6 +199,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'data-protection-officer-email': organizationAttributes.dataProtectionOfficerEmail,
             'administration-team-id': organizationAttributes.administrationTeamId,
             features: organizationAttributes.features,
+            'country-code': organizationAttributes.countryCode,
           },
         },
       });
@@ -230,6 +232,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             active: organizationAttributes.features.MULTIPLE_SENDING_ASSESSMENT.active,
           },
         },
+        countryCode: 99100,
       });
       expect(organization).to.be.instanceOf(OrganizationForAdmin);
       expect(organization).to.deep.equal(expectedOrganization);
@@ -303,6 +306,24 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
 
       // then
       expect(organization.parentOrganizationId).to.equal(5);
+    });
+
+    it('should not deserialize country code if not present', function () {
+      // when
+      const organization = organizationForAdminSerializer.deserialize({
+        data: {
+          type: 'organizations',
+          id: '7',
+          attributes: {
+            name: 'Lycée St Cricq',
+            type: Organization.types.SCO,
+            'country-code': undefined,
+          },
+        },
+      });
+
+      // then
+      expect(organization.countryCode).undefined;
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de l'ajout du champ Pays dans les infos d'une orga, on souhaite pouvoir enregistrer le code pays lors de la modification d'une orga.

## 🌰 Proposition

Pour la route **PATCH** `/api/admin/organizations/{organizationId}`, ajouter la propriété `countryCode` afin de pouvoir l'enregistrer en base.

## 🍁 Remarques
Le `countryCode` n'est pas encore obligatoire en base mais on a choisi de ne pas pouvoir le rendre `null` lors de la modification, afin de faciliter la transition.
On a choisi de laisser la possibilité pour le countryCode d'être absent du payload car la route de création utilise le même `deserializer` et celle-ci n'a pas encore été traitée.

## 🪵 Pour tester

- trouver l'id d'une orga dont le pays est FRANCE
- utiliser un client HTTP pour requêter la route PATCH https://admin-pr14186.review.pix.fr/api/admin/organizations/<id-de-l'orga-à-modifier> 
passer le payload suivant (country code du Canada):
```
{
  "data": {
    "id": "id-de-l'orga-à-modifier",
    "attributes": {
      "administration-team-id": "1000",
      "country-code": "99401"
    },
    "type": "organizations"
  }
}
```
- constater dans la réponse que le country code a bien été mis à jour vers 99401

