### PR TITLE
[TECH] Retourner le shortId dans l'api interne getModuleStatuses dans l'API (PIX-20386).

### DIFF
--- a/api/src/devcomp/application/api/models/ModuleStatus.js
+++ b/api/src/devcomp/application/api/models/ModuleStatus.js
@@ -1,6 +1,7 @@
 export class ModuleStatus {
-  constructor({ id, slug, title, status, duration, image, createdAt, updatedAt, terminatedAt }) {
+  constructor({ id, shortId, slug, title, status, duration, image, createdAt, updatedAt, terminatedAt }) {
     this.id = id;
+    this.shortId = shortId;
     this.slug = slug;
     this.title = title;
     this.status = status;

--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -14,8 +14,9 @@ import { ModuleStatus } from './models/ModuleStatus.js';
  * @property {number} id
  * @property {string} title
  * @property {string} slug
- * @property {duration} number
+ * @property {number} duration
  * @property {string} status ('not_started' | 'in_progress' | 'completed')
+ * @property {string} shortId
  *
  * @returns {ModuleStatus[]}
  * @throws {BadRequestError} UserId field is missing
@@ -38,7 +39,7 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
   });
 
   return userModuleStatus.map((userModuleStatus) => {
-    const { id, slug, title, duration, image } = moduleMetadataId.get(userModuleStatus.moduleId);
+    const { id, slug, title, duration, image, shortId } = moduleMetadataId.get(userModuleStatus.moduleId);
 
     return new ModuleStatus({
       id,
@@ -50,6 +51,7 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
       terminatedAt: userModuleStatus.terminatedAt,
       duration,
       image,
+      shortId,
     });
   });
 };

--- a/api/src/devcomp/domain/models/module/ModuleMetadata.js
+++ b/api/src/devcomp/domain/models/module/ModuleMetadata.js
@@ -2,8 +2,9 @@ import { DomainError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 export class ModuleMetadata {
-  constructor({ id, slug, title, isBeta, duration, image }) {
+  constructor({ id, shortId, slug, title, isBeta, duration, image }) {
     assertNotNullOrUndefined(id, 'The id is required for a module metadata');
+    assertNotNullOrUndefined(shortId, 'The short id is required for a module metadata');
     assertNotNullOrUndefined(slug, 'The slug is required for a module metadata');
     assertNotNullOrUndefined(title, 'The title is required for a module metadata');
     assertNotNullOrUndefined(isBeta, 'Field isBeta is required for a module metadata');
@@ -12,6 +13,7 @@ export class ModuleMetadata {
     this.#assertDurationHasPositiveValue(Number(duration));
 
     this.id = id;
+    this.shortId = shortId;
     this.slug = slug;
     this.title = title;
     this.isBeta = isBeta;

--- a/api/src/devcomp/domain/usecases/get-module-metadata-list.js
+++ b/api/src/devcomp/domain/usecases/get-module-metadata-list.js
@@ -4,8 +4,8 @@ async function getModuleMetadataList({ ids, moduleRepository }) {
   const modules = await moduleRepository.getAllByIds({ ids });
 
   return modules.map(
-    ({ id, slug, title, isBeta, details }) =>
-      new ModuleMetadata({ id, slug, title, isBeta, duration: details.duration, image: details.image }),
+    ({ id, shortId, slug, title, isBeta, details }) =>
+      new ModuleMetadata({ id, shortId, slug, title, isBeta, duration: details.duration, image: details.image }),
   );
 }
 

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -15,7 +15,7 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
     clock.restore();
   });
 
-  describe('#getModuleStatuses', function () {
+  describe('#getUserModuleStatuses', function () {
     it('should return a list of Module statuses', async function () {
       // given
       nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
@@ -50,6 +50,7 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
       const expectedResult = [
         {
           id: existingModuleIdWithoutRelatedPassage,
+          shortId: '6a68bf32',
           slug: 'bac-a-sable',
           title: 'Bac à sable',
           duration: 5,
@@ -61,6 +62,7 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
         },
         {
           id: existingModuleId2,
+          shortId: '9d4dcab8',
           slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire une adresse mail',
           duration: 10,
@@ -72,6 +74,7 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
         },
         {
           id: existingModuleId3,
+          shortId: 'ecc13f55',
           slug: 'adresse-ip-publique-et-vous',
           title: "L'adresse IP publique : ce qu'elle révèle sur vous !",
           duration: 10,

--- a/api/tests/devcomp/unit/application/api/models/ModuleStatus_test.js
+++ b/api/tests/devcomp/unit/application/api/models/ModuleStatus_test.js
@@ -5,6 +5,7 @@ describe('Unit | Devcomp | Application | Api | Models | ModuleStatus', function 
   it('should init and keep attributes', function () {
     // given
     const id = '4016621a-8777-46c6-876b-ab39f2c737c2';
+    const shortId = '534ert65';
     const slug = 'bien-ecrire-son-adresse-mail';
     const title = 'Bien écrire une adresse mail';
     const duration = 10;
@@ -14,6 +15,7 @@ describe('Unit | Devcomp | Application | Api | Models | ModuleStatus', function 
     // when
     const moduleStatus = new ModuleStatus({
       id,
+      shortId,
       slug,
       status,
       title,
@@ -23,6 +25,7 @@ describe('Unit | Devcomp | Application | Api | Models | ModuleStatus', function 
 
     // then
     expect(moduleStatus.id).to.equal(id);
+    expect(moduleStatus.shortId).to.equal(shortId);
     expect(moduleStatus.slug).to.deep.equal(slug);
     expect(moduleStatus.status).to.equal(status);
     expect(moduleStatus.title).to.equal(title);

--- a/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleMetadata_test.js
@@ -3,10 +3,11 @@ import { DomainError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function () {
-  let id, isBeta, slug, title, duration, image;
+  let id, isBeta, slug, title, duration, image, shortId;
 
   beforeEach(function () {
     id = '12a3a2b4-e873-4789-ae1c-57f6f2b99890';
+    shortId = '87ejdt65';
     slug = 'tmp-module-test';
     title = "Test d'un module";
     isBeta = false;
@@ -16,10 +17,11 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
 
   it('should init and keep attributes', function () {
     // when
-    const module = new ModuleMetadata({ id, slug, title, isBeta, duration, image });
+    const module = new ModuleMetadata({ id, shortId, slug, title, isBeta, duration, image });
 
     // then
     expect(module.id).to.equal(id);
+    expect(module.shortId).to.equal(shortId);
     expect(module.slug).to.equal(slug);
     expect(module.title).to.equal(title);
     expect(module.isBeta).to.equal(isBeta);
@@ -47,6 +49,27 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
     });
   });
 
+  describe('if a module does not have a short id', function () {
+    it('should throw an error', function () {
+      // when
+      const error = catchErrSync(
+        () =>
+          new ModuleMetadata({
+            id,
+            slug,
+            title,
+            isBeta,
+            duration,
+            image,
+          }),
+      )();
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+      expect(error.message).to.equal('The short id is required for a module metadata');
+    });
+  });
+
   describe('if a module does not have a slug', function () {
     it('should throw an error', function () {
       // when
@@ -58,6 +81,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             isBeta,
             duration,
             image,
+            shortId,
           }),
       )();
 
@@ -78,6 +102,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             isBeta,
             duration,
             image,
+            shortId,
           }),
       )();
 
@@ -98,6 +123,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             slug,
             duration,
             image,
+            shortId,
           }),
       )();
 
@@ -118,6 +144,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             slug,
             isBeta,
             image,
+            shortId,
           }),
       )();
 
@@ -142,6 +169,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             slug,
             isBeta,
             image,
+            shortId,
           }),
       )();
 
@@ -166,6 +194,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             slug,
             isBeta,
             image,
+            shortId,
           }),
       )();
 
@@ -186,6 +215,7 @@ describe('Unit | Devcomp | Domain | Models | Module | ModuleMetadata', function 
             title,
             slug,
             isBeta,
+            shortId,
           }),
       )();
 

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
@@ -9,6 +9,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
   beforeEach(function () {
     firstModule = {
       id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+      shortId: 'jh87et25',
       slug: 'getAllByIdsModuleSlug1',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
@@ -46,6 +47,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
     };
     secondModule = {
       id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      shortId: '87ki0tr7',
       slug: 'getAllByIdsModuleSlug2',
       title: 'Bac à sable',
       isBeta: true,
@@ -95,6 +97,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
     const expectedModuleMetadataList = [
       {
         id: firstModule.id,
+        shortId: firstModule.shortId,
         slug: firstModule.slug,
         title: firstModule.title,
         isBeta: firstModule.isBeta,
@@ -103,6 +106,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
       },
       {
         id: secondModule.id,
+        shortId: secondModule.shortId,
         slug: secondModule.slug,
         title: secondModule.title,
         isBeta: secondModule.isBeta,


### PR DESCRIPTION
## 🍂 Problème

Actuellement, côté parcours apprenant, on liste l'état des modules en cours. Avec le chantier d'ajout du shortId dans l'url, on souhaite qu'ils utilisent ce dernier comme référence lors de la redirection vers les modules.

## 🌰 Proposition

Retourner le shortId dans l'api interne getModuleStatuses dans l'API.

## 🍁 Remarques

On laissera le soin à la team combinix de consommer ce shortId dans leur code.

## 🪵 Pour tester

les test passent :)
