### PR TITLE
[FEATURE] Ajouter le nouveau format /modules/:shortId/:slug (PIX-20385)

### DIFF
--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participant-result-repository.js
@@ -45,7 +45,7 @@ const get = async function ({ userId, campaignId, badges, reachedStage, stages, 
       // if the stage is a stage level, we need to add the converted threshold
       reachedStage = {
         ...reachedStage,
-        threshold: stage.threshold,
+        threshold: stage?.threshold,
       };
     }
   }

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y-not-authenticated.test.js
@@ -31,8 +31,8 @@ describe("a11y", () => {
       { url: "/nonconnecte" },
       { url: "/recuperer-mon-compte", skipFailures: true },
       { url: "/verification-certificat" },
-      { url: "/modules/bac-a-sable/details" },
-      { url: "/modules/bac-a-sable/passage" },
+      { url: "/modules/6a68bf32/bac-a-sable/details" },
+      { url: "/modules/6a68bf32/bac-a-sable/passage" },
     ];
 
     notAuthenticatedPages.forEach(({ url, skipFailures = false }) => {

--- a/mon-pix/app/adapters/module.js
+++ b/mon-pix/app/adapters/module.js
@@ -2,8 +2,13 @@ import ApplicationAdapter from './application';
 
 export default class Module extends ApplicationAdapter {
   queryRecord(store, type, query) {
-    if (query.slug) {
-      let url = `${this.host}/${this.namespace}/modules/${query.slug}`;
+    if (query.shortId || query.slug) {
+      let url = '';
+      if (query.shortId) {
+        url = `${this.host}/${this.namespace}/modules/v2/${query.shortId}`;
+      } else if (query.slug) {
+        url = `${this.host}/${this.namespace}/modules/${query.slug}`;
+      }
 
       if (query.encryptedRedirectionUrl) {
         const encryptedRedirectionUrl = encodeURIComponent(query.encryptedRedirectionUrl);

--- a/mon-pix/app/components/module/instruction/details.gjs
+++ b/mon-pix/app/components/module/instruction/details.gjs
@@ -29,7 +29,8 @@ export default class ModulixDetails extends Component {
       category: 'Modulix',
       moduleId: this.args.module.id,
     });
-    this.router.transitionTo('module.passage', this.args.module.slug);
+
+    this.router.transitionTo('module.passage');
   }
 
   @action
@@ -38,7 +39,7 @@ export default class ModulixDetails extends Component {
       category: 'Modulix',
       moduleId: this.args.module.id,
     });
-    this.router.transitionTo('module.passage', this.args.module.slug);
+    this.router.transitionTo('module.passage');
   }
 
   @action

--- a/mon-pix/app/controllers/old-module.js
+++ b/mon-pix/app/controllers/old-module.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class OldModule extends Controller {
+  queryParams = ['redirection'];
+}

--- a/mon-pix/app/models/combined-course-item.js
+++ b/mon-pix/app/models/combined-course-item.js
@@ -22,9 +22,10 @@ export default class CombinedCourseItem extends Model {
   @attr('boolean') isLocked;
   @attr('number') duration;
   @attr('string') image;
+  @belongsTo('combined-course', { async: false, inverse: 'items' }) combinedCourse;
 
   get route() {
-    return this.type === CombinedCourseItemTypes.CAMPAIGN ? 'campaigns' : 'module';
+    return this.type === CombinedCourseItemTypes.CAMPAIGN ? 'campaigns' : 'old-module';
   }
 
   get iconUrl() {
@@ -50,6 +51,4 @@ export default class CombinedCourseItem extends Model {
   get validatedStages() {
     return this.validatedStagesCount - 1;
   }
-
-  @belongsTo('combined-course', { async: false, inverse: 'items' }) combinedCourse;
 }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -117,6 +117,12 @@ Router.map(function () {
     this.route('recap');
   });
 
+  this.route('old-module', { path: '/modules/:slug' }, function () {
+    this.route('details');
+    this.route('passage');
+    this.route('recap');
+  });
+
   this.route('terms-of-service', { path: '/cgu' });
 
   this.route('inscription', function () {

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -109,7 +109,9 @@ Router.map(function () {
 
   this.route('module-preview-existing', { path: '/modules/preview/:slug' });
   this.route('module-preview', { path: '/modules/preview' });
-  this.route('module', { path: '/modules/:slug' }, function () {
+
+  // eslint-disable-next-line ember/routes-segments-snake-case
+  this.route('module', { path: '/modules/:shortId/:slug' }, function () {
     this.route('details');
     this.route('passage');
     this.route('recap');

--- a/mon-pix/app/routes/module.js
+++ b/mon-pix/app/routes/module.js
@@ -4,9 +4,10 @@ import { service } from '@ember/service';
 export default class ModuleRoute extends Route {
   @service store;
   @service metrics;
+  @service router;
 
   model(params) {
-    return this.store.queryRecord('module', { slug: params.slug, encryptedRedirectionUrl: params.redirection });
+    return this.store.queryRecord('module', { shortId: params.shortId, encryptedRedirectionUrl: params.redirection });
   }
 
   activate() {

--- a/mon-pix/app/routes/module/index.js
+++ b/mon-pix/app/routes/module/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class ModuleIndexRoute extends Route {
+  @service('store') store;
   @service router;
 
   buildRouteInfoMetadata() {

--- a/mon-pix/app/routes/old-module.js
+++ b/mon-pix/app/routes/old-module.js
@@ -1,0 +1,22 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModuleRoute extends Route {
+  @service store;
+  @service metrics;
+  @service router;
+
+  model(params) {
+    return this.store.queryRecord('module', { slug: params.slug, encryptedRedirectionUrl: params.redirection });
+  }
+
+  activate() {
+    this.metrics.context.code = this.paramsFor('module').slug;
+    this.metrics.context.type = 'module';
+  }
+
+  deactivate() {
+    delete this.metrics.context.code;
+    delete this.metrics.context.type;
+  }
+}

--- a/mon-pix/app/routes/old-module/details.js
+++ b/mon-pix/app/routes/old-module/details.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModuleDetailsRoute extends Route {
+  @service router;
+
+  redirect(model) {
+    this.router.replaceWith('module.details', model);
+  }
+}

--- a/mon-pix/app/routes/old-module/index.js
+++ b/mon-pix/app/routes/old-module/index.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class OldModuleIndexRoute extends Route {
+  @service router;
+
+  buildRouteInfoMetadata() {
+    return { doNotTrackPage: true };
+  }
+
+  redirect(model) {
+    this.router.replaceWith('module.details', model);
+  }
+}

--- a/mon-pix/app/routes/old-module/passage.js
+++ b/mon-pix/app/routes/old-module/passage.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class OldModulePassageRoute extends Route {
+  @service router;
+
+  buildRouteInfoMetadata() {
+    return { doNotTrackPage: true };
+  }
+
+  redirect(model) {
+    this.router.replaceWith('module.passage', model);
+  }
+}

--- a/mon-pix/app/routes/old-module/recap.js
+++ b/mon-pix/app/routes/old-module/recap.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModuleRecapRoute extends Route {
+  @service store;
+  @service router;
+
+  model(transition) {
+    const model = this.modelFor('old-module');
+
+    if (!transition.from) {
+      return this.router.replaceWith('module.details', model);
+    }
+
+    return model;
+  }
+}

--- a/mon-pix/mirage/routes/modules/get-module.js
+++ b/mon-pix/mirage/routes/modules/get-module.js
@@ -1,4 +1,4 @@
 export default function (schema, request) {
-  const slug = request.params.slug;
-  return schema.modules.find(slug);
+  const shortId = request.params.shortId;
+  return schema.modules.findBy({ shortId });
 }

--- a/mon-pix/mirage/routes/modules/get-old-module.js
+++ b/mon-pix/mirage/routes/modules/get-old-module.js
@@ -1,0 +1,4 @@
+export default function (schema, request) {
+  const slug = request.params.slug;
+  return schema.modules.findBy({ slug });
+}

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -1,5 +1,5 @@
 import getModule from './get-module';
 
 export default function index(config) {
-  config.get('/modules/:slug', getModule);
+  config.get('/modules/v2/:shortId', getModule);
 }

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -1,5 +1,7 @@
 import getModule from './get-module';
+import getOldModule from './get-old-module';
 
 export default function index(config) {
   config.get('/modules/v2/:shortId', getModule);
+  config.get('/modules/:slug', getOldModule);
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
@@ -12,11 +12,12 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('when user arrive on the module details page', function () {
+  module('when user arrives on the module details page', function () {
     test('should display the link to passage button', async function (assert) {
       // given
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         sections: [],
@@ -30,7 +31,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
+      const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/details');
 
       // then
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.details.startModule') })).exists({ count: 1 });
@@ -46,6 +47,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         sections: [section],
@@ -59,11 +61,11 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
+      const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/details');
       await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
       // then
-      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/passage');
+      assert.strictEqual(currentURL(), '/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
     });
   });
 });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -16,6 +16,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         sections,
@@ -26,7 +27,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
 
       // then
       assert.strictEqual(screen.getAllByRole('article').length, 1);
@@ -42,13 +43,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
+          shortId: 'm4tth7a5',
           slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
           sections,
         });
 
         // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+        const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
 
         // then
         assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
@@ -69,13 +71,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
+          shortId: 'm4tth7a5',
           slug: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
           sections,
         });
 
         // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+        const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
 
         // then
         assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
@@ -114,6 +117,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       });
       const module = server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         sections: [section1],
@@ -124,7 +128,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
@@ -137,7 +141,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         return screen.queryByRole('heading', { name: 'Module terminé !', level: 1 });
       });
 
-      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
+      assert.strictEqual(currentURL(), '/modules/m4tth7a5/bien-ecrire-son-adresse-mail/recap');
     });
   });
 
@@ -148,13 +152,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         sections,
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
       const navigation = screen.getByRole('navigation', { name: t('navigation.nav-bar.aria-label') });
       const firstSectionButton = within(navigation).getByRole('button', {
         name: `${t('pages.modulix.navigation.buttons.aria-label.steps', {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -36,6 +36,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7a5',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
@@ -50,7 +51,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       });
       await authenticate(user);
 
-      screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/passage');
       await clickByName('Terminer');
     });
 

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -62,6 +62,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'di4n3c0r',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: { tabletSupport: 'comfortable' },
@@ -76,7 +77,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     });
 
     // when
-    let screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    let screen = await visit('/modules/di4n3c0r/bien-ecrire-son-adresse-mail/passage');
     await click(screen.getByLabelText('I am the right answer!'));
 
     const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
@@ -93,7 +94,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
       return screen.queryByRole('heading', { name: 'Module terminé !', level: 1 });
     });
 
-    screen = await visit('/modules/bien-ecrire-son-adresse-mail/');
+    screen = await visit('/modules/di4n3c0r/bien-ecrire-son-adresse-mail/');
 
     const startModuleButton = screen.getByRole('button', { name: 'Commencer le module' });
     await click(startModuleButton);

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -51,12 +51,13 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'di4n3c0r',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       sections: [section],
     });
 
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/di4n3c0r/bien-ecrire-son-adresse-mail/passage');
 
     const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
@@ -129,13 +130,14 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'di4n3c0r',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: false,
       sections: [section],
     });
 
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/di4n3c0r/bien-ecrire-son-adresse-mail/passage');
 
     const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -59,13 +59,14 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'm4tth74s',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
       sections: [section],
     });
 
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/m4tth74s/bien-ecrire-son-adresse-mail/passage');
 
     const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
@@ -145,6 +146,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
 
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'm4tth74s',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
@@ -159,7 +161,7 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
       solution: qcu1.proposals[1].id,
     });
 
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/m4tth74s/bien-ecrire-son-adresse-mail/passage');
 
     const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });
     const rightAnswerRadio = screen.getByLabelText('I am the right answer!');

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -68,7 +68,8 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     });
 
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: true,
@@ -76,7 +77,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
 
     const qrocmForm = screen.getByRole('group');
 
@@ -201,7 +202,8 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     });
 
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: false,
@@ -209,7 +211,7 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
 
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier ma réponse' });
     const input = screen.getByLabelText('Réponse 1');

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -76,7 +76,8 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
     });
 
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       sections: [section],
@@ -97,7 +98,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
     const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier ma réponse' });
     const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
 

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -52,14 +52,15 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
     });
 
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       sections: [section],
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const screen = await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
     const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier ma réponse' });
     const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
 

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -15,6 +15,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     // given
     const module = server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'm4tth7as',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       isBeta: false,
@@ -30,10 +31,9 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     });
 
     // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
-
+    const screen = await visit('/modules/m4tth7as/bien-ecrire-son-adresse-mail/details');
     // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+    assert.strictEqual(currentURL(), '/modules/m4tth7as/bien-ecrire-son-adresse-mail/details');
     assert.ok(document.title.includes(module.title));
     assert.dom(screen.queryByRole('alert')).doesNotExist();
     assert.dom(screen.queryByText(t('pages.modulix.beta-banner'))).doesNotExist();
@@ -45,6 +45,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
       // given
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
+        shortId: 'm4tth7as',
         slug: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
         isBeta: true,
@@ -60,7 +61,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
       });
 
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
+      const screen = await visit('/modules/m4tth7as/bien-ecrire-son-adresse-mail/details');
 
       // then
       assert.dom(screen.getByRole('alert')).exists();
@@ -80,6 +81,7 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'm4tth7as',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       details: {
@@ -94,9 +96,9 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail');
+    await visit('/modules/m4tth7as/bien-ecrire-son-adresse-mail');
 
     // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+    assert.strictEqual(currentURL(), '/modules/m4tth7as/bien-ecrire-son-adresse-mail/details');
   });
 });

--- a/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-passage-page_test.js
@@ -20,17 +20,18 @@ module('Acceptance | Module | Routes | get', function (hooks) {
       ],
     });
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
       sections: [section],
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
 
     // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/passage');
+    assert.strictEqual(currentURL(), '/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
   });
 
   test('should include the module title inside the page title', async function (assert) {
@@ -49,14 +50,15 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     });
 
     server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
+      id: 'def0f7e1-8f4d-4352-a7b3-1cccff1038d6',
+      shortId: '3r7cl7m3',
       slug: 'bien-ecrire-son-adresse-mail',
       title: module.title,
       sections: [section],
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    await visit('/modules/3r7cl7m3/bien-ecrire-son-adresse-mail/passage');
 
     // then
     assert.ok(document.title.includes(module.title));

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
@@ -15,14 +15,15 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
     // given
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
+      shortId: 'm4tth74s',
       slug: 'bien-ecrire-son-adresse-mail',
       details: { tabletSupport: 'comfortable' },
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+    await visit('/modules/m4tth74s/bien-ecrire-son-adresse-mail/recap');
 
     // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+    assert.strictEqual(currentURL(), '/modules/m4tth74s/bien-ecrire-son-adresse-mail/details');
   });
 });

--- a/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-combined-course-workflow-test.js
@@ -103,6 +103,7 @@ module('Acceptance | Combined course | Start Combined course workflow', function
         campaign = server.create('campaign', { code: 'ABCDIAG', organizationId: 1 });
         const module = server.create('module', {
           id: 'combinix-slug',
+          shortId: 'm4tth74s',
           slug: 'combinix-slug',
           title: 'combinix-title',
           details: { tabletSupport: 'comfortable' },
@@ -180,9 +181,8 @@ module('Acceptance | Combined course | Start Combined course workflow', function
 
             //when
             await click(screen.getByText(combinedCourseModuleItem.title));
-
             //then
-            assert.strictEqual(currentURL(), '/modules/combinix-slug/details');
+            assert.strictEqual(currentURL(), '/modules/m4tth74s/combinix-slug/details');
           });
         });
       });

--- a/mon-pix/tests/integration/components/module/details_test.gjs
+++ b/mon-pix/tests/integration/components/module/details_test.gjs
@@ -63,7 +63,7 @@ module('Integration | Component | Module | Details', function (hooks) {
         await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
         // then
-        sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
+        sinon.assert.calledWithExactly(router.transitionTo, 'module.passage');
         assert.ok(true);
       });
     });
@@ -97,7 +97,7 @@ module('Integration | Component | Module | Details', function (hooks) {
           await click(screen.getByRole('button', { name: t('pages.modulix.details.startModule') }));
 
           // then
-          sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
+          sinon.assert.calledWithExactly(router.transitionTo, 'module.passage');
           assert.ok(true);
         });
       });
@@ -186,7 +186,7 @@ module('Integration | Component | Module | Details', function (hooks) {
             );
 
             // then
-            sinon.assert.calledWithExactly(router.transitionTo, 'module.passage', module.slug);
+            sinon.assert.calledWithExactly(router.transitionTo, 'module.passage');
             assert.ok(true);
           });
         });
@@ -258,6 +258,7 @@ function prepareDetailsComponentContext(tabletSupport, breakpoint = 'desktop') {
   const module = store.createRecord('module', {
     id: 'module-title',
     slug: 'module-slug',
+    shortId: '3r7cl7m3',
     title: 'Module title',
     details,
   });

--- a/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
+++ b/mon-pix/tests/integration/components/routes/combined-courses/presentation-test.gjs
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 
 import { CombinedCourseStatuses } from '../../../../../models/combined-course.js';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering.js';
+
 module('Integration | Component | Combined Courses | Presentation', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -281,7 +282,7 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
       assert.strictEqual(
         screen.getByRole('link', { name: /mon module/ }).getAttribute('href'),
         router.urlFor(
-          'module',
+          'old-module',
           {
             slug: combinedCourseItem.reference,
           },
@@ -361,7 +362,7 @@ module('Integration | Component | Combined Courses | Presentation', function (ho
     // then
     await click(screen.getByRole('button', { name: t('pages.combined-courses.content.resume-button') }));
     assert.ok(
-      router.transitionTo.calledWith('module', 'mon-module', { queryParams: { redirection: 'une+url+chiffree' } }),
+      router.transitionTo.calledWith('old-module', 'mon-module', { queryParams: { redirection: 'une+url+chiffree' } }),
     );
   });
   test('when an item is locked, its link does not exist', async function (assert) {

--- a/mon-pix/tests/unit/adapters/module-test.js
+++ b/mon-pix/tests/unit/adapters/module-test.js
@@ -49,5 +49,50 @@ module('Unit | Adapter | Module | Module', function (hooks) {
         assert.ok(true);
       });
     });
+
+    module('when query.shortId is not defined', function () {
+      test('should trigger an ajax call with the default url and method', async function (assert) {
+        // given
+        const query = {
+          'other-prop': 'bac-a-sable',
+        };
+
+        const store = this.owner.lookup('service:store');
+        const adapter = this.owner.lookup('adapter:module');
+        const type = { modelName: 'module' };
+        sinon.stub(adapter, 'ajax').resolves();
+        const expectedUrl = `http://localhost:3000/api/modules`;
+
+        // when
+        await adapter.queryRecord(store, type, query);
+
+        // then
+        sinon.assert.calledWithExactly(adapter.ajax, expectedUrl, 'GET', { data: { 'other-prop': 'bac-a-sable' } });
+        assert.ok(true);
+      });
+    });
+
+    module('when query.shortId is defined', function () {
+      test('should trigger an ajax call with the right url (v2) and method', async function (assert) {
+        // given
+        const query = {
+          slug: 'bac-a-sable',
+          shortId: 'egd653do',
+        };
+
+        const store = this.owner.lookup('service:store');
+        const adapter = this.owner.lookup('adapter:module');
+        const type = { modelName: 'module' };
+        sinon.stub(adapter, 'ajax').resolves();
+        const expectedUrl = `http://localhost:3000/api/modules/v2/${query.shortId}`;
+
+        // when
+        await adapter.queryRecord(store, type, query);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'GET');
+        assert.ok(true);
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/models/combined-course-item-test.js
+++ b/mon-pix/tests/unit/models/combined-course-item-test.js
@@ -41,7 +41,7 @@ module('Unit | Model | Combined Course Item', function (hooks) {
       const combinedCourseItem = store.createRecord('combined-course-item', {
         type: CombinedCourseItemTypes.MODULE,
       });
-      assert.strictEqual(combinedCourseItem.route, 'module');
+      assert.strictEqual(combinedCourseItem.route, 'old-module');
     });
 
     test('return iconUrl related for campaign', function (assert) {

--- a/mon-pix/tests/unit/routes/module/module-test.js
+++ b/mon-pix/tests/unit/routes/module/module-test.js
@@ -21,10 +21,10 @@ module('Unit | Route | modules | module', function (hooks) {
     const module = Symbol('the-module');
 
     store.queryRecord = sinon.stub();
-    store.queryRecord.withArgs('module', { slug: 'the-module', encryptedRedirectionUrl: 'somehash' }).resolves(module);
+    store.queryRecord.withArgs('module', { shortId: 'dfc4isne', encryptedRedirectionUrl: 'somehash' }).resolves(module);
 
     // when
-    const model = await route.model({ slug: 'the-module', redirection: 'somehash' });
+    const model = await route.model({ shortId: 'dfc4isne', redirection: 'somehash' });
 
     // then
     assert.strictEqual(model, module);


### PR DESCRIPTION
## 🍂 Contexte

On souhaite changer le format des urls des modules en `/modules/:shortId/:slug`

## 🌰 Proposition

Faire cela 😄 
Pour les parcours apprenants, nous avons aussi ajouté une autre route `old-module` avant l'ancien format d'url des modules. Ceci afin qu'il redirige vers le nouveau format (ex: /modules/bac-a-sable => /modules/6a68bf32/bac-a-sable). 

Cela permet de merger cette PR et de ne pas être bloqué par les développements côté parcours apprenants pour prendre en compte ce nouveau format.

## 🍁 Remarques

- Il reste le format d'url de la preview des modules à migrer. On préfère le faire dans la prochaine PR.
- Du code a été ajouté dans le dernier commit afin de faire fonctionner les parcours apprenants en local. A voir avec l'équipe concernée s'il faut le garder ou non 😄 
- Il ne faudra pas que le métier renomme les slugs des modules, avant d'avoir pris en compte l'utilisation du shortId côté combinix. Sinon on aura des 404.

## 🪵 Pour tester

### Nouveau format
- Saisir l'url d'un module (ex: [bac-a-sable](https://app-pr14238.review.pix.fr/modules/6a68bf32/bac-a-sable)) /modules/6a68bf32/bac-a-sable
- Vérifier que cela redirige bien vers `/modules/6a68bf32/bac-a-sable/details`
- Passer le module et constater qu'il n'y a pas de régression !
- Faire de même sur d'autres modules

### Parcours apprenant
- Se connecter sur [Pix App](https://app-pr14238.review.pix.fr/) (ex: `dave-comp@example.net`)
- Aller sur l'url [/parcours/COMBINIX1](https://app-pr14238.review.pix.fr/parcours/COMBINIX1)
- Passer le diagnostic pour arriver sur les modules
- Passer le curseur sur le module démo combinix 1. Constater que l'url est toujours sur l'ancien format `/modules/demo-combinix-1`
- Cliquer sur le module et vérifier qu'on est bien redirigé vers /modules/27d6ca4f/demo-combinix-1/details.
- Passer le module et cliquer sur continuer sur la page de récap
- Constater qu'on revient bien sur le parcours combiné 😄 

### Test redirection
- Saisir l'url d'un module avec l'ancien format (ex: /modules/bac-a-sable)
- Constater qu'on redirige bien vers le nouveau format en /details (ex: /modules/6a68bf32/bac-a-sable/details).

#### Test de /details
- Saisir l'url d'un module avec l'ancien format (ex: /modules/bac-a-sable/details)
- Constater qu'on redirige bien vers le nouveau format en /details (ex: /modules/6a68bf32/bac-a-sable/details).

#### Test de /passage
- Saisir l'url d'un module avec l'ancien format (ex: /modules/bac-a-sable/passage)
- Constater qu'on redirige bien vers le nouveau format en /passage (ex: /modules/6a68bf32/bac-a-sable/passage).

#### Test de /recap
- Saisir l'url d'un module avec l'ancien format (ex: /modules/bac-a-sable/recap)
- Constater qu'on redirige bien vers le nouveau format en /details (ex: /modules/6a68bf32/bac-a-sable/recap).