### PR TITLE
[FEATURE] Créer une table de configuration des dates de réouverture en BDD (PIX-20403)

### DIFF
--- a/api/db/migrations/20251110104207_create-table-sco-blocked-access-dates-table.js
+++ b/api/db/migrations/20251110104207_create-table-sco-blocked-access-dates-table.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'certification_sco_blocked_access_dates';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table
+      .string('scoOrganizationTagName', 255)
+      .primary()
+      .notNullable()
+      .comment('Type of school organization affected by the reopening of their access');
+
+    table
+      .timestamp('reopeningDate')
+      .notNullable()
+      .comment('Date of reopening of school organizations access to Pix Certif');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## 🍂 Problème

Actuellement, la visualisation des dates actuellement actives ainsi que le paramétrage des dates de réouverture des espaces Pix Certif SCO sont gérés par les Captains directement en base de données.

## 🌰 Proposition

Créer une table de configuration des dates de réouverture en BDD

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
