### PR TITLE
[BUGFIX] Les images plus petites que la largeur d'un module sont agrandies (PIX-20515)

### DIFF
--- a/mon-pix/app/components/module/element/_image.scss
+++ b/mon-pix/app/components/module/element/_image.scss
@@ -9,7 +9,6 @@
 .element-image-container {
   &__image {
     display: block;
-    width: 100%;
     max-width: 700px;
     margin: auto;
     object-fit: contain;

--- a/mon-pix/app/utils/resize-image.js
+++ b/mon-pix/app/utils/resize-image.js
@@ -36,6 +36,13 @@ export function resizeByHeight(imageInformation, MAX_HEIGHT) {
 }
 
 export function resizeByWidth(imageInformation, MAX_WIDTH) {
+  if (imageInformation.width <= MAX_WIDTH) {
+    return {
+      width: imageInformation.width,
+      height: imageInformation.height,
+    };
+  }
+
   const height = Math.round((MAX_WIDTH * imageInformation.height) / imageInformation.width);
   const width = MAX_WIDTH;
   return {

--- a/mon-pix/app/utils/resize-image.js
+++ b/mon-pix/app/utils/resize-image.js
@@ -13,20 +13,20 @@
  * or `null` if the image information is invalid.
  */
 export function resizeImage(imageInformation, options) {
-  if (!imageInformation || !hasDimensions(imageInformation)) {
+  if (!imageInformation || !_hasDimensions(imageInformation)) {
     return null;
   }
 
-  if (!validateOptions(options)) {
+  if (!_validateOptions(options)) {
     return imageInformation;
   }
 
-  if (options.MAX_HEIGHT) return resizeByHeight(imageInformation, options.MAX_HEIGHT);
+  if (options.MAX_HEIGHT) return _resizeByHeight(imageInformation, options.MAX_HEIGHT);
 
-  return resizeByWidth(imageInformation, options.MAX_WIDTH);
+  return _resizeByWidth(imageInformation, options.MAX_WIDTH);
 }
 
-export function resizeByHeight(imageInformation, MAX_HEIGHT) {
+function _resizeByHeight(imageInformation, MAX_HEIGHT) {
   const width = Math.round((MAX_HEIGHT * imageInformation.width) / imageInformation.height);
   const height = MAX_HEIGHT;
   return {
@@ -35,7 +35,7 @@ export function resizeByHeight(imageInformation, MAX_HEIGHT) {
   };
 }
 
-export function resizeByWidth(imageInformation, MAX_WIDTH) {
+function _resizeByWidth(imageInformation, MAX_WIDTH) {
   if (imageInformation.width <= MAX_WIDTH) {
     return {
       width: imageInformation.width,
@@ -51,11 +51,11 @@ export function resizeByWidth(imageInformation, MAX_WIDTH) {
   };
 }
 
-export function hasDimensions(imageInformation) {
+function _hasDimensions(imageInformation) {
   return imageInformation.width > 0 && imageInformation.height > 0;
 }
 
-export function validateOptions(options) {
+function _validateOptions(options) {
   if (options === undefined) return false;
 
   const isDimensionsKeysProvided = Object.entries(options).some(([key, value]) => {

--- a/mon-pix/tests/unit/utils/resize-image-test.js
+++ b/mon-pix/tests/unit/utils/resize-image-test.js
@@ -61,7 +61,7 @@ module('Unit | Utility | Resize Image', function () {
       assert.deepEqual(dimensions, { height: 100, width: 200 });
     });
 
-    test('should return accurate result when MAX_WIDTH option is provided', function (assert) {
+    test('should return current width if MAX_WIDTH option is provided and larger than width', function (assert) {
       // given
       const imageInformation = { height: 100, width: 50 };
       const options = {
@@ -72,7 +72,21 @@ module('Unit | Utility | Resize Image', function () {
       const dimensions = resizeImage(imageInformation, options);
 
       //then
-      assert.deepEqual(dimensions, { height: 200, width: 100 });
+      assert.deepEqual(dimensions, { height: 100, width: 50 });
+    });
+
+    test('should return MAX_WIDTH if MAX_WIDTH option is provided and smaller than width', function (assert) {
+      // given
+      const imageInformation = { height: 100, width: 500 };
+      const options = {
+        MAX_WIDTH: 100,
+      };
+
+      // when
+      const dimensions = resizeImage(imageInformation, options);
+
+      //then
+      assert.deepEqual(dimensions, { height: 20, width: 100 });
     });
   });
 
@@ -98,7 +112,7 @@ module('Unit | Utility | Resize Image', function () {
       const dimensions = resizeByWidth(imageInformation, MAX_WIDTH);
 
       // then
-      assert.deepEqual(dimensions, { width: 100, height: 200 });
+      assert.deepEqual(dimensions, { width: 50, height: 100 });
     });
   });
 

--- a/mon-pix/tests/unit/utils/resize-image-test.js
+++ b/mon-pix/tests/unit/utils/resize-image-test.js
@@ -1,4 +1,4 @@
-import { resizeByHeight, resizeByWidth, resizeImage, validateOptions } from 'mon-pix/utils/resize-image';
+import { resizeImage } from 'mon-pix/utils/resize-image';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | Resize Image', function () {
@@ -87,92 +87,6 @@ module('Unit | Utility | Resize Image', function () {
 
       //then
       assert.deepEqual(dimensions, { height: 20, width: 100 });
-    });
-  });
-
-  module('#resizeByHeight', function () {
-    test('should return the accurate result for a resize by height', function (assert) {
-      // given
-      const imageInformation = { width: 100, height: 50 };
-      const MAX_HEIGHT = 100;
-      // when
-      const dimensions = resizeByHeight(imageInformation, MAX_HEIGHT);
-
-      // then
-      assert.deepEqual(dimensions, { width: 200, height: 100 });
-    });
-  });
-
-  module('#resizeByWidth', function () {
-    test('should return the accurate result for a resize by width', function (assert) {
-      // given
-      const imageInformation = { width: 50, height: 100 };
-      const MAX_WIDTH = 100;
-      // when
-      const dimensions = resizeByWidth(imageInformation, MAX_WIDTH);
-
-      // then
-      assert.deepEqual(dimensions, { width: 50, height: 100 });
-    });
-  });
-
-  module('#validateOptions', function () {
-    test('should return false if options is undefined', function (assert) {
-      // given
-      const options = undefined;
-
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.false(validationStatus);
-    });
-    test('should return false if options has neither MAX_WIDTH nor MAX_HEIGHT', function (assert) {
-      // given
-      const options = {};
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.false(validationStatus);
-    });
-    test('should return true if options contains MAX_WIDTH', function (assert) {
-      // given
-      const options = { MAX_WIDTH: 20 };
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.true(validationStatus);
-    });
-    test('should return true if options contains MAX_HEIGHT', function (assert) {
-      // given
-      const options = { MAX_HEIGHT: 20 };
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.true(validationStatus);
-    });
-
-    test('should return false if provided MAX_WIDTH equals 0', function (assert) {
-      // given
-      const options = { MAX_WIDTH: 0 };
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.false(validationStatus);
-    });
-
-    test('should return false if provided MAX_HEIGHT equals 0', function (assert) {
-      // given
-      const options = { MAX_HEIGHT: 0 };
-      // when
-      const validationStatus = validateOptions(options);
-
-      // then
-      assert.false(validationStatus);
     });
   });
 });


### PR DESCRIPTION
## 🍂 Problème

Les images plus petites que la largeur d'un module sont agrandies et du coup pixellisées car affichées trop grandes par rapport à leur taille réelle.

<img width="825" height="1133" alt="Capture d’écran 2025-11-21 à 11 10 46" src="https://github.com/user-attachments/assets/135e5196-946f-4d07-96fb-847e1c45df24" />

## 🌰 Proposition

Redimensionner les images de manière à ce qu'elles ne soient jamais plus grandes que leur taille réelle.
<img width="806" height="665" alt="Capture d’écran 2025-11-21 à 11 23 44" src="https://github.com/user-attachments/assets/63485fc9-6cb0-45b4-92fd-e65f939beb95" />

## 🍁 Remarques

- Avant le merge, il faudra retirer le premier commit qui est une modif du contenu d'un module qui n'a pas encore été mergée
- Dans l'avant-dernier commit, je propose de supprimer des tests de méthodes qui devraient être privées car les cas sont déjà couverts par les tests de la méthode `resize`
- Cela permet, dans le dernier commit, de rendre privées les méthodes qui ne sont pas des points d'entrée

## 🪵 Pour tester

1. Se rendre sur le module "[Comment font les IA génératives pour répondre à nos demandes ?](https://app-pr14227.review.pix.fr/modules/tmp-ia-fonctionnement-debut/passage)"
2. Constater que l'image "ChatGPT" de la section "Se questionner" s'affiche à sa taille réelle, en mobile et en desktop
3. Passer le module jusqu'à la section "Exprer pour comprendre"
4. Constater que l'image du schema s'affiche correctement


