### PR TITLE
[FEATURE] Améliorer le style du bouton d'oralisation des épreuves (PIX-20473).

### DIFF
--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -1,6 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn, get } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -28,21 +27,13 @@ export default class ChallengeStatement extends Component {
         <div class="challenge-statement__instruction-section">
           <div class="challenge-statement__instructions-and-text-to-speech-container">
             {{#if this.showTextToSpeechButton}}
-              <PixTooltip @position="right" @isInline={{true}}>
-                <:triggerElement>
-                  <button
-                    type="button"
-                    class="challenge-statement__text-to-speech-trigger"
-                    aria-label={{this.textToSpeechButtonTooltipText}}
-                    {{on "click" this.toggleInstructionTextToSpeech}}
-                  >
-                    <PixIcon @name={{if this.isSpeaking "stopCircle" "volumeOn"}} />
-                  </button>
-                </:triggerElement>
-                <:tooltip>
-                  {{this.textToSpeechButtonTooltipText}}
-                </:tooltip>
-              </PixTooltip>
+              <PixButton
+                @triggerAction={{this.toggleInstructionTextToSpeech}}
+                @variant="tertiary"
+                @iconBefore={{if this.isSpeaking "stopCircle" "volumeOn"}}
+              >
+                {{this.textToSpeechButtonTooltipText}}
+              </PixButton>
             {{/if}}
             <MarkdownToHtmlUnsafe
               @class="challenge-statement-instruction__text"

--- a/mon-pix/tests/acceptance/challenge-page-banner-test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner-test.js
@@ -92,7 +92,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
         await click(screen.getByRole('button', { name: 'Activer la vocalisation' }));
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Lire à haute voix' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Lire la consigne à haute voix' })).exists();
       });
 
       test("should hide text-to-speech button in challenge instruction when it's been deactivated in the banner", async function (assert) {
@@ -103,7 +103,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
         await click(screen.getByRole('button', { name: 'Désactiver la vocalisation' }));
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Lire à haute voix' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: 'Lire la consigne à haute voix' })).doesNotExist();
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1153,8 +1153,8 @@
         "text-to-speech": {
           "activate": "Activate text-to-speech",
           "deactivate": "Deactivate text-to-speech",
-          "play": "Read out loud",
-          "stop": "Stop reading"
+          "play": "Read the instructions out loud",
+          "stop": "Stop reading the instructions"
         },
         "tooltip": {
           "aria-label": "Show question's warning",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1154,8 +1154,8 @@
         "text-to-speech": {
           "activate": "Activer la vocalisation",
           "deactivate": "Désactiver la vocalisation",
-          "play": "Lire à haute voix",
-          "stop": "Arrêter la lecture"
+          "play": "Lire la consigne à haute voix",
+          "stop": "Arrêter la lecture de la consigne"
         },
         "tooltip": {
           "aria-label": "Afficher l'indication sur l'épreuve.",


### PR DESCRIPTION
## 🍂 Problème

Un bouton d’oralisation a été ajouté pour les candidats pour lesquels un besoin de test aménagé a été déclaré lors de leur inscription : 
- le bouton déclencheur est une icône petite et peu visible
- aucun texte explicatif n’est directement présent sur la page

## 🌰 Proposition

- Bouton de lecture/de pause en tertiary

- Texte explicatif du bouton lisible à côté du bouton (et non en tooltip) : 
  - “Lire **la consigne** à haute voix”
  - “Arrêter la lecture de la consigne”

## 🪵 Pour tester

- Rentrer en certif avec un candidat avec ajustement d'accessibilité
- Visualiser le nouveau bouton d'oralisation sur les épreuves
