### PR TITLE
[FEATURE] Permettre de connaitre l'état de la fonctionnalité `CAMPAIGN_WITHOUT_USER_PROFILE` sur une organisation dans PixAdmin (PIX-20476).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -48,6 +48,7 @@ export default class Organization extends Model {
       LEARNER_IMPORT: 'LEARNER_IMPORT',
       IS_MANAGING_STUDENTS: 'IS_MANAGING_STUDENTS',
       SHOW_NPS: 'SHOW_NPS',
+      CAMPAIGN_WITHOUT_USER_PROFILE: 'CAMPAIGN_WITHOUT_USER_PROFILE',
       SHOW_SKILLS: 'SHOW_SKILLS',
       ATTESTATIONS_MANAGEMENT: 'ATTESTATIONS_MANAGEMENT',
     };
@@ -58,6 +59,7 @@ export default class Organization extends Model {
       Organization.featureList,
       'MULTIPLE_SENDING_ASSESSMENT',
       'IS_MANAGING_STUDENTS',
+      'CAMPAIGN_WITHOUT_USER_PROFILE',
       'SHOW_SKILLS',
       'PLACES_MANAGEMENT',
     );

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -190,67 +190,105 @@ module('Integration | Component | organizations/information-section-edit', funct
     });
 
     module('#features', function () {
-      test('should display place management features as deactivated', async function (assert) {
-        organization.features = {
-          PLACES_MANAGEMENT: {
-            active: false,
-            params: null,
-          },
-        };
+      module('PLACES_MANAGEMENT', function () {
+        test('should display features as deactivated', async function (assert) {
+          organization.features = {
+            PLACES_MANAGEMENT: {
+              active: false,
+              params: null,
+            },
+          };
 
-        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+          const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
-        assert.false(
-          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
-            .checked,
-        );
-        assert.notOk(
-          screen.queryByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
-          ),
-        );
+          assert.false(
+            screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+              .checked,
+          );
+          assert.notOk(
+            screen.queryByLabelText(
+              t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
+            ),
+          );
+        });
+
+        test('should display features as activated and lockThreshold deactivated', async function (assert) {
+          organization.features = {
+            PLACES_MANAGEMENT: {
+              active: true,
+              params: { enableMaximumPlacesLimit: false },
+            },
+          };
+
+          const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+          assert.true(
+            screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+              .checked,
+          );
+          assert.false(
+            screen.getByLabelText(
+              t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
+            ).checked,
+          );
+        });
+
+        test('should display features as activated  and lockThreshold activated', async function (assert) {
+          organization.features = {
+            PLACES_MANAGEMENT: {
+              active: true,
+              params: { enableMaximumPlacesLimit: true },
+            },
+          };
+
+          const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+          assert.true(
+            screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
+              .checked,
+          );
+          assert.true(
+            screen.getByLabelText(
+              t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
+            ).checked,
+          );
+        });
       });
 
-      test('should display place management features as activated and lockThreshold deactivated', async function (assert) {
-        organization.features = {
-          PLACES_MANAGEMENT: {
-            active: true,
-            params: { enableMaximumPlacesLimit: false },
-          },
-        };
+      module('CAMPAIGN_WITHOUT_USER_PROFILE', function () {
+        test('should display features as deactivated', async function (assert) {
+          organization.features = {
+            CAMPAIGN_WITHOUT_USER_PROFILE: {
+              active: false,
+              params: null,
+            },
+          };
 
-        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+          const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
-        assert.true(
-          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
-            .checked,
-        );
-        assert.false(
-          screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
-          ).checked,
-        );
-      });
+          assert.false(
+            screen.getByLabelText(
+              t('components.organizations.information-section-view.features.CAMPAIGN_WITHOUT_USER_PROFILE'),
+            ).checked,
+          );
+        });
 
-      test('should display place management features as activated  and lockThreshold activated', async function (assert) {
-        organization.features = {
-          PLACES_MANAGEMENT: {
-            active: true,
-            params: { enableMaximumPlacesLimit: true },
-          },
-        };
+        test('should display features as activated', async function (assert) {
+          organization.features = {
+            CAMPAIGN_WITHOUT_USER_PROFILE: {
+              active: true,
+              params: null,
+            },
+          };
 
-        const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+          const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
-        assert.true(
-          screen.getByLabelText(t('components.organizations.information-section-view.features.PLACES_MANAGEMENT'))
-            .checked,
-        );
-        assert.true(
-          screen.getByLabelText(
-            t('components.organizations.information-section-view.features.ORGANIZATION_PLACES_LIMIT.label'),
-          ).checked,
-        );
+          assert.true(
+            screen.getByLabelText(
+              t('components.organizations.information-section-view.features.CAMPAIGN_WITHOUT_USER_PROFILE'),
+            ).checked,
+          );
+        });
       });
     });
   });

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -536,6 +536,48 @@ module('Integration | Component | organizations/information-section-view', funct
         });
       });
 
+      module('CAMPAIGN_WITHOUT_USER_PROFILE', function () {
+        test('should display block enabled message, if this features is enabled', async function (assert) {
+          // given
+          const organization = EmberObject.create({
+            features: {
+              CAMPAIGN_WITHOUT_USER_PROFILE: { active: true, params: null },
+            },
+          });
+
+          // when
+          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+          // then
+          assert.ok(
+            screen.getByText(
+              t('components.organizations.information-section-view.features.CAMPAIGN_WITHOUT_USER_PROFILE'),
+            ),
+          );
+        });
+
+        test('should display block disabled message, if this features is not enabled', async function (assert) {
+          // given
+          // given
+          const organization = EmberObject.create({
+            features: {
+              CAMPAIGN_WITHOUT_USER_PROFILE: { active: false },
+            },
+          });
+
+          // when
+          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+
+          // then
+          assert.ok(
+            screen.getByLabelText(
+              `${t(
+                'components.organizations.information-section-view.features.CAMPAIGN_WITHOUT_USER_PROFILE',
+              )} : ${t('common.words.no')}`,
+            ),
+          );
+        });
+      });
+
       module('Net Promoter Score', function () {
         module('when NPS is enabled', function () {
           test('should display a link to formNPSUrl', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -646,6 +646,7 @@
         "external-id": "External identifier",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
+          "CAMPAIGN_WITHOUT_USER_PROFILE": "interro mode (temporary name)",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Automatic certificability",
           "IS_MANAGING_STUDENTS": "Managing students",
           "LEARNER_IMPORT": "Import",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -647,6 +647,7 @@
         "external-id": "Identifiant externe",
         "features": {
           "ATTESTATIONS_MANAGEMENT": "Attestations",
+          "CAMPAIGN_WITHOUT_USER_PROFILE": "Mode interro (nom non définitif)",
           "COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY": "Certificabilité automatique",
           "IS_MANAGING_STUDENTS": "Gestion d'élèves/étudiants",
           "LEARNER_IMPORT": "Import",


### PR DESCRIPTION
## 🍂 Problème

La fonctionnalité est disponible depuis un moment sur certaines organisation,mais nous n'avons aucune remonté côté back office pour connaitre l'état de la fonctionnalité sur une organisation en particilier à moins de faire des requêtes en base ( pas fifou ça)

## 🌰 Proposition

Afficher l'état de la fonctionnalité CAMPAIGN_WITHOUT_USER_PROFILE sur les organisations. 


## 🍁 Remarques

RAS

## 🪵 Pour tester

Aller sur PixAdmin
Aller sur l'organisation Pro Classic
Vérifier la présence de la fonctionnalité ( Mode interro ( nom non définitif ) )

En bonus possibilité d'activé la fonctionnalité à la volé dans le mode édition. ( des étoiles dans les yeux )