### PR TITLE
[TECH] :recycle: Utilise le terme `invigilator` plutôt que `supervisor` dans le repo `supervisor-access-repository` (PIX-20481)

### DIFF
--- a/api/src/certification/session-management/application/pre-handlers/authorization.js
+++ b/api/src/certification/session-management/application/pre-handlers/authorization.js
@@ -3,7 +3,7 @@ import jsonapiSerializer from 'jsonapi-serializer';
 import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 import { extractUserIdFromRequest } from '../../../../shared/infrastructure/utils/request-response-utils.js';
 import * as sessionRepository from '../../../session-management/infrastructure/repositories/session-repository.js';
-import * as supervisorAccessRepository from '../../infrastructure/repositories/supervisor-access-repository.js';
+import * as invigilatorAccessRepository from '../../infrastructure/repositories/invigilator-access-repository.js';
 
 const { Error: JSONAPIError } = jsonapiSerializer;
 
@@ -41,12 +41,12 @@ async function checkUserHaveCertificationCenterMembershipForSession(request, h, 
   }
 }
 
-async function checkUserHaveInvigilatorAccessForSession(request, h, dependencies = { supervisorAccessRepository }) {
+async function checkUserHaveInvigilatorAccessForSession(request, h, dependencies = { invigilatorAccessRepository }) {
   const userId = extractUserIdFromRequest(request);
   const sessionId = request.params.sessionId;
 
   try {
-    const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSession({
+    const isSupervisorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSession({
       sessionId,
       userId,
     });

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -30,7 +30,7 @@ import * as sessionPublicationService from '../services/session-publication-serv
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationCourseRepository} CertificationCourseRepository
  * @typedef {import('../../infrastructure/repositories/index.js').FinalizedSessionRepository} FinalizedSessionRepository
  * @typedef {import('../../infrastructure/repositories/index.js').JuryCertificationSummaryRepository} JuryCertificationSummaryRepository
- * @typedef {import('../../infrastructure/repositories/index.js').SupervisorAccessRepository} SupervisorAccessRepository
+ * @typedef {import('../../infrastructure/repositories/index.js').InvigilatorAccessRepository} InvigilatorAccessRepository
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationOfficerRepository} CertificationOfficerRepository
  * @typedef {import('../../infrastructure/repositories/index.js').CertificationIssueReportRepository} CertificationIssueReportRepository
  * @typedef {import('../../infrastructure/repositories/index.js').FinalizedSessionRepository} FinalizedSessionRepository

--- a/api/src/certification/session-management/domain/usecases/supervise-session.js
+++ b/api/src/certification/session-management/domain/usecases/supervise-session.js
@@ -1,7 +1,7 @@
 //@ts-check
 /**
  * @typedef {import('./index.js').InvigilatorSessionRepository} InvigilatorSessionRepository
- * @typedef {import('./index.js').SupervisorAccessRepository} SupervisorAccessRepository
+ * @typedef {import('./index.js').InvigilatorAccessRepository} InvigilatorAccessRepository
  * @typedef {import('./index.js').CertificationCenterRepository} CertificationCenterRepository
  * @typedef {import('./index.js').CertificationCenterAccessRepository} CertificationCenterAccessRepository
  */
@@ -20,7 +20,7 @@ export const superviseSession = withTransaction(
    * @param {string} params.invigilatorPassword
    * @param {number} params.userId
    * @param {InvigilatorSessionRepository} params.invigilatorSessionRepository
-   * @param {SupervisorAccessRepository} params.supervisorAccessRepository
+   * @param {InvigilatorAccessRepository} params.invigilatorAccessRepository
    * @param {CertificationCenterRepository} params.certificationCenterRepository
    * @param {CertificationCenterAccessRepository} params.certificationCenterAccessRepository
    */
@@ -29,7 +29,7 @@ export const superviseSession = withTransaction(
     invigilatorPassword,
     userId,
     invigilatorSessionRepository,
-    supervisorAccessRepository,
+    invigilatorAccessRepository,
     certificationCenterRepository,
     certificationCenterAccessRepository,
   }) => {
@@ -69,6 +69,6 @@ export const superviseSession = withTransaction(
       throw new CertificationCenterIsArchivedError();
     }
 
-    await supervisorAccessRepository.create({ sessionId, userId });
+    await invigilatorAccessRepository.create({ sessionId, userId });
   },
 );

--- a/api/src/certification/session-management/infrastructure/repositories/index.js
+++ b/api/src/certification/session-management/infrastructure/repositories/index.js
@@ -28,6 +28,7 @@ import * as competenceMarkRepository from './competence-mark-repository.js';
 import * as courseAssessmentResultRepository from './course-assessment-result-repository.js';
 import * as cpfExportRepository from './cpf-export-repository.js';
 import * as finalizedSessionRepository from './finalized-session-repository.js';
+import * as invigilatorAccessRepository from './invigilator-access-repository.js';
 import * as invigilatorSessionRepository from './invigilator-session-repository.js';
 import * as juryCertificationRepository from './jury-certification-repository.js';
 import * as juryCertificationSummaryRepository from './jury-certification-summary-repository.js';
@@ -37,7 +38,6 @@ import * as sessionForSupervisingRepository from './session-for-supervising-repo
 import * as sessionJuryCommentRepository from './session-jury-comment-repository.js';
 import * as sessionRepository from './session-repository.js';
 import * as sessionSummaryRepository from './session-summary-repository.js';
-import * as supervisorAccessRepository from './supervisor-access-repository.js';
 import * as v3CertificationCourseDetailsForAdministrationRepository from './v3-certification-course-details-for-administration-repository.js';
 
 /**
@@ -61,7 +61,7 @@ import * as v3CertificationCourseDetailsForAdministrationRepository from './v3-c
  * @typedef {sessionSummaryRepository} SessionSummaryRepository
  * @typedef {sessionRepository} SessionRepository
  * @typedef {invigilatorSessionRepository} InvigilatorSessionRepository
- * @typedef {supervisorAccessRepository} SupervisorAccessRepository
+ * @typedef {invigilatorAccessRepository} InvigilatorAccessRepository
  * @typedef {certificationReportRepository} CertificationReportRepository
  * @typedef {certificationRepository} CertificationRepository
  * @typedef {v3CertificationCourseDetailsForAdministrationRepository} V3CertificationCourseDetailsForAdministrationRepository
@@ -103,7 +103,7 @@ const repositoriesWithoutInjectedDependencies = {
   sessionJuryCommentRepository,
   certificationRepository,
   certificationIssueReportRepository,
-  supervisorAccessRepository,
+  invigilatorAccessRepository,
   certificationReportRepository,
   v3CertificationCourseDetailsForAdministrationRepository,
   competenceRepository,

--- a/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
@@ -5,13 +5,13 @@ const create = async function ({ sessionId, userId }) {
   await knexConn('supervisor-accesses').insert({ sessionId, userId });
 };
 
-const isUserSupervisorForSession = async function ({ sessionId, userId }) {
+const isUserInvigilatorForSession = async function ({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn.select(1).from('supervisor-accesses').where({ sessionId, userId }).first();
   return Boolean(result);
 };
 
-const isUserSupervisorForSessionCandidate = async function ({ supervisorId, certificationCandidateId }) {
+const isUserInvigilatorForSessionCandidate = async function ({ supervisorId, certificationCandidateId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn
     .select(1)
@@ -22,4 +22,4 @@ const isUserSupervisorForSessionCandidate = async function ({ supervisorId, cert
   return Boolean(result);
 };
 
-export { create, isUserSupervisorForSession, isUserSupervisorForSessionCandidate };
+export { create, isUserInvigilatorForSession, isUserInvigilatorForSessionCandidate };

--- a/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
@@ -1,10 +1,10 @@
 import { extractUserIdFromRequest } from '../../../../shared/infrastructure/utils/request-response-utils.js';
-import * as supervisorAccessRepository from '../../../session-management/infrastructure/repositories/supervisor-access-repository.js';
+import * as invigilatorAccessRepository from '../../../session-management/infrastructure/repositories/invigilator-access-repository.js';
 
-const verifyByCertificationCandidateId = async function (request, h, dependencies = { supervisorAccessRepository }) {
+const verifyByCertificationCandidateId = async function (request, h, dependencies = { invigilatorAccessRepository }) {
   const supervisorUserId = extractUserIdFromRequest(request);
   const certificationCandidateId = request.params.certificationCandidateId;
-  const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSessionCandidate({
+  const isSupervisorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
     supervisorId: supervisorUserId,
     certificationCandidateId,
   });
@@ -16,11 +16,11 @@ const verifyByCertificationCandidateId = async function (request, h, dependencie
   return true;
 };
 
-const verifyBySessionId = async function (request, h, dependencies = { supervisorAccessRepository }) {
+const verifyBySessionId = async function (request, h, dependencies = { invigilatorAccessRepository }) {
   const userId = extractUserIdFromRequest(request);
   const sessionId = request.params.sessionId;
 
-  const isSupervisorForSession = await dependencies.supervisorAccessRepository.isUserSupervisorForSession({
+  const isSupervisorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSession({
     sessionId,
     userId,
   });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
@@ -1,16 +1,16 @@
-import * as supervisorAccessRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/supervisor-access-repository.js';
+import * as invigilatorAccessRepository from '../../../../../../src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js';
 import { databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
-describe('Integration | Repository | supervisor-access-repository', function () {
+describe('Integration | Repository | invigilator-access-repository', function () {
   describe('#create', function () {
-    it('should save a supervisor access', async function () {
+    it('should save an invigilator access', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
 
       // when
-      await supervisorAccessRepository.create({ sessionId, userId });
+      await invigilatorAccessRepository.create({ sessionId, userId });
 
       // then
       const supervisorAccessInDB = await knex.from('supervisor-accesses').first();
@@ -19,8 +19,8 @@ describe('Integration | Repository | supervisor-access-repository', function () 
     });
   });
 
-  describe('#isUserSupervisorForSession', function () {
-    it('should return true if user is supervising the session', async function () {
+  describe('#isUserInvigilatorForSession', function () {
+    it('should return true if user is invigilating the session', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;
@@ -28,16 +28,16 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       await databaseBuilder.commit();
 
       // when
-      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+      const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSession({
         sessionId,
         userId,
       });
 
       // then
-      expect(isUserSupervisorForSession).to.be.true;
+      expect(isUserInvigilatorForSession).to.be.true;
     });
 
-    it('should return false if user is not supervising the session', async function () {
+    it('should return false if user is not invigilating the session', async function () {
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;
@@ -45,18 +45,18 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       await databaseBuilder.commit();
 
       // when
-      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSession({
+      const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSession({
         sessionId: 123,
         userId: 456,
       });
 
       // then
-      expect(isUserSupervisorForSession).to.be.false;
+      expect(isUserInvigilatorForSession).to.be.false;
     });
   });
 
-  describe('#isUserSupervisorForSessionCandidate', function () {
-    it("should return true if the user is supervising the candidate's session", async function () {
+  describe('#isUserInvigilatorForSessionCandidate', function () {
+    it("should return true if the user is invigilating the candidate's session", async function () {
       // given
       const supervisorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
@@ -66,16 +66,16 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       await databaseBuilder.commit();
 
       // when
-      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSessionCandidate({
+      const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
         certificationCandidateId,
         supervisorId,
       });
 
       // then
-      expect(isUserSupervisorForSession).to.be.true;
+      expect(isUserInvigilatorForSession).to.be.true;
     });
 
-    it("should return false if the user is not supervising the candidate's session", async function () {
+    it("should return false if the user is not invigilating the candidate's session", async function () {
       // given
       const supervisorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
@@ -85,13 +85,13 @@ describe('Integration | Repository | supervisor-access-repository', function () 
       await databaseBuilder.commit();
 
       // when
-      const isUserSupervisorForSession = await supervisorAccessRepository.isUserSupervisorForSessionCandidate({
+      const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
         certificationCandidateId,
         supervisorId,
       });
 
       // then
-      expect(isUserSupervisorForSession).to.be.false;
+      expect(isUserInvigilatorForSession).to.be.false;
     });
   });
 });

--- a/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/supervise-session_test.js
@@ -10,7 +10,7 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-help
 
 describe('Unit | UseCase | supervise-session', function () {
   let invigilatorSessionRepository;
-  let supervisorAccessRepository;
+  let invigilatorAccessRepository;
   let certificationCenterRepository;
   let certificationCenterAccessRepository;
 
@@ -21,7 +21,7 @@ describe('Unit | UseCase | supervise-session', function () {
     invigilatorSessionRepository = {
       get: sinon.stub(),
     };
-    supervisorAccessRepository = {
+    invigilatorAccessRepository = {
       create: sinon.stub(),
     };
     certificationCenterRepository = {
@@ -55,7 +55,7 @@ describe('Unit | UseCase | supervise-session', function () {
       invigilatorPassword,
       userId,
       invigilatorSessionRepository,
-      supervisorAccessRepository,
+      invigilatorAccessRepository,
       certificationCenterRepository,
       certificationCenterAccessRepository,
     });
@@ -87,7 +87,7 @@ describe('Unit | UseCase | supervise-session', function () {
       invigilatorPassword: session.invigilatorPassword,
       userId,
       invigilatorSessionRepository,
-      supervisorAccessRepository,
+      invigilatorAccessRepository,
       certificationCenterRepository,
       certificationCenterAccessRepository,
     });
@@ -117,7 +117,7 @@ describe('Unit | UseCase | supervise-session', function () {
       invigilatorPassword: session.invigilatorPassword,
       userId,
       invigilatorSessionRepository,
-      supervisorAccessRepository,
+      invigilatorAccessRepository,
       certificationCenterRepository,
       certificationCenterAccessRepository,
     });
@@ -150,7 +150,7 @@ describe('Unit | UseCase | supervise-session', function () {
         invigilatorPassword: session.invigilatorPassword,
         userId,
         invigilatorSessionRepository,
-        supervisorAccessRepository,
+        invigilatorAccessRepository,
         certificationCenterRepository,
         certificationCenterAccessRepository,
       });
@@ -160,7 +160,7 @@ describe('Unit | UseCase | supervise-session', function () {
     });
   });
 
-  it('should create a supervisor access', async function () {
+  it('should create an invigilator access', async function () {
     // given
     const sessionId = 123;
     const userId = 434;
@@ -181,12 +181,12 @@ describe('Unit | UseCase | supervise-session', function () {
       invigilatorPassword: session.invigilatorPassword,
       userId,
       invigilatorSessionRepository,
-      supervisorAccessRepository,
+      invigilatorAccessRepository,
       certificationCenterRepository,
       certificationCenterAccessRepository,
     });
 
     // then
-    expect(supervisorAccessRepository.create).to.have.been.calledWithExactly({ sessionId, userId });
+    expect(invigilatorAccessRepository.create).to.have.been.calledWithExactly({ sessionId, userId });
   });
 });

--- a/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
@@ -2,15 +2,15 @@ import { assessmentInvigilatorAuthorization as sessionInvigilatorAuthorization }
 import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Pre-handler | Invigilator Authorization', function () {
-  let supervisorAccessRepository;
+  let invigilatorAccessRepository;
   let dependencies;
 
   beforeEach(function () {
-    supervisorAccessRepository = {
-      isUserSupervisorForSessionCandidate: sinon.stub(),
-      isUserSupervisorForSession: sinon.stub(),
+    invigilatorAccessRepository = {
+      isUserInvigilatorForSessionCandidate: sinon.stub(),
+      isUserInvigilatorForSession: sinon.stub(),
     };
-    dependencies = { supervisorAccessRepository };
+    dependencies = { invigilatorAccessRepository };
   });
 
   describe('#verifyByCertificationCandidateId', function () {
@@ -24,7 +24,7 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
     describe('When user is the invigilator of the assessment session', function () {
       it('should return true', async function () {
         // given
-        supervisorAccessRepository.isUserSupervisorForSessionCandidate
+        invigilatorAccessRepository.isUserInvigilatorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
             supervisorId: 100,
@@ -46,7 +46,7 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
     describe('When user is not the invigilator of the assessment session', function () {
       it('should return 401', async function () {
         // given
-        supervisorAccessRepository.isUserSupervisorForSessionCandidate
+        invigilatorAccessRepository.isUserInvigilatorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
             supervisorId: 100,
@@ -77,13 +77,13 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
     describe('When user is the invigilator of the assessment session', function () {
       it('should return true', async function () {
         // given
-        supervisorAccessRepository.isUserSupervisorForSession.resolves(true);
+        invigilatorAccessRepository.isUserInvigilatorForSession.resolves(true);
 
         // when
         const response = await sessionInvigilatorAuthorization.verifyBySessionId(request, hFake, dependencies);
 
         // then
-        sinon.assert.calledWith(supervisorAccessRepository.isUserSupervisorForSession, {
+        sinon.assert.calledWith(invigilatorAccessRepository.isUserInvigilatorForSession, {
           sessionId: 201,
           userId: 100,
         });
@@ -94,7 +94,7 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
     describe('When user is not the invigilator of the session', function () {
       it('should return status code 401', async function () {
         // given
-        supervisorAccessRepository.isUserSupervisorForSession.resolves(false);
+        invigilatorAccessRepository.isUserInvigilatorForSession.resolves(false);
         request.headers = generateAuthenticatedUserRequestHeaders({ userId: 101 });
 
         // when


### PR DESCRIPTION
## 🍂 Problème

La traduction de surveillant en supervisor n’est  pas  approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/99330aa9-fd56-4535-b2c4-389304793813" />


## 🌰 Proposition

Renommer `supervisor` en `invigilator` dans le fichier  `supervisor-access-repository.js`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

- Télécharger le kit surveillant en étant connecté en tant que surveillant (ça doit fonctionner) en tant que non surveillant (vous ne devez pas y avoir accès).
- Faire diverses manipulations dans l'interface surveillant pour s'assurer que tout fonctionne si nous sommes identifiés comme surveillant, et que ça ne fonctionne pas si nous ne le sommes pas
