### PR TITLE
[BUGFIX] Linter tous les fichiers de traduction de Pix App

### DIFF
--- a/mon-pix/eslint.config.mjs
+++ b/mon-pix/eslint.config.mjs
@@ -14,7 +14,7 @@ const compiledOutputFiles = ['dist/*', 'tmp/*'];
 const dependenciesFiles = ['bower_components/*', 'node_modules/*'];
 const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache'];
 const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];
-const nonPhraseGeneratedFiles = ['translations/en.json', 'translations/fr.json'];
+const translationFiles = ['translations/*.json'];
 
 const nodeFiles = [
   'eslint.config.cjs',
@@ -136,7 +136,7 @@ export default [
     },
   },
   {
-    files: nonPhraseGeneratedFiles,
+    files: translationFiles,
     plugins: { 'i18n-json': i18nJsonPlugin },
     processor: {
       meta: { name: '.json' },

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -35,9 +35,6 @@
     "description": "Pix es una plataforma en línea para evaluar y certificar las competencias digitales de ciudadanos (alumnos/as, estudiantes, jóvenes que dejan la escuela, demandantes de empleo, personas mayores)"
   },
   "common": {
-    "display": {
-      "percentage": "{value, number, ::percent}"
-    },
     "actions": {
       "back": "Volver",
       "cancel": "Cancelar",
@@ -98,6 +95,9 @@
       "title": "Nuestra política de privacidad ha cambiado. Te invitamos a consultarla: ",
       "url-label": "Política de protección de datos."
     },
+    "display": {
+      "percentage": "{value, number, ::percent}"
+    },
     "error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
     "form": {
       "error": "error",
@@ -116,7 +116,6 @@
       "nl": "Holandés"
     },
     "level": "nivel",
-    "no-level": "No nivel",
     "loading": {
       "default": "Cargando",
       "results": "Preparación de tus resultados",
@@ -125,6 +124,7 @@
     "new-information-banner": {
       "close-label": "Cerrar el banner"
     },
+    "no-level": "No nivel",
     "or": "o",
     "pagination": {
       "action": {
@@ -163,6 +163,17 @@
       }
     },
     "authentication": {
+      "authentication-identity-providers": {
+        "login": {
+          "heading": "Otros medios de conexión",
+          "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
+        },
+        "select-another-organization-link": "Elegir otra organización",
+        "signup": {
+          "heading": "Otros medios de registro",
+          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
+        }
+      },
       "login-form": {
         "fields": {
           "login": {
@@ -182,17 +193,6 @@
         "label": "Buscar una organización",
         "placeholder": "Seleccione una organización",
         "searchLabel": "Búsqueda por palabras clave"
-      },
-      "authentication-identity-providers": {
-        "login": {
-          "heading": "Otros medios de conexión",
-          "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
-        },
-        "select-another-organization-link": "Elegir otra organización",
-        "signup": {
-          "heading": "Otros medios de registro",
-          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
-        }
       },
       "password-reset-demand-form": {
         "actions": {
@@ -377,21 +377,17 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Página de inicio de Pix.{ tld }",
-    "user-logged-menu": {
-      "details": "Consultar mis datos"
-    },
     "user": {
       "account": "Mi cuenta",
       "certifications": "Mis certificaciones",
       "sign-out": "Desconectarse",
       "tests": "Mis tests"
+    },
+    "user-logged-menu": {
+      "details": "Consultar mis datos"
     }
   },
   "pages": {
-    "attestations": {
-      "title": "Mis títulos",
-      "subtitle": "Acceda a todos sus certificados Pix y descárguelos."
-    },
     "account-recovery": {
       "errors": {
         "account-exists": "Ya existe una cuenta con esta dirección de correo electrónico.",
@@ -543,6 +539,10 @@
       },
       "title": "Fin de la prueba"
     },
+    "attestations": {
+      "subtitle": "Acceda a todos sus certificados Pix y descárguelos.",
+      "title": "Mis títulos"
+    },
     "authentication": {
       "login": {
         "signup-button": "Regístrate"
@@ -572,6 +572,15 @@
           "legal-informations": "Con o sin cuenta Pix, la información relativa a tu progreso en el test nos llegará a nosotros.'<br>'Esta información la utiliza Pix para mejorar el servicio.",
           "title": "Empieza el test:"
         }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "El test no está accesible para ti.",
+        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
+        "existing-participation-user-info": "Hay una participación asociada a nombre de {lastName} {firstName}",
+        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
+        "not-accessible": "Uy, la página solicitada no está disponible."
       }
     },
     "campaign-landing": {
@@ -607,6 +616,9 @@
       "warning-message": "¿No eres { firstName } { lastName }?",
       "warning-message-logout": "Desconectarse"
     },
+    "campaign-participation": {
+      "title": "Test"
+    },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Finalizado el {date}",
@@ -632,34 +644,14 @@
       },
       "title": "Test"
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
-    "campaign": {
-      "errors": {
-        "existing-participation": "El test no está accesible para ti.",
-        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
-        "existing-participation-user-info": "Hay una participación asociada a nombre de {lastName} {firstName}",
-        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
-        "not-accessible": "Uy, la página solicitada no está disponible."
-      }
-    },
     "certificate": {
-      "congratulations": "¡Felicidades!",
-      "global": {
-        "explanation": {
-          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
-          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
-        },
-        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
-        "labels": {
-          "advanced": "Advanced",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Independent",
-          "level": "Your level"
-        }
-      },
+      "attestation": "Descargar mi certificado",
+      "back-link": "Volver a mis certificaciones",
+      "candidate": "Candidato :",
+      "candidate-birth": "Nacido/a el {birthdate}",
+      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
+      "certification-center": "Centro de certificación :",
+      "certification-date": "Fecha de examen :",
       "certification-value": {
         "paragraphs": {
           "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
@@ -667,48 +659,56 @@
           "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
         }
       },
-      "attestation": "Descargar mi certificado",
-      "back-link": "Volver a mis certificaciones",
-      "candidate-birth": "Nacido/a el {birthdate}",
-      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
-      "certification-center": "Centro de certificación :",
+      "competences": {
+        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
+      },
+      "complementary": {
+        "alternative": "Certificación complementaria",
+        "clea": "Certificación CléA Numérique by Pix",
+        "title": "No hay ninguna certificación obtenida"
+      },
+      "congratulations": "¡Felicidades!",
       "delivered-at": "Fecha de emisión :",
-      "subtitle": "(niveles de {maxReachableLevel})",
       "details": {
         "competences": {
           "description": "Tu puntuación Pix da una estimación de tu nivel en las 16 competencias digitales.",
           "title": "Su perfil de competencias digitales"
         }
       },
-      "certification-date": "Fecha de examen :",
-      "candidate": "Candidato :",
-      "competences": {
-        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
-      },
-      "complementary": {
-        "alternative": "Certificación complementaria",
-        "title": "No hay ninguna certificación obtenida",
-        "clea": "Certificación CléA Numérique by Pix"
-      },
       "exam-date": "Fecha de presentación:",
+      "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        },
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+      },
       "hexagon-score": {
         "certified": "certificados"
       },
       "issued-on": "Entregado el",
       "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
       "jury-title": "Observaciones del tribunal",
+      "learn-about-certification-results": "¿Cómo interpretar los resultados?",
       "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
+      "subtitle": "(niveles de {maxReachableLevel})",
       "title": "Certificado Pix",
       "verification-code": {
-        "share": "Share your certificate",
-        "information": "Your unique verification code",
         "alt": "Copiar",
         "copied": "¡Código copiado!",
         "copy": "Copiar el código",
+        "information": "Your unique verification code",
+        "share": "Share your certificate",
         "title": "Código de comprobación",
         "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
-      },
-      "learn-about-certification-results": "¿Cómo interpretar los resultados?"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -829,22 +829,19 @@
         },
         "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
         "language-not-supported-link": "Mi cuenta",
+        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
         "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al supervisor.",
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        },
-        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación."
+        }
       },
       "first-title": "Unirse a una sesión",
       "form": {
         "actions": {
           "submit": "Continuar"
-        },
-        "fields-validation": {
-          "session-number-error": "El número de sesión se compone únicamente de dígitos."
         },
         "fields": {
           "birth-date": "Fecha de nacimiento",
@@ -855,6 +852,9 @@
           "first-name": "Nombre",
           "session-number": "Número de sesión",
           "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+        },
+        "fields-validation": {
+          "session-number-error": "El número de sesión se compone únicamente de dígitos."
         },
         "placeholders": {
           "birth-day": "DD",
@@ -917,25 +917,25 @@
       "title": "Unirse a una sesión de certificación"
     },
     "certifications-list": {
-      "comment": "Comentario:",
-      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
-      "no-certification": {
-        "text": "Aún no tienes Pix certificación"
-      },
       "buttons": {
         "details": "Ver detalles",
-        "download-certificate": "Descargar certificado",
-        "download-attestation": "Descargar certificado"
+        "download-attestation": "Descargar certificado",
+        "download-certificate": "Descargar certificado"
       },
-      "statuses": {
-        "cancelled": "Cancelado",
-        "rejected": "No obtenido",
-        "not-published": "Resultados pendientes",
-        "validated": "Obtenido"
-      },
+      "comment": "Comentario:",
+      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
       "information": {
         "certification-center": "Centro de certificación :",
         "date": "Fecha del examen :"
+      },
+      "no-certification": {
+        "text": "Aún no tienes Pix certificación"
+      },
+      "statuses": {
+        "cancelled": "Cancelado",
+        "not-published": "Resultados pendientes",
+        "rejected": "No obtenido",
+        "validated": "Obtenido"
       },
       "title": "Mis certificaciones"
     },
@@ -959,15 +959,6 @@
         },
         "title": "Certificación {certificationNumber}"
       },
-      "embed-simulator": {
-        "actions": {
-          "launch": "Empezar",
-          "launch-label": "Empezar simulación",
-          "reset": "Restablecer",
-          "reset-label": "Reiniciar simulación"
-        },
-        "placeholder": "Cargando la aplicación"
-      },
       "certification-feedback-panel": {
         "actions": {
           "no-send-feedback": "No, vuelvo a la prueba",
@@ -976,6 +967,15 @@
         },
         "description": "¿Estás seguro/a de que quieres informar de un problema?",
         "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Empezar",
+          "launch-label": "Empezar simulación",
+          "reset": "Restablecer",
+          "reset-label": "Reiniciar simulación"
+        },
+        "placeholder": "Cargando la aplicación"
       },
       "feedback-panel": {
         "actions": {
@@ -991,12 +991,12 @@
             "category-selection": {
               "label": "Tengo un problema con",
               "options": {
-                "other": "Otro",
                 "accessibility": "La accesibilidad a la prueba",
                 "answer": "La respuesta",
                 "download": "El archivo que se debe descargar",
                 "embed": "El simulador/la aplicación",
                 "link": "El enlace indicado en la pregunta",
+                "other": "Otro",
                 "picture": "La imagen",
                 "question": "La pregunta",
                 "tutorial": "El tutorial"
@@ -1011,7 +1011,6 @@
                 "answer-not-accepted": "Mi respuesta es correcta, pero no ha sido validada",
                 "answer-not-agreed": "No estoy de acuerdo con la respuesta",
                 "download": {
-                  "other": "Tengo otro problema con el archivo",
                   "edit-failure": {
                     "label": "No puedo modificar el archivo",
                     "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
@@ -1023,7 +1022,8 @@
                   "open-failure": {
                     "label": "No puedo abrir el archivo en un ordenador",
                     "solution": "Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas."
-                  }
+                  },
+                  "other": "Tengo otro problema con el archivo"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "En un ordenador, aparece el simulador, pero tiene un problema",
@@ -1199,34 +1199,34 @@
       }
     },
     "combined-courses": {
-      "process-custom-passages": {
-        "title": "Cálculo de los siguientes pasos en tu curso actual.",
-        "description": "Analizamos tus resultados y elaboramos tu plan de formación personalizado.",
-        "list": {
-          "results-analysis": "Análisis de tus resultados.",
-          "select-passages": "Selección de cursos de formación adecuados.",
-          "generate-personalise-course": "Generación de su curso personalizado."
-        }
+      "completed": {
+        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
+        "title": "¡Enhorabuena! ¡Ya ha terminado!"
       },
       "content": {
-        "start-button": "Iniciar el curso",
-        "resume-course": "Reanudar mi curso"
-      },
-      "completed": {
-        "title": "¡Enhorabuena! ¡Ya ha terminado!",
-        "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital."
+        "resume-course": "Reanudar mi curso",
+        "start-button": "Iniciar el curso"
       },
       "items": {
-        "formation": {
-          "title": "Me estoy formando",
-          "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados."
-        },
         "aria-label-completed-campaign": "Este elemento se completa con una tasa de éxito del {value, number, ::percent}",
         "aria-label-completed-campaign-with-stages": "Ha obtenido {acquired, plural, =0 {no estrella} =1 {# estrella} other {# estrellas}} de {total}",
+        "aria-label-duration": "Duración estimada: {duration} minutos",
         "completed": "¡Completado!",
-        "tagText": "¡Ya estás ahí!",
         "duration": "≈ {duration} min.",
-        "aria-label-duration": "Duración estimada: {duration} minutos"
+        "formation": {
+          "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados.",
+          "title": "Me estoy formando"
+        },
+        "tagText": "¡Ya estás ahí!"
+      },
+      "process-custom-passages": {
+        "description": "Analizamos tus resultados y elaboramos tu plan de formación personalizado.",
+        "list": {
+          "generate-personalise-course": "Generación de su curso personalizado.",
+          "results-analysis": "Análisis de tus resultados.",
+          "select-passages": "Selección de cursos de formación adecuados."
+        },
+        "title": "Cálculo de los siguientes pasos en tu curso actual."
       }
     },
     "comparison-window": {
@@ -1547,126 +1547,7 @@
       "iframe-title": "ChatPix",
       "title": "Previsualización ChatPix"
     },
-    "oidc-signup-or-login": {
-      "error": {
-        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
-        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
-        "error-message": "Debes aceptar las condiciones de uso de Pix.",
-        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
-        "invalid-email": "Tu dirección de correo electrónico no es válida.",
-        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
-        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
-      },
-      "login-form": {
-        "button": "Iniciar sesión",
-        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
-        "email": "Dirección de correo electrónico",
-        "password": "Contraseña",
-        "title": "Ya tengo una cuenta Pix"
-      },
-      "signup-form": {
-        "button": "Creo una cuenta",
-        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "last-name-label-and-value": "Apellidos: {lastName}",
-        "first-name-label-and-value": "Nombre: {firstName}",
-        "title": "No tengo una cuenta Pix"
-      },
-      "title": "Crea una cuenta Pix"
-    },
-    "sco-signup-or-login": {
-      "invitation": "{ organizationName } te invita a unirte a Pix",
-      "login-form": {
-        "button": "Conectarse",
-        "fields": {
-          "login": {
-            "label": "Dirección de correo electrónico o nombre de usuario"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "forgotten-password": {
-          "email": "Una dirección de correo electrónico:",
-          "instruction": "¿Olvidaste tu contraseña? Tienes una cuenta Pix con:",
-          "other-identity": "Un nombre de usuario: ponte en contacto con tu profesor para restablecerlo",
-          "reset-link": "Haz clic aquí para restablecerlo"
-        },
-        "title": "Ya tengo una cuenta Pix",
-        "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
-      },
-      "signup-form": {
-        "button": "Inscribirse",
-        "button-form": "Crear cuenta",
-        "fields": {
-          "birthdate": {
-            "day": {
-              "error": "Tu día de nacimiento no es válido.",
-              "label": "Día de nacimiento",
-              "placeholder": "DD"
-            },
-            "label": "Fecha de nacimiento (DD/MM/AAAA)",
-            "month": {
-              "error": "Tu mes de nacimiento no es válido.",
-              "label": "Mes de nacimiento",
-              "placeholder": "MM"
-            },
-            "year": {
-              "error": "Tu año de nacimiento no es válido.",
-              "label": "Año de nacimiento",
-              "placeholder": "AAAA"
-            }
-          },
-          "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'",
-          "email": {
-            "error": "Tu correo electrónico no es válido.",
-            "help": "(ej. nombre@ejemplo.fr)",
-            "label": "Dirección de correo electrónico"
-          },
-          "firstname": {
-            "error": "No has indicado tu nombre.",
-            "label": "Nombre"
-          },
-          "lastname": {
-            "error": "No has indicado tus apellidos.",
-            "label": "Apellidos"
-          },
-          "password": {
-            "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
-            "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
-            "label": "Contraseña",
-            "show-button": "mostrar la contraseña"
-          },
-          "username": {
-            "label": "Mi nombre de usuario"
-          }
-        },
-        "not-me": "No soy yo",
-        "options": {
-          "email": "Mi dirección de correo electrónico",
-          "text": "Me inscribo con:",
-          "username": "Mi nombre de usuario"
-        },
-        "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
-        "rgpd-legal-notice-link": "aviso legal.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
-        "title": "Crear cuenta"
-      },
-      "title": "Conectarse a Pix"
-    },
     "modulix": {
-      "navigation": {
-        "buttons": {
-          "aria-label": {
-            "steps": "Paso {indexSection} de {totalSections}.",
-            "disabled": "No disponible. Finalizar el paso anterior.",
-            "enabled": "Acceder al paso {sectionTitle}"
-          }
-        },
-        "tooltip": {
-          "disabled": "A continuación: {sectionTitle}"
-        }
-      },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
       "buttons": {
         "activity": {
@@ -1765,8 +1646,8 @@
         },
         "direction": "Busca la respuesta y gira la tarjeta",
         "navigation": {
-          "shortCurrentStep": "{current}/{total}",
-          "longCurrentStep": "{current} Paso a paso {total}"
+          "longCurrentStep": "{current} Paso a paso {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "{currentCardPosition}Tarjeta /{totalCards}"
       },
@@ -1788,6 +1669,18 @@
         },
         "transcription": {
           "title": "Transcripción"
+        }
+      },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "No disponible. Finalizar el paso anterior.",
+            "enabled": "Acceder al paso {sectionTitle}",
+            "steps": "Paso {indexSection} de {totalSections}."
+          }
+        },
+        "tooltip": {
+          "disabled": "A continuación: {sectionTitle}"
         }
       },
       "preview": {
@@ -1826,11 +1719,11 @@
         "title": "¡Módulo completado!"
       },
       "section": {
-        "question-yourself": "Pregúntate a ti mismo",
         "explore-to-understand": "Explora para comprender",
-        "retain-the-essentials": "Retén lo esencial",
+        "go-further": "Ve más allá",
         "practise": "Practica",
-        "go-further": "Ve más allá"
+        "question-yourself": "Pregúntate a ti mismo",
+        "retain-the-essentials": "Retén lo esencial"
       },
       "sidebar": {
         "button": "Visualizar los pasos del módulo"
@@ -1838,8 +1731,8 @@
       "stepper": {
         "aria-role-description": "Secuencia de etapas",
         "step": {
-          "aria-role-description": "etapa",
-          "aria-label": "{currentStep} de {totalSteps}"
+          "aria-label": "{currentStep} de {totalSteps}",
+          "aria-role-description": "etapa"
         }
       },
       "verification-precondition-failed-alert": {
@@ -1866,20 +1759,35 @@
       "title": "¡Atención!",
       "username": "Nombre de usuario"
     },
+    "oidc-signup-or-login": {
+      "error": {
+        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
+        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
+        "error-message": "Debes aceptar las condiciones de uso de Pix.",
+        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
+        "invalid-email": "Tu dirección de correo electrónico no es válida.",
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
+        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
+      },
+      "login-form": {
+        "button": "Iniciar sesión",
+        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
+        "email": "Dirección de correo electrónico",
+        "password": "Contraseña",
+        "title": "Ya tengo una cuenta Pix"
+      },
+      "signup-form": {
+        "button": "Creo una cuenta",
+        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "Nombre: {firstName}",
+        "last-name-label-and-value": "Apellidos: {lastName}",
+        "title": "No tengo una cuenta Pix"
+      },
+      "title": "Crea una cuenta Pix"
+    },
     "password-reset-demand": {
       "title": "¿Olvidaste tu contraseña?"
-    },
-    "profile-already-shared": {
-      "actions": {
-        "continue": "Continúa tu experiencia Pix"
-      },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
-      "first-title": "Ha habido un imprevisto",
-      "retry": {
-        "button": "Reenviar mi perfil",
-        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
-      },
-      "title": "Perfil ya enviado"
     },
     "profile": {
       "accessibility": {
@@ -1896,6 +1804,7 @@
           "no-level": "Competencia sin empezar"
         }
       },
+      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix.",
       "first-title": "Tienes 16 competencias en las que hacer pruebas. '<br>'¡Concéntrate y a por ello!",
       "resume-campaign-banner": {
         "accessibility": {
@@ -1917,8 +1826,19 @@
         "icon": "Información sobre los pix",
         "label": "Abrir la información emergente",
         "title": "¿Por qué 1024 pix?"
+      }
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Continúa tu experiencia Pix"
       },
-      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix."
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "first-title": "Ha habido un imprevisto",
+      "retry": {
+        "button": "Reenviar mi perfil",
+        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
+      },
+      "title": "Perfil ya enviado"
     },
     "reset-password": {
       "error": {
@@ -1937,6 +1857,86 @@
       "ko": "Respuesta incorrecta",
       "ok": "Respuesta correcta",
       "timedout": "Tiempo superado"
+    },
+    "sco-signup-or-login": {
+      "invitation": "{ organizationName } te invita a unirte a Pix",
+      "login-form": {
+        "button": "Conectarse",
+        "fields": {
+          "login": {
+            "label": "Dirección de correo electrónico o nombre de usuario"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "forgotten-password": {
+          "email": "Una dirección de correo electrónico:",
+          "instruction": "¿Olvidaste tu contraseña? Tienes una cuenta Pix con:",
+          "other-identity": "Un nombre de usuario: ponte en contacto con tu profesor para restablecerlo",
+          "reset-link": "Haz clic aquí para restablecerlo"
+        },
+        "title": "Ya tengo una cuenta Pix",
+        "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
+      },
+      "signup-form": {
+        "button": "Inscribirse",
+        "button-form": "Crear cuenta",
+        "fields": {
+          "birthdate": {
+            "day": {
+              "error": "Tu día de nacimiento no es válido.",
+              "label": "Día de nacimiento",
+              "placeholder": "DD"
+            },
+            "label": "Fecha de nacimiento (DD/MM/AAAA)",
+            "month": {
+              "error": "Tu mes de nacimiento no es válido.",
+              "label": "Mes de nacimiento",
+              "placeholder": "MM"
+            },
+            "year": {
+              "error": "Tu año de nacimiento no es válido.",
+              "label": "Año de nacimiento",
+              "placeholder": "AAAA"
+            }
+          },
+          "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'",
+          "email": {
+            "error": "Tu correo electrónico no es válido.",
+            "help": "(ej. nombre@ejemplo.fr)",
+            "label": "Dirección de correo electrónico"
+          },
+          "firstname": {
+            "error": "No has indicado tu nombre.",
+            "label": "Nombre"
+          },
+          "lastname": {
+            "error": "No has indicado tus apellidos.",
+            "label": "Apellidos"
+          },
+          "password": {
+            "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
+            "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
+            "label": "Contraseña",
+            "show-button": "mostrar la contraseña"
+          },
+          "username": {
+            "label": "Mi nombre de usuario"
+          }
+        },
+        "not-me": "No soy yo",
+        "options": {
+          "email": "Mi dirección de correo electrónico",
+          "text": "Me inscribo con:",
+          "username": "Mi nombre de usuario"
+        },
+        "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
+        "rgpd-legal-notice-link": "aviso legal.",
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "title": "Crear cuenta"
+      },
+      "title": "Conectarse a Pix"
     },
     "send-profile": {
       "disabled-share": "Este test ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
@@ -1978,8 +1978,8 @@
     "signup": {
       "actions": {
         "login": "Iniciar sesión",
-        "submit": "Crear cuenta",
-        "sign-up-on-pix": "Crear cuenta en Pix"
+        "sign-up-on-pix": "Crear cuenta en Pix",
+        "submit": "Crear cuenta"
       },
       "fields": {
         "email": {
@@ -2034,7 +2034,6 @@
       "error": "¡Uy, se ha producido un error!",
       "hero": {
         "acquired-badges-title": "Premios obtenidos",
-        "thanks": "¡Gracias, {name}, por participar!",
         "explanations": {
           "improve": "Si quieres mejorar tu puntuación, puedes volver a intentar algunas preguntas.",
           "send-results": "Envíe sus resultados al organizador del curso y siga avanzando con los cursos recomendados.",
@@ -2051,7 +2050,8 @@
           "title": "Mejora tus resultados"
         },
         "see-trainings": "Ver los cursos",
-        "shared-message": "Tus resultados se enviaron el {date} a las {time}."
+        "shared-message": "Tus resultados se enviaron el {date} a las {time}.",
+        "thanks": "¡Gracias, {name}, por participar!"
       },
       "improve": {
         "description": "Puedes volver a intentar algunas de las preguntas",
@@ -2117,7 +2117,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Cerrar y volver a los resultados",
-            "subtitle": "¿Listo para desarrollar tus habilidades? \uD83C\uDF93",
+            "subtitle": "¿Listo para desarrollar tus habilidades? 🎓",
             "title": "Resultados compartidos"
           },
           "tab-label": "Formación",
@@ -2160,13 +2160,9 @@
         "webinaire": "Webinario"
       }
     },
-    "tutorial-panel": {
-      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
-      "title": "Para tener éxito la próxima vez"
-    },
     "tutorial": {
-      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dot-action-description": "Acceder al paso {stepNumber} en {stepsCount}",
+      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dots-nav-label": "Pasos del tutorial",
       "next": "Siguiente",
       "next-title": "Mostrar siguiente paso",
@@ -2197,6 +2193,10 @@
       "start": "Comenzar el test",
       "title": "Tutorial de la campaña"
     },
+    "tutorial-panel": {
+      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+      "title": "Para tener éxito la próxima vez"
+    },
     "update-expired-password": {
       "button": "Restablecer",
       "fields": {
@@ -2211,6 +2211,31 @@
       "validation": "Tu contraseña ha sido actualizada."
     },
     "user-account": {
+      "account-update-email": {
+        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
+        "fields": {
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "new-email-confirmation": {
+            "label": "Confirmación de la dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "password-information": "Introduce tu contraseña para confirmar",
+        "save-button": "Confirmar",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
       "account-update-email-with-validation": {
         "fields": {
           "errors": {
@@ -2229,31 +2254,6 @@
           }
         },
         "save-button": "Recibir un código de comprobación",
-        "title": "Cambio de la dirección de correo electrónico"
-      },
-      "account-update-email": {
-        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
-        "fields": {
-          "errors": {
-            "empty-password": "Tu contraseña no puede estar vacía.",
-            "invalid-password": "La contraseña que has introducido no es válida.",
-            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
-            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
-          },
-          "new-email-confirmation": {
-            "label": "Confirmación de la dirección de correo electrónico"
-          },
-          "new-email": {
-            "label": "Nueva dirección de correo electrónico"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "password-information": "Introduce tu contraseña para confirmar",
-        "save-button": "Confirmar",
         "title": "Cambio de la dirección de correo electrónico"
       },
       "connexion-methods": {
@@ -2317,8 +2317,6 @@
       "title": "Mi cuenta"
     },
     "user-tests": {
-      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
-      "title": "Mis tests",
       "anonymised-participations": {
         "course": "Recorrido",
         "states": {
@@ -2326,7 +2324,9 @@
           "started": "comenzado"
         },
         "title": "rutas desactivadas"
-      }
+      },
+      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
+      "title": "Mis tests"
     },
     "user-trainings": {
       "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -603,7 +603,7 @@
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
         "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
-        "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
+        "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"
       },
       "profiles-collection": {
         "action": "¡Empecemos!",
@@ -1089,7 +1089,7 @@
       "is-focused-challenge": {
         "info-alert": {
           "adjusted-course-title": "Responde a esta pregunta sin utilizar Internet ni ninguna aplicación.",
-          "subtitle": " ",
+          "subtitle": "Si cambia de página o pestaña durante una prueba de certificación, su respuesta no será validada.",
           "title": "Responde a esta pregunta sin buscar en internet ni utilizar ningún programa informático."
         }
       },
@@ -1201,32 +1201,36 @@
     "combined-courses": {
       "completed": {
         "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
+        "retry-text": "¿Quieres repasar? ¡Puedes volver a reproducir todos los módulos libremente!",
+        "survey-button": "Responder a la encuesta de satisfacción",
+        "survey-button-description": "Responda al cuestionario para dar su opinión sobre el recorrido.",
         "title": "¡Enhorabuena! ¡Ya ha terminado!"
       },
       "content": {
         "resume-course": "Reanudar mi curso",
-        "start-button": "Iniciar el curso"
+        "start-button": "Iniciar el curso",
+        "step": "Paso {stepNumber}"
       },
       "items": {
         "aria-label-completed-campaign": "Este elemento se completa con una tasa de éxito del {value, number, ::percent}",
         "aria-label-completed-campaign-with-stages": "Ha obtenido {acquired, plural, =0 {no estrella} =1 {# estrella} other {# estrellas}} de {total}",
-        "aria-label-duration": "Duración estimada: {duration} minutos",
+        "aria-label-duration": "Duración estimada: {duration} minutos.",
         "completed": "¡Completado!",
         "duration": "≈ {duration} min.",
         "formation": {
-          "description": "¡Completa tu prueba y desbloquea módulos de formación personalizados! Su número dependerá de tus resultados.",
-          "title": "Me estoy formando"
+          "description": "¡Completa tu diagnóstico para desbloquear un programa de módulos adaptado a tu resultado!",
+          "title": "Programa personalizado de módulos"
         },
         "tagText": "¡Ya estás ahí!"
       },
       "process-custom-passages": {
-        "description": "Analizamos tus resultados y elaboramos tu plan de formación personalizado.",
+        "description": "Analizamos tus resultados y creamos tu plan de formación personalizado",
         "list": {
-          "generate-personalise-course": "Generación de su curso personalizado.",
-          "results-analysis": "Análisis de tus resultados.",
+          "generate-personalise-course": "Generación de tu curso personalizado.",
+          "results-analysis": "Análisis de tus resultados",
           "select-passages": "Selección de cursos de formación adecuados."
         },
-        "title": "Cálculo de los siguientes pasos en tu curso actual."
+        "title": "Cálculo de los siguientes pasos en tu curso actual"
       }
     },
     "comparison-window": {
@@ -1400,7 +1404,7 @@
       "title": "Descargar los resultados de la sesión"
     },
     "error": {
-      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
+      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>'Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
       "first-title": "¡Uy, se ha producido un error!"
     },
     "evaluation-results": {
@@ -1685,6 +1689,7 @@
       },
       "preview": {
         "showJson": "Show JSON",
+        "stepper": "Preview : stepper {direction}",
         "textarea-label": "Contenido del módulo"
       },
       "qab": {
@@ -1832,7 +1837,7 @@
       "actions": {
         "continue": "Continúa tu experiencia Pix"
       },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}'<br>'lo hiciste el {date} a las {hour,time,hhmm}",
       "first-title": "Ha habido un imprevisto",
       "retry": {
         "button": "Reenviar mi perfil",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -35,15 +35,12 @@
     "description": "Pix es una plataforma en línea para evaluar y certificar las competencias digitales de ciudadanos (alumnos/as, estudiantes, jóvenes que dejan la escuela, demandantes de empleo, personas mayores)"
   },
   "common": {
-    "display": {
-      "percentage": "{value, number, ::percent}"
-    },
     "actions": {
       "back": "Volver",
       "cancel": "Cancelar",
       "close": "Cerrar",
-      "continue": "Continuar",
       "confirm": "Confirmar",
+      "continue": "Continuar",
       "download": "Descargar",
       "lets-go": "¡Empecemos!",
       "login": "Iniciar sesión",
@@ -98,6 +95,9 @@
       "title": "Nuestra política de privacidad ha cambiado. Te invitamos a consultarla: ",
       "url-label": "Política de protección de datos."
     },
+    "display": {
+      "percentage": "{value, number, ::percent}"
+    },
     "error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
     "form": {
       "error": "error",
@@ -116,7 +116,6 @@
       "nl": "Holandés"
     },
     "level": "nivel",
-    "no-level": "No nivel",
     "loading": {
       "default": "Cargando",
       "results": "Preparación de tus resultados",
@@ -125,6 +124,7 @@
     "new-information-banner": {
       "close-label": "Cerrar el banner"
     },
+    "no-level": "No nivel",
     "or": "o",
     "pagination": {
       "action": {
@@ -163,6 +163,17 @@
       }
     },
     "authentication": {
+      "authentication-identity-providers": {
+        "login": {
+          "heading": "Otros medios de conexión",
+          "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
+        },
+        "select-another-organization-link": "Elegir otra organización",
+        "signup": {
+          "heading": "Otros medios de registro",
+          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
+        }
+      },
       "login-form": {
         "fields": {
           "login": {
@@ -182,17 +193,6 @@
         "label": "Buscar una organización",
         "placeholder": "Seleccione una organización",
         "searchLabel": "Búsqueda por palabras clave"
-      },
-      "authentication-identity-providers": {
-        "login": {
-          "heading": "Otros medios de conexión",
-          "login-with-featured-identity-provider-link": "Conectar con {featuredIdentityProvider}"
-        },
-        "select-another-organization-link": "Elegir otra organización",
-        "signup": {
-          "heading": "Otros medios de registro",
-          "signup-with-featured-identity-provider-link": "Regístrese en {featuredIdentityProvider}"
-        }
       },
       "password-reset-demand-form": {
         "actions": {
@@ -377,21 +377,17 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Página de inicio de Pix.{ tld }",
-    "user-logged-menu": {
-      "details": "Consultar mis datos"
-    },
     "user": {
       "account": "Mi cuenta",
       "certifications": "Mis certificaciones",
       "sign-out": "Desconectarse",
       "tests": "Mis tests"
+    },
+    "user-logged-menu": {
+      "details": "Consultar mis datos"
     }
   },
   "pages": {
-    "attestations": {
-      "title": "Mis títulos",
-      "subtitle": "Acceda a todos sus certificados Pix y descárguelos."
-    },
     "account-recovery": {
       "errors": {
         "account-exists": "Ya existe una cuenta con esta dirección de correo electrónico.",
@@ -543,6 +539,10 @@
       },
       "title": "Fin de la prueba"
     },
+    "attestations": {
+      "subtitle": "Acceda a todos sus certificados Pix y descárguelos.",
+      "title": "Mis títulos"
+    },
     "authentication": {
       "login": {
         "signup-button": "Regístrate"
@@ -572,6 +572,15 @@
           "legal-informations": "Con o sin cuenta Pix, la información relativa a tu progreso en el test nos llegará a nosotros.'<br>'Esta información la utiliza Pix para mejorar el servicio.",
           "title": "Empieza el test:"
         }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "El test no está accesible para ti.",
+        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
+        "existing-participation-user-info": "Hay una participación asociada a nombre de {lastName} {firstName}",
+        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
+        "not-accessible": "Uy, la página solicitada no está disponible."
       }
     },
     "campaign-landing": {
@@ -607,6 +616,9 @@
       "warning-message": "¿No eres { firstName } { lastName }?",
       "warning-message-logout": "Desconectarse"
     },
+    "campaign-participation": {
+      "title": "Test"
+    },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Finalizado el {date}",
@@ -632,34 +644,14 @@
       },
       "title": "Test"
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
-    "campaign": {
-      "errors": {
-        "existing-participation": "El test no está accesible para ti.",
-        "existing-participation-info": "Ponte en contacto con tu profesor para que retire tu participación en Pix Orga.",
-        "existing-participation-user-info": "Hay una participación asociada a nombre de {lastName} {firstName}",
-        "no-longer-accessible": "Uy, la página solicitada ya no está disponible.",
-        "not-accessible": "Uy, la página solicitada no está disponible."
-      }
-    },
     "certificate": {
-      "congratulations": "¡Felicidades!",
-      "global": {
-        "explanation": {
-          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
-          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
-        },
-        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )",
-        "labels": {
-          "advanced": "Advanced",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Independent",
-          "level": "Your level"
-        }
-      },
+      "attestation": "Descargar mi certificado",
+      "back-link": "Volver a mis certificaciones",
+      "candidate": "Candidato :",
+      "candidate-birth": "Nacido/a el {birthdate}",
+      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
+      "certification-center": "Centro de certificación :",
+      "certification-date": "Fecha de examen :",
       "certification-value": {
         "paragraphs": {
           "1": "Officially recognised, Pix Certification attests to your mastery of digital skills. You'll be joining a community of millions of certified users. Congratulations on this important step in your career!",
@@ -667,48 +659,56 @@
           "3": "On the day of your certification, it was possible to reach level 7 and a maximum of 895 pix (Expert 1 level)."
         }
       },
-      "attestation": "Descargar mi certificado",
-      "back-link": "Volver a mis certificaciones",
-      "candidate-birth": "Nacido/a el {birthdate}",
-      "candidate-birth-complete": "Nacido/a el {birthdate} en {birthplace}",
-      "certification-center": "Centro de certificación :",
+      "competences": {
+        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
+      },
+      "complementary": {
+        "alternative": "Certificación complementaria",
+        "clea": "Certificación CléA Numérique by Pix",
+        "title": "No hay ninguna certificación obtenida"
+      },
+      "congratulations": "¡Felicidades!",
       "delivered-at": "Fecha de emisión :",
-      "subtitle": "(niveles de {maxReachableLevel})",
       "details": {
         "competences": {
           "description": "Tu puntuación Pix da una estimación de tu nivel en las 16 competencias digitales.",
           "title": "Su perfil de competencias digitales"
         }
       },
-      "certification-date": "Fecha de examen :",
-      "candidate": "Candidato :",
-      "competences": {
-        "information": "Tu puntuación certificada se ha calculado a partir de tus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de competencias y {maxReachablePixCountOnCertificationDate} pix como máximo."
-      },
-      "complementary": {
-        "alternative": "Certificación complementaria",
-        "title": "No hay ninguna certificación obtenida",
-        "clea": "Certificación CléA Numérique by Pix"
-      },
       "exam-date": "Fecha de presentación:",
+      "global": {
+        "explanation": {
+          "default": "You've reached {globalLevelLabel} level of Pix Certification!",
+          "pre-beginner-level": "You have completed your Pix Certification test, but your results do not allow you to obtain the first level."
+        },
+        "labels": {
+          "advanced": "Advanced",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Independent",
+          "level": "Your level"
+        },
+        "progressbar-explanation": "Progress bar indicating the level you have reached ( {level}, i.e. level {globalLevelLabel} ) out of a maximum attainable level of 7 ( Expert 1 level )"
+      },
       "hexagon-score": {
         "certified": "certificados"
       },
       "issued-on": "Entregado el",
       "jury-info": "Las observaciones del tribunal no se comparten en la página de comprobación de tu certificado.",
       "jury-title": "Observaciones del tribunal",
+      "learn-about-certification-results": "¿Cómo interpretar los resultados?",
       "professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 pix.",
+      "subtitle": "(niveles de {maxReachableLevel})",
       "title": "Certificado Pix",
       "verification-code": {
-        "share": "Share your certificate",
-        "information": "Your unique verification code",
         "alt": "Copiar",
         "copied": "¡Código copiado!",
         "copy": "Copiar el código",
+        "information": "Your unique verification code",
+        "share": "Share your certificate",
         "title": "Código de comprobación",
         "tooltip": "Facilita este código para que un tercero pueda comprobar la autenticidad de tu certificado"
-      },
-      "learn-about-certification-results": "¿Cómo interpretar los resultados?"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -829,22 +829,19 @@
         },
         "language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puedes elegir otro idioma en la página",
         "language-not-supported-link": "Mi cuenta",
+        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
         "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al supervisor.",
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        },
-        "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación."
+        }
       },
       "first-title": "Unirse a una sesión",
       "form": {
         "actions": {
           "submit": "Continuar"
-        },
-        "fields-validation": {
-          "session-number-error": "El número de sesión se compone únicamente de dígitos."
         },
         "fields": {
           "birth-date": "Fecha de nacimiento",
@@ -855,6 +852,9 @@
           "first-name": "Nombre",
           "session-number": "Número de sesión",
           "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+        },
+        "fields-validation": {
+          "session-number-error": "El número de sesión se compone únicamente de dígitos."
         },
         "placeholders": {
           "birth-day": "DD",
@@ -917,25 +917,25 @@
       "title": "Unirse a una sesión de certificación"
     },
     "certifications-list": {
-      "comment": "Comentario:",
-      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
-      "no-certification": {
-        "text": "Aún no tienes Pix certificación"
-      },
       "buttons": {
         "details": "Ver detalles",
-        "download-certificate": "Descargar certificado",
-        "download-attestation": "Descargar certificado"
+        "download-attestation": "Descargar certificado",
+        "download-certificate": "Descargar certificado"
       },
-      "statuses": {
-        "cancelled": "Cancelado",
-        "rejected": "No obtenido",
-        "not-published": "Resultados pendientes",
-        "validated": "Obtenido"
-      },
+      "comment": "Comentario:",
+      "description": "Acceda a todas sus certificaciones Pix. Consulta los detalles y descarga tus certificados.",
       "information": {
         "certification-center": "Centro de certificación :",
         "date": "Fecha del examen :"
+      },
+      "no-certification": {
+        "text": "Aún no tienes Pix certificación"
+      },
+      "statuses": {
+        "cancelled": "Cancelado",
+        "not-published": "Resultados pendientes",
+        "rejected": "No obtenido",
+        "validated": "Obtenido"
       },
       "title": "Mis certificaciones"
     },
@@ -959,15 +959,6 @@
         },
         "title": "Certificación {certificationNumber}"
       },
-      "embed-simulator": {
-        "actions": {
-          "launch": "Empezar",
-          "launch-label": "Empezar simulación",
-          "reset": "Restablecer",
-          "reset-label": "Reiniciar simulación"
-        },
-        "placeholder": "Cargando la aplicación"
-      },
       "certification-feedback-panel": {
         "actions": {
           "no-send-feedback": "No, vuelvo a la prueba",
@@ -976,6 +967,15 @@
         },
         "description": "¿Estás seguro/a de que quieres informar de un problema?",
         "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Empezar",
+          "launch-label": "Empezar simulación",
+          "reset": "Restablecer",
+          "reset-label": "Reiniciar simulación"
+        },
+        "placeholder": "Cargando la aplicación"
       },
       "feedback-panel": {
         "actions": {
@@ -991,12 +991,12 @@
             "category-selection": {
               "label": "Tengo un problema con",
               "options": {
-                "other": "Otro",
                 "accessibility": "La accesibilidad a la prueba",
                 "answer": "La respuesta",
                 "download": "El archivo que se debe descargar",
                 "embed": "El simulador/la aplicación",
                 "link": "El enlace indicado en la pregunta",
+                "other": "Otro",
                 "picture": "La imagen",
                 "question": "La pregunta",
                 "tutorial": "El tutorial"
@@ -1011,7 +1011,6 @@
                 "answer-not-accepted": "Mi respuesta es correcta, pero no ha sido validada",
                 "answer-not-agreed": "No estoy de acuerdo con la respuesta",
                 "download": {
-                  "other": "Tengo otro problema con el archivo",
                   "edit-failure": {
                     "label": "No puedo modificar el archivo",
                     "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
@@ -1023,7 +1022,8 @@
                   "open-failure": {
                     "label": "No puedo abrir el archivo en un ordenador",
                     "solution": "Si no puedes abrir un archivo, consulta la '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\">' documentación de ayuda'</a>' situada bajo el botón de descarga. Allí encontrarás programas o herramientas en línea recomendadas."
-                  }
+                  },
+                  "other": "Tengo otro problema con el archivo"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "En un ordenador, aparece el simulador, pero tiene un problema",
@@ -1199,38 +1199,38 @@
       }
     },
     "combined-courses": {
-      "process-custom-passages": {
-        "title": "Cálculo de los siguientes pasos en tu curso actual",
-        "description": "Analizamos tus resultados y creamos tu plan de formación personalizado",
-        "list": {
-          "results-analysis": "Análisis de tus resultados",
-          "select-passages": "Selección de cursos de formación adecuados.",
-          "generate-personalise-course": "Generación de tu curso personalizado."
-        }
-      },
-      "content": {
-        "start-button": "Iniciar el curso",
-        "resume-course": "Reanudar mi curso",
-        "step": "Paso {stepNumber}"
-      },
       "completed": {
-        "title": "¡Enhorabuena! ¡Ya ha terminado!",
         "description": "¡Bien hecho! Ha dado un paso importante para navegar por el mundo digital.",
+        "retry-text": "¿Quieres repasar? ¡Puedes volver a reproducir todos los módulos libremente!",
         "survey-button": "Responder a la encuesta de satisfacción",
         "survey-button-description": "Responda al cuestionario para dar su opinión sobre el recorrido.",
-        "retry-text": "¿Quieres repasar? ¡Puedes volver a reproducir todos los módulos libremente!"
+        "title": "¡Enhorabuena! ¡Ya ha terminado!"
+      },
+      "content": {
+        "resume-course": "Reanudar mi curso",
+        "start-button": "Iniciar el curso",
+        "step": "Paso {stepNumber}"
       },
       "items": {
-        "formation": {
-          "title": "Programa personalizado de módulos",
-          "description": "¡Completa tu diagnóstico para desbloquear un programa de módulos adaptado a tu resultado!"
-        },
         "aria-label-completed-campaign": "Este elemento se completa con una tasa de éxito del {value, number, ::percent}",
         "aria-label-completed-campaign-with-stages": "Ha obtenido {acquired, plural, =0 {no estrella} =1 {# estrella} other {# estrellas}} de {total}",
+        "aria-label-duration": "Duración estimada: {duration} minutos.",
         "completed": "¡Completado!",
-        "tagText": "¡Ya estás ahí!",
         "duration": "≈ {duration} min.",
-        "aria-label-duration": "Duración estimada: {duration} minutos."
+        "formation": {
+          "description": "¡Completa tu diagnóstico para desbloquear un programa de módulos adaptado a tu resultado!",
+          "title": "Programa personalizado de módulos"
+        },
+        "tagText": "¡Ya estás ahí!"
+      },
+      "process-custom-passages": {
+        "description": "Analizamos tus resultados y creamos tu plan de formación personalizado",
+        "list": {
+          "generate-personalise-course": "Generación de tu curso personalizado.",
+          "results-analysis": "Análisis de tus resultados",
+          "select-passages": "Selección de cursos de formación adecuados."
+        },
+        "title": "Cálculo de los siguientes pasos en tu curso actual"
       }
     },
     "comparison-window": {
@@ -1551,126 +1551,7 @@
       "iframe-title": "ChatPix",
       "title": "Previsualización ChatPix"
     },
-    "oidc-signup-or-login": {
-      "error": {
-        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
-        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
-        "error-message": "Debes aceptar las condiciones de uso de Pix.",
-        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
-        "invalid-email": "Tu dirección de correo electrónico no es válida.",
-        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
-        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
-      },
-      "login-form": {
-        "button": "Iniciar sesión",
-        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
-        "email": "Dirección de correo electrónico",
-        "password": "Contraseña",
-        "title": "Ya tengo una cuenta Pix"
-      },
-      "signup-form": {
-        "button": "Creo una cuenta",
-        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "last-name-label-and-value": "Apellidos: {lastName}",
-        "first-name-label-and-value": "Nombre: {firstName}",
-        "title": "No tengo una cuenta Pix"
-      },
-      "title": "Crea una cuenta Pix"
-    },
-    "sco-signup-or-login": {
-      "invitation": "{ organizationName } te invita a unirte a Pix",
-      "login-form": {
-        "button": "Conectarse",
-        "fields": {
-          "login": {
-            "label": "Dirección de correo electrónico o nombre de usuario"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "forgotten-password": {
-          "email": "Una dirección de correo electrónico:",
-          "instruction": "¿Olvidaste tu contraseña? Tienes una cuenta Pix con:",
-          "other-identity": "Un nombre de usuario: ponte en contacto con tu profesor para restablecerlo",
-          "reset-link": "Haz clic aquí para restablecerlo"
-        },
-        "title": "Ya tengo una cuenta Pix",
-        "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
-      },
-      "signup-form": {
-        "button": "Inscribirse",
-        "button-form": "Crear cuenta",
-        "fields": {
-          "birthdate": {
-            "day": {
-              "error": "Tu día de nacimiento no es válido.",
-              "label": "Día de nacimiento",
-              "placeholder": "DD"
-            },
-            "label": "Fecha de nacimiento (DD/MM/AAAA)",
-            "month": {
-              "error": "Tu mes de nacimiento no es válido.",
-              "label": "Mes de nacimiento",
-              "placeholder": "MM"
-            },
-            "year": {
-              "error": "Tu año de nacimiento no es válido.",
-              "label": "Año de nacimiento",
-              "placeholder": "AAAA"
-            }
-          },
-          "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'",
-          "email": {
-            "error": "Tu correo electrónico no es válido.",
-            "help": "(ej. nombre@ejemplo.fr)",
-            "label": "Dirección de correo electrónico"
-          },
-          "firstname": {
-            "error": "No has indicado tu nombre.",
-            "label": "Nombre"
-          },
-          "lastname": {
-            "error": "No has indicado tus apellidos.",
-            "label": "Apellidos"
-          },
-          "password": {
-            "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
-            "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
-            "label": "Contraseña",
-            "show-button": "mostrar la contraseña"
-          },
-          "username": {
-            "label": "Mi nombre de usuario"
-          }
-        },
-        "not-me": "No soy yo",
-        "options": {
-          "email": "Mi dirección de correo electrónico",
-          "text": "Me inscribo con:",
-          "username": "Mi nombre de usuario"
-        },
-        "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
-        "rgpd-legal-notice-link": "aviso legal.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
-        "title": "Crear cuenta"
-      },
-      "title": "Conectarse a Pix"
-    },
     "modulix": {
-      "navigation": {
-        "buttons": {
-          "aria-label": {
-            "steps": "Paso {indexSection} de {totalSections}.",
-            "disabled": "No disponible. Finalizar el paso anterior.",
-            "enabled": "Acceder al paso {sectionTitle}"
-          }
-        },
-        "tooltip": {
-          "disabled": "A continuación: {sectionTitle}"
-        }
-      },
       "beta-banner": "Este módulo está en versión beta. Se podrán realizar modificaciones a lo largo del tiempo.",
       "buttons": {
         "activity": {
@@ -1769,8 +1650,8 @@
         },
         "direction": "Busca la respuesta y gira la tarjeta",
         "navigation": {
-          "shortCurrentStep": "{current}/{total}",
-          "longCurrentStep": "{current} Paso a paso {total}"
+          "longCurrentStep": "{current} Paso a paso {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "{currentCardPosition}Tarjeta /{totalCards}"
       },
@@ -1794,10 +1675,22 @@
           "title": "Transcripción"
         }
       },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "No disponible. Finalizar el paso anterior.",
+            "enabled": "Acceder al paso {sectionTitle}",
+            "steps": "Paso {indexSection} de {totalSections}."
+          }
+        },
+        "tooltip": {
+          "disabled": "A continuación: {sectionTitle}"
+        }
+      },
       "preview": {
         "showJson": "Show JSON",
-        "textarea-label": "Contenido del módulo",
-        "stepper": "Preview : stepper {direction}"
+        "stepper": "Preview : stepper {direction}",
+        "textarea-label": "Contenido del módulo"
       },
       "qab": {
         "correct-answer": "Respuesta correcta",
@@ -1831,11 +1724,11 @@
         "title": "¡Módulo completado!"
       },
       "section": {
-        "question-yourself": "Pregúntate a ti mismo",
         "explore-to-understand": "Explora para comprender",
-        "retain-the-essentials": "Retén lo esencial",
+        "go-further": "Ve más allá",
         "practise": "Practica",
-        "go-further": "Ve más allá"
+        "question-yourself": "Pregúntate a ti mismo",
+        "retain-the-essentials": "Retén lo esencial"
       },
       "sidebar": {
         "button": "Visualizar los pasos del módulo"
@@ -1843,8 +1736,8 @@
       "stepper": {
         "aria-role-description": "Secuencia de etapas",
         "step": {
-          "aria-role-description": "etapa",
-          "aria-label": "{currentStep} de {totalSteps}"
+          "aria-label": "{currentStep} de {totalSteps}",
+          "aria-role-description": "etapa"
         }
       },
       "verification-precondition-failed-alert": {
@@ -1871,20 +1764,35 @@
       "title": "¡Atención!",
       "username": "Nombre de usuario"
     },
+    "oidc-signup-or-login": {
+      "error": {
+        "account-conflict": "Esta cuenta ya está asociada a esta organización. Conéctate con otra cuenta o ponte en contacto con el servicio de asistencia.",
+        "data-sharing-refused": "Te informamos de que la transmisión de tus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
+        "error-message": "Debes aceptar las condiciones de uso de Pix.",
+        "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
+        "invalid-email": "Tu dirección de correo electrónico no es válida.",
+        "login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
+        "password-reset-token-invalid-or-expired": "Ha pasado demasiado tiempo para validar su nueva contraseña. Vuelva a la página de inicio de sesión para volver a introducir su nombre de usuario y contraseña temporal."
+      },
+      "login-form": {
+        "button": "Iniciar sesión",
+        "description": "Conéctate para vincular tu cuenta existente y recuperar tus competencias evaluadas anteriormente.",
+        "email": "Dirección de correo electrónico",
+        "password": "Contraseña",
+        "title": "Ya tengo una cuenta Pix"
+      },
+      "signup-form": {
+        "button": "Creo una cuenta",
+        "description": "Se va a crear una cuenta utilizando la información facilitada por la organización",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "Nombre: {firstName}",
+        "last-name-label-and-value": "Apellidos: {lastName}",
+        "title": "No tengo una cuenta Pix"
+      },
+      "title": "Crea una cuenta Pix"
+    },
     "password-reset-demand": {
       "title": "¿Olvidaste tu contraseña?"
-    },
-    "profile-already-shared": {
-      "actions": {
-        "continue": "Continúa tu experiencia Pix"
-      },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
-      "first-title": "Ha habido un imprevisto",
-      "retry": {
-        "button": "Reenviar mi perfil",
-        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
-      },
-      "title": "Perfil ya enviado"
     },
     "profile": {
       "accessibility": {
@@ -1901,6 +1809,7 @@
           "no-level": "Competencia sin empezar"
         }
       },
+      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix.",
       "first-title": "Tienes 16 competencias en las que hacer pruebas. '<br>'¡Concéntrate y a por ello!",
       "resume-campaign-banner": {
         "accessibility": {
@@ -1922,8 +1831,19 @@
         "icon": "Información sobre los pix",
         "label": "Abrir la información emergente",
         "title": "¿Por qué 1024 pix?"
+      }
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Continúa tu experiencia Pix"
       },
-      "description": "Evalúe a su propio ritmo en 16 habilidades digitales. Elige una habilidad y empieza a ganar pix."
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "first-title": "Ha habido un imprevisto",
+      "retry": {
+        "button": "Reenviar mi perfil",
+        "message": "{organization} te invita a volver a enviar tu perfil para medir tu progreso."
+      },
+      "title": "Perfil ya enviado"
     },
     "reset-password": {
       "error": {
@@ -1942,6 +1862,86 @@
       "ko": "Respuesta incorrecta",
       "ok": "Respuesta correcta",
       "timedout": "Tiempo superado"
+    },
+    "sco-signup-or-login": {
+      "invitation": "{ organizationName } te invita a unirte a Pix",
+      "login-form": {
+        "button": "Conectarse",
+        "fields": {
+          "login": {
+            "label": "Dirección de correo electrónico o nombre de usuario"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "forgotten-password": {
+          "email": "Una dirección de correo electrónico:",
+          "instruction": "¿Olvidaste tu contraseña? Tienes una cuenta Pix con:",
+          "other-identity": "Un nombre de usuario: ponte en contacto con tu profesor para restablecerlo",
+          "reset-link": "Haz clic aquí para restablecerlo"
+        },
+        "title": "Ya tengo una cuenta Pix",
+        "unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario es incorrecto. Para continuar, debes conectarte a tu cuenta, que tiene la forma: "
+      },
+      "signup-form": {
+        "button": "Inscribirse",
+        "button-form": "Crear cuenta",
+        "fields": {
+          "birthdate": {
+            "day": {
+              "error": "Tu día de nacimiento no es válido.",
+              "label": "Día de nacimiento",
+              "placeholder": "DD"
+            },
+            "label": "Fecha de nacimiento (DD/MM/AAAA)",
+            "month": {
+              "error": "Tu mes de nacimiento no es válido.",
+              "label": "Mes de nacimiento",
+              "placeholder": "MM"
+            },
+            "year": {
+              "error": "Tu año de nacimiento no es válido.",
+              "label": "Año de nacimiento",
+              "placeholder": "AAAA"
+            }
+          },
+          "cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'",
+          "email": {
+            "error": "Tu correo electrónico no es válido.",
+            "help": "(ej. nombre@ejemplo.fr)",
+            "label": "Dirección de correo electrónico"
+          },
+          "firstname": {
+            "error": "No has indicado tu nombre.",
+            "label": "Nombre"
+          },
+          "lastname": {
+            "error": "No has indicado tus apellidos.",
+            "label": "Apellidos"
+          },
+          "password": {
+            "error": "Tu contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un dígito.",
+            "help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un dígito)",
+            "label": "Contraseña",
+            "show-button": "mostrar la contraseña"
+          },
+          "username": {
+            "label": "Mi nombre de usuario"
+          }
+        },
+        "not-me": "No soy yo",
+        "options": {
+          "email": "Mi dirección de correo electrónico",
+          "text": "Me inscribo con:",
+          "username": "Mi nombre de usuario"
+        },
+        "rgpd-legal-notice": "Para saber cómo se tratan tus datos y cuáles son tus derechos, puedes leer el",
+        "rgpd-legal-notice-link": "aviso legal.",
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "title": "Crear cuenta"
+      },
+      "title": "Conectarse a Pix"
     },
     "send-profile": {
       "disabled-share": "Este test ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
@@ -1983,8 +1983,8 @@
     "signup": {
       "actions": {
         "login": "Iniciar sesión",
-        "submit": "Crear cuenta",
-        "sign-up-on-pix": "Crear cuenta en Pix"
+        "sign-up-on-pix": "Crear cuenta en Pix",
+        "submit": "Crear cuenta"
       },
       "fields": {
         "email": {
@@ -2039,7 +2039,6 @@
       "error": "¡Uy, se ha producido un error!",
       "hero": {
         "acquired-badges-title": "Premios obtenidos",
-        "thanks": "¡Gracias, {name}, por participar!",
         "explanations": {
           "improve": "Si quieres mejorar tu puntuación, puedes volver a intentar algunas preguntas.",
           "send-results": "Envíe sus resultados al organizador del curso y siga avanzando con los cursos recomendados.",
@@ -2056,7 +2055,8 @@
           "title": "Mejora tus resultados"
         },
         "see-trainings": "Ver los cursos",
-        "shared-message": "Tus resultados se enviaron el {date} a las {time}."
+        "shared-message": "Tus resultados se enviaron el {date} a las {time}.",
+        "thanks": "¡Gracias, {name}, por participar!"
       },
       "improve": {
         "description": "Puedes volver a intentar algunas de las preguntas",
@@ -2122,7 +2122,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Cerrar y volver a los resultados",
-            "subtitle": "¿Listo para desarrollar tus habilidades? \uD83C\uDF93",
+            "subtitle": "¿Listo para desarrollar tus habilidades? 🎓",
             "title": "Resultados compartidos"
           },
           "tab-label": "Formación",
@@ -2165,13 +2165,9 @@
         "webinaire": "Webinario"
       }
     },
-    "tutorial-panel": {
-      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
-      "title": "Para tener éxito la próxima vez"
-    },
     "tutorial": {
-      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dot-action-description": "Acceder al paso {stepNumber} en {stepsCount}",
+      "dot-action-title": "Paso {stepNumber} de {stepsCount}",
       "dots-nav-label": "Pasos del tutorial",
       "next": "Siguiente",
       "next-title": "Mostrar siguiente paso",
@@ -2202,6 +2198,10 @@
       "start": "Comenzar el test",
       "title": "Tutorial de la campaña"
     },
+    "tutorial-panel": {
+      "info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+      "title": "Para tener éxito la próxima vez"
+    },
     "update-expired-password": {
       "button": "Restablecer",
       "fields": {
@@ -2216,6 +2216,31 @@
       "validation": "Tu contraseña ha sido actualizada."
     },
     "user-account": {
+      "account-update-email": {
+        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
+        "fields": {
+          "errors": {
+            "empty-password": "Tu contraseña no puede estar vacía.",
+            "invalid-password": "La contraseña que has introducido no es válida.",
+            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
+            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
+            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
+          },
+          "new-email": {
+            "label": "Nueva dirección de correo electrónico"
+          },
+          "new-email-confirmation": {
+            "label": "Confirmación de la dirección de correo electrónico"
+          },
+          "password": {
+            "label": "Contraseña"
+          }
+        },
+        "password-information": "Introduce tu contraseña para confirmar",
+        "save-button": "Confirmar",
+        "title": "Cambio de la dirección de correo electrónico"
+      },
       "account-update-email-with-validation": {
         "fields": {
           "errors": {
@@ -2234,31 +2259,6 @@
           }
         },
         "save-button": "Recibir un código de comprobación",
-        "title": "Cambio de la dirección de correo electrónico"
-      },
-      "account-update-email": {
-        "email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvides tu contraseña. '<br>' Esta será tu nueva dirección de conexión.",
-        "fields": {
-          "errors": {
-            "empty-password": "Tu contraseña no puede estar vacía.",
-            "invalid-password": "La contraseña que has introducido no es válida.",
-            "mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, comprueba la información introducida.",
-            "new-email-already-exist": "Esta dirección de correo electrónico ya se está utilizando.",
-            "unknown-error": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
-            "wrong-email-format": "Tu dirección de correo electrónico no es válida."
-          },
-          "new-email-confirmation": {
-            "label": "Confirmación de la dirección de correo electrónico"
-          },
-          "new-email": {
-            "label": "Nueva dirección de correo electrónico"
-          },
-          "password": {
-            "label": "Contraseña"
-          }
-        },
-        "password-information": "Introduce tu contraseña para confirmar",
-        "save-button": "Confirmar",
         "title": "Cambio de la dirección de correo electrónico"
       },
       "connexion-methods": {
@@ -2322,8 +2322,6 @@
       "title": "Mi cuenta"
     },
     "user-tests": {
-      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
-      "title": "Mis tests",
       "anonymised-participations": {
         "course": "Recorrido",
         "states": {
@@ -2331,7 +2329,9 @@
           "started": "comenzado"
         },
         "title": "rutas desactivadas"
-      }
+      },
+      "description": "Accede a sus tests Pix, sigue su progreso y continúe donde lo dejó.",
+      "title": "Mis tests"
     },
     "user-trainings": {
       "description": "Sigue progresando gracias a las formaciones recomendadas al final de tu evaluación.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -603,7 +603,7 @@
         "legal": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, haciendo clic en el botón «Envío mis resultados», se enviarán tus resultados al organizador.",
         "legal-with-auto-share": "Al hacer clic en «Empiezo» te conectarás a la plataforma y se enviará la información sobre tu progreso en el test al organizador del mismo para que pueda ayudarte si es necesario. Al final del test, sus resultados se enviarán automáticamente al organizador.",
         "title": "Empieza tu test Pix",
-        "title-with-username": "<span>¿{userFirstName},</span><br>Listo para evaluar tus habilidades?"
+        "title-with-username": "'<span>'¿{userFirstName}'</span>','<br>' Listo para evaluar tus habilidades?"
       },
       "profiles-collection": {
         "action": "¡Empecemos!",
@@ -1089,7 +1089,7 @@
       "is-focused-challenge": {
         "info-alert": {
           "adjusted-course-title": "Responde a esta pregunta sin utilizar Internet ni ninguna aplicación.",
-          "subtitle": " ",
+          "subtitle": "Si cambia de página o pestaña durante una prueba de certificación, su respuesta no será validada.",
           "title": "Responde a esta pregunta sin buscar en internet ni utilizar ningún programa informático."
         }
       },
@@ -1404,7 +1404,7 @@
       "title": "Descargar los resultados de la sesión"
     },
     "error": {
-      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
+      "content-text": "'<p>'Por favor, vuelve a cargar esta página o vuelve a la página de inicio.'</p><p>'También puedes ponerte en contacto con nosotros con '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>'Te pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo Pix.'</p>'",
       "first-title": "¡Uy, se ha producido un error!"
     },
     "evaluation-results": {
@@ -1837,7 +1837,7 @@
       "actions": {
         "continue": "Continúa tu experiencia Pix"
       },
-      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}',<br>'lo hiciste el {date} a las {hour,time,hhmm}",
+      "explanation": "Ya has enviado el siguiente perfil a la organización {organization}'<br>'lo hiciste el {date} a las {hour,time,hhmm}",
       "first-title": "Ha habido un imprevisto",
       "retry": {
         "button": "Reenviar mi perfil",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -35,9 +35,6 @@
     "description": "Pix is een online platform voor het beoordelen en certificeren van de digitale vaardigheden van Franstalige burgers (scholieren, studenten, schoolverlaters, werkzoekenden, senioren)."
   },
   "common": {
-    "display": {
-      "percentage": "{value, number, ::percent}"
-    },
     "actions": {
       "back": "Terug",
       "cancel": "Annuleer",
@@ -98,6 +95,9 @@
       "title": "Ons privacybeleid is gewijzigd. Lees het hier:",
       "url-label": "Gegevensbeschermingsbeleid."
     },
+    "display": {
+      "percentage": "{value, number, ::percent}"
+    },
     "error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
     "form": {
       "error": "Fout",
@@ -116,7 +116,6 @@
       "nl": "Nederlands"
     },
     "level": "niveau",
-    "no-level": "Geen niveau",
     "loading": {
       "default": "Bezig met laden",
       "results": "Je resultaten voorbereiden",
@@ -125,6 +124,7 @@
     "new-information-banner": {
       "close-label": "Sluit de banner"
     },
+    "no-level": "Geen niveau",
     "or": "of",
     "pagination": {
       "action": {
@@ -163,6 +163,17 @@
       }
     },
     "authentication": {
+      "authentication-identity-providers": {
+        "login": {
+          "heading": "Andere inlogmethodes",
+          "login-with-featured-identity-provider-link": "Inloggen via de {featuredIdentityProvider}"
+        },
+        "select-another-organization-link": "Kies een andere organisatie",
+        "signup": {
+          "heading": "Andere registratiemethodes",
+          "signup-with-featured-identity-provider-link": "Registreren bij {featuredIdentityProvider}"
+        }
+      },
       "login-form": {
         "fields": {
           "login": {
@@ -182,17 +193,6 @@
         "label": "Een organisatie zoeken",
         "placeholder": "Selecteer een organisatie",
         "searchLabel": "Zoeken op trefwoorden"
-      },
-      "authentication-identity-providers": {
-        "login": {
-          "heading": "Andere inlogmethodes",
-          "login-with-featured-identity-provider-link": "Inloggen via de {featuredIdentityProvider}"
-        },
-        "select-another-organization-link": "Kies een andere organisatie",
-        "signup": {
-          "heading": "Andere registratiemethodes",
-          "signup-with-featured-identity-provider-link": "Registreren bij {featuredIdentityProvider}"
-        }
       },
       "password-reset-demand-form": {
         "actions": {
@@ -377,21 +377,17 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Startpagina Pix.{ tld }",
-    "user-logged-menu": {
-      "details": "Mijn informatie bekijken"
-    },
     "user": {
       "account": "Mijn account",
       "certifications": "Mijn certificaten",
       "sign-out": "Uitloggen",
       "tests": "Mijn tests"
+    },
+    "user-logged-menu": {
+      "details": "Mijn informatie bekijken"
     }
   },
   "pages": {
-    "attestations": {
-      "title": "Mijn getuigschriften",
-      "subtitle": "Krijg toegang tot al je Pix-certificaten en download ze."
-    },
     "account-recovery": {
       "errors": {
         "account-exists": "Er bestaat al een account met dit e-mailadres.",
@@ -543,6 +539,10 @@
       },
       "title": "Einde test"
     },
+    "attestations": {
+      "subtitle": "Krijg toegang tot al je Pix-certificaten en download ze.",
+      "title": "Mijn getuigschriften"
+    },
     "authentication": {
       "login": {
         "signup-button": "Registreren"
@@ -572,6 +572,15 @@
           "legal-informations": "Of je nu een Pix-account hebt of niet, de gegevens over je voortgang worden naar ons verstuurd.'<br>'Deze informatie wordt door Pix gebruikt om de service te verbeteren.",
           "title": "Start de test:"
         }
+      }
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "De cursus is niet toegankelijk voor jou.",
+        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
+        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van {lastName} {firstName}",
+        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
+        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
       }
     },
     "campaign-landing": {
@@ -607,6 +616,9 @@
       "warning-message": "Ben jij niet {firstName} {lastName }?",
       "warning-message-logout": "Uitloggen"
     },
+    "campaign-participation": {
+      "title": "Test"
+    },
     "campaign-participation-overview": {
       "card": {
         "finished-at": "Voltooid op {date}",
@@ -632,38 +644,18 @@
       },
       "title": "Test"
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
-    "campaign": {
-      "errors": {
-        "existing-participation": "De cursus is niet toegankelijk voor jou.",
-        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
-        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van {lastName} {firstName}",
-        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
-        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
-      }
-    },
     "certificate": {
       "actions": {
         "download-attestation": "Mijn certificaat downloaden",
         "download-certificate": "Mijn certificaat downloaden"
       },
-      "congratulations": "Gefeliciteerd!",
-      "progressbar-explanation": "oortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, i.e. level {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
-      "global": {
-        "labels": {
-          "advanced": "Geavanceerd",
-          "beginner": "Beginner",
-          "expert": "Expert",
-          "independent": "Onafhankelijk",
-          "level": "Jouw niveau"
-        },
-        "explanation": {
-          "default": "Je hebt het {globalLevelLabel} niveau van Pix Certification bereikt!",
-          "pre-beginner-level": "Je hebt je Pix-certificeringstest afgerond, maar je resultaten staan je niet toe om het eerste niveau te behalen."
-        }
-      },
+      "attestation": "Mijn certificaat downloaden",
+      "back-link": "Terug naar mijn certificaten",
+      "candidate": "Kandidaat :",
+      "candidate-birth": "Geboren op {birthdate}",
+      "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}",
+      "certification-center": "Certificeringscentrum :",
+      "certification-date": "Examendatum :",
       "certification-value": {
         "paragraphs": {
           "1": "Pix certificering is officieel erkend en getuigt van je beheersing van digitale vaardigheden. Je wordt lid van een gemeenschap van miljoenen gecertificeerde gebruikers. Gefeliciteerd met deze belangrijke stap in je carrière!",
@@ -671,47 +663,55 @@
           "3": "Op de dag van je certificering was het mogelijk om niveau 7 en maximaal 895 pix te bereiken (niveau Expert 1)."
         }
       },
-      "attestation": "Mijn certificaat downloaden",
-      "back-link": "Terug naar mijn certificaten",
-      "candidate-birth": "Geboren op {birthdate}",
-      "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}",
-      "certification-center": "Certificeringscentrum :",
-      "delivered-at": "Datum van uitgifte :",
-      "certification-date": "Examendatum :",
-      "candidate": "Kandidaat :",
       "competences": {
         "information": "Je gecertificeerde score is berekend op basis van je antwoorden tijdens het certificeringsproces. Deze kan daarom afwijken van het aantal Pix dat wordt weergegeven in je profiel. Op de dag van je certificering was het mogelijk om het {maxReachableLevelOnCertificationDate} vaardigheidsniveau en {maxReachablePixCountOnCertificationDate} pix maximaal te behalen."
       },
+      "complementary": {
+        "alternative": "Aanvullende certificering",
+        "clea": "Certificering CléA Numérique by Pix",
+        "title": "Andere behaalde certificering"
+      },
+      "congratulations": "Gefeliciteerd!",
+      "delivered-at": "Datum van uitgifte :",
       "details": {
         "competences": {
           "description": "Je Pix-score geeft een schatting van je niveau in de 16 digitale vaardigheden.",
           "title": "Je digitale vaardigheidsprofiel"
         }
       },
-      "complementary": {
-        "alternative": "Aanvullende certificering",
-        "title": "Andere behaalde certificering",
-        "clea": "Certificering CléA Numérique by Pix"
-      },
       "exam-date": "Datum bezoek :",
+      "global": {
+        "explanation": {
+          "default": "Je hebt het {globalLevelLabel} niveau van Pix Certification bereikt!",
+          "pre-beginner-level": "Je hebt je Pix-certificeringstest afgerond, maar je resultaten staan je niet toe om het eerste niveau te behalen."
+        },
+        "labels": {
+          "advanced": "Geavanceerd",
+          "beginner": "Beginner",
+          "expert": "Expert",
+          "independent": "Onafhankelijk",
+          "level": "Jouw niveau"
+        }
+      },
       "hexagon-score": {
         "certified": "gecertificeerd"
       },
       "issued-on": "Uitgegeven op",
       "jury-info": "De opmerkingen van de jury worden niet gedeeld op de verificatiepagina van je certificaat.",
       "jury-title": "Commentaar van de jury",
+      "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?",
       "professionalizing-warning": "Het Pix-certificaat wordt door France Compétences erkend als een professionele kwalificatie zodra een minimale score van 120 pix is behaald.",
+      "progressbar-explanation": "oortgangsbalk die aangeeft welk niveau je hebt bereikt ( {level}, i.e. level {globalLevelLabel} ) van het maximaal haalbare niveau van 7 (niveau Expert 1)",
       "title": "Pix-certificaat",
       "verification-code": {
-        "share": "Deel uw certificaat",
-        "information": "Je unieke verificatiecode",
         "alt": "Kopieer",
         "copied": "Code gekopieerd!",
         "copy": "Kopieer de code",
+        "information": "Je unieke verificatiecode",
+        "share": "Deel uw certificaat",
         "title": "Verificatie code",
         "tooltip": "Geef deze code om een derde partij de echtheid van je certificaat te laten controleren"
-      },
-      "learn-about-certification-results": "Hoe moeten de resultaten worden geïnterpreteerd?"
+      }
     },
     "certification-ender": {
       "candidate": {
@@ -833,22 +833,19 @@
         },
         "language-not-supported": "Pix-certificering is nog niet beschikbaar in het {userLanguage}. '<br>' De talen die momenteel beschikbaar zijn voor certificering zijn: {availableLanguages}. '<br>' Je kunt een andere taal kiezen op de pagina",
         "language-not-supported-link": "Mijn account",
+        "missing-center-habilitation": "U kunt niet deelnemen aan de sessie. Het certificeringscentrum is niet bevoegd om u deze certificering te laten afleggen.",
         "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
         "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de supervisor om hulp.",
         "wrong-account-sco-link": {
           "label": "Hoe vind ik de rekening die aan de vestiging is gekoppeld?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
-        },
-        "missing-center-habilitation": "U kunt niet deelnemen aan de sessie. Het certificeringscentrum is niet bevoegd om u deze certificering te laten afleggen."
+        }
       },
       "first-title": "Deelnemen aan een sessie",
       "form": {
         "actions": {
           "submit": "Ga verder met"
-        },
-        "fields-validation": {
-          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
         },
         "fields": {
           "birth-date": "Geboortedatum",
@@ -859,6 +856,9 @@
           "first-name": "Voornaam",
           "session-number": "Sessienummer",
           "session-number-information": "Alleen meegedeeld door de surveillant aan het begin van de sessie"
+        },
+        "fields-validation": {
+          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
         },
         "placeholders": {
           "birth-day": "DD",
@@ -921,25 +921,25 @@
       "title": "Doe mee aan een certificeringssessie"
     },
     "certifications-list": {
-      "comment": "Opmerking :",
-      "description": "Krijg toegang tot al je Pix-certificaten. Bekijk details en download je certificaten.",
-      "no-certification": {
-        "text": "Je hebt nog geen Pix-certificering"
-      },
       "buttons": {
         "details": "Zie details",
-        "download-certificate": "Het certificaat downloaden",
-        "download-attestation": "Het certificaat downloaden"
+        "download-attestation": "Het certificaat downloaden",
+        "download-certificate": "Het certificaat downloaden"
       },
-      "statuses": {
-        "cancelled": "Geannuleerd",
-        "rejected": "Niet verkregen",
-        "not-published": "In afwachting van resultaten",
-        "validated": "Verkregen"
-      },
+      "comment": "Opmerking :",
+      "description": "Krijg toegang tot al je Pix-certificaten. Bekijk details en download je certificaten.",
       "information": {
         "certification-center": "Certificeringscentrum :",
         "date": "Datum bezoek :"
+      },
+      "no-certification": {
+        "text": "Je hebt nog geen Pix-certificering"
+      },
+      "statuses": {
+        "cancelled": "Geannuleerd",
+        "not-published": "In afwachting van resultaten",
+        "rejected": "Niet verkregen",
+        "validated": "Verkregen"
       },
       "title": "Mijn certificaten"
     },
@@ -963,15 +963,6 @@
         },
         "title": "Certificering {certificationNumber}"
       },
-      "embed-simulator": {
-        "actions": {
-          "launch": "Start",
-          "launch-label": "Simulatie starten",
-          "reset": "Reset",
-          "reset-label": "Simulatie resetten"
-        },
-        "placeholder": "De huidige toepassing laden"
-      },
       "certification-feedback-panel": {
         "actions": {
           "no-send-feedback": "Nee, ik kom terug op de test",
@@ -980,6 +971,15 @@
         },
         "description": "Weet je zeker dat je een probleem wilt melden?",
         "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren."
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Start",
+          "launch-label": "Simulatie starten",
+          "reset": "Reset",
+          "reset-label": "Simulatie resetten"
+        },
+        "placeholder": "De huidige toepassing laden"
       },
       "feedback-panel": {
         "actions": {
@@ -995,12 +995,12 @@
             "category-selection": {
               "label": "Ik heb een probleem met",
               "options": {
-                "other": "Overig",
                 "accessibility": "Toegankelijkheid van de test",
                 "answer": "Het antwoord",
                 "download": "Het te downloaden bestand",
                 "embed": "De simulator/toepassing",
                 "link": "De link in de vraag",
+                "other": "Overig",
                 "picture": "De afbeelding",
                 "question": "De vraag",
                 "tutorial": "De handleiding"
@@ -1015,7 +1015,6 @@
                 "answer-not-accepted": "Mijn antwoord is correct, maar niet gevalideerd",
                 "answer-not-agreed": "Ik ben het niet eens met het antwoord",
                 "download": {
-                  "other": "Ik heb een ander probleem met de",
                   "edit-failure": {
                     "label": "Ik kan de",
                     "solution": "Het bestand staat waarschijnlijk open in \"Alleen lezen\" of \"Beveiligde modus\". '<br>'Klik op \"Bewerken inschakelen\" of \"Document bewerken\" op de banner bovenaan het bestand als deze verschijnt. '<br>'Sla anders het bestand op onder een andere naam en open dit nieuwe bestand."
@@ -1027,7 +1026,8 @@
                   "open-failure": {
                     "label": "Ik kan het bestand niet openen op een computer",
                     "solution": "Als je een bestand niet kunt openen, raadpleeg dan de '<a href=\"https://pix.org/nl-be/support/particulier/particulier/een-gedownload-bestand-openen-wijzigen-of-ophalen\">'helpdocumentatie'</a>' onder de downloadknop. Je vindt er aanbevolen software of online hulpmiddelen."
-                  }
+                  },
+                  "other": "Ik heb een ander probleem met de"
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "Op een computer wordt de simulator weergegeven, maar er is een probleem",
@@ -1203,38 +1203,38 @@
       }
     },
     "combined-courses": {
-      "process-custom-passages": {
-        "title": "De volgende stappen in uw huidige cursus berekenen.",
-        "description": "We analyseren uw resultaten en stellen uw gepersonaliseerde trainingsplan op.",
-        "list": {
-          "results-analysis": "Analyse van uw resultaten.",
-          "select-passages": "Geschikte trainingen selecteren.",
-          "generate-personalise-course": "Uw gepersonaliseerde cursus genereren."
-        }
-      },
-      "content": {
-        "start-button": "Cursus starten",
-        "resume-button": "Cursus hervatten",
-        "step": "Stap {stepNumber}"
-      },
       "completed": {
-        "title": "Gefeliciteerd! Je bent klaar!",
         "description": "Bravo! Je hebt een belangrijke stap gezet om je weg te vinden in de digitale wereld.",
+        "retry-text": "Zin om te herhalen? Je kunt alle modules vrij opnieuw spelen!",
         "survey-button": "De tevredenheidsenquête invullen",
         "survey-button-description": "Beantwoord de vragenlijst om uw mening te geven over het parcours",
-        "retry-text": "Zin om te herhalen? Je kunt alle modules vrij opnieuw spelen!"
+        "title": "Gefeliciteerd! Je bent klaar!"
+      },
+      "content": {
+        "resume-button": "Cursus hervatten",
+        "start-button": "Cursus starten",
+        "step": "Stap {stepNumber}"
       },
       "items": {
-        "formation": {
-          "title": "Gepersonaliseerd programma met modules",
-          "description": "Voltooi uw diagnose om een moduleprogramma te ontgrendelen dat is afgestemd op uw resultaat!"
-        },
         "aria-label-completed-campaign": "Dit element wordt aangevuld met een slagingspercentage van {value, number, ::percent}",
         "aria-label-completed-campaign-with-stages": "Je hebt {acquired, plural, =0 {gen ster} =1 {# ster} other {# strerren}} van de {total}",
+        "aria-label-duration": "Geschatte duur: {duration} minuten",
         "completed": "Voltooid!",
-        "tagText": "U bent er nu!",
         "duration": "≈ {duration} min",
-        "aria-label-duration": "Geschatte duur: {duration} minuten"
+        "formation": {
+          "description": "Voltooi uw diagnose om een moduleprogramma te ontgrendelen dat is afgestemd op uw resultaat!",
+          "title": "Gepersonaliseerd programma met modules"
+        },
+        "tagText": "U bent er nu!"
+      },
+      "process-custom-passages": {
+        "description": "We analyseren uw resultaten en stellen uw gepersonaliseerde trainingsplan op.",
+        "list": {
+          "generate-personalise-course": "Uw gepersonaliseerde cursus genereren.",
+          "results-analysis": "Analyse van uw resultaten.",
+          "select-passages": "Geschikte trainingen selecteren."
+        },
+        "title": "De volgende stappen in uw huidige cursus berekenen."
       }
     },
     "comparison-window": {
@@ -1555,126 +1555,7 @@
       "iframe-title": "ChatPix",
       "title": "ChatPix voorbeeld"
     },
-    "oidc-signup-or-login": {
-      "error": {
-        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
-        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
-        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
-        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
-        "invalid-email": "Je e-mailadres is ongeldig.",
-        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist.",
-        "password-reset-token-invalid-or-expired": "Er is te veel tijd verstreken om uw nieuwe wachtwoord te valideren. Ga terug naar de inlogpagina om uw gebruikersnaam en tijdelijke wachtwoord opnieuw in te voeren."
-      },
-      "login-form": {
-        "button": "Inloggen",
-        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen.",
-        "email": "E-mailadres",
-        "password": "Wachtwoord",
-        "title": "Ik heb al een Pix-account"
-      },
-      "signup-form": {
-        "button": "Ik maak mijn account aan",
-        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
-        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
-        "last-name-label-and-value": "Naam: {lastName}",
-        "first-name-label-and-value": "Voornaam: {firstName}",
-        "title": "Ik heb geen Pix-account"
-      },
-      "title": "Maak je Pix-account aan"
-    },
-    "sco-signup-or-login": {
-      "invitation": "{ organizationName } nodigt je uit om je aan te sluiten bij Pix",
-      "login-form": {
-        "button": "Inloggen",
-        "fields": {
-          "login": {
-            "label": "E-mailadres of gebruikersnaam"
-          },
-          "password": {
-            "label": "Wachtwoord"
-          }
-        },
-        "forgotten-password": {
-          "email": "Een e-mailadres :",
-          "instruction": "Wachtwoord vergeten? Je hebt een Pix-account bij :",
-          "other-identity": "Een login: Neem contact op met uw docent om het opnieuw in te stellen",
-          "reset-link": "Klik hier om het opnieuw in te stellen"
-        },
-        "title": "Ik heb al een Pix-account",
-        "unexpected-user-account-error": "Het e-mailadres of de gebruikersnaam is onjuist. Om verder te gaan, moet u inloggen op uw account, die in de vorm :"
-      },
-      "signup-form": {
-        "button": "Meld je nu aan",
-        "button-form": "Registreren",
-        "fields": {
-          "birthdate": {
-            "day": {
-              "error": "Je geboortedatum is niet geldig.",
-              "label": "Geboortedag",
-              "placeholder": "JJ"
-            },
-            "label": "Geboortedatum (dd-mm-jjjj)",
-            "month": {
-              "error": "Je geboortemaand is niet geldig.",
-              "label": "Maand van geboorte",
-              "placeholder": "MM"
-            },
-            "year": {
-              "error": "Je geboortejaar is niet geldig.",
-              "label": "Geboortejaar",
-              "placeholder": "AAAA"
-            }
-          },
-          "cgu": "Ik ga akkoord met de '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'gebruiksvoorwaarden van Pix'</a>'.",
-          "email": {
-            "error": "Je e-mailadres is ongeldig.",
-            "help": "(voorbeeld: naam.voornaam@voorbeeld.org)",
-            "label": "E-mailadres"
-          },
-          "firstname": {
-            "error": "Je voornaam is niet ingevuld.",
-            "label": "Voornaam"
-          },
-          "lastname": {
-            "error": "Je achternaam is niet ingevuld.",
-            "label": "Achternaam"
-          },
-          "password": {
-            "error": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten.",
-            "help": "(minstens 8 tekenss, waaronder een hoofdletter, een kleine letter en een cijfer)",
-            "label": "Wachtwoord",
-            "show-button": "het wachtwoord leesbaar maken"
-          },
-          "username": {
-            "label": "Mijn aanmelding"
-          }
-        },
-        "not-me": "Ik ben het niet",
-        "options": {
-          "email": "Mijn e-mailadres",
-          "text": "Ik wil me graag registreren bij :",
-          "username": "Mijn aanmelding"
-        },
-        "rgpd-legal-notice": "Als u wilt weten hoe uw gegevens worden verwerkt en wat uw rechten zijn, kunt u het volgende lezen",
-        "rgpd-legal-notice-link": "Informatie.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
-        "title": "Ik wil me registreren"
-      },
-      "title": "Verbinding maken met Pix"
-    },
     "modulix": {
-      "navigation": {
-        "buttons": {
-          "aria-label": {
-            "steps": "Stap {indexSection} van {totalSections}.",
-            "disabled": "Niet beschikbaar. Vorige stap voltooien.",
-            "enabled": "Ga naar stap {sectionTitle}"
-          }
-        },
-        "tooltip": {
-          "disabled": "Te volgen: {sectionTitle}"
-        }
-      },
       "beta-banner": "Deze module is in bètaversie. In de loop van de tijd kunnen er wijzigingen worden aangebracht.",
       "buttons": {
         "activity": {
@@ -1773,8 +1654,8 @@
         },
         "direction": "Zoek het antwoord en draai de sitemap om",
         "navigation": {
-          "shortCurrentStep": "{current}/{total}",
-          "longCurrentStep": "{current} Stap op {total}"
+          "longCurrentStep": "{current} Stap op {total}",
+          "shortCurrentStep": "{current}/{total}"
         },
         "position": "{currentCardPosition}sitemap /{totalCards}"
       },
@@ -1798,10 +1679,22 @@
           "title": "Transcriptie"
         }
       },
+      "navigation": {
+        "buttons": {
+          "aria-label": {
+            "disabled": "Niet beschikbaar. Vorige stap voltooien.",
+            "enabled": "Ga naar stap {sectionTitle}",
+            "steps": "Stap {indexSection} van {totalSections}."
+          }
+        },
+        "tooltip": {
+          "disabled": "Te volgen: {sectionTitle}"
+        }
+      },
       "preview": {
         "showJson": "Show JSON",
-        "textarea-label": "Inhoud module",
-        "stepper": "Preview : stepper {direction}"
+        "stepper": "Preview : stepper {direction}",
+        "textarea-label": "Inhoud module"
       },
       "qab": {
         "correct-answer": "Correct antwoord",
@@ -1835,11 +1728,11 @@
         "title": "Module voltooid!"
       },
       "section": {
-        "question-yourself": "Stel jezelf vragen",
         "explore-to-understand": "Onderzoek om te begrijpen",
-        "retain-the-essentials": "Onthoud de essentie",
+        "go-further": "Ga verder",
         "practise": "Oefen",
-        "go-further": "Ga verder"
+        "question-yourself": "Stel jezelf vragen",
+        "retain-the-essentials": "Onthoud de essentie"
       },
       "sidebar": {
         "button": "De modulestappen weergeven"
@@ -1847,8 +1740,8 @@
       "stepper": {
         "aria-role-description": "reeks stappen",
         "step": {
-          "aria-role-description": "stap",
-          "aria-label": "{currentStep} op {totalSteps}"
+          "aria-label": "{currentStep} op {totalSteps}",
+          "aria-role-description": "stap"
         }
       },
       "verification-precondition-failed-alert": {
@@ -1875,20 +1768,35 @@
       "title": "Let op!",
       "username": "Inloggen"
     },
+    "oidc-signup-or-login": {
+      "error": {
+        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
+        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
+        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
+        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
+        "invalid-email": "Je e-mailadres is ongeldig.",
+        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist.",
+        "password-reset-token-invalid-or-expired": "Er is te veel tijd verstreken om uw nieuwe wachtwoord te valideren. Ga terug naar de inlogpagina om uw gebruikersnaam en tijdelijke wachtwoord opnieuw in te voeren."
+      },
+      "login-form": {
+        "button": "Inloggen",
+        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen.",
+        "email": "E-mailadres",
+        "password": "Wachtwoord",
+        "title": "Ik heb al een Pix-account"
+      },
+      "signup-form": {
+        "button": "Ik maak mijn account aan",
+        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "first-name-label-and-value": "Voornaam: {firstName}",
+        "last-name-label-and-value": "Naam: {lastName}",
+        "title": "Ik heb geen Pix-account"
+      },
+      "title": "Maak je Pix-account aan"
+    },
     "password-reset-demand": {
       "title": "Wachtwoord vergeten?"
-    },
-    "profile-already-shared": {
-      "actions": {
-        "continue": "Zet je Pix-ervaring voort"
-      },
-      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
-      "first-title": "Niet alles gaat volgens plan",
-      "retry": {
-        "button": "Mijn profiel opnieuw verzenden",
-        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
-      },
-      "title": "Profiel al verzonden"
     },
     "profile": {
       "accessibility": {
@@ -1929,6 +1837,18 @@
         "title": "Waarom 1024 pix?"
       }
     },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Zet je Pix-ervaring voort"
+      },
+      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
+      "first-title": "Niet alles gaat volgens plan",
+      "retry": {
+        "button": "Mijn profiel opnieuw verzenden",
+        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
+      },
+      "title": "Profiel al verzonden"
+    },
     "reset-password": {
       "error": {
         "expired-demand": "Het spijt ons, maar uw wachtwoordaanvraag is al gebruikt of verlopen. Probeer het opnieuw."
@@ -1946,6 +1866,86 @@
       "ko": "Onjuist antwoord",
       "ok": "Juist antwoord",
       "timedout": "Time-out"
+    },
+    "sco-signup-or-login": {
+      "invitation": "{ organizationName } nodigt je uit om je aan te sluiten bij Pix",
+      "login-form": {
+        "button": "Inloggen",
+        "fields": {
+          "login": {
+            "label": "E-mailadres of gebruikersnaam"
+          },
+          "password": {
+            "label": "Wachtwoord"
+          }
+        },
+        "forgotten-password": {
+          "email": "Een e-mailadres :",
+          "instruction": "Wachtwoord vergeten? Je hebt een Pix-account bij :",
+          "other-identity": "Een login: Neem contact op met uw docent om het opnieuw in te stellen",
+          "reset-link": "Klik hier om het opnieuw in te stellen"
+        },
+        "title": "Ik heb al een Pix-account",
+        "unexpected-user-account-error": "Het e-mailadres of de gebruikersnaam is onjuist. Om verder te gaan, moet u inloggen op uw account, die in de vorm :"
+      },
+      "signup-form": {
+        "button": "Meld je nu aan",
+        "button-form": "Registreren",
+        "fields": {
+          "birthdate": {
+            "day": {
+              "error": "Je geboortedatum is niet geldig.",
+              "label": "Geboortedag",
+              "placeholder": "JJ"
+            },
+            "label": "Geboortedatum (dd-mm-jjjj)",
+            "month": {
+              "error": "Je geboortemaand is niet geldig.",
+              "label": "Maand van geboorte",
+              "placeholder": "MM"
+            },
+            "year": {
+              "error": "Je geboortejaar is niet geldig.",
+              "label": "Geboortejaar",
+              "placeholder": "AAAA"
+            }
+          },
+          "cgu": "Ik ga akkoord met de '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'gebruiksvoorwaarden van Pix'</a>'.",
+          "email": {
+            "error": "Je e-mailadres is ongeldig.",
+            "help": "(voorbeeld: naam.voornaam@voorbeeld.org)",
+            "label": "E-mailadres"
+          },
+          "firstname": {
+            "error": "Je voornaam is niet ingevuld.",
+            "label": "Voornaam"
+          },
+          "lastname": {
+            "error": "Je achternaam is niet ingevuld.",
+            "label": "Achternaam"
+          },
+          "password": {
+            "error": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten.",
+            "help": "(minstens 8 tekenss, waaronder een hoofdletter, een kleine letter en een cijfer)",
+            "label": "Wachtwoord",
+            "show-button": "het wachtwoord leesbaar maken"
+          },
+          "username": {
+            "label": "Mijn aanmelding"
+          }
+        },
+        "not-me": "Ik ben het niet",
+        "options": {
+          "email": "Mijn e-mailadres",
+          "text": "Ik wil me graag registreren bij :",
+          "username": "Mijn aanmelding"
+        },
+        "rgpd-legal-notice": "Als u wilt weten hoe uw gegevens worden verwerkt en wat uw rechten zijn, kunt u het volgende lezen",
+        "rgpd-legal-notice-link": "Informatie.",
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "title": "Ik wil me registreren"
+      },
+      "title": "Verbinding maken met Pix"
     },
     "send-profile": {
       "disabled-share": "Deze cursus is gedeactiveerd door de organisator. Het is niet langer mogelijk om resultaten te versturen.",
@@ -1987,8 +1987,8 @@
     "signup": {
       "actions": {
         "login": "Inloggen",
-        "submit": "Registreren",
-        "sign-up-on-pix": "Inschrijven bij Pix"
+        "sign-up-on-pix": "Inschrijven bij Pix",
+        "submit": "Registreren"
       },
       "fields": {
         "email": {
@@ -2043,7 +2043,6 @@
       "error": "Oeps, er is een fout gemaakt!",
       "hero": {
         "acquired-badges-title": "Gewonnen prijzen",
-        "thanks": "Bedankt {name} voor je deelname!",
         "explanations": {
           "improve": "Als je je score wilt verbeteren, kun je bepaalde vragen opnieuw proberen.",
           "send-results": "Stuur je resultaten naar de cursusorganisator en ga verder met de aanbevolen cursussen.",
@@ -2060,7 +2059,8 @@
           "title": "Verbeter uw resultaten"
         },
         "see-trainings": "Bekijk de cursussen",
-        "shared-message": "Je resultaten zijn verzonden op {date} om {time}."
+        "shared-message": "Je resultaten zijn verzonden op {date} om {time}.",
+        "thanks": "Bedankt {name} voor je deelname!"
       },
       "improve": {
         "description": "Je kunt sommige vragen opnieuw proberen",
@@ -2126,7 +2126,7 @@
           },
           "shared-results-modal": {
             "return-results-action": "Sluiten en terugkeren naar resultaten",
-            "subtitle": "Klaar om je vaardigheden te ontwikkelen? \uD83C\uDF93",
+            "subtitle": "Klaar om je vaardigheden te ontwikkelen? 🎓",
             "title": "Verdeelde resultaten!"
           },
           "tab-label": "Training",
@@ -2169,13 +2169,9 @@
         "webinaire": "Webinar"
       }
     },
-    "tutorial-panel": {
-      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
-      "title": "Om de volgende keer te slagen"
-    },
     "tutorial": {
-      "dot-action-title": "Stap {stepNumber} van {stepsCount}",
       "dot-action-description": "Ga naar stap {stepNumber} op {stepsCount}",
+      "dot-action-title": "Stap {stepNumber} van {stepsCount}",
       "dots-nav-label": "Stappen uit de tutorial",
       "next": "Volgende",
       "next-title": "Volgende stap tonen",
@@ -2206,6 +2202,10 @@
       "start": "Begin mijn reis",
       "title": "Campagne handleiding"
     },
+    "tutorial-panel": {
+      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
+      "title": "Om de volgende keer te slagen"
+    },
     "update-expired-password": {
       "button": "Reset",
       "fields": {
@@ -2220,6 +2220,31 @@
       "validation": "Je wachtwoord is bijgewerkt."
     },
     "user-account": {
+      "account-update-email": {
+        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
+        "fields": {
+          "errors": {
+            "empty-password": "Je wachtwoord mag niet leeg zijn.",
+            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
+            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
+            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
+            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
+            "wrong-email-format": "Je e-mailadres is ongeldig."
+          },
+          "new-email": {
+            "label": "Nieuw e-mailadres"
+          },
+          "new-email-confirmation": {
+            "label": "Bevestiging van e-mailadres"
+          },
+          "password": {
+            "label": "Wachtwoord"
+          }
+        },
+        "password-information": "Voer uw wachtwoord in om te bevestigen",
+        "save-button": "Bevestig",
+        "title": "Je e-mailadres wijzigen"
+      },
       "account-update-email-with-validation": {
         "fields": {
           "errors": {
@@ -2238,31 +2263,6 @@
           }
         },
         "save-button": "Een verificatiecode ontvangen",
-        "title": "Je e-mailadres wijzigen"
-      },
-      "account-update-email": {
-        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
-        "fields": {
-          "errors": {
-            "empty-password": "Je wachtwoord mag niet leeg zijn.",
-            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
-            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
-            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
-            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
-            "wrong-email-format": "Je e-mailadres is ongeldig."
-          },
-          "new-email-confirmation": {
-            "label": "Bevestiging van e-mailadres"
-          },
-          "new-email": {
-            "label": "Nieuw e-mailadres"
-          },
-          "password": {
-            "label": "Wachtwoord"
-          }
-        },
-        "password-information": "Voer uw wachtwoord in om te bevestigen",
-        "save-button": "Bevestig",
         "title": "Je e-mailadres wijzigen"
       },
       "connexion-methods": {
@@ -2326,8 +2326,6 @@
       "title": "Mijn account"
     },
     "user-tests": {
-      "title": "Mijn tests",
-      "description": "Bekijk je Pix-trajecten, volg je voortgang en ga eenvoudig verder waar je was gebleven.",
       "anonymised-participations": {
         "course": "Route",
         "states": {
@@ -2335,7 +2333,9 @@
           "started": "begonnen"
         },
         "title": "Uitgeschakelde trajecten"
-      }
+      },
+      "description": "Bekijk je Pix-trajecten, volg je voortgang en ga eenvoudig verder waar je was gebleven.",
+      "title": "Mijn tests"
     },
     "user-trainings": {
       "description": "Blijf vooruitgang boeken dankzij de trainingen die aan het einde van je assessment worden aanbevolen.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -603,7 +603,7 @@
         "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Als je aan het einde van de cursus op de knop \"Stuur mijn resultaten\" klikt, worden je resultaten naar de organisator gestuurd.",
         "legal-with-auto-share": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Aan het einde van je test worden je resultaten automatisch gedeeld met je organisatie.",
         "title": "Begin je Pix-reis",
-        "title-with-username": "<span>{userFirstName},</span><br> ben je klaar om je vaardigheden te testen?"
+        "title-with-username": "'<span>'{userFirstName}'</span>','<br>' ben je klaar om je vaardigheden te testen?"
       },
       "profiles-collection": {
         "action": "Laten we gaan!",
@@ -1380,7 +1380,7 @@
           "text": "Om er meer over te weten",
           "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
         },
-        "message": "<h2>Welkom bij Pix in het Nederlands!</h2><p>De vertaling van al onze vaardigheden is binnenkort beschikbaar. '<'a href=\"https://pix.org/nl-be/de-planning-voor-de-uitrol-van-pix-in-het-nederlan\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer informatie'</a>'</p></p>"
+        "message": "<h2>Welkom bij Pix in het Nederlands!</h2><p>De vertaling van al onze vaardigheden is binnenkort beschikbaar. '<'a href=\"https://pix.org/nl-be/de-planning-voor-de-uitrol-van-pix-in-het-nederlan\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Meer informatie'</a>'</p>"
       },
       "recommended-competences": {
         "extra-information": "Toegang tot alle aanbevolen vaardigheden",


### PR DESCRIPTION
## 🍂 Problème

Seuls les fichiers de traduction `fr.json` et `en.json` de Pix App sont lintés. En effet les fichiers pour les autres langues (`nl.json`, `es.json`, etc.) étant anciennement gérés dans _Phrase_ ils étaient volontairement ignorés.

Les règles appliquées sont principalement de l'ordre du style pour trier par ordre alphabétique mais aussi pour éviter quelques erreurs (traduction manquante, format des clés de traduction incorrect).

## 🌰 Proposition

* Linter tous les fichiers de traduction
* Ajouter la traduction manquante
* Corriger les problèmes de format

Il manquait la traduction en espagnol pour `If you switch pages or tabs during a certification test, you answer will not be validated.`. La traduction ajoutée est : `Si cambia de página o pestaña durante una prueba de certificación, su respuesta no será validada.`. Cette traduction a été validée par une personne de l’équipe internationale maîtrisant l’espagnol.

## 🍁 Remarques

Le fichier `es-419.json` n’est pas pertinent car il est actuellement une copie de `es.json`.

Cette PR reprend #12852 qui n’avait pas pu être terminée.

## 🪵 Pour tester

* CI ✅ 
* Modifier l’ordre de quelques traductions dans chacun des fichiers `*.json`
* Exécuter la commande `npm run lint:fix` et constater que les traductions ont été retriées par ordre alphabétique
* Aller sur Pix App avec les locales `nl` et  `es` et vérifier  que l’affichage du semble cohérent
