### PR TITLE
[TECH] Éviter les warnings "mixed-decls" de Sass

### DIFF
--- a/mon-pix/app/components/module/_passage.scss
+++ b/mon-pix/app/components/module/_passage.scss
@@ -3,6 +3,10 @@
 
 
 .module-passage {
+  max-width: var(--modulix-max-content-width);
+  margin: 0 auto;
+  padding: 0 var(--pix-spacing-4x);
+
   @include breakpoints.device-is('mobile') {
     padding-top: 0;
 
@@ -10,10 +14,6 @@
       padding-top: 70px;
     }
   }
-
-  max-width: var(--modulix-max-content-width);
-  margin: 0 auto;
-  padding: 0 var(--pix-spacing-4x);
 
   .auto-scroll {
     min-height: calc(100vh - var(--scroll-offset));

--- a/mon-pix/app/components/module/grain/_grain.scss
+++ b/mon-pix/app/components/module/grain/_grain.scss
@@ -23,6 +23,10 @@ $grain-card-border-radius: var(--pix-spacing-4x);
     font-weight: var(--pix-font-bold);
   }
 
+  &__card {
+    border-radius: $grain-card-border-radius;
+  }
+
   &__card,
   &-card__tag,
   &-card__footer {
@@ -43,10 +47,6 @@ $grain-card-border-radius: var(--pix-spacing-4x);
         }
       }
     }
-  }
-
-  &__card {
-    border-radius: $grain-card-border-radius;
   }
 
   &:focus-visible {


### PR DESCRIPTION
## 🍂 Problème

Des warnings de dépréciation Sass étaient générés lors de la compilation du projet mon-pix.

```shell
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls
``` 

Techniquement, ces avertissements signalent que des déclarations de style étaient définies après des règles imbriquées (comme des `@media` ou `@include`) dans les fichiers .scss.

Ce positionnement est déprécié et le comportement de Sass changera dans les futures versions, ce qui pourrait altérer le rendu CSS actuel.

## 🌰 Proposition

Déplacer les déclarations de style concernées avant les règles imbriquées.

## 🪵 Pour tester

- Lancer mon-pix en local à partir de cette branche
- Plus aucun warning Sass ne devrait être affiché
