### PR TITLE
[FEATURE] Utilisation dans Pix Certif de la table de config des dates de réouverture des espaces Pix Certif SCO (PIX-20405)

### DIFF
--- a/api/src/certification/configuration/application/sco-blocked-access-dates-controller.js
+++ b/api/src/certification/configuration/application/sco-blocked-access-dates-controller.js
@@ -1,9 +1,17 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone.js';
+import utc from 'dayjs/plugin/utc.js';
+
 import { usecases } from '../domain/usecases/index.js';
 import { serialize } from '../infrastructure/serializers/sco-blocked-access-dates-serializer.js';
 
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 const updateScoBlockedAccessDate = async function (request, h) {
   const scoOrganizationTagName = request.params.key;
-  const reopeningDate = request.payload.data.attributes.value;
+  const dateString = request.payload.data.attributes.value;
+  const reopeningDate = dayjs.tz(dateString, 'Europe/Paris').toDate();
   await usecases.updateScoBlockedAccessDate({ scoOrganizationTagName, reopeningDate });
   return h.response().code(200);
 };

--- a/api/src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/src/identity-access-management/domain/read-models/AllowedCertificationCenterAccess.js
@@ -1,10 +1,13 @@
-import { config } from '../../../shared/config.js';
-
-const { features } = config;
 class AllowedCertificationCenterAccess {
   #isInWhitelist = false;
 
-  constructor({ center, isRelatedToManagingStudentsOrganization, relatedOrganizationTags }) {
+  constructor({
+    center,
+    isRelatedToManagingStudentsOrganization,
+    relatedOrganizationTags,
+    scoBlockedAccessDateCollege,
+    scoBlockedAccessDateLycee,
+  }) {
     this.id = center.id;
     this.name = center.name;
     this.externalId = center.externalId;
@@ -13,6 +16,8 @@ class AllowedCertificationCenterAccess {
     this.#isInWhitelist = !!center.isInWhitelist;
     this.isRelatedToManagingStudentsOrganization = isRelatedToManagingStudentsOrganization;
     this.relatedOrganizationTags = relatedOrganizationTags;
+    this.pixCertifScoBlockedAccessDateCollege = scoBlockedAccessDateCollege;
+    this.pixCertifScoBlockedAccessDateLycee = scoBlockedAccessDateLycee;
   }
 
   isAccessBlockedCollege() {
@@ -20,22 +25,20 @@ class AllowedCertificationCenterAccess {
       this.isCollege() &&
       !this.isLycee() &&
       !this.isInWhitelist() &&
-      new Date() < new Date(features.pixCertifScoBlockedAccessDateCollege)
+      new Date() < new Date(this.pixCertifScoBlockedAccessDateCollege)
     );
   }
 
   isAccessBlockedLycee() {
-    return (
-      this.isLycee() && !this.isInWhitelist() && new Date() < new Date(features.pixCertifScoBlockedAccessDateLycee)
-    );
+    return this.isLycee() && !this.isInWhitelist() && new Date() < new Date(this.pixCertifScoBlockedAccessDateLycee);
   }
 
   isAccessBlockedAEFE() {
-    return this.isAEFE() && !this.isInWhitelist() && new Date() < new Date(features.pixCertifScoBlockedAccessDateLycee);
+    return this.isAEFE() && !this.isInWhitelist() && new Date() < new Date(this.pixCertifScoBlockedAccessDateLycee);
   }
 
   isAccessBlockedAgri() {
-    return this.isAgri() && !this.isInWhitelist() && new Date() < new Date(features.pixCertifScoBlockedAccessDateLycee);
+    return this.isAgri() && !this.isInWhitelist() && new Date() < new Date(this.pixCertifScoBlockedAccessDateLycee);
   }
 
   hasTag(tagName) {
@@ -64,14 +67,6 @@ class AllowedCertificationCenterAccess {
 
   isInWhitelist() {
     return this.#isInWhitelist;
-  }
-
-  get pixCertifScoBlockedAccessDateLycee() {
-    return features.pixCertifScoBlockedAccessDateLycee ?? null;
-  }
-
-  get pixCertifScoBlockedAccessDateCollege() {
-    return features.pixCertifScoBlockedAccessDateCollege ?? null;
   }
 }
 

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js
@@ -69,8 +69,8 @@ const serialize = function (certificationPointOfContact) {
             isAccessBlockedLycee: access.isAccessBlockedLycee(),
             isAccessBlockedAEFE: access.isAccessBlockedAEFE(),
             isAccessBlockedAgri: access.isAccessBlockedAgri(),
-            pixCertifScoBlockedAccessDateCollege: access.pixCertifScoBlockedAccessDateCollege,
-            pixCertifScoBlockedAccessDateLycee: access.pixCertifScoBlockedAccessDateLycee,
+            pixCertifScoBlockedAccessDateCollege: access.pixCertifScoBlockedAccessDateCollege ?? null,
+            pixCertifScoBlockedAccessDateLycee: access.pixCertifScoBlockedAccessDateLycee ?? null,
           };
         },
       );

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -282,8 +282,6 @@ const configuration = (function () {
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),
       newYearOrganizationLearnersImportDate: _getDate(process.env.NEW_YEAR_ORGANIZATION_LEARNERS_IMPORT_DATE),
       successProbabilityThreshold: parseFloat(process.env.SUCCESS_PROBABILITY_THRESHOLD ?? '0.95'),
-      pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
-      pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,
       scheduleComputeOrganizationLearnersCertificability: {
         cron: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_JOB_CRON || '0 21 * * *',
         chunkSize: process.env.SCHEDULE_COMPUTE_LEARNERS_CERTIFICABILITY_CHUNK_SIZE || 1000,
@@ -531,8 +529,6 @@ const configuration = (function () {
     config.features.dayBeforeCompetenceResetV2 = 7;
     config.features.garAccessV2 = false;
     config.features.maxReachableLevel = 5;
-    config.features.pixCertifScoBlockedAccessDateLycee = null;
-    config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.deprecatePoleEmploiPushNotification = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.test.js
@@ -1,6 +1,5 @@
 import * as certificationPointOfContactSerializer from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/certification-point-of-contact.serializer.js';
-import { config as settings } from '../../../../../../src/shared/config.js';
-import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Serializer | JSONAPI | certification-point-of-contact-serializer', function () {
   describe('#serialize()', function () {
@@ -8,10 +7,6 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | certificati
       // given
       const habilitation1 = { id: 1, label: 'Certif comp 1', key: 'CERTIF_COMP_1' };
       const habilitation2 = { id: 2, label: 'Certif comp 2', key: 'CERTIF_COMP_2' };
-      sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value('2022-06-01');
-      sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value('2022-08-01');
-
-      settings.features.pixCertifScoBlockedAccessDateLycee = '2022-08-01';
 
       const allowedCertificationCenterAccess1 = domainBuilder.buildAllowedCertificationCenterAccess({
         id: 123,
@@ -21,6 +16,8 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | certificati
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
         habilitations: [habilitation1, habilitation2],
+        scoBlockedAccessDateCollege: '2022-06-01',
+        scoBlockedAccessDateLycee: '2022-08-01',
       });
 
       const allowedCertificationCenterAccess2 = domainBuilder.buildAllowedCertificationCenterAccess({
@@ -31,6 +28,8 @@ describe('Unit | Identity Access Management | Serializer | JSONAPI | certificati
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: ['tag1'],
         habilitations: [],
+        scoBlockedAccessDateCollege: '2022-06-01',
+        scoBlockedAccessDateLycee: '2022-08-01',
       });
 
       const certificationCenterMemberships = [

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact.repository.test.js
@@ -111,6 +111,8 @@ describe('Integration | Identity Access Management |  Repository | Certification
           habilitations: [],
           isRelatedToManagingStudentsOrganization: false,
           relatedOrganizationTags: [],
+          pixCertifScoBlockedAccessDateCollege: undefined,
+          pixCertifScoBlockedAccessDateLycee: undefined,
         },
       ];
 
@@ -185,6 +187,8 @@ describe('Integration | Identity Access Management |  Repository | Certification
         habilitations: [],
         isRelatedToManagingStudentsOrganization: false,
         relatedOrganizationTags: [],
+        pixCertifScoBlockedAccessDateCollege: undefined,
+        pixCertifScoBlockedAccessDateLycee: undefined,
       };
 
       expect(allowedCertificationCenterAccess).to.deep.equal(expectedAllowedCertificationCenterAccess);

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -11,6 +11,8 @@ function buildAllowedCertificationCenterAccess({
   relatedOrganizationTags = [],
   habilitations = [],
   isInWhitelist,
+  scoBlockedAccessDateCollege,
+  scoBlockedAccessDateLycee,
 } = {}) {
   return new AllowedCertificationCenterAccess({
     center: {
@@ -23,6 +25,8 @@ function buildAllowedCertificationCenterAccess({
     },
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
+    scoBlockedAccessDateCollege,
+    scoBlockedAccessDateLycee,
   });
 }
 

--- a/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
+++ b/api/tests/unit/domain/read-models/AllowedCertificationCenterAccess_test.js
@@ -1,20 +1,7 @@
-import { config as settings } from '../../../../src/shared/config.js';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', function () {
   context('#isInWhitelist', function () {
-    let originalEnvValueDateCollege, originalEnvValueDateLycee;
-
-    beforeEach(function () {
-      originalEnvValueDateCollege = settings.features.pixCertifScoBlockedAccessDateCollege;
-      originalEnvValueDateLycee = settings.features.pixCertifScoBlockedAccessDateLycee;
-    });
-
-    afterEach(function () {
-      settings.features.pixCertifScoBlockedAccessDateCollege = originalEnvValueDateCollege;
-      settings.features.pixCertifScoBlockedAccessDateLycee = originalEnvValueDateLycee;
-    });
-
     it('should return true when certification center is in whitelist', function () {
       // given
       const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
@@ -319,12 +306,12 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessDateCollege = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: ['COLLEGE', 'some_other_tag'],
+        scoBlockedAccessDateCollege: '2021-01-01',
       };
     });
 
@@ -407,11 +394,11 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
+        scoBlockedAccessDateLycee: '2021-01-01',
         relatedOrganizationTags: ['LYCEE PRO', 'some_other_tag'],
       };
     });
@@ -489,12 +476,12 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: ['AEFE', 'some_other_tag'],
+        scoBlockedAccessDateLycee: '2021-01-01',
       };
     });
 
@@ -565,12 +552,12 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     let clock;
 
     beforeEach(function () {
-      settings.features.pixCertifScoBlockedAccessDateLycee = '2021-01-01';
       validData = {
         externalId: 'NOT_WHITELISTED',
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
         relatedOrganizationTags: ['AGRICULTURE', 'some_other_tag'],
+        scoBlockedAccessDateLycee: '2021-01-01',
       };
     });
 
@@ -684,10 +671,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     describe('when pixCertifScoBlockedAccessDateLycee is defined', function () {
       it('should return the french formated pixCertifScoBlockedAccessDateLycee', function () {
         // given
-        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value('2022-02-01');
-
         const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
           id: 1,
+          scoBlockedAccessDateLycee: '2022-02-01',
         });
 
         // when
@@ -699,10 +685,8 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     });
 
     describe('when pixCertifScoBlockedAccessDateLycee is not defined', function () {
-      it('should return null', function () {
+      it('should return undefined', function () {
         // given
-        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateLycee').value(undefined);
-
         const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
           id: 1,
         });
@@ -711,7 +695,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
         const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateLycee;
 
         // then
-        expect(result).to.be.null;
+        expect(result).to.be.undefined;
       });
     });
   });
@@ -720,9 +704,9 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     describe('when pixCertifScoBlockedAccessDateCollege is defined', function () {
       it('should return the french formated pixCertifScoBlockedAccessDateCollege', function () {
         // given
-        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value('2022-02-01');
         const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
           id: 1,
+          scoBlockedAccessDateCollege: '2022-02-01',
         });
 
         // when
@@ -734,9 +718,8 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
     });
 
     describe('when pixCertifScoBlockedAccessDateCollege is not defined', function () {
-      it('should return null', function () {
+      it('should return undefined', function () {
         // given
-        sinon.stub(settings.features, 'pixCertifScoBlockedAccessDateCollege').value(undefined);
         const allowedCertificationCenterAccess = domainBuilder.buildAllowedCertificationCenterAccess({
           id: 1,
         });
@@ -745,7 +728,7 @@ describe('Unit | Domain | Read-Models | AllowedCertificationCenterAccess', funct
         const result = allowedCertificationCenterAccess.pixCertifScoBlockedAccessDateCollege;
 
         // then
-        expect(result).to.be.null;
+        expect(result).to.be.undefined;
       });
     });
   });

--- a/certif/app/components/login-session-supervisor/form.gjs
+++ b/certif/app/components/login-session-supervisor/form.gjs
@@ -7,7 +7,11 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import dayjs from 'dayjs';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
+
+dayjs.extend(LocalizedFormat);
 
 export default class LoginSessionSupervisor extends Component {
   @service intl;
@@ -48,7 +52,7 @@ export default class LoginSessionSupervisor extends Component {
           break;
         case 'SESSION_NOT_ACCESSIBLE':
           this.formError = this.intl.t('pages.session-supervising.login.form.errors.session-not-accessible', {
-            date: error.meta?.blockedAccessDate,
+            date: dayjs(error.meta?.blockedAccessDate).format('L'),
           });
           break;
         default:

--- a/certif/app/controllers/authenticated/restricted-access.js
+++ b/certif/app/controllers/authenticated/restricted-access.js
@@ -13,13 +13,13 @@ export default class RestrictedAccessController extends Controller {
   get certificationOpeningDate() {
     if (this.model.isAccessBlockedCollege) {
       return this.intl.t('pages.sco.restricted-access.title-access', {
-        date: dayjs.utc(this.model.pixCertifScoBlockedAccessDateCollege).format('L'),
+        date: dayjs(this.model.pixCertifScoBlockedAccessDateCollege).format('L'),
       });
     }
 
     if (this.model.isAccessBlockedLycee || this.model.isAccessBlockedAEFE || this.model.isAccessBlockedAgri) {
       return this.intl.t('pages.sco.restricted-access.title-access', {
-        date: dayjs.utc(this.model.pixCertifScoBlockedAccessDateLycee).format('L'),
+        date: dayjs(this.model.pixCertifScoBlockedAccessDateLycee).format('L'),
       });
     }
 

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -17,8 +17,8 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() isAccessBlockedAgri;
   @attr() relatedOrganizationTags;
   @attr() habilitations;
-  @attr() pixCertifScoBlockedAccessDateLycee;
-  @attr() pixCertifScoBlockedAccessDateCollege;
+  @attr('date') pixCertifScoBlockedAccessDateLycee;
+  @attr('date') pixCertifScoBlockedAccessDateCollege;
 
   get isSco() {
     return this.type === CERTIFICATION_CENTER_TYPES.SCO;

--- a/certif/tests/integration/components/login-session-supervisor/form-test.gjs
+++ b/certif/tests/integration/components/login-session-supervisor/form-test.gjs
@@ -119,7 +119,7 @@ module('Integration | Component | Login session supervisor | Form', function (ho
         assert
           .dom(
             within(screen.getByRole('alert')).getByText(
-              t('pages.session-supervising.login.form.errors.session-not-accessible', { date: blockedAccessDate }),
+              t('pages.session-supervising.login.form.errors.session-not-accessible', { date: '01/09/2025' }),
             ),
           )
           .exists();


### PR DESCRIPTION
## 🍂 Problème

Actuellement, la visualisation des dates actuellement actives ainsi que le paramétrage des dates de réouverture des espaces Pix Certif SCO sont gérés par les Captains directement en base de données.

## 🌰 Proposition

- Récupérer les dates de réouverture dans la  nouvelle table de configuration
- Afficher les dates dans Pix Certif 

## 🍁 Remarques

Les dates configurées sont toujours considérée comme 0h heure france métropolitaine indépendamment du fuseau horaire de l'utilisateur

- [x] attendre la livraison de l'API dans la PR #14131 
- [x] attendre la livraison de l'UI dans la PR #14166
- [x] attendre la livraison de la migration de la PR #14226 

## 🪵 Pour tester

Modifier les dates de blocage dans l'onglet "Certification" dans la section Administration de Pix Admin, attribuer le(s) tags `COLLEGE` et `LYCEE` à l'organisation SCO et vérifier que l'espace Pix Certif et l'espace surveillant est bloqué ou non selon les dates et les tags configurés.
