### PR TITLE
[TECH] Mise à jour epreuves-components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.1.0",
+        "@1024pix/epreuves-components": "^2.1.1",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.0.tgz",
-      "integrity": "sha512-TRwWj5vA1fmsgDTL8J+RpHxZXmovvgtdw0Y48jY1ON5/IVVjU/g1Ud+2SBwEVOUMcNQpukvfNLUjVRpWEBeSoQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.1.tgz",
+      "integrity": "sha512-LFUUsPRng8jha6kn10u3fjLnzvTkMtOL9ylWXje1JBRUOpS668ZKcjh4r/ApsXdYSbOpYNNxIiju4bUvyxlZQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.1.0",
+    "@1024pix/epreuves-components": "^2.1.1",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.1.0",
+        "@1024pix/epreuves-components": "^2.1.1",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.31.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.0.tgz",
-      "integrity": "sha512-TRwWj5vA1fmsgDTL8J+RpHxZXmovvgtdw0Y48jY1ON5/IVVjU/g1Ud+2SBwEVOUMcNQpukvfNLUjVRpWEBeSoQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.1.tgz",
+      "integrity": "sha512-LFUUsPRng8jha6kn10u3fjLnzvTkMtOL9ylWXje1JBRUOpS668ZKcjh4r/ApsXdYSbOpYNNxIiju4bUvyxlZQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.1.0",
+    "@1024pix/epreuves-components": "^2.1.1",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.31.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.24",
-        "@1024pix/epreuves-components": "^2.1.0",
+        "@1024pix/epreuves-components": "^2.1.1",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.31.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.0.tgz",
-      "integrity": "sha512-TRwWj5vA1fmsgDTL8J+RpHxZXmovvgtdw0Y48jY1ON5/IVVjU/g1Ud+2SBwEVOUMcNQpukvfNLUjVRpWEBeSoQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.1.1.tgz",
+      "integrity": "sha512-LFUUsPRng8jha6kn10u3fjLnzvTkMtOL9ylWXje1JBRUOpS668ZKcjh4r/ApsXdYSbOpYNNxIiju4bUvyxlZQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.24",
-    "@1024pix/epreuves-components": "^2.1.0",
+    "@1024pix/epreuves-components": "^2.1.1",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.31.2",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## 🍂 Problème

Des modifs visuelles ont été faites sur complete-phrase, calcul-capacity et qcm deepfake

## 🌰 Proposition

Faire la montée de version

## 🍁 Remarques

RAS

## 🪵 Pour tester

Aller sur la page de démo et vérifier que les POI complete-phrase, calcul-capacity et qcm deepfake fonctionnent toujours