### PR TITLE
[BUGFIX]  Affichage buggé sur les solutions à afficher.  (PIX-20480)

### DIFF
--- a/mon-pix/app/components/solution-panel/formatted-solution.gjs
+++ b/mon-pix/app/components/solution-panel/formatted-solution.gjs
@@ -3,6 +3,7 @@ import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 
 export default class FormattedSolution extends Component {
   get displayedSolution() {
+    if (typeof this.args.solutionToDisplay === 'number') return `${this.args.solutionToDisplay}`;
     return this.args.solutionToDisplay?.replaceAll('\n', ' <br>');
   }
 

--- a/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/solution-panel/qrocm-dep-solution-panel-test.js
@@ -247,4 +247,31 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
+
+  module('When solutions are numbers and challenge skipped', function (hooks) {
+    hooks.beforeEach(function () {
+      this.solution = 'el1:\n- 2\nel2:\n- 3';
+      this.solutionsWithoutGoodAnswers = [];
+      this.answer = EmberObject.create({
+        id: 'answer_id',
+        value: SKIPPED_VALUE,
+        result: CHALLENGE_SKIPPED_FLAG,
+        assessment: EmberObject.create({ id: 'assessment_id' }),
+      });
+      this.challenge = EmberObject.create({
+        id: 'challengeId',
+        proposals: 'Numéros des éléments : ${el1 options=["1", "2", "3"]} ${el2 options=["1", "2", "3"]}',
+        format: FORMATS[0].format,
+      });
+      this.answersEvaluation = [false, false];
+      this.solutionToDisplay = null;
+    });
+
+    test('it should display solution panel', async function (assert) {
+      // when
+      const screen = await renderComponent();
+      // then
+      assert.dom(screen.getByText('Numéros des éléments :')).exists();
+    });
+  });
 });


### PR DESCRIPTION
## 🍂 Problème
Lorsque l'on passe une question dont les solutions sont des chiffres, les solutions à afficher ne s'affichent pas.

## 🌰 Proposition
Ca ne s'affiche pas parce que quand la solution est un nombre, il ne peut pas faire l'opération de mise à la ligne vu que ce n'est pas un string. On le convertit donc en string.

## 🍁 Remarques
RAS

## 🪵 Pour tester
modifier une épreuve avec  :
 proposals :
`Numéros des éléments : ${el1#- Sélectionner - options=["1", "2", "3", "4","5", "6", "7", "8"]} ${el2#- Sélectionner - options=["1", "2", "3", "4","5", "6", "7", "8"]} ${el3#- Sélectionner - options=["1", "2", "3", "4","5", "6", "7", "8"]}`
solutions: 
```
el1:
- 1
el2 : 
- 4
el3:
- 7
```
passer l'épreuve puis afficher la solution à l'épreuve.