### PR TITLE
[FEATURE] Permettre au prescripteur de voir une liste de suivi en fonction de l'attestation séléctionné (Pix-20240).

### DIFF
--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -114,7 +114,10 @@ async function _createProOrganization(databaseBuilder) {
     memberIds: [USER_ID_MEMBER_ORGANIZATION],
     features: [
       { id: FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID },
-      { id: FEATURE_ATTESTATIONS_MANAGEMENT_ID, params: JSON.stringify([ATTESTATIONS.PARENTHOOD]) },
+      {
+        id: FEATURE_ATTESTATIONS_MANAGEMENT_ID,
+        params: JSON.stringify([ATTESTATIONS.PARENTHOOD, 'MINARM', 'EDUSECU']),
+      },
       { id: FEATURE_PLACES_MANAGEMENT_ID },
       { id: FEATURE_COVER_RATE_ID },
       { id: FEATURE_CAMPAIGN_WITHOUT_USER_PROFILE_ID },

--- a/api/db/seeds/data/team-prescription/build-quests.js
+++ b/api/db/seeds/data/team-prescription/build-quests.js
@@ -14,6 +14,7 @@ import {
   AEFE_TAG,
   COUNTRY_FRANCE_CODE,
   FEATURE_ATTESTATIONS_MANAGEMENT_ID,
+  PRO_ORGANIZATION_ID,
   SCO_ORGANIZATION_ID,
   USER_ID_ADMIN_ORGANIZATION,
   USER_ID_MEMBER_ORGANIZATION,
@@ -506,7 +507,6 @@ export const buildQuests = async (databaseBuilder) => {
   const allAttestationIds = [
     rewardId, // sixth-grade attestation
     parenthoodAttestationId, // parenthood attestation
-    ...educationAttestations.map((attestation) => attestation.id),
   ];
 
   allAttestationIds.forEach((attestationId) => {
@@ -515,5 +515,21 @@ export const buildQuests = async (databaseBuilder) => {
       rewardType: REWARD_TYPES.ATTESTATION,
       rewardId: attestationId,
     });
+  });
+
+  educationAttestations.forEach((attestation) => {
+    const rewardId = databaseBuilder.factory.buildProfileReward({
+      userId: allAttestationsUser.id,
+      rewardType: REWARD_TYPES.ATTESTATION,
+      rewardId: attestation.id,
+    }).id;
+
+    if (['MINARM', 'EDUSECU'].includes(attestation.key)) {
+      databaseBuilder.factory.buildOrganizationsProfileRewards({
+        userId: allAttestationsUser.id,
+        organizationId: PRO_ORGANIZATION_ID,
+        profileRewardId: rewardId,
+      });
+    }
   });
 };

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -17,12 +17,17 @@ export const PARENTHOOD_ATTESTATION_KEY = 'PARENTHOOD';
 
 export default class Attestations extends Component {
   @service currentUser;
+  @service intl;
 
   get displaySixthGrade() {
     return (
       this.currentUser.prescriber.availableAttestations.includes(SIXTH_GRADE_ATTESTATION_KEY) &&
       this.args.divisions != undefined
     );
+  }
+
+  get attestationName() {
+    return this.intl.t('pages.attestations.' + this.args.attestationKey);
   }
 
   get availableAttestations() {
@@ -58,13 +63,18 @@ export default class Attestations extends Component {
       {{/if}}
 
       {{#if this.displayAttestations}}
-        <OtherAttestations @attestations={{this.availableAttestations}} @onSubmit={{@onSubmit}} />
+        <OtherAttestations
+          @attestations={{this.availableAttestations}}
+          @selectedAttestation={{@attestationKey}}
+          @onFilter={{@onFilter}}
+          @onSubmit={{@onSubmit}}
+        />
       {{/if}}
     </section>
 
     <section class="attestation-page__list">
       <h2 class="attestations-page__section-title attestations-page__section-title--list">
-        {{t "pages.attestations.section.list"}}
+        {{t "pages.attestations.section.list" attestationName=this.attestationName}}
       </h2>
       <List
         @participantStatuses={{@participantStatuses}}
@@ -81,7 +91,6 @@ export default class Attestations extends Component {
 
 class OtherAttestations extends Component {
   @service intl;
-  @tracked selectedAttestation = null;
 
   get options() {
     return this.args.attestations.map((attestation) => ({
@@ -94,16 +103,16 @@ class OtherAttestations extends Component {
   async onSubmit(event) {
     event.preventDefault();
 
-    await this.args.onSubmit(this.selectedAttestation, []);
-    this.selectedAttestation = null;
+    await this.args.onSubmit(this.args.selectedAttestation, []);
+    this.args.onFilter('attestationKey', null);
   }
 
   @action
   onSelectedAttestationChange(value) {
     if (value === '') {
-      this.selectedAttestation = null;
+      this.args.onFilter('attestationKey', null);
     } else {
-      this.selectedAttestation = value;
+      this.args.onFilter('attestationKey', value);
     }
   }
 
@@ -114,7 +123,7 @@ class OtherAttestations extends Component {
       </p>
       <form class="attestations-page__action" {{on "submit" this.onSubmit}}>
         <PixSelect
-          @value={{this.selectedAttestation}}
+          @value={{@selectedAttestation}}
           @options={{this.options}}
           @onChange={{this.onSelectedAttestationChange}}
           @placeholder={{t "common.filters.placeholder"}}

--- a/orga/app/controllers/authenticated/attestations.js
+++ b/orga/app/controllers/authenticated/attestations.js
@@ -14,6 +14,7 @@ export default class AuthenticatedAttestationsController extends Controller {
   @service notifications;
   @service intl;
 
+  @tracked attestationKey = null;
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
   @tracked statuses = [];

--- a/orga/app/routes/authenticated/attestations.js
+++ b/orga/app/routes/authenticated/attestations.js
@@ -4,6 +4,9 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedAttestationsRoute extends Route {
   queryParams = {
+    attestationKey: {
+      refreshModel: true,
+    },
     pageNumber: {
       refreshModel: true,
     },
@@ -32,7 +35,7 @@ export default class AuthenticatedAttestationsRoute extends Route {
   }
 
   async model(params) {
-    const attestationKey = this.currentUser.prescriber.availableAttestations[0];
+    const attestationKey = params.attestationKey ?? this.currentUser.prescriber.availableAttestations[0];
     const organizationId = this.currentUser.organization.id;
     const attestationParticipantStatuses = await this.store.query('attestation-participant-status', {
       organizationId,
@@ -51,10 +54,10 @@ export default class AuthenticatedAttestationsRoute extends Route {
     if (this.currentUser.organization.isManagingStudents) {
       const divisions = await this.currentUser.organization.divisions;
       const options = divisions.map(({ name }) => ({ label: name, value: name }));
-      return { options, attestationParticipantStatuses };
+      return { options, attestationParticipantStatuses, attestationKey };
     }
 
-    return { attestationParticipantStatuses };
+    return { attestationParticipantStatuses, attestationKey };
   }
 
   resetController(controller, isExiting) {
@@ -64,6 +67,7 @@ export default class AuthenticatedAttestationsRoute extends Route {
       controller.search = null;
       controller.pageSize = 50;
       controller.pageNumber = 1;
+      controller.attestationKey = null;
     }
   }
 

--- a/orga/app/templates/authenticated/attestations.gjs
+++ b/orga/app/templates/authenticated/attestations.gjs
@@ -6,6 +6,7 @@ import Attestations from 'pix-orga/components/attestations';
 
   <div class="attestations-page">
     <Attestations
+      @attestationKey={{@model.attestationKey}}
       @participantStatuses={{@model.attestationParticipantStatuses}}
       @divisions={{@model.options}}
       @onSubmit={{@controller.downloadAttestations}}

--- a/orga/tests/integration/components/attestations_test.gjs
+++ b/orga/tests/integration/components/attestations_test.gjs
@@ -106,7 +106,7 @@ module('Integration | Component | Attestations', function (hooks) {
     });
   });
 
-  module('when organization does not have divisions and SIXTH_GRADE attestation', function () {
+  module('when organization does not managing student with SIXTH_GRADE attestation', function () {
     test('it should display all basics information', async function (assert) {
       // given
       const noop = sinon.stub();
@@ -132,7 +132,14 @@ module('Integration | Component | Attestations', function (hooks) {
 
       // when
       const screen = await render(
-        <template><Attestations @divisions={{divisions}} @onSubmit={{onSubmit}} @onFilter={{noop}} /></template>,
+        <template>
+          <Attestations
+            @attestationKey={{SIXTH_GRADE_ATTESTATION_KEY}}
+            @divisions={{divisions}}
+            @onSubmit={{onSubmit}}
+            @onFilter={{noop}}
+          />
+        </template>,
       );
 
       const downloadButton = await screen.getByRole('button', {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -568,7 +568,7 @@
       "no-attestations": "No attestation available",
       "section": {
         "download": "Download",
-        "list": "Follow-up"
+        "list": "Follow-up  : {attestationName}"
       },
       "select-divisions-label": "Select attestations for one or more classes",
       "select-label": "Attestation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -568,7 +568,7 @@
       "no-attestations": "Aucune attestation disponible pour votre sélection",
       "section": {
         "download": "Téléchargement",
-        "list": "Suivi"
+        "list": "Suivi : {attestationName}"
       },
       "select-divisions-label": "Sélectionnez les attestations d'une ou plusieurs classes",
       "select-label": "Attestation",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -568,7 +568,7 @@
       "no-attestations": "Er zijn geen certificaten beschikbaar voor jouw selectie",
       "section": {
         "download": "Downloaden",
-        "list": "Follow-up"
+        "list": "Opvolging : {attestationName}"
       },
       "select-divisions-label": "Selecteer de certificaten voor een of meer klassen",
       "select-label": "Certificat",


### PR DESCRIPTION
## 🍂 Problème

La liste de suivi ne prend que la première attestation disponible de l'organisation et ne permet pas de savoir quelle attestation est obtenue ou non

## 🌰 Proposition

Lié la liste de suivi à la selection des attestations, par défaut il y en a toujours une de selectionné. 

## 🍁 Remarques

ajout de seeds pour avoir un utilisateur avec plusieurs attestations

## 🪵 Pour tester

Aller sur PixOrga => ProClassic, liste des attestations et vérifier que l'on peut cliquer dessus
Se connecter avec all-attestation@example.net sur PixApp
Participer à une campagne PROASSMUL 
Retourner sur PixOrga et vérifier qu'il apparaît maintenant dans la liste des attestations. et lorsque l'on filtre il apparaît aussi.