### PR TITLE
[FEATURE] Ajouter la route GET /api/modules/v2/shortId (PIX-20384)

### DIFF
--- a/api/src/devcomp/application/modules/module-controller.js
+++ b/api/src/devcomp/application/modules/module-controller.js
@@ -1,4 +1,6 @@
-const getBySlug = async function (request, h, { moduleSerializer, usecases }) {
+import { usecases } from '../../domain/usecases/index.js';
+
+const getBySlug = async function (request, h, { moduleSerializer }) {
   const { slug } = request.params;
   const encryptedRedirectionUrl = request.query.encryptedRedirectionUrl;
   const module = await usecases.getModule({ slug, encryptedRedirectionUrl });

--- a/api/src/devcomp/application/modules/module-controller.js
+++ b/api/src/devcomp/application/modules/module-controller.js
@@ -1,5 +1,13 @@
 import { usecases } from '../../domain/usecases/index.js';
 
+const getByShortId = async function (request, h, { moduleSerializer }) {
+  const { shortId } = request.params;
+  const encryptedRedirectionUrl = request.query.encryptedRedirectionUrl;
+  const module = await usecases.getModuleByShortId({ shortId, encryptedRedirectionUrl });
+
+  return moduleSerializer.serialize(module);
+};
+
 const getBySlug = async function (request, h, { moduleSerializer }) {
   const { slug } = request.params;
   const encryptedRedirectionUrl = request.query.encryptedRedirectionUrl;
@@ -8,6 +16,6 @@ const getBySlug = async function (request, h, { moduleSerializer }) {
   return moduleSerializer.serialize(module);
 };
 
-const modulesController = { getBySlug };
+const modulesController = { getByShortId, getBySlug };
 
 export { modulesController };

--- a/api/src/devcomp/application/modules/module-route.js
+++ b/api/src/devcomp/application/modules/module-route.js
@@ -22,6 +22,24 @@ const register = async function (server) {
       },
     },
   ]);
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/modules/v2/{shortId}',
+      config: {
+        auth: false,
+        handler: handlerWithDependencies(modulesController.getByShortId),
+        validate: {
+          params: Joi.object({ shortId: Joi.string().required() }),
+          query: Joi.object({
+            encryptedRedirectionUrl: Joi.string(),
+          }),
+        },
+        notes: ['- Permet de récupérer un module grâce à son id raccourci'],
+        tags: ['api', 'modules'],
+      },
+    },
+  ]);
 };
 
 const name = 'modules-api';

--- a/api/src/devcomp/domain/usecases/get-module-by-short-id.js
+++ b/api/src/devcomp/domain/usecases/get-module-by-short-id.js
@@ -1,0 +1,21 @@
+import { config } from '../../../shared/config.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
+
+async function getModuleByShortId({ shortId, encryptedRedirectionUrl, moduleRepository }) {
+  const module = await moduleRepository.getByShortId({ shortId });
+
+  if (encryptedRedirectionUrl) {
+    let redirectionUrl = null;
+    try {
+      redirectionUrl = await cryptoService.decrypt(encryptedRedirectionUrl, config.module.secret);
+      if (redirectionUrl) {
+        module.setRedirectionUrl(redirectionUrl);
+      }
+    } catch {
+      return module;
+    }
+  }
+  return module;
+}
+
+export { getModuleByShortId };

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -53,6 +53,7 @@ import { findRecommendedModulesByCampaignParticipationIds } from './find-recomme
 import { findTargetProfileSummariesForTraining } from './find-target-profile-summaries-for-training.js';
 import { findTutorials } from './find-tutorials.js';
 import { getModule } from './get-module.js';
+import { getModuleByShortId } from './get-module-by-short-id.js';
 import { getModuleMetadataList } from './get-module-metadata-list.js';
 import { getTraining } from './get-training.js';
 import { getUserModuleStatuses } from './get-user-module-statuses.js';
@@ -86,6 +87,7 @@ const usecasesWithoutInjectedDependencies = {
   findTutorials,
   getModuleMetadataList,
   getModule,
+  getModuleByShortId,
   getTraining,
   getUserModuleStatuses,
   handleTrainingRecommendation,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -29,6 +29,15 @@ const moduleDatasource = {
 
     return foundModule;
   },
+  getByShortId: async (shortId) => {
+    const foundModule = referential.modules.find((module) => module.shortId === shortId);
+
+    if (foundModule === undefined) {
+      throw new ModuleDoesNotExistError();
+    }
+
+    return foundModule;
+  },
   getBySlug: async (slug) => {
     const foundModule = referential.modules.find((module) => module.slug === slug);
 

--- a/api/tests/devcomp/acceptance/application/modules/module-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/module-route_test.js
@@ -53,4 +53,38 @@ describe('Acceptance | Controller | Modules | Route', function () {
       });
     });
   });
+
+  describe('GET /api/modules/v2/:shortId', function () {
+    context('when a module with given shortId exist', function () {
+      it('should return modules data', async function () {
+        nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+        const options = {
+          method: 'GET',
+          url: `/api/modules/v2/9d4dcab8`,
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.equal('modules');
+      });
+
+      context('when redirectionUrl query params is passed to api url', function () {
+        it('should return module data with redirectionUrl', async function () {
+          nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+          const expectedUrl = 'https://app.pix.fr/parcours/COMBINIX1';
+          const encryptedRedirectionUrl = await cryptoService.encrypt(expectedUrl, config.module.secret);
+          const options = {
+            method: 'GET',
+            url: `/api/modules/v2/9d4dcab8?encryptedRedirectionUrl=${encodeURIComponent(encryptedRedirectionUrl)}`,
+          };
+
+          const response = await server.inject(options);
+
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.data.attributes['redirection-url']).to.equal(expectedUrl);
+        });
+      });
+    });
+  });
 });

--- a/api/tests/devcomp/acceptance/application/modules/module-route_test.js
+++ b/api/tests/devcomp/acceptance/application/modules/module-route_test.js
@@ -2,7 +2,7 @@ import { config } from '../../../../../src/shared/config.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { createServer, expect, nock } from '../../../../test-helper.js';
 
-describe('Acceptance | Controller | modules-controller-getBySlug', function () {
+describe('Acceptance | Controller | Modules | Route', function () {
   let server;
 
   beforeEach(async function () {

--- a/api/tests/devcomp/integration/application/modules/module-route_test.js
+++ b/api/tests/devcomp/integration/application/modules/module-route_test.js
@@ -49,4 +49,52 @@ describe('Integration | Devcomp | Application | Module | Router | module-router'
       });
     });
   });
+
+  describe('GET /api/modules/v2/{shortId}', function () {
+    describe('when controller throws a ModuleInstantiationError', function () {
+      it('should return an HTTP 502 error', async function () {
+        // given
+        sinon.stub(modulesController, 'getByShortId').throws(new ModuleInstantiationError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const notExistingShortId = 'not-existing-short-id';
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'module-id': 'not existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('GET', `/api/modules/v2/${notExistingShortId}`, invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(502);
+      });
+    });
+
+    describe('when controller throws an ElementInstantiationError', function () {
+      it('should return an HTTP 502 error', async function () {
+        // given
+        sinon.stub(modulesController, 'getByShortId').throws(new ElementInstantiationError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const notExistingShortId = 'not-existing-short-id';
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'module-id': 'not existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('GET', `/api/modules/v2/${notExistingShortId}`, invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(502);
+      });
+    });
+  });
 });

--- a/api/tests/devcomp/unit/application/modules/module-controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/module-controller_test.js
@@ -1,6 +1,7 @@
 import { modulesController } from '../../../../../src/devcomp/application/modules/module-controller.js';
 import * as moduleUnderTest from '../../../../../src/devcomp/application/modules/module-route.js';
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
+import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Modules | Module Controller', function () {
@@ -10,9 +11,7 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
       const encryptedRedirectionUrl = 'encryptedRedirectionUrl';
       const serializedModule = Symbol('serialized modules');
       const module = Symbol('modules');
-      const usecases = {
-        getModule: sinon.stub(),
-      };
+      sinon.stub(usecases, 'getModule');
       usecases.getModule.withArgs({ slug, encryptedRedirectionUrl }).returns(module);
       const moduleSerializer = {
         serialize: sinon.stub(),

--- a/api/tests/devcomp/unit/application/modules/module-controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/module-controller_test.js
@@ -1,8 +1,6 @@
 import { modulesController } from '../../../../../src/devcomp/application/modules/module-controller.js';
-import * as moduleUnderTest from '../../../../../src/devcomp/application/modules/module-route.js';
-import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { usecases } from '../../../../../src/devcomp/domain/usecases/index.js';
-import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Modules | Module Controller', function () {
   describe('#getBySlug', function () {
@@ -24,18 +22,6 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
       });
 
       expect(result).to.equal(serializedModule);
-    });
-
-    it('should throw an error if referential data is incorrect', async function () {
-      // given
-      sinon.stub(modulesController, 'getBySlug').throws(new ModuleInstantiationError());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/modules/slug');
-
-      expect(response.statusCode).to.equal(502);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/usecases/get-module-by-short-id_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-by-short-id_test.js
@@ -1,0 +1,51 @@
+import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
+import { getModuleByShortId } from '../../../../../src/devcomp/domain/usecases/get-module-by-short-id.js';
+import { config } from '../../../../../src/shared/config.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | get-module-by-short-id', function () {
+  describe('#getModuleByShortId', function () {
+    it('should get and return a Module', async function () {
+      // given
+      const expectedModule = Symbol('module');
+      const shortId = 'l4cr4me7';
+      const moduleRepository = {
+        getByShortId: sinon.stub(),
+      };
+      moduleRepository.getByShortId.withArgs({ shortId }).resolves(expectedModule);
+
+      // when
+      const module = await getModuleByShortId({ shortId, moduleRepository });
+
+      // then
+      expect(module).to.equal(expectedModule);
+    });
+
+    it('should get and return a Module with a redirection url', async function () {
+      // given
+      const id = 1;
+      const shortId = 'f9f8bk1d';
+      const slug = 'les-adresses-email';
+      const title = 'Les adresses email';
+      const isBeta = false;
+      const sections = [Symbol('text')];
+      const details = Symbol('details');
+      const version = Symbol('version');
+
+      const expectedModule = new Module({ id, shortId, slug, title, isBeta, sections, details, version });
+      const moduleRepository = {
+        getByShortId: sinon.stub(),
+      };
+      moduleRepository.getByShortId.withArgs({ shortId }).resolves(expectedModule);
+      const expectedUrl = '/parcours/COMBINIX1';
+      const encryptedRedirectionUrl = await cryptoService.encrypt(expectedUrl, config.module.secret);
+
+      // when
+      const module = await getModuleByShortId({ shortId, encryptedRedirectionUrl, moduleRepository });
+
+      // then
+      expect(module.redirectionUrl).to.equal(expectedUrl);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -43,6 +43,34 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
     });
   });
 
+  describe('#getByShortId', function () {
+    describe('when a module with the given shortId exist', function () {
+      it('should return a module', async function () {
+        // Given
+        const bacASableShortId = '6a68bf32';
+
+        // When
+        const module = await moduleDatasource.getByShortId(bacASableShortId);
+
+        // Then
+        expect(module).to.exist;
+      });
+    });
+
+    describe('when a module with the given shortId does not exist', function () {
+      it('should throw an ModuleDoesNotExistError', async function () {
+        // given
+        const id = 'inexistent-shortId';
+
+        // when
+        const error = await catchErr(moduleDatasource.getByShortId)(id);
+
+        // then
+        expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+      });
+    });
+  });
+
   describe('#getById', function () {
     describe('when exists', function () {
       it('should return something', async function () {


### PR DESCRIPTION
## 🍂 Problème

On souhaite changer le format des urls des modules. Pour cela, nous avons besoin d'une api permettant de récupérer le contenu d'un module à partir de son shortId.

## 🌰 Proposition

Le faire avec le chemin suivant GET /api/modules/v2/:shortId

## 🍁 Remarques

On a crée une nouvelle route pour pouvoir enlever l'ancienne plus facilement une fois la migration terminée.

## 🪵 Pour tester

- Appeler l'api de Pix avec le path suivant : `/api/modules/v2/6a68bf32`
- Vérifier que le contenu du module est bien renvoyé 😄 
