### PR TITLE
[TECH] Modifier le domaine des contenus des modules (PIX-20514).

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -5,7 +5,7 @@
   "title": "IA génératives : Qui programme la morale ?",
   "isBeta": true,
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Les IA génératives produisent souvent des résultats convaincants, mais elles peuvent aussi <strong>commettre des erreurs, halluciner ou reproduire des biais</strong>. Ces <strong>limites</strong> proviennent en partie de la façon dont elles sont <strong>entraînées</strong> à partir d’immenses ensembles de textes.</p><p>Or, <strong>l’entraînement d’une IA n’est jamais neutre</strong>&nbsp;: il intègre des choix humains sur ce qu’elle doit apprendre… et sur ce qu’elle doit éviter. Comment alors <strong>transmettre des valeurs humaines</strong> à une IA, quand ces valeurs diffèrent d’un pays à l’autre ?</p><p>Ce module vous invite à explorer <strong>les enjeux techniques, moraux et politiques</strong> de cette question centrale&nbsp;: <em>qui programme la morale ?</em></p>",
     "duration": 10,
     "level": "advanced",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -5,7 +5,7 @@
   "title": "Ce qu’il faut éviter de dire à une IA générative",
   "isBeta": true,
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Quand vous discutez avec un logiciel d’<strong>intelligence artificielle (IA</strong>) générative, la conversation n’est pas privée.</p><p>Tout ce que vous écrivez peut être <strong>enregistré et parfois réutilisé</strong> pour améliorer l’IA.</p><p>Dans ce module, vous allez comprendre<strong> pourquoi les échanges avec une IA générative ne sont pas totalement privés</strong> et <strong>quelles informations il vaut mieux éviter d’écrire</strong> dans vos instructions (prompts).</p>",
     "duration": 10,
     "level": "novice",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/nr_durabilite_ind.json
@@ -5,7 +5,7 @@
   "title": "Le numérique : pourquoi privilégier le réemploi ?",
   "isBeta": false,
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "<p>Nos smartphones et ordinateurs renferment de nombreux métaux comme le lithium, le cobalt ou les terres rares. Leur extraction consomme beaucoup d’eau et de produits chimiques, au détriment de l’environnement et de la santé des travailleurs. 🌍</p><p>Dans ce module, vous découvrirez l’envers du numérique&nbsp;: les impacts cachés de la fabrication de nos appareils, mais aussi comment le réemploi et le reconditionnement peuvent en réduire durablement les effets. 🔁</p>",
     "duration": 10,
     "level": "independent",

--- a/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements-csv_test.js
@@ -45,7 +45,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
         title: 'Bac à sable',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: '<p>Découvrez avec ce didacticiel comment fonctionne Modulix !</p>',
           duration: 5,
           level: 'novice',

--- a/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-answerable-elements_test.js
@@ -8,7 +8,7 @@ describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
       slug: 'bac-a-sable',
       title: 'Bac à sable',
       details: {
-        image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+        image: 'https://assets.pix.org/modules/placeholder-details.svg',
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'novice',
@@ -79,7 +79,7 @@ describe('Acceptance | Script | Helper | Get Answerable Elements', function () {
                   element: {
                     id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                     type: 'image',
-                    url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                    url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                     alt: "Dessin détaillé dans l'alternative textuelle",
                     alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
                   },

--- a/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
+++ b/api/tests/devcomp/acceptance/scripts/utils/get-grains_test.js
@@ -8,7 +8,7 @@ describe('Acceptance | Script | Helper | Get grains', function () {
       slug: 'bac-a-sable',
       title: 'Bac à sable',
       details: {
-        image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+        image: 'https://assets.pix.org/modules/placeholder-details.svg',
         description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
         duration: 5,
         level: 'novice',
@@ -78,7 +78,7 @@ describe('Acceptance | Script | Helper | Get grains', function () {
                   element: {
                     id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                     type: 'image',
-                    url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                    url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                     alt: "Dessin détaillé dans l'alternative textuelle",
                     alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
                   },

--- a/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/integration/infrastructure/factories/module-factory_test.js
@@ -38,7 +38,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             title: 'title',
             isBeta: true,
             details: {
-              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
               duration: 5,
               level: 'novice',
@@ -94,7 +94,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             title: 'title',
             isBeta: true,
             details: {
-              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
               duration: 5,
               level: 'novice',
@@ -150,7 +150,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
             title: 'title',
             isBeta: true,
             details: {
-              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              image: 'https://assets.pix.org/modules/placeholder-details.svg',
               description: 'Description',
               duration: 5,
               level: 'novice',
@@ -216,7 +216,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         version,
         isBeta: true,
         details: {
-          image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',
           duration: 5,
           level: 'novice',
@@ -238,7 +238,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                     element: {
                       id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                       type: 'image',
-                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                      url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                       alt: 'Alternative',
                       alternativeText: 'Alternative textuelle',
                     },
@@ -273,7 +273,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -372,7 +372,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -424,7 +424,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -446,7 +446,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                       element: {
                         id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                         type: 'image',
-                        url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                        url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                         alt: 'Alternative',
                         alternativeText: 'Alternative textuelle',
                         legend: 'legend',
@@ -476,7 +476,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -528,7 +528,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -696,7 +696,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -749,7 +749,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -800,7 +800,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -862,7 +862,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -933,7 +933,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1016,7 +1016,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1092,7 +1092,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1184,7 +1184,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1209,20 +1209,20 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                         title: "Introduction à l'adresse e-mail",
                         instruction: '<p>...</p>',
                         introImage: {
-                          url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                          url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                         },
                         cards: [
                           {
                             id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
                             recto: {
                               image: {
-                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                                url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                               },
                               text: "A quoi sert l'arobase dans mon adresse email ?",
                             },
                             verso: {
                               image: {
-                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                                url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                               },
                               text: "Parce que c'est joli",
                             },
@@ -1255,7 +1255,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1312,7 +1312,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1341,7 +1341,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             id: '4420c9f6-ae21-4401-a16c-41296d898a66',
                             text: 'La Terre est plus proche du Soleil que Mars.',
                             image: {
-                              url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                              url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                               altText: 'coucou',
                             },
                             proposalA: 'Vrai',
@@ -1391,7 +1391,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1416,7 +1416,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                             {
                               id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                               type: 'image',
-                              url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                              url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                               alt: "Dessin détaillé dans l'alternative textuelle",
                               alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
                             },
@@ -1449,7 +1449,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1504,7 +1504,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1561,7 +1561,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1621,7 +1621,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://assets.pix.org/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1679,7 +1679,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1740,7 +1740,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1800,7 +1800,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1871,7 +1871,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -1950,7 +1950,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2034,7 +2034,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2132,7 +2132,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2160,20 +2160,20 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
                               title: "Introduction à l'adresse e-mail",
                               instruction: '<p>...</p>',
                               introImage: {
-                                url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                                url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                               },
                               cards: [
                                 {
                                   id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
                                   recto: {
                                     image: {
-                                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                                      url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                                     },
                                     text: "A quoi sert l'arobase dans mon adresse email ?",
                                   },
                                   verso: {
                                     image: {
-                                      url: 'https://assets.pix.org/modulix/didacticiel/ordi-spatial.svg',
+                                      url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                                     },
                                     text: "Parce que c'est joli",
                                   },
@@ -2209,7 +2209,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2272,7 +2272,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2337,7 +2337,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
           title: 'title',
           isBeta: true,
           details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            image: 'https://assets.pix.org/modules/placeholder-details.svg',
             description: 'Description',
             duration: 5,
             level: 'novice',
@@ -2393,7 +2393,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         title: 'title',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',
           duration: 5,
           level: 'novice',
@@ -2452,7 +2452,7 @@ describe('Integration | Devcomp | Infrastructure | Factories | Module ', functio
         title: 'title',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Description',
           duration: 5,
           level: 'novice',

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -40,7 +40,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         title: 'Bac à sable',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'novice',
@@ -132,7 +132,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         title: 'Bac à sable',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'novice',
@@ -269,7 +269,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         title: 'Bac à sable',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'novice',

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -20,7 +20,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,
@@ -230,7 +230,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,
@@ -387,7 +387,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,
@@ -536,7 +536,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,

--- a/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/get-module-metadata-list_test.js
@@ -13,7 +13,7 @@ describe('Unit | Devcomp | Domain | UseCases | get-module-metadata-list', functi
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       details: {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -500,7 +500,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
       const invalidImage = {
         id: '167907eb-ee0d-4de0-9fc8-609b2b62ed9f',
         type: 'image',
-        url: 'https://images.pix.fr/modulix/placeholder-image.svg',
+        url: 'https://assets.pix.org/modules/placeholder-image.svg',
         alt: '<p>cooucou</p>',
         alternativeText: '',
       };
@@ -661,7 +661,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         title: '<h1>Bac à sable</h1>',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          image: 'https://assets.pix.org/modules/placeholder-details.svg',
           description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
           duration: 5,
           level: 'novice',

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -32,7 +32,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const isBeta = true;
       const version = Symbol('version');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,
@@ -82,7 +82,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const isBeta = true;
       const version = Symbol('version');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,
@@ -139,7 +139,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const isBeta = true;
       const version = Symbol('version');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,
@@ -211,7 +211,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const isBeta = true;
       const version = Symbol('version');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,

--- a/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
+++ b/api/tests/devcomp/unit/scripts/get-modules-csv_test.js
@@ -31,7 +31,7 @@ describe('Unit | Scripts | Get Modules as CSV', function () {
               element: {
                 id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
                 type: 'image',
-                url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
                 alt: "Dessin détaillé dans l'alternative textuelle",
                 alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
               },

--- a/mon-pix/app/components/module/preview.gjs
+++ b/mon-pix/app/components/module/preview.gjs
@@ -25,7 +25,7 @@ export default class ModulixPreview extends Component {
   "slug": "demo-preview-modulix",
   "title": "Démo preview Modulix",
   "details": {
-    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "image": "https://assets.pix.org/modules/placeholder-details.svg",
     "description": "Découvrez la page de prévisualisation pour contribuer à Modulix !",
     "duration": 5,
     "level": "novice",
@@ -65,7 +65,7 @@ export default class ModulixPreview extends Component {
             "element": {
               "id": "4444444a-4444-4bcd-e444-4f4444gh4444",
               "type": "image",
-              "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
+              "url": "https://assets.pix.org/modules/didacticiel/ordi-spatial.svg",
               "alt": "Dessin détaillé dans l'alternative textuelle",
               "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
             }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
         title: 'Bien écrire son adresse mail',
         sections: [],
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',
@@ -50,7 +50,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
         title: 'Bien écrire son adresse mail',
         sections: [section],
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -41,7 +41,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
         isBeta: true,
         sections: [section],
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description: '<p>Description</p>',
           duration: 'duration',
           level: 'level',

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -19,7 +19,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
       title: 'Bien écrire son adresse mail',
       isBeta: false,
       details: {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,
@@ -49,7 +49,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
         title: 'Bien écrire son adresse mail',
         isBeta: true,
         details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
           description:
             'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
           duration: 12,
@@ -83,7 +83,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description:
           'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
         duration: 12,

--- a/mon-pix/tests/integration/components/module/component/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/component/element_test.gjs
@@ -111,7 +111,7 @@ module('Integration | Component | Module | Element', function (hooks) {
     const element = {
       id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
       type: 'image',
-      url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+      url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
       alt: "Dessin détaillé dans l'alternative textuelle",
       alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
     };
@@ -384,18 +384,18 @@ module('Integration | Component | Module | Element', function (hooks) {
       type: 'flashcards',
       title: "Introduction à l'adresse e-mail",
       instruction: '<p>...</p>',
-      introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+      introImage: { url: 'https://assets.pix.org/modules/placeholder-details.svg' },
       cards: [
         {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
             image: {
-              url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+              url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
             },
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
             text: "Parce que c'est joli",
           },
         },

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | Module | Details', function (hooks) {
     const store = this.owner.lookup('service:store');
     const descriptionContent = 'description';
     const details = {
-      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+      image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
       description: `<p>${descriptionContent}</p>`,
       duration: 12,
       level: 'novice',
@@ -248,7 +248,7 @@ function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
   const store = this.owner.lookup('service:store');
 
   const details = {
-    image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+    image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
     description: '<p>Description</p>',
     duration: 12,
     level: 'novice',

--- a/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-card_test.gjs
@@ -16,12 +16,12 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
         id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
         recto: {
           image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
           },
           text: "A quoi sert l'arobase dans mon adresse email ?",
         },
         verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
           text: "Parce que c'est joli",
         },
       };
@@ -35,7 +35,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
       assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
       assert.strictEqual(
         screen.getByRole('presentation').getAttribute('src'),
-        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       );
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
     });
@@ -49,7 +49,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
             text: "Parce que c'est joli",
           },
         };
@@ -71,7 +71,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
           id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
           recto: {
             image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+              url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
               information: { height: 400, width: 300 },
             },
             text: "A quoi sert l'arobase dans mon adresse email ?",
@@ -104,12 +104,12 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
         id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
         recto: {
           image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
           },
           text: "A quoi sert l'arobase dans mon adresse email ?",
         },
         verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
           text: "Parce que c'est joli",
         },
       };
@@ -123,7 +123,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
       assert.ok(screen.getByText("Parce que c'est joli"));
       assert.strictEqual(
         screen.getByRole('presentation').getAttribute('src'),
-        'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+        'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
       );
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAgain') })).exists();
     });
@@ -137,7 +137,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
             text: "A quoi sert l'arobase dans mon adresse email ?",
           },
           verso: {
-            image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+            image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
             text: "Parce que c'est joli",
           },
         };
@@ -162,7 +162,7 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
           },
           verso: {
             image: {
-              url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+              url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
               information: { height: 400, width: 300 },
             },
             text: "Parce que c'est joli",
@@ -192,12 +192,12 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
         id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
         recto: {
           image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
           },
           text: "A quoi sert l'arobase dans mon adresse email ?",
         },
         verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
           text: "Parce que c'est joli",
         },
       };
@@ -223,12 +223,12 @@ module('Integration | Component | Module | Flashcards Card', function (hooks) {
         id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
         recto: {
           image: {
-            url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+            url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
           },
           text: "A quoi sert l'arobase dans mon adresse email ?",
         },
         verso: {
-          image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+          image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
           text: "Parce que c'est joli",
         },
       };

--- a/mon-pix/tests/integration/components/module/flashcards-intro-card_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards-intro-card_test.gjs
@@ -12,7 +12,7 @@ module('Integration | Component | Module | Flashcards Intro Card', function (hoo
   test('should display an intro card', async function (assert) {
     // given
     const introImage = {
-      url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
     };
     const title = 'Introduction à la poésie';
 
@@ -25,7 +25,7 @@ module('Integration | Component | Module | Flashcards Intro Card', function (hoo
     assert.ok(screen.getByRole('heading', { name: 'Introduction à la poésie' }));
     assert.strictEqual(
       screen.getByRole('presentation').getAttribute('src'),
-      'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
     );
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') })).exists();
   });
@@ -71,7 +71,7 @@ module('Integration | Component | Module | Flashcards Intro Card', function (hoo
     test('should set them to the image', async function (assert) {
       // given
       const introImage = {
-        url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
         information: { height: 400, width: 300 },
       };
       const title = 'Introduction à la poésie';

--- a/mon-pix/tests/integration/components/module/flashcards_test.gjs
+++ b/mon-pix/tests/integration/components/module/flashcards_test.gjs
@@ -42,7 +42,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
     assert.ok(screen.getByRole('heading', { name: "Introduction à l'adresse e-mail", level: 4 }));
     assert.strictEqual(
       screen.getByRole('presentation').getAttribute('src'),
-      'https://images.pix.fr/modulix/flashcards-intro.png',
+      'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
     );
     assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.start') })).exists();
     assert.dom(screen.queryByText(t('pages.modulix.flashcards.direction'))).doesNotExist();
@@ -175,7 +175,7 @@ module('Integration | Component | Module | Flashcards', function (hooks) {
       assert.ok(screen.getByText("A quoi sert l'arobase dans mon adresse email ?"));
       assert.strictEqual(
         screen.getByRole('presentation').getAttribute('src'),
-        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       );
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.buttons.flashcards.seeAnswer') })).exists();
       assert.ok(screen.getByText(t('pages.modulix.flashcards.direction')));
@@ -373,12 +373,12 @@ function _getFlashcards() {
     id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
     recto: {
       image: {
-        url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+        url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       },
       text: "A quoi sert l'arobase dans mon adresse email ?",
     },
     verso: {
-      image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+      image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
       text: "Parce que c'est joli",
     },
   };
@@ -386,13 +386,13 @@ function _getFlashcards() {
     id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
     recto: {
       image: {
-        url: 'https://images.pix.fr/modulix/didacticiel/icon.svg',
+        url: 'https://assets.pix.org/modules/didacticiel/icon.svg',
       },
       text: 'Qui a écrit le Dormeur du Val ?',
     },
     verso: {
       image: {
-        url: 'https://images.pix.fr/modulix/didacticiel/chaton.jpg',
+        url: 'https://assets.pix.org/modules/didacticiel/chaton.jpg',
       },
       text: 'Arthur Rimbaud',
     },
@@ -403,7 +403,7 @@ function _getFlashcards() {
     type: 'flashcards',
     title: "Introduction à l'adresse e-mail",
     instruction: 'Lisez la question, essayez de trouver la réponse puis retourner la carte en cliquant dessus',
-    introImage: { url: 'https://images.pix.fr/modulix/flashcards-intro.png' },
+    introImage: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
     cards: [firstCard, secondCard],
   };
 

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -275,7 +275,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       test('should display image element', async function (assert) {
         // given
         const url =
-          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+          'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
         const imageElement = {
           url,
           alt: 'alt text',
@@ -326,19 +326,19 @@ module('Integration | Component | Module | Grain', function (hooks) {
           type: 'flashcards',
           title: "Introduction à l'adresse e-mail",
           instruction: '<p>...</p>',
-          introImage: { url: 'https://images.pix.fr/modulix/placeholder-details.svg' },
+          introImage: { url: 'https://assets.pix.org/modules/placeholder-details.svg' },
           isAnswerable: true,
           cards: [
             {
               id: 'e1de6394-ff88-4de3-8834-a40057a50ff4',
               recto: {
                 image: {
-                  url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+                  url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
                 },
                 text: "A quoi sert l'arobase dans mon adresse email ?",
               },
               verso: {
-                image: { url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg' },
+                image: { url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg' },
                 text: "Parce que c'est joli",
               },
             },

--- a/mon-pix/tests/integration/components/module/image_test.gjs
+++ b/mon-pix/tests/integration/components/module/image_test.gjs
@@ -13,7 +13,7 @@ module('Integration | Component | Module | Image', function (hooks) {
   test('should display an image', async function (assert) {
     // given
     const url =
-      'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+      'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
 
     const imageElement = {
       url,
@@ -74,7 +74,7 @@ module('Integration | Component | Module | Image', function (hooks) {
     const alternativeText = 'alternative instruction';
 
     const imageElement = {
-      url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       alt: 'alt text',
       alternativeText,
     };
@@ -102,7 +102,7 @@ module('Integration | Component | Module | Image', function (hooks) {
   test('should not be able to open the modal if there is no alternative instruction', async function (assert) {
     // given
     const imageElement = {
-      url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
+      url: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
       alt: 'alt text',
       alternativeText: '',
     };

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -556,7 +556,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const element = {
         id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
         type: 'image',
-        url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+        url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
         alt: "Dessin détaillé dans l'alternative textuelle",
         alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
       };
@@ -592,7 +592,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const element = {
         id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
         type: 'image',
-        url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+        url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
         alt: "Dessin détaillé dans l'alternative textuelle",
         alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
       };
@@ -633,7 +633,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
         const imageElement = {
           id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
           type: 'image',
-          url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+          url: 'https://assets.pix.org/modules/didacticiel/ordi-spatial.svg',
           alt: "Dessin détaillé dans l'alternative textuelle",
           alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
         };

--- a/mon-pix/tests/integration/components/module/recap_test.gjs
+++ b/mon-pix/tests/integration/components/module/recap_test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | Module | Recap', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description: '<p>Description</p>',
         duration: 12,
         level: 'novice',
@@ -37,7 +37,7 @@ module('Integration | Component | Module | Recap', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const details = {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
         description: '<p>Description</p>',
         duration: 12,
         level: 'novice',
@@ -57,7 +57,7 @@ module('Integration | Component | Module | Recap', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const details = {
-      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+      image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
       description: '<p>Description</p>',
       duration: 12,
       level: 'novice',


### PR DESCRIPTION
## 🍂 Problème

Actuellement quelques modules possèdent encore une url pointant vers images.pix.fr.
Or nous voulons nous défaire de l'usage de pix-images pour pix-assets.

## 🌰 Proposition

Modifier le domaine des urls liées aux modules.
Occurences dans les tests et dans 3 modules.

## 🪵 Pour tester

- https://app-pr14216.review.pix.fr/modules/tmp-iagenbiais-avance
- https://app-pr14216.review.pix.fr/modules/tmp-iagenethique
- https://app-pr14216.review.pix.fr/modules/metaux-eau-reemploi
- Constater pour ces 3 modules que l'illustration de début de module pointe vers assets.pix.org
