### PR TITLE
[TECH] :recycle: Renomme supervisor dans `session-supervisor-authorization.js` par invigilator (PIX-20483) 

### DIFF
--- a/api/src/certification/session-management/application/certification-candidate-route.js
+++ b/api/src/certification/session-management/application/certification-candidate-route.js
@@ -2,7 +2,7 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
-import { assessmentSupervisorAuthorization } from '../../shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization } from '../../shared/application/pre-handlers/session-invigilator-authorization.js';
 import { certificationCandidateController } from './certification-candidate-controller.js';
 
 const Joi = BaseJoi.extend(JoiDate);
@@ -23,7 +23,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyByCertificationCandidateId,
+            method: assessmentInvigilatorAuthorization.verifyByCertificationCandidateId,
             assign: 'authorizationCheck',
           },
         ],
@@ -46,7 +46,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyByCertificationCandidateId,
+            method: assessmentInvigilatorAuthorization.verifyByCertificationCandidateId,
             assign: 'authorizationCheck',
           },
         ],
@@ -64,7 +64,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyByCertificationCandidateId,
+            method: assessmentInvigilatorAuthorization.verifyByCertificationCandidateId,
             assign: 'authorizationCheck',
           },
         ],

--- a/api/src/certification/session-management/application/companion-alert-route.js
+++ b/api/src/certification/session-management/application/companion-alert-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
-import { assessmentSupervisorAuthorization } from '../../shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization } from '../../shared/application/pre-handlers/session-invigilator-authorization.js';
 import { companionAlertController } from './companion-alert-controller.js';
 
 export function register(server) {
@@ -33,7 +33,7 @@ export function register(server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyBySessionId,
+            method: assessmentInvigilatorAuthorization.verifyBySessionId,
             assign: 'isSupervisorForSession',
           },
         ],

--- a/api/src/certification/session-management/application/session-for-supervising-route.js
+++ b/api/src/certification/session-management/application/session-for-supervising-route.js
@@ -4,7 +4,7 @@ const Joi = BaseJoi.extend(JoiDate);
 
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { sessionForSupervisingController } from '../../session-management/application/session-for-supervising-controller.js';
-import { assessmentSupervisorAuthorization } from '../../shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization } from '../../shared/application/pre-handlers/session-invigilator-authorization.js';
 
 const register = async function (server) {
   server.route([
@@ -19,7 +19,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyBySessionId,
+            method: assessmentInvigilatorAuthorization.verifyBySessionId,
             assign: 'isSupervisorForSession',
           },
         ],

--- a/api/src/certification/session-management/application/session-live-alert-route.js
+++ b/api/src/certification/session-management/application/session-live-alert-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { responseObjectErrorDoc } from '../../../shared/infrastructure/open-api-doc/response-object-error-doc.js';
-import { assessmentSupervisorAuthorization } from '../../shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization } from '../../shared/application/pre-handlers/session-invigilator-authorization.js';
 import { sessionLiveAlertController } from './session-live-alert-controller.js';
 
 const register = async function (server) {
@@ -34,7 +34,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyBySessionId,
+            method: assessmentInvigilatorAuthorization.verifyBySessionId,
             assign: 'isSupervisorForSession',
           },
         ],
@@ -73,7 +73,7 @@ const register = async function (server) {
         },
         pre: [
           {
-            method: assessmentSupervisorAuthorization.verifyBySessionId,
+            method: assessmentInvigilatorAuthorization.verifyBySessionId,
             assign: 'isSupervisorForSession',
           },
         ],

--- a/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
@@ -31,6 +31,6 @@ const verifyBySessionId = async function (request, h, dependencies = { superviso
   return true;
 };
 
-const assessmentSupervisorAuthorization = { verifyByCertificationCandidateId, verifyBySessionId };
+const assessmentInvigilatorAuthorization = { verifyByCertificationCandidateId, verifyBySessionId };
 
-export { assessmentSupervisorAuthorization };
+export { assessmentInvigilatorAuthorization };

--- a/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
@@ -1,14 +1,14 @@
 import { certificationCandidateController } from '../../../../../src/certification/session-management/application/certification-candidate-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/certification-candidate-route.js';
-import { assessmentSupervisorAuthorization as sessionSupervisorAuthorization } from '../../../../../src/certification/shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization as sessionInvigilatorAuthorization } from '../../../../../src/certification/shared/application/pre-handlers/session-invigilator-authorization.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Application | Routes | Certification Candidate', function () {
   describe('POST certification-candidates/{certificationCandidateId}/authorize-to-start', function () {
-    it('should return 200 if the user is a supervisor of the session linked to the candidate', async function () {
+    it('should return 200 if the user is an invigilator of the session linked to the candidate', async function () {
       //given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response(true));
       sinon.stub(certificationCandidateController, 'authorizeToStart').returns('ok');
 
@@ -27,10 +27,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return 401 if the user is not a supervisor of the session linked to the candidate and certification center is in the whitelist', async function () {
+    it('should return 401 if the user is not an invigilator of the session linked to the candidate and certification center is in the whitelist', async function () {
       //given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response().code(401).takeover());
 
       const httpTestServer = new HttpTestServer();
@@ -50,10 +50,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
   });
 
   describe('POST certification-candidates/{certificationCandidateId}/authorize-to-resume', function () {
-    it('should return 204 if the user is a supervisor of the session linked to the candidate', async function () {
+    it('should return 204 if the user is an invigilator of the session linked to the candidate', async function () {
       // given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response(true));
       sinon
         .stub(certificationCandidateController, 'authorizeToResume')
@@ -68,10 +68,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       expect(response.statusCode).to.equal(204);
     });
 
-    it('should return 401 if the user is not a supervisor of the session linked to the candidate', async function () {
+    it('should return 401 if the user is not an invigilator of the session linked to the candidate', async function () {
       // given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response().code(401).takeover());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -85,10 +85,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
   });
 
   describe('PATCH certification-candidates/{certificationCandidateId}/end-assessment-by-supervisor', function () {
-    it('should return 200 if the user is a supervisor of the session linked to the candidate', async function () {
+    it('should return 200 if the user is an invigilator of the session linked to the candidate', async function () {
       // given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response(true));
       sinon.stub(certificationCandidateController, 'endAssessmentBySupervisor').returns(null);
       const httpTestServer = new HttpTestServer();
@@ -104,10 +104,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       expect(response.statusCode).to.equal(204);
     });
 
-    it('should return 401 if the user is not a supervisor of the session linked to the candidate', async function () {
+    it('should return 401 if the user is not an invigilator of the session linked to the candidate', async function () {
       // given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyByCertificationCandidateId')
+        .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response().code(401).takeover());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/certification/session-management/unit/application/session-for-supervising-route_test.js
+++ b/api/tests/certification/session-management/unit/application/session-for-supervising-route_test.js
@@ -1,13 +1,13 @@
 import { sessionForSupervisingController } from '../../../../../src/certification/session-management/application/session-for-supervising-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/session-for-supervising-route.js';
-import { assessmentSupervisorAuthorization as sessionSupervisorAuthorization } from '../../../../../src/certification/shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization as sessionInvigilatorAuthorization } from '../../../../../src/certification/shared/application/pre-handlers/session-invigilator-authorization.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Application | Routes | Session For Supervising', function () {
   describe('GET /api/sessions/{sessionId}/supervising', function () {
-    it('should return 200 if the user is a supervisor of the session', async function () {
+    it('should return 200 if the user is an invigilator of the session', async function () {
       //given
-      sinon.stub(sessionSupervisorAuthorization, 'verifyBySessionId').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionInvigilatorAuthorization, 'verifyBySessionId').callsFake((request, h) => h.response(true));
       sinon.stub(sessionForSupervisingController, 'get').returns('ok');
 
       const httpTestServer = new HttpTestServer();
@@ -20,10 +20,10 @@ describe('Certification | Session Management | Unit | Application | Routes | Ses
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return 401 if the user is not a supervisor of the session', async function () {
+    it('should return 401 if the user is not an invigilator of the session', async function () {
       //given
       sinon
-        .stub(sessionSupervisorAuthorization, 'verifyBySessionId')
+        .stub(sessionInvigilatorAuthorization, 'verifyBySessionId')
         .callsFake((request, h) => h.response().code(401).takeover());
       sinon.stub(sessionForSupervisingController, 'get').returns('ok');
 

--- a/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
@@ -1,7 +1,7 @@
-import { assessmentSupervisorAuthorization as sessionSupervisorAuthorization } from '../../../../src/certification/shared/application/pre-handlers/session-supervisor-authorization.js';
+import { assessmentInvigilatorAuthorization as sessionInvigilatorAuthorization } from '../../../../src/certification/shared/application/pre-handlers/session-invigilator-authorization.js';
 import { expect, generateAuthenticatedUserRequestHeaders, hFake, sinon } from '../../../test-helper.js';
 
-describe('Unit | Pre-handler | Supervisor Authorization', function () {
+describe('Unit | Pre-handler | Invigilator Authorization', function () {
   let supervisorAccessRepository;
   let dependencies;
 
@@ -21,7 +21,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       },
     };
 
-    describe('When user is the supervisor of the assessment session', function () {
+    describe('When user is the invigilator of the assessment session', function () {
       it('should return true', async function () {
         // given
         supervisorAccessRepository.isUserSupervisorForSessionCandidate
@@ -32,7 +32,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
           .resolves(true);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(
+        const response = await sessionInvigilatorAuthorization.verifyByCertificationCandidateId(
           request,
           hFake,
           dependencies,
@@ -43,7 +43,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       });
     });
 
-    describe('When user is not the supervisor of the assessment session', function () {
+    describe('When user is not the invigilator of the assessment session', function () {
       it('should return 401', async function () {
         // given
         supervisorAccessRepository.isUserSupervisorForSessionCandidate
@@ -54,7 +54,7 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
           .resolves(false);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyByCertificationCandidateId(
+        const response = await sessionInvigilatorAuthorization.verifyByCertificationCandidateId(
           request,
           hFake,
           dependencies,
@@ -74,13 +74,13 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       },
     };
 
-    describe('When user is the supervisor of the assessment session', function () {
+    describe('When user is the invigilator of the assessment session', function () {
       it('should return true', async function () {
         // given
         supervisorAccessRepository.isUserSupervisorForSession.resolves(true);
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake, dependencies);
+        const response = await sessionInvigilatorAuthorization.verifyBySessionId(request, hFake, dependencies);
 
         // then
         sinon.assert.calledWith(supervisorAccessRepository.isUserSupervisorForSession, {
@@ -91,14 +91,14 @@ describe('Unit | Pre-handler | Supervisor Authorization', function () {
       });
     });
 
-    describe('When user is not the supervisor of the session', function () {
+    describe('When user is not the invigilator of the session', function () {
       it('should return status code 401', async function () {
         // given
         supervisorAccessRepository.isUserSupervisorForSession.resolves(false);
         request.headers = generateAuthenticatedUserRequestHeaders({ userId: 101 });
 
         // when
-        const response = await sessionSupervisorAuthorization.verifyBySessionId(request, hFake, dependencies);
+        const response = await sessionInvigilatorAuthorization.verifyBySessionId(request, hFake, dependencies);
 
         // then
         expect(response.statusCode).to.equal(401);


### PR DESCRIPTION
## 🍂 Problème

Le terme `supervisor` n'est pas approprié pour désigner un surveillant. Il faut lui préférer le terme `invigilator` même si c'est moins simple à dire à priori.

## 🌰 Proposition

Renommer les éléments du pre-handler ` session-supervisor-authorization.js` pour utiliser `invigilator` au lieu de `supervisor`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Les changements de nommage portent sur l'élément gérant les autorisation à manipuler une session en cours (un surveillant peu le faire, un utilisateur non surveillant ne peut pas).

- Indiquer la présence d'un candidat pour permettre ou bloquer son entrée en session
- Autoriser la reprise du test par le candidat
- Finaliser une participation
- Finaliser une session
