### PR TITLE
[BUGFIX] Erreur Ember à l'affichage d'une page user dans PixAdmin (PIX-19901)

### DIFF
--- a/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
+++ b/api/src/prescription/learner-management/domain/read-models/OrganizationLearnerForAdmin.js
@@ -6,8 +6,8 @@ import { IMPORT_KEY_FIELD } from '../constants.js';
 
 const validationSchema = Joi.object({
   id: Joi.number().integer().required(),
-  firstName: Joi.string().required(),
-  lastName: Joi.string().required(),
+  firstName: Joi.string().required().allow(''),
+  lastName: Joi.string().required().allow(''),
   birthdate: Joi.string().required().allow(null),
   division: Joi.string().required().allow(null),
   group: Joi.string().required().allow(null),

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -339,6 +339,26 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
           },
         ]);
       });
+
+      describe('When user has a learner without firstName and lastName (ex: from a simplified campaign)', function () {
+        it('returns 200', async function () {
+          // given
+          const superAdmin = await insertUserWithRoleSuperAdmin();
+          const user = databaseBuilder.factory.buildUser();
+          databaseBuilder.factory.buildOrganizationLearner({ firstName: '', lastName: '', userId: user.id });
+          await databaseBuilder.commit();
+
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: `/api/admin/users/${user.id}`,
+            headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
+      });
     });
   });
 

--- a/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/read-models/OrganizationLearnerForAdmin_test.js
@@ -29,6 +29,26 @@ describe('Unit | Domain | Read-models | OrganizationLearnerForAdmin', function (
       expect(() => new OrganizationLearnerForAdmin(validArguments)).not.to.throw(ObjectValidationError);
     });
 
+    it('should successfully instantiate learner from anonymous user flows (ex: simplified campaign)', function () {
+      const leanerFromAnonymousUser = {
+        id: 1,
+        firstName: '',
+        lastName: '',
+        birthdate: null,
+        division: null,
+        group: null,
+        organizationId: 1,
+        organizationName: 'Simplified access',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isDisabled: false,
+        organizationIsManagingStudents: false,
+      };
+
+      // when
+      expect(() => new OrganizationLearnerForAdmin(leanerFromAnonymousUser)).not.to.throw(ObjectValidationError);
+    });
+
     describe('additionalColumns', function () {
       it('should not throw when addtionalInformations is not defined', function () {
         const learner = new OrganizationLearnerForAdmin({


### PR DESCRIPTION
## 🍂 Problème

Quand on accède à certains utilisateurs sur Pix Admin, une erreur Ember apparaît causée par une erreur de validation côté API.

## 🌰 Proposition

Le problème de validation survient pour les utilisateurs qui ont fait un parcours en accès simplifié en tant qu'utilisateurs anonymes et qui ont créé ensuite un compte.

Dans ce cas, un `organization-learner` est créé en base de données avec un `firstName` et `lastName` vide (chaîne vide). Or quand on récupère les données de l'utilisateur dans Pix Admin on vérifie la validité des informations du leaner et n'autorise pas la chaîne vide sur le nom et prénom. (via le modèle `OrganizationLeanerForAdmin`.

**Correction:** Autoriser la chaîne vide comme valeur possible pour le `firstName` et le `lastName`

## 🪵 Pour tester

Dans Pix Admin, aller sur l'utilisateur suivant https://admin-pr14204.review.pix.fr/users/1000003. Cet utilisateur a été créé suite à un parcours autonome.
- Si vous voulez tester avec votre propre utilisateur, faire le parcours https://app-pr14204.review.pix.fr/campagnes/AUTOCOUR1, puis créer son compte à la fin du parcours. Enfin, aller sur sa page dans Pix Admin

> Vérifier qu'il n'y a pas d'erreur à l'affichage de la page utilisateur dans Pix Admin et que dans la partie "Informations prescrit", le nom et prénom sont vides.