### PR TITLE
[FEATURE] Ajouter de la validation sur l'import de feature dans PixAdmin (Pix-20523).

### DIFF
--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -53,8 +53,8 @@ export const ORGANIZATIONS_UPDATE_HEADER = {
 export const ORGANIZATION_FEATURES_HEADER = {
   columns: [
     new CsvColumn({
-      property: 'featureId',
-      name: 'Feature ID',
+      property: 'featureName',
+      name: 'Feature Name',
       isRequired: true,
     }),
     new CsvColumn({

--- a/api/src/organizational-entities/domain/models/OrganizationFeature.js
+++ b/api/src/organizational-entities/domain/models/OrganizationFeature.js
@@ -1,15 +1,97 @@
+import Joi from 'joi';
+
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
+import { EntityValidationError } from '../../../shared/domain/errors.js';
+
 class OrganizationFeature {
+  #schema = Joi.object({
+    featureName: Joi.string()
+      .valid(
+        ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+        ORGANIZATION_FEATURE.COVER_RATE.key,
+        ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key,
+        ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key,
+        ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+        ORGANIZATION_FEATURE.COVER_RATE.key,
+        ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+        ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+        ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+        ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+        ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      )
+      .required(),
+    params: Joi.when('featureName', {
+      switch: [
+        {
+          is: Joi.valid(ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key),
+          then: Joi.array().required(),
+        },
+        {
+          is: Joi.valid(
+            ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+            ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key,
+          ),
+          then: Joi.object().allow(null).optional(),
+        },
+        {
+          is: Joi.valid(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
+          then: Joi.object().required(),
+        },
+        {
+          is: Joi.valid(
+            ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+            ORGANIZATION_FEATURE.COVER_RATE.key,
+            ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key,
+            ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+            ORGANIZATION_FEATURE.COVER_RATE.key,
+            ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+            ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+          ),
+          then: Joi.valid(null, '').optional(),
+        },
+      ],
+    }),
+    deleteLearner: Joi.when('featureName', {
+      is: Joi.string().required().valid(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
+      then: Joi.valid('Y', 'N').allow(null).optional(),
+      otherwise: Joi.valid(null, '').optional(),
+    }),
+    organizationId: Joi.number().integer().required(),
+  });
+
   #deleteLearner;
-  constructor({ featureId, organizationId, params, deleteLearner }) {
-    this.featureId = parseInt(featureId, 10);
-    this.organizationId = parseInt(organizationId, 10);
-    this.params = params ? JSON.parse(params) : null;
+  constructor({ featureName, organizationId, params, deleteLearner, features }) {
+    const parsedParams = params ? JSON.parse(params) : null;
+    const parsedOrganizationId = parseInt(organizationId, 10);
+    const selectedFeature = features.find(({ key }) => key === featureName);
+
+    if (!selectedFeature) {
+      throw new EntityValidationError(
+        {
+          invalidAttributes: [{ attribute: 'featureName', message: 'feature not found' }],
+        },
+        'UNKNOWN_FEATURE',
+      );
+    }
+
+    this.#validate({ featureName, params: parsedParams, deleteLearner, organizationId });
+
+    this.featureId = selectedFeature.id;
+    this.organizationId = parsedOrganizationId;
+    this.params = parsedParams;
 
     this.#deleteLearner = deleteLearner === 'Y';
   }
 
   get deleteLearner() {
     return this.#deleteLearner;
+  }
+
+  #validate(data) {
+    const { error } = this.#schema.validate(data, { allowUnknown: false });
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
   }
 }
 

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -4,6 +4,7 @@ import * as schoolRepository from '../../../school/infrastructure/repositories/s
 import * as codeGenerator from '../../../shared/domain/services/code-generator.js';
 import { adminMemberRepository } from '../../../shared/infrastructure/repositories/admin-member.repository.js';
 import * as countryRepository from '../../../shared/infrastructure/repositories/country-repository.js';
+import * as featureRepository from '../../../shared/infrastructure/repositories/feature-repository.js';
 import * as organizationRepository from '../../../shared/infrastructure/repositories/organization-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as administrationTeamRepository from '../../infrastructure/repositories/administration-team-repository.js';
@@ -50,6 +51,7 @@ const repositories = {
   certificationCenterRepository,
   certificationCenterForAdminRepository,
   countryRepository,
+  featureRepository,
   dataProtectionOfficerRepository,
   certificationCenterApiRepository,
   complementaryCertificationHabilitationRepository,

--- a/api/src/shared/infrastructure/repositories/feature-repository.js
+++ b/api/src/shared/infrastructure/repositories/feature-repository.js
@@ -12,4 +12,11 @@ const getFeatureByKey = async function (key) {
   return new Feature(feature);
 };
 
-export { getFeatureByKey };
+const findAll = async function () {
+  const knexConn = DomainTransaction.getConnection();
+  const features = await knexConn('features').select('*');
+
+  return features.map((feature) => new Feature(feature));
+};
+
+export { findAll, getFeatureByKey };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -925,7 +925,10 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       let feature, firstOrganization, otherOrganization;
 
       beforeEach(async function () {
-        feature = databaseBuilder.factory.buildFeature({ key: 'feature', description: ' best feature ever' });
+        feature = databaseBuilder.factory.buildFeature({
+          key: ORGANIZATION_FEATURE.COVER_RATE.key,
+          description: ' best feature ever',
+        });
         firstOrganization = databaseBuilder.factory.buildOrganization({ name: 'first organization', type: 'PRO' });
         otherOrganization = databaseBuilder.factory.buildOrganization({ name: 'other organization', type: 'PRO' });
 
@@ -934,9 +937,9 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
 
       it('responds with a 204 - no content', async function () {
         // given
-        const input = `Feature ID;Organization ID;Params
-      ${feature.id};${firstOrganization.id};{"id": 123}
-      ${feature.id};${otherOrganization.id};{"id": 123}`;
+        const input = `Feature Name;Organization ID;Params
+      ${feature.key};${firstOrganization.id};
+      ${feature.key};${otherOrganization.id};`;
 
         const options = {
           method: 'POST',

--- a/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/add-organization-feature-in-batch.usecase.test.js
@@ -3,8 +3,8 @@ import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants
 import { createTempFile, databaseBuilder, expect, knex, removeTempFile, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Organizational Entities | Domain | UseCase | add-organization-feature-in-batch', function () {
-  let learnerImportfeatureId,
-    campaignWithoutUserProfilefeatureId,
+  let learnerImportFeature,
+    campaignWithoutUserProfileFeature,
     filePath,
     userId,
     learnerImportOrganizationId,
@@ -12,10 +12,12 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
 
   beforeEach(async function () {
     userId = databaseBuilder.factory.buildUser().id;
-    learnerImportfeatureId = databaseBuilder.factory.buildFeature({ key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key }).id;
-    campaignWithoutUserProfilefeatureId = databaseBuilder.factory.buildFeature({
+    learnerImportFeature = databaseBuilder.factory.buildFeature({
+      key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+    });
+    campaignWithoutUserProfileFeature = databaseBuilder.factory.buildFeature({
       key: ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
-    }).id;
+    });
 
     learnerImportOrganizationId = databaseBuilder.factory.buildOrganization().id;
     campaignWithoutUserProfileOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -31,9 +33,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
     // given
     filePath = await createTempFile(
       'test.csv',
-      `Feature ID;Organization ID;Params
-    ${learnerImportfeatureId};${learnerImportOrganizationId};{"id": 123}
-    ${campaignWithoutUserProfilefeatureId};${campaignWithoutUserProfileOrganizationId};{"id": 456}
+      `Feature Name;Organization ID;Params
+    ${learnerImportFeature.key};${learnerImportOrganizationId};{"id": 123}
+    ${campaignWithoutUserProfileFeature.key};${campaignWithoutUserProfileOrganizationId};
 `,
     );
     // when
@@ -45,14 +47,14 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
     //eslint-disable-next-line no-unused-vars
     expect(result.map(({ id, ...data }) => data)).deep.members([
       {
-        featureId: learnerImportfeatureId,
+        featureId: learnerImportFeature.id,
         organizationId: learnerImportOrganizationId,
         params: { id: 123 },
       },
       {
-        featureId: campaignWithoutUserProfilefeatureId,
+        featureId: campaignWithoutUserProfileFeature.id,
         organizationId: campaignWithoutUserProfileOrganizationId,
-        params: { id: 456 },
+        params: null,
       },
     ]);
   });
@@ -91,9 +93,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
     it('should not delete learners without parameters', async function () {
       filePath = await createTempFile(
         'test.csv',
-        `Feature ID;Organization ID;Params
-      ${learnerImportfeatureId};${learnerImportOrganizationId};{"id": 123}
-      ${campaignWithoutUserProfilefeatureId};${campaignWithoutUserProfileOrganizationId};{"id": 456}
+        `Feature Name;Organization ID;Params
+      ${learnerImportFeature.key};${learnerImportOrganizationId};{"id": 123}
+      ${campaignWithoutUserProfileFeature.key};${campaignWithoutUserProfileOrganizationId};
   `,
       );
 
@@ -117,9 +119,9 @@ describe('Integration | Organizational Entities | Domain | UseCase | add-organiz
 
       filePath = await createTempFile(
         'test.csv',
-        `"Feature ID";"Organization ID";"Params";"Delete Learner"
-      ${learnerImportfeatureId};${learnerImportOrganizationId};{"id": 123};Y
-      ${campaignWithoutUserProfilefeatureId};${campaignWithoutUserProfileOrganizationId};{"id": 456};
+        `"Feature Name";"Organization ID";"Params";"Delete Learner"
+      ${learnerImportFeature.key};${learnerImportOrganizationId};{"id": 123};Y
+      ${campaignWithoutUserProfileFeature.key};${campaignWithoutUserProfileOrganizationId};;
   `,
       );
 

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
@@ -1,5 +1,4 @@
 import { FeatureNotFound, OrganizationNotFound } from '../../../../../src/organizational-entities/domain/errors.js';
-import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
 import { OrganizationFeatureItem } from '../../../../../src/organizational-entities/domain/models/OrganizationFeatureItem.js';
 import * as organizationFeatureRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-feature-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
@@ -21,16 +20,16 @@ describe('Integration | Repository | Organization-for-admin', function () {
       await databaseBuilder.commit();
 
       const organizationFeatures = [
-        new OrganizationFeature({
+        {
           featureId: feature.id,
           organizationId: organization.id,
           params: `{ "id": 123 }`,
-        }),
-        new OrganizationFeature({
+        },
+        {
           featureId: feature.id,
           organizationId: otherOrganization.id,
           params: `{ "id": 456 }`,
-        }),
+        },
       ];
 
       // when
@@ -61,16 +60,16 @@ describe('Integration | Repository | Organization-for-admin', function () {
       await databaseBuilder.commit();
 
       const organizationFeatures = [
-        new OrganizationFeature({
+        {
           featureId: feature.id,
           organizationId: organization.id,
           params: `["SOMETHING"]`,
-        }),
-        new OrganizationFeature({
+        },
+        {
           featureId: feature.id,
           organizationId: otherOrganization.id,
           params: `{ "id": 456 }`,
-        }),
+        },
       ];
 
       // when
@@ -95,11 +94,11 @@ describe('Integration | Repository | Organization-for-admin', function () {
       await databaseBuilder.commit();
 
       const organizationFeatures = [
-        new OrganizationFeature({
+        {
           featureId: feature.id,
           organizationId: organization.id,
           params: `{ "id": 123 }`,
-        }),
+        },
       ];
 
       // when
@@ -109,11 +108,11 @@ describe('Integration | Repository | Organization-for-admin', function () {
     it('throws an error if organization does not exists', async function () {
       const notExistingId = 999;
       const organizationFeatures = [
-        new OrganizationFeature({
+        {
           featureId: feature.id,
           organizationId: notExistingId,
           params: `{ "id": 123 }`,
-        }),
+        },
       ];
 
       // when
@@ -125,11 +124,11 @@ describe('Integration | Repository | Organization-for-admin', function () {
     it('throws an error if feature does not exists', async function () {
       const notExistingId = 999;
       const organizationFeatures = [
-        new OrganizationFeature({
+        {
           featureId: notExistingId,
           organizationId: organization.id,
           params: `{ "id": 123 }`,
-        }),
+        },
       ];
 
       // when
@@ -220,7 +219,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
       expect(results[0].params).to.be.deep.equal(featureParams);
     });
 
-    it('should return empty arry when no feature detected', async function () {
+    it('should return empty array when no feature detected', async function () {
       // when
       const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
         organizationId: organization.id,

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
@@ -1,20 +1,95 @@
 import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
-import { expect } from '../../../../test-helper.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature', function () {
-  let organizationFeature, featureId, organizationId, params;
+  let organizationFeature, featureName, organizationId, params, features;
 
-  beforeEach(function () {
-    // given
-    featureId = '1';
-    organizationId = '2';
-    params = `{"id": 3}`;
+  describe('#DEFAULT', function () {
+    beforeEach(function () {
+      // given
+      featureName = 'TOTO';
+      organizationId = '2';
+      params = `{"id": 3}`;
+      features = [
+        {
+          key: 'TATA',
+          id: 1,
+        },
+      ];
+    });
+
+    it('should throw EntityErrorValidation given unknown feature', function () {
+      //when
+      const error = catchErrSync(() => new OrganizationFeature({ featureName, organizationId, params, features }))();
+
+      expect(error).instanceOf(EntityValidationError);
+      expect(error.code).equal('UNKNOWN_FEATURE');
+    });
   });
 
-  describe('#constructor', function () {
+  describe('#ATTESTATIONS_MANAGEMENT', function () {
+    beforeEach(function () {
+      // given
+      featureName = ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key;
+      organizationId = '2';
+      params = `["RIRI","FIFI","LOULOU"]`;
+      features = [
+        {
+          key: ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+          id: 1,
+        },
+      ];
+    });
+
     it('should initialize an instance with given params', function () {
       //when
-      organizationFeature = new OrganizationFeature({ featureId, organizationId, params });
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, params, features });
+      // then
+      expect(organizationFeature).to.deep.equal({
+        featureId: 1,
+        organizationId: 2,
+        params: ['RIRI', 'FIFI', 'LOULOU'],
+      });
+    });
+
+    it('should throw EntityErrorValidation given empty params', function () {
+      //when
+      const error = catchErrSync(() => new OrganizationFeature({ featureName, organizationId, features }))();
+
+      // then
+      expect(error).instanceOf(EntityValidationError);
+    });
+
+    it('should throw EntityErrorValidation on deleteLearner', function () {
+      //when
+      const error = catchErrSync(
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+      )();
+
+      // then
+      expect(error).instanceOf(EntityValidationError);
+    });
+  });
+
+  describe('#ORALIZATION_MANAGED_BY_PRESCRIBER', function () {
+    beforeEach(function () {
+      // given
+      featureName = ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key;
+      organizationId = '2';
+      params = `{"id": 3}`;
+      features = [
+        {
+          key: ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER.key,
+          id: 1,
+        },
+      ];
+    });
+
+    it('should initialize an instance with given params', function () {
+      //when
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, params, features });
       // then
       expect(organizationFeature).to.deep.equal({
         featureId: 1,
@@ -22,21 +97,217 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationFeature'
         params: { id: 3 },
       });
     });
-  });
 
-  describe('#deleteLearner', function () {
-    it('should activate learner deletion given params', function () {
+    it('should initialize an instance with given empty params', function () {
       //when
-      organizationFeature = new OrganizationFeature({ featureId, organizationId, params, deleteLearner: 'Y' });
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, features });
+
       // then
-      expect(organizationFeature.deleteLearner).to.be.true;
+      expect(organizationFeature).to.deep.equal({
+        featureId: 1,
+        organizationId: 2,
+        params: null,
+      });
     });
 
-    it('should deactivate learner deletion given params', function () {
+    it('should throw EntityErrorValidation on deleteLearner', function () {
       //when
-      organizationFeature = new OrganizationFeature({ featureId, organizationId, params });
+      const error = catchErrSync(
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+      )();
+
       // then
-      expect(organizationFeature.deleteLearner).to.be.false;
+      expect(error).instanceOf(EntityValidationError);
+    });
+  });
+
+  describe('#PLACES_MANAGEMENT', function () {
+    beforeEach(function () {
+      // given
+      featureName = ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key;
+      organizationId = '2';
+      params = `{"id": 3}`;
+      features = [
+        {
+          key: ORGANIZATION_FEATURE.PLACES_MANAGEMENT.key,
+          id: 1,
+        },
+      ];
+    });
+
+    it('should initialize an instance with given params', function () {
+      //when
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, params, features });
+      // then
+      expect(organizationFeature).to.deep.equal({
+        featureId: 1,
+        organizationId: 2,
+        params: { id: 3 },
+      });
+    });
+
+    it('should initialize an instance with given empty params', function () {
+      //when
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, features });
+
+      // then
+      expect(organizationFeature).to.deep.equal({
+        featureId: 1,
+        organizationId: 2,
+        params: null,
+      });
+    });
+
+    it('should throw EntityErrorValidation on deleteLearner', function () {
+      //when
+      const error = catchErrSync(
+        () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+      )();
+
+      // then
+      expect(error).instanceOf(EntityValidationError);
+    });
+  });
+
+  describe('#LEARNER_IMPORT', function () {
+    beforeEach(function () {
+      // given
+      featureName = ORGANIZATION_FEATURE.LEARNER_IMPORT.key;
+      organizationId = '2';
+      params = `{"id": 3}`;
+      features = [
+        {
+          key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+          id: 1,
+        },
+      ];
+    });
+
+    it('should initialize an instance with given params', function () {
+      //when
+      organizationFeature = new OrganizationFeature({ featureName, organizationId, params, features });
+      // then
+      expect(organizationFeature).to.deep.equal({
+        featureId: 1,
+        organizationId: 2,
+        params: { id: 3 },
+      });
+    });
+
+    it('should throw EntityErrorValidation on empty params', function () {
+      //when
+      const error = catchErrSync(() => new OrganizationFeature({ featureName, organizationId, features }))();
+
+      // then
+      expect(error).instanceOf(EntityValidationError);
+    });
+
+    it('should throw EntityErrorValidation on non object params', function () {
+      //when
+      const error = catchErrSync(
+        () => new OrganizationFeature({ featureName, organizationId, features, params: '[]' }),
+      )();
+
+      // then
+      expect(error).instanceOf(EntityValidationError);
+    });
+
+    describe('#deleteLearner', function () {
+      it('should activate learner deletion given yes params', function () {
+        //when
+        organizationFeature = new OrganizationFeature({
+          featureName,
+          organizationId,
+          params,
+          deleteLearner: 'Y',
+          features,
+        });
+        // then
+        expect(organizationFeature.deleteLearner).to.be.true;
+      });
+
+      it('should deactivate learner deletion given no params', function () {
+        //when
+        organizationFeature = new OrganizationFeature({
+          featureName,
+          organizationId,
+          params,
+          deleteLearner: 'N',
+          features,
+        });
+        // then
+        expect(organizationFeature.deleteLearner).to.be.false;
+      });
+
+      it('should deactivate learner deletion given empty params', function () {
+        //when
+        organizationFeature = new OrganizationFeature({ featureName, organizationId, params, features });
+        // then
+        expect(organizationFeature.deleteLearner).to.be.false;
+      });
+
+      it('should throw EntityErrorValidation on invalid value deleteLearner', function () {
+        //when
+        const error = catchErrSync(
+          () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Oui oui', features }),
+        )();
+
+        // then
+        expect(error).instanceOf(EntityValidationError);
+      });
+    });
+  });
+
+  [
+    ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+    ORGANIZATION_FEATURE.COVER_RATE.key,
+    ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key,
+    ORGANIZATION_FEATURE.CAMPAIGN_WITHOUT_USER_PROFILE.key,
+    ORGANIZATION_FEATURE.COVER_RATE.key,
+    ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key,
+    ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key,
+  ].forEach((featureName) => {
+    describe(`#${featureName}`, function () {
+      beforeEach(function () {
+        // given
+        organizationId = '2';
+        params = `{"id": 3}`;
+        features = [
+          {
+            key: featureName,
+            id: 1,
+          },
+        ];
+      });
+
+      it('should initialize an instance with given params', function () {
+        //when
+        organizationFeature = new OrganizationFeature({ featureName, organizationId, features });
+        // then
+        expect(organizationFeature).to.deep.equal({
+          featureId: 1,
+          organizationId: 2,
+          params: null,
+        });
+      });
+
+      it('should throw EntityErrorValidation given params', function () {
+        //when
+        const error = catchErrSync(() => new OrganizationFeature({ featureName, organizationId, features, params }))();
+
+        // then
+        expect(error).instanceOf(EntityValidationError);
+      });
+
+      it('should throw EntityErrorValidation on deleteLearner', function () {
+        //when
+        const error = catchErrSync(
+          () => new OrganizationFeature({ featureName, organizationId, deleteLearner: 'Y', features }),
+        )();
+
+        // then
+        expect(error).instanceOf(EntityValidationError);
+      });
     });
   });
 });

--- a/api/tests/shared/integration/infrastructure/repositories/feature-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/feature-repository_test.js
@@ -33,4 +33,26 @@ describe('Integration | Infrastructure | Repositories | feature-repository', fun
       });
     });
   });
+
+  describe('#findAll', function () {
+    it('list all features from database', async function () {
+      //given
+      const firstFeature = databaseBuilder.factory.buildFeature({
+        key: 'ORALIZATION',
+        description: 'Ma description de feature',
+      });
+      const secondFeature = databaseBuilder.factory.buildFeature({
+        key: 'ATTESTATIONS_MANAGEMENT',
+        description: 'Ma description de feature',
+      });
+
+      await databaseBuilder.commit();
+      // when
+      const results = await featureRepository.findAll();
+
+      // then
+      expect(results).lengthOf(2);
+      expect(results).deep.members([new Feature(firstFeature), new Feature(secondFeature)]);
+    });
+  });
 });


### PR DESCRIPTION
## 🍂 Problème

L'ajout de feature en masse est un peu trop permissive actuellement, nous pouvons supprimer par exemple tout les learners d'une organisation en activant le taux de couverture si on a fait du 💩 dans le csv.

## 🌰 Proposition

Ajouter une validation plus contraignante pour ne pas faire n'importe quoi. c'est en ne faisant pas n'importe quoi que l'on maitrise ce que l'on fait

## 🍁 Remarques

Changement du format du CSV, nous avons maintenant en entrée la key de la feature et non son id. ce qui permet d'avoir un csv  cross-plateforme ( moyennant l'organisationId bien entendu )

## 🪵 Pour tester

Ajouter via PixAdmin un import CSV avec une feature. vérifier que tout est ok. 