### PR TITLE
[TECH] Linter tous les fichiers de traduction de Pix Certif

### DIFF
--- a/certif/eslint.config.mjs
+++ b/certif/eslint.config.mjs
@@ -14,7 +14,7 @@ const compiledOutputFiles = ['dist/*', 'tmp/*'];
 const dependenciesFiles = ['node_modules/*'];
 const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache'];
 const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];
-const nonPhraseGeneratedFiles = ['translations/en.json', 'translations/fr.json'];
+const translationFiles = ['translations/*.json'];
 
 const nodeFiles = [
   'eslint.config.js',
@@ -108,7 +108,7 @@ export default [
     },
   },
   {
-    files: nonPhraseGeneratedFiles,
+    files: translationFiles,
     plugins: { 'i18n-json': i18nJsonPlugin },
     processor: {
       meta: { name: '.json' },


### PR DESCRIPTION
## 🍂 Problème

Dans la configuration de ESLint de Pix Certif seuls les fichiers de traduction `fr.json` et `en.json` sont lintés. Si une nouvelle traduction était ajoutée à Pix Certif alors elle ne bénéficierait pas de la même assurance qualité que les autres fichiers de traduction.

## 🌰 Proposition

Dans la configuration de ESLint, linter tous les fichiers de traduction et pas spécifiquement uniquement `fr.json` et `en.json`. Cela ne produit aucun effet pour l’instant mais cela met en place une assurance qualité pour toute nouvelle traduction qui serait ajoutée à Pix Certif dans le futur.

## 🍁 Remarques

Cette PR fait suite à #14233 pour s’assurer que tous les fichiers de traduction sont bien corrects dans toutes les applications.

## 🪵 Pour tester

CI ✅
