### PR TITLE
[TECH] Modifier le domaine des illustrations des cartes de formation sur Pix App (PIX-20461).

### DIFF
--- a/high-level-tests/e2e/cypress/fixtures/trainings.json
+++ b/high-level-tests/e2e/cypress/fixtures/trainings.json
@@ -7,6 +7,6 @@
     "duration": "0 years 0 mons 0 days 6 hours 0 mins 0.0 secs",
     "locale": "fr",
     "editorName": "Ministère de l'éducation nationale",
-    "editorLogoUrl": "https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg"
+    "editorLogoUrl": "https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg"
   }
 ]

--- a/mon-pix/app/components/training/card.gjs
+++ b/mon-pix/app/components/training/card.gjs
@@ -79,21 +79,21 @@ export default class Card extends Component {
   get imageSrc() {
     const randomNumber = this._getRandomImageNumber();
     if (this.args.training.isAutoformation) {
-      return `https://images.pix.fr/contenu-formatif/type/Autoformation-${randomNumber}.svg`;
+      return `https://assets.pix.org/contenu-formatif/type/Autoformation-${randomNumber}.svg`;
     }
     if (this.args.training.isElearning) {
-      return 'https://images.pix.fr/contenu-formatif/type/E-learning-1.svg';
+      return 'https://assets.pix.org/contenu-formatif/type/E-learning-1.svg';
     }
     if (this.args.training.isHybrid) {
-      return 'https://images.pix.fr/contenu-formatif/type/Hybrid-1.svg';
+      return 'https://assets.pix.org/contenu-formatif/type/Hybrid-1.svg';
     }
     if (this.args.training.isInPerson) {
-      return 'https://images.pix.fr/contenu-formatif/type/In-person-1.svg';
+      return 'https://assets.pix.org/contenu-formatif/type/In-person-1.svg';
     }
     if (this.args.training.isModulix) {
-      return `https://images.pix.fr/contenu-formatif/type/Modulix-${randomNumber}.svg`;
+      return `https://assets.pix.org/contenu-formatif/type/Modulix-${randomNumber}.svg`;
     }
-    return `https://images.pix.fr/contenu-formatif/type/Webinaire-${randomNumber}.svg`;
+    return `https://assets.pix.org/contenu-formatif/type/Webinaire-${randomNumber}.svg`;
   }
 
   _getRandomImageNumber() {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-shared-results-modal-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results/evaluation-shared-results-modal-test.gjs
@@ -22,7 +22,7 @@ module('Integration | Component | evaluation-shared-results-modal', function (ho
           duration: { hours: 6 },
           editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
           editorLogoUrl:
-            'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
         },
         {
           title: 'Mon super training 2',
@@ -32,7 +32,7 @@ module('Integration | Component | evaluation-shared-results-modal', function (ho
           duration: { hours: 8 },
           editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
           editorLogoUrl:
-            'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
         },
         {
           title: 'Mon super training 3',
@@ -42,7 +42,7 @@ module('Integration | Component | evaluation-shared-results-modal', function (ho
           duration: { hours: 10 },
           editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
           editorLogoUrl:
-            'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+            'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
         },
       ];
 

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/evaluation-results-test.js
@@ -235,7 +235,7 @@ function generateTrainings(numberOfTrainings) {
       duration: { hours: 6 },
       editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
       editorLogoUrl:
-        'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+        'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
     };
     results.push(training);
   }

--- a/mon-pix/tests/integration/components/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/training/card-test.gjs
@@ -40,7 +40,7 @@ module('Integration | Component | Training | Card', function (hooks) {
       )
       .hasAttribute(
         'src',
-        'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+        'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
       );
   });
 
@@ -74,24 +74,24 @@ module('Integration | Component | Training | Card', function (hooks) {
     [
       {
         type: 'webinaire',
-        src: new RegExp(/https:\/\/images.pix.fr\/contenu-formatif\/type\/Webinaire-[1-3].svg/g),
+        src: new RegExp(/https:\/\/assets.pix.org\/contenu-formatif\/type\/Webinaire-[1-3].svg/g),
         tagName: 'tertiary',
       },
       {
         type: 'autoformation',
-        src: new RegExp(/https:\/\/images.pix.fr\/contenu-formatif\/type\/Autoformation-[1-3].svg/g),
+        src: new RegExp(/https:\/\/assets.pix.org\/contenu-formatif\/type\/Autoformation-[1-3].svg/g),
         tagName: 'primary',
       },
-      { type: 'e-learning', src: 'https://images.pix.fr/contenu-formatif/type/E-learning-1.svg', tagName: 'success' },
-      { type: 'hybrid-training', src: 'https://images.pix.fr/contenu-formatif/type/Hybrid-1.svg', tagName: 'error' },
+      { type: 'e-learning', src: 'https://assets.pix.org/contenu-formatif/type/E-learning-1.svg', tagName: 'success' },
+      { type: 'hybrid-training', src: 'https://assets.pix.org/contenu-formatif/type/Hybrid-1.svg', tagName: 'error' },
       {
         type: 'in-person-training',
-        src: 'https://images.pix.fr/contenu-formatif/type/In-person-1.svg',
+        src: 'https://assets.pix.org/contenu-formatif/type/In-person-1.svg',
         tagName: 'secondary',
       },
       {
         type: 'modulix',
-        src: new RegExp(/https:\/\/images.pix.fr\/contenu-formatif\/type\/Modulix-[1-3].svg/g),
+        src: new RegExp(/https:\/\/assets.pix.org\/contenu-formatif\/type\/Modulix-[1-3].svg/g),
         tagName: 'primary',
       },
     ].forEach(({ type, src, tagName }) => {
@@ -153,7 +153,7 @@ module('Integration | Component | Training | Card', function (hooks) {
       duration: duration ?? { hours: 6 },
       editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
       editorLogoUrl:
-        'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+        'https://assets.pix.org/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
     };
   }
 });


### PR DESCRIPTION
## 🍂 Problème

Actuellement sur Pix App, plusieurs illustrations liées aux cartes formations possèdent une url pointant vers images.pix.fr.
Or nous voulons nous défaire de l'usage de pix-images pour pix-assets.

## 🌰 Proposition

Modifier le domaine des illustrations des cartes de formation.

## 🍁 Remarques

Modification d'un test e2e

## 🪵 Pour tester

- Se connecter sur Pix App avec dave-comp@example.net
- Sur la page d'accueil, poursuivre et terminer un parcours
- Dans la page de fin du parcours, cliquer sur la partie Formations
- Vérifier que les illustrations de ces cartes de formations pointent sur le domaine `assets.pix.org`
