### PR TITLE
[TECH] Renommage d'éléments relatifs aux référentiels de certification (PIX-20501)

### DIFF
--- a/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
@@ -16,7 +16,7 @@ import { t } from 'ember-intl';
       <:columns as |version context|>
         <PixTableColumn @context={{context}}>
           <:header>
-            Version
+            {{t "components.complementary-certifications.item.framework.history.label"}}
           </:header>
           <:cell>
             {{version}}

--- a/admin/app/components/complementary-certifications/item/header.gjs
+++ b/admin/app/components/complementary-certifications/item/header.gjs
@@ -25,7 +25,7 @@ export default class Header extends Component {
 
     <div class="complementary-certification-header">
       <h1 class="complementary-certification-header__title">
-        <small>{{t "components.complementary-certifications.item.complementary-certification"}}</small>
+        <small>{{t "components.complementary-certifications.item.certification-framework"}}</small>
         <span>{{@complementaryCertificationLabel}}</span>
       </h1>
     </div>

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -67,9 +67,9 @@ export default class Sidebar extends Component {
           class="sidebar__link"
           @route="authenticated.complementary-certifications"
           @icon="extension"
-          aria-label={{t "components.layout.sidebar.complementary-certifications-label"}}
+          aria-label={{t "components.layout.sidebar.certification-frameworks-label"}}
         >
-          {{t "components.layout.sidebar.complementary-certifications"}}
+          {{t "components.layout.sidebar.certification-frameworks"}}
         </PixNavigationButton>
         {{#if this.accessControl.hasAccessToTargetProfilesActionsScope}}
           <PixNavigationButton class="sidebar__link" @route="authenticated.target-profiles" @icon="assignment">

--- a/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/list-test.js
@@ -32,15 +32,15 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
       assert.strictEqual(currentURL(), '/complementary-certifications/list');
     });
 
-    test('it should set complementary certifications menubar item active', async function (assert) {
+    test('it should set certification frameworks menubar item active', async function (assert) {
       // when
       const screen = await visit('/complementary-certifications/list');
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).hasClass('active');
+      assert.dom(screen.getByRole('link', { name: 'Référentiels de certification' })).hasClass('active');
     });
 
-    test('it should render the complementary certifications list', async function (assert) {
+    test('it should render the certification frameworks list', async function (assert) {
       // given
       server.create('complementary-certification', { id: 1, key: 'AN', label: 'TOINE' });
 
@@ -55,7 +55,7 @@ module('Acceptance | Complementary certifications | list ', function (hooks) {
       assert.dom(screen.getByText('TOINE')).exists({ count: 1 });
     });
 
-    test('it should redirect to complementary certification framework details on click if not double certification', async function (assert) {
+    test('it should redirect to certification framework details on click if not double certification', async function (assert) {
       // given
       server.create('complementary-certification', {
         id: 1,

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation-test.js
@@ -78,8 +78,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       await fillByLabel(/Nom interne/, 'Un profil cible interne, et vite !');
       await fillByLabel(/Identifiant de l'organisation de référence/, 1);
       await clickByName(/Permettre la remise à zéro des acquis du profil cible/);
-
-      await fillByLabel(/Référentiel/, 'Pi');
+      await fillByLabel(/Référentiels :/, 'Pi');
       const otherFrameworkChoice = screen.getByLabelText('Pix + Cuisine');
       await click(otherFrameworkChoice);
       await _selectLearningContent(screen);

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/edition-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/edition-test.js
@@ -39,7 +39,7 @@ module('Acceptance | Target Profile Edition', function (hooks) {
   test('it should edit target profile informations and selected tubes', async function (assert) {
     await fillByLabel(/Nom interne/, 'Un nouveau nom interne');
 
-    await fillByLabel(/Référentiel/, 'Pi');
+    await fillByLabel(/Référentiels :/, 'Pi');
     await click(screen.getByLabelText('Pix + Cuisine'));
     await clickByName('area_f2_a1 code · area_f2_a1 title');
     await clickByName('competence_f2_a1_c1 index competence_f2_a1_c1 name');

--- a/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
@@ -22,8 +22,8 @@ module('Integration | Component | complementary-certifications/item/header', fun
     );
 
     // then
-    assert.ok(screen.getByRole('heading', { name: 'Certification complémentaire Pix+Droit', level: 1 }));
+    assert.ok(screen.getByRole('heading', { name: 'Référentiel de certification Pix+Droit', level: 1 }));
     const nav = screen.getByRole('navigation');
-    assert.ok(within(nav).getByRole('link', { name: 'Toutes les certifications complémentaires' }));
+    assert.ok(within(nav).getByRole('link', { name: 'Tous les référentiels de certification' }));
   });
 });

--- a/admin/tests/integration/components/layout/sidebar_test.gjs
+++ b/admin/tests/integration/components/layout/sidebar_test.gjs
@@ -324,8 +324,8 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
     });
   });
 
-  module('Complementary certifications tab', function () {
-    test('should contain link to "complementary certifications" management page', async function (assert) {
+  module('Certification frameworks tab', function () {
+    test('should contain link to "Certification frameworks" management page', async function (assert) {
       // given
       class AccessControlStub extends Service {
         hasAccessToComplementaryCertificationsScope = true;
@@ -336,7 +336,7 @@ module('Integration | Component | Layout | Sidebar', function (hooks) {
       const screen = await render(<template><Sidebar /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Certifications complémentaires' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Référentiels de certification' })).exists();
     });
   });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -511,9 +511,9 @@
         "autonomous-courses": "Autonomous courses",
         "certification-centers": "Certif centers",
         "certification-centers-label": "Certifications centers",
+        "certification-frameworks": "Certif frameworks",
+        "certification-frameworks-label": "Certification frameworks",
         "certifications": "Certifications",
-        "complementary-certifications": "Compl. certifications",
-        "complementary-certifications-label": "Complementary certifications",
         "labels": {
           "close": "Close navigation",
           "main": "Main navigation",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -439,7 +439,7 @@
           "creation-form": {
             "submit-button": "Submit the new certification framework",
             "success-notification": "The new certification framework has been successfully created.",
-            "title": "Creating a new certification framework for {complementaryCertificationLabel}"
+            "title": "Creating a new version of the certification framework for {complementaryCertificationLabel}"
           },
           "details": {
             "title": "Current certification framework details"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -433,7 +433,7 @@
     },
     "complementary-certifications": {
       "item": {
-        "complementary-certification": "Complementary certification",
+        "certification-framework": "Complementary certification",
         "framework": {
           "create-button": "Create a new version of the certification framework",
           "creation-form": {
@@ -486,7 +486,7 @@
           "title": "Historique des profils cibles rattachés"
         }
       },
-      "title": "All complementary certifications"
+      "title": "All certification frameworks"
     },
     "layout": {
       "menu-bar": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -435,7 +435,7 @@
       "item": {
         "complementary-certification": "Complementary certification",
         "framework": {
-          "create-button": "Create a new certification framework",
+          "create-button": "Create a new version of the certification framework",
           "creation-form": {
             "submit-button": "Submit the new certification framework",
             "success-notification": "The new certification framework has been successfully created.",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -445,6 +445,7 @@
             "title": "Current certification framework details"
           },
           "history": {
+            "label": "Versions",
             "table": {
               "caption": "Versions list in descending order"
             },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -433,7 +433,7 @@
     },
     "complementary-certifications": {
       "item": {
-        "complementary-certification": "Certification complémentaire",
+        "certification-framework": "Référentiel de certification",
         "framework": {
           "create-button": "Créer une nouvelle version du référentiel",
           "creation-form": {
@@ -487,7 +487,7 @@
           "title": "Historique des profils cibles rattachés"
         }
       },
-      "title": "Toutes les certifications complémentaires"
+      "title": "Tous les référentiels de certification"
     },
     "layout": {
       "menu-bar": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -435,7 +435,7 @@
       "item": {
         "complementary-certification": "Certification complémentaire",
         "framework": {
-          "create-button": "Créer un nouveau référentiel de certification",
+          "create-button": "Créer une nouvelle version du référentiel",
           "creation-form": {
             "submit-button": "Créer le nouveau référentiel de certification",
             "success-notification": "Le nouveau référentiel de certification a été créé avec succès",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -446,6 +446,7 @@
             "title": "Détails du référentiel de certification actuel"
           },
           "history": {
+            "label": "Versions",
             "table": {
               "caption": "Liste des versions par ordre décroissant"
             },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -512,9 +512,9 @@
         "autonomous-courses": "Parcours autonomes",
         "certification-centers": "Centres de certif",
         "certification-centers-label": "Centres de certifications",
+        "certification-frameworks": "Référentiels de certif",
+        "certification-frameworks-label": "Référentiels de certification",
         "certifications": "Certifications",
-        "complementary-certifications": "Certifications compl.",
-        "complementary-certifications-label": "Certifications complémentaires",
         "labels": {
           "close": "Fermer la navigation",
           "main": "Navigation principale",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -439,7 +439,7 @@
           "creation-form": {
             "submit-button": "Créer le nouveau référentiel de certification",
             "success-notification": "Le nouveau référentiel de certification a été créé avec succès",
-            "title": "Créer un nouveau référentiel de certification pour {complementaryCertificationLabel}"
+            "title": "Créer une nouvelle version du référentiel de certification pour {complementaryCertificationLabel}"
           },
           "details": {
             "empty-current-framework": "Le référentiel de certification actuel est vide.",


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de la gestion des certifications Pix, il faut renommer des éléments relatifs aux référentiels de certification dans Pix Admin ; en particulier la notion de "certification complémentaire" doit être remplacée 

## 🌰 Proposition

<img width="474" height="185" alt="image" src="https://github.com/user-attachments/assets/61e13a81-5ad0-4bf0-93e3-468f6c6ca843" />

<img width="783" height="209" alt="image" src="https://github.com/user-attachments/assets/0848e027-4b13-4600-afab-e1338d1f73bf" />

<img width="381" height="205" alt="image" src="https://github.com/user-attachments/assets/c195a58c-7c60-4ce5-b00f-c771b67360bc" />

<img width="789" height="139" alt="image" src="https://github.com/user-attachments/assets/5b4d6d79-f584-4309-88fa-9d8b86ab1c0f" />

<img width="245" height="107" alt="image" src="https://github.com/user-attachments/assets/c3f08fc5-bd90-48ae-9118-887570512401" />


## 🍁 Remarques

- je n'ai pas modifié toutes les occurrences de "complementary-certification" des clés de traduction quand elles se trouvent proche de la racine, par exemple : components.**complementary-certification**s.items.certification-framework > , car cela entraînerait la modification d'une soixantaine de clés.
- Les composants `components/layout/index.gjs`, `components/layout/menu-bar/index.gjs` et `components/layout/menu-bar/entry.gjs `sont-ils utilisés ? Il me semble que les deux premiers font concurrence à `admin/app/components/layout/index.gjs`, et que le troisième n'est utilisé que par le deuxième.

## 🪵 Pour tester

Comparer le rendu avec les captures d'écran sur les pages :
https://admin.dev.pix.fr/organizations/list
https://admin.dev.pix.fr/complementary-certifications/list
https://admin.dev.pix.fr/complementary-certifications/53/framework