### PR TITLE
[TECH] :recycle: Renomme le cas d'utilsation `end-assessment-by-supervisor` pour utiliser `invigilator` (PIX-20507)

### DIFF
--- a/api/src/certification/session-management/application/certification-candidate-controller.js
+++ b/api/src/certification/session-management/application/certification-candidate-controller.js
@@ -22,10 +22,10 @@ const authorizeToResume = async function (request, h) {
   return h.response().code(204);
 };
 
-const endAssessmentBySupervisor = async function (request) {
+const endAssessmentByInvigilator = async function (request) {
   const certificationCandidateId = request.params.certificationCandidateId;
 
-  await usecases.endAssessmentBySupervisor({ certificationCandidateId });
+  await usecases.endAssessmentByInvigilator({ certificationCandidateId });
 
   return null;
 };
@@ -33,6 +33,6 @@ const endAssessmentBySupervisor = async function (request) {
 const certificationCandidateController = {
   authorizeToStart,
   authorizeToResume,
-  endAssessmentBySupervisor,
+  endAssessmentByInvigilator,
 };
 export { certificationCandidateController };

--- a/api/src/certification/session-management/application/certification-candidate-route.js
+++ b/api/src/certification/session-management/application/certification-candidate-route.js
@@ -73,7 +73,7 @@ const register = async function (server) {
             certificationCandidateId: identifiersType.certificationCandidateId,
           }),
         },
-        handler: certificationCandidateController.endAssessmentBySupervisor,
+        handler: certificationCandidateController.endAssessmentByInvigilator,
         tags: ['api'],
       },
     },

--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -97,7 +97,7 @@ class CertificationAssessment {
     }
   }
 
-  endBySupervisor({ now }) {
+  endByInvigilator({ now }) {
     this.state = states.ENDED_BY_SUPERVISOR;
     this.endedAt = now;
   }

--- a/api/src/certification/session-management/domain/usecases/end-assessment-by-invigilator.js
+++ b/api/src/certification/session-management/domain/usecases/end-assessment-by-invigilator.js
@@ -1,4 +1,4 @@
-const endAssessmentBySupervisor = async function ({ certificationCandidateId, certificationAssessmentRepository }) {
+const endAssessmentByInvigilator = async function ({ certificationCandidateId, certificationAssessmentRepository }) {
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCandidateId({
     certificationCandidateId,
   });
@@ -7,8 +7,8 @@ const endAssessmentBySupervisor = async function ({ certificationCandidateId, ce
     return;
   }
 
-  certificationAssessment.endBySupervisor({ now: new Date() });
+  certificationAssessment.endByInvigilator({ now: new Date() });
   await certificationAssessmentRepository.save(certificationAssessment);
 };
 
-export { endAssessmentBySupervisor };
+export { endAssessmentByInvigilator };

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -152,7 +152,7 @@ import { createCertificationChallengeLiveAlert } from './create-certification-ch
 import { deleteCertificationIssueReport } from './delete-certification-issue-report.js';
 import { deleteSessionJuryComment } from './delete-session-jury-comment.js';
 import { dismissLiveAlert } from './dismiss-live-alert.js';
-import { endAssessmentBySupervisor } from './end-assessment-by-supervisor.js';
+import { endAssessmentByInvigilator } from './end-assessment-by-invigilator.js';
 import { finalizeSession } from './finalize-session.js';
 import { findFinalizedSessionsToPublish } from './find-finalized-sessions-to-publish.js';
 import { findFinalizedSessionsWithRequiredAction } from './find-finalized-sessions-with-required-action.js';
@@ -196,7 +196,7 @@ const usecasesWithoutInjectedDependencies = {
   deleteCertificationIssueReport,
   deleteSessionJuryComment,
   dismissLiveAlert,
-  endAssessmentBySupervisor,
+  endAssessmentByInvigilator,
   finalizeSession,
   findFinalizedSessionsToPublish,
   findFinalizedSessionsWithRequiredAction,

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -294,7 +294,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.resolves(certifCourse);
           certificationBadgesService.findStillValidBadgeAcquisitions.resolves([]);
           const assessment = domainBuilder.buildCertificationAssessment();
-          assessment.endBySupervisor({ now: new Date() });
+          assessment.endByInvigilator({ now: new Date() });
           certificationAssessmentRepository.getByCertificationCandidateId.resolves(assessment);
 
           // when

--- a/api/tests/certification/session-management/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-candidate-controller_test.js
@@ -61,20 +61,20 @@ describe('Certification | Session Management | Unit | Application | Controller |
     });
   });
 
-  describe('#endAssessmentBySupervisor', function () {
-    it('should call the endAssessmentBySupervisor use case', async function () {
+  describe('#endAssessmentByInvigilator', function () {
+    it('should call the endAssessmentByInvigilator use case', async function () {
       // given
       const certificationCandidateId = 2;
-      sinon.stub(usecases, 'endAssessmentBySupervisor');
-      usecases.endAssessmentBySupervisor.resolves();
+      sinon.stub(usecases, 'endAssessmentByInvigilator');
+      usecases.endAssessmentByInvigilator.resolves();
 
       // when
-      await certificationCandidateController.endAssessmentBySupervisor({
+      await certificationCandidateController.endAssessmentByInvigilator({
         params: { certificationCandidateId },
       });
 
       // then
-      expect(usecases.endAssessmentBySupervisor).to.have.been.calledWithExactly({
+      expect(usecases.endAssessmentByInvigilator).to.have.been.calledWithExactly({
         certificationCandidateId,
       });
     });

--- a/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
@@ -90,7 +90,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       sinon
         .stub(sessionInvigilatorAuthorization, 'verifyByCertificationCandidateId')
         .callsFake((request, h) => h.response(true));
-      sinon.stub(certificationCandidateController, 'endAssessmentBySupervisor').returns(null);
+      sinon.stub(certificationCandidateController, 'endAssessmentByInvigilator').returns(null);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -492,7 +492,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      certificationAssessment.endBySupervisor({ now });
+      certificationAssessment.endByInvigilator({ now });
 
       // then
       expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_SUPERVISOR);

--- a/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
@@ -1,8 +1,8 @@
 import { CertificationAssessment } from '../../../../../../src/certification/session-management/domain/models/CertificationAssessment.js';
-import { endAssessmentBySupervisor } from '../../../../../../src/certification/session-management/domain/usecases/end-assessment-by-supervisor.js';
+import { endAssessmentByInvigilator } from '../../../../../../src/certification/session-management/domain/usecases/end-assessment-by-invigilator.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
-describe('Unit | UseCase | end-assessment-by-supervisor', function () {
+describe('Unit | UseCase | end-assessment-by-invigilator', function () {
   let certificationAssessmentRepository;
 
   beforeEach(function () {
@@ -26,7 +26,7 @@ describe('Unit | UseCase | end-assessment-by-supervisor', function () {
         .withArgs({ certificationCandidateId })
         .resolves(completedCertificationAssessment);
 
-      await endAssessmentBySupervisor({
+      await endAssessmentByInvigilator({
         certificationCandidateId,
         certificationAssessmentRepository,
       });
@@ -50,7 +50,7 @@ describe('Unit | UseCase | end-assessment-by-supervisor', function () {
         .withArgs({ certificationCandidateId })
         .resolves(startedCertificationAssessment);
 
-      await endAssessmentBySupervisor({
+      await endAssessmentByInvigilator({
         certificationCandidateId,
         certificationAssessmentRepository,
       });


### PR DESCRIPTION
## 🍂 Problème

La traduction  de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/1b1e0440-6127-4822-946c-f9e2c505d0b3" />


## 🌰 Proposition

Renommer le cas d'utilisation et les usages qui sont autour pour utiliser la terminologie `invigilator`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Démarrer une session de certification ;
Faire terminer le test par le surveillant 

<img width="791" height="158" alt="image" src="https://github.com/user-attachments/assets/93545646-d4fc-4ecc-a671-679bc6cfe91a" />



