### PR TITLE
[BUGFIX] Corriger l'erreur de typographie sur la page de chargement des contenu formatifs (PIX-20555).

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1233,7 +1233,7 @@
         "list": {
           "generate-personalize-course": "Génération de votre parcours personnalisé.",
           "results-analysis": "Analyse de vos résultats.",
-          "select-passages": "Séléction des formations adaptées."
+          "select-passages": "Sélection des formations adaptées."
         },
         "title": "Calcul de la suite du parcours en cours."
       }


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌰 Proposition
Enlever l’accent sur le mot “sélection” sur la page loader


## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester
Passer un parcours apprenant. Vérifier le bon orthographe sur le loader
