### PR TITLE
[BUGFIX] Afficher le titre du palier atteint sur la page de résultat d'une campagne (PIX-19855).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results/evaluation-results-hero/index.gjs
@@ -210,7 +210,8 @@ export default class EvaluationResultsHero extends Component {
         </h2>
 
         {{#if @campaignParticipationResult.hasReachedStage}}
-          <div class="evaluation-results-hero-details__stage-message" data-testid="stage-message">
+          <div class="evaluation-results-hero-details__stage-message">
+            <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.title}} />
             <MarkdownToHtml @isInline={{true}} @markdown={{@campaignParticipationResult.reachedStage.message}} />
           </div>
         {{/if}}

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-results-hero/index-test.gjs
@@ -850,7 +850,12 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         const campaign = { organizationId: 1 };
         const campaignParticipationResult = {
           hasReachedStage: true,
-          reachedStage: { reachedStage: 4, totalStage: 5, message: 'lorem ipsum dolor sit amet' },
+          reachedStage: {
+            reachedStage: 4,
+            totalStage: 5,
+            message: 'existing message stages',
+            title: 'existing title stages',
+          },
         };
 
         // when
@@ -870,7 +875,8 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         };
         assert.strictEqual(screen.getAllByText(t('pages.skill-review.stage.starsAcquired', stars)).length, 2);
 
-        assert.dom(screen.getByText(campaignParticipationResult.reachedStage.message)).exists();
+        assert.ok(screen.getByText(campaignParticipationResult.reachedStage.title));
+        assert.ok(screen.getByText(campaignParticipationResult.reachedStage.message));
       });
     });
 
@@ -910,7 +916,7 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
         const campaign = { organizationId: 1 };
         const campaignParticipationResult = {
           hasReachedStage: false,
-          reachedStage: { message: 'not existing message' },
+          reachedStage: { message: 'not existing message', title: 'not existing title' },
         };
 
         // when
@@ -925,9 +931,10 @@ module('Integration | Components | Campaigns | Assessment | Results | Evaluation
 
         // then
         const stars = { acquired: 0, total: 0 };
-        assert.dom(screen.queryByText(t('pages.skill-review.stage.starsAcquired', stars))).doesNotExist();
+        assert.notOk(screen.queryByText(t('pages.skill-review.stage.starsAcquired', stars)));
 
-        assert.dom(screen.queryByTestId('stage-message')).doesNotExist();
+        assert.notOk(screen.queryByText(campaignParticipationResult.reachedStage.message));
+        assert.notOk(screen.queryByText(campaignParticipationResult.reachedStage.title));
       });
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Nous n'affihcons pas le titre que nous configurons pour l'utilisateur. c'est un peu dommage

## 🌰 Proposition

Afficher le titre du palier atteint au dessus du message de ce palier

## 🍁 Remarques

RAS

## 🪵 Pour tester

Faire une campagne avec palier. et vérifier que l'on voit bien le titre dudit palier