### PR TITLE
[BUGFIX] Appeler le job pour synchroniser les passages lorsque le userId n'est pas null (PIX-20482).

### DIFF
--- a/api/src/devcomp/domain/usecases/terminate-passage.js
+++ b/api/src/devcomp/domain/usecases/terminate-passage.js
@@ -14,10 +14,12 @@ const terminatePassage = withTransaction(async function ({
   passage.terminate();
   const terminatedPassage = await passageRepository.update({ passage });
 
-  await updateCombinedCourseJobRepository.performAsync({
-    userId: passage.userId,
-    moduleId: passage.moduleId,
-  });
+  if (passage.userId) {
+    await updateCombinedCourseJobRepository.performAsync({
+      userId: passage.userId,
+      moduleId: passage.moduleId,
+    });
+  }
 
   return terminatedPassage;
 });

--- a/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/terminate-passage_test.js
@@ -132,6 +132,45 @@ describe('Unit | Devcomp | Domain | UseCases | terminate-passage', function () {
           moduleId: passage.moduleId,
         });
       });
+
+      it('should not schedule a job to notify passage termination', async function () {
+        // given
+        const passageId = 1234;
+
+        const passageRepository = {
+          get: sinon.stub(),
+          update: sinon.stub(),
+        };
+
+        const passage = {
+          id: passageId,
+          userId: null,
+          moduleId: Symbol('module-id'),
+          terminatedAt: null,
+          terminate: sinon.stub(),
+        };
+        passageRepository.get.withArgs({ passageId }).resolves(passage);
+
+        const updatedPassage = {
+          id: passageId,
+          terminatedAt: new Date('2025-03-04'),
+        };
+        passageRepository.update.withArgs({ passage }).resolves(updatedPassage);
+
+        const updateCombinedCourseJobRepository = {
+          performAsync: sinon.stub(),
+        };
+
+        // when
+        await terminatePassage({
+          passageId,
+          passageRepository,
+          updateCombinedCourseJobRepository,
+        });
+
+        // then
+        expect(updateCombinedCourseJobRepository.performAsync.called).false;
+      });
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Lorsque nous passons un module, à la fin nous déclenchons un usecase terminatePassage . qui déclenche un job pgboss pour synchroniser les passages participations aux learners associé à cet utilisateur. 

Sauf que les modules sont passable en mode démo / test sans compte directement via url ce qui déclenche un job avec un userId null et fait péter le worker

## 🌰 Proposition

Ne pas appeler le job lorque le userId n'est pas définit

## 🍁 Remarques

FYI: Ce usecase mériterait un test d'integration plutôt qu'un test unitaire @1024pix/team-devcomp pour gérer tout les cas de ce usecase

## 🪵 Pour tester

Faire un module en mode test et vérifier que rien n'est inséré dans pgboss