### PR TITLE
[FEATURE] Permettre de vider le champs "crédits" d'une orga sur Pix Admin (PIX-20453)

### DIFF
--- a/admin/app/models/organization-form.js
+++ b/admin/app/models/organization-form.js
@@ -82,6 +82,7 @@ const Validations = buildValidations({
         allowString: true,
         integer: true,
         positive: true,
+        allowBlank: true,
         message: 'Le nombre de crédits doit être un nombre supérieur ou égal à 0.',
       }),
     ],

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -34,6 +34,7 @@ module('Integration | Component | organizations/information-section-edit', funct
       externalId: 'VELIT',
       provinceCode: 'h50',
       email: 'sco.generic.account@example.net',
+      administrationTeamId: '123',
       isOrganizationSCO: true,
       credit: 0,
       documentationUrl: 'https://pix.fr/',
@@ -142,10 +143,21 @@ module('Integration | Component | organizations/information-section-edit', funct
       const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
 
       // when
-      await fillByLabel(t('components.organizations.information-section-view.credits'), 'credit');
+      await fillByLabel(t('components.organizations.information-section-view.credits'), '-7');
 
       // then
       assert.dom(screen.getByText('Le nombre de crédits doit être un nombre supérieur ou égal à 0.')).exists();
+    });
+
+    test('it should allow empty value for credit', async function (assert) {
+      // given
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // when
+      await fillByLabel(t('components.organizations.information-section-view.credits'), '');
+
+      // then
+      assert.notOk(screen.queryByText('Le nombre de crédits doit être un nombre supérieur ou égal à 0.'));
     });
 
     test("it should show error message if organization's documentationUrl is not valid", async function (assert) {


### PR DESCRIPTION
## 🍂 Problème

Le système de crédits est progressivement en train de devenir obsolète.
Actuellement, lorsqu'on modifie une orga qui a déjà un nombre de crédits, on ne peut que lui mettre un nombre positif ou 0. Or on voudrait pouvoir supprimer la notion de crédit sur une orga sans pour autant passer les crédits à 0.

## 🌰 Proposition

Avoir la possibilité de vider le champ crédits et ne mettre aucune valeur.

## 🍁 Remarques

RAS

## 🪵 Pour tester

Sur Pix Admin
- aller sur la page d'une orga qui possède des crédits
- cliquer sur modifier
- vider le champ crédit
- constater que cette action est possible et qu'elle ne génère pas d'erreur