### PR TITLE
[FEATURE] Permettre de sélectionner un pays lors de la modification d'une orga (PIX-20295)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -25,6 +25,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked showArchivingConfirmationModal = false;
   @tracked toggleLockPlaces = false;
   @tracked administrationTeams = [];
+  @tracked countries = [];
 
   noIdentityProviderOption = { label: this.intl.t('common.words.none'), value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
@@ -39,6 +40,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
   async #onMount() {
     this._initForm();
     this.administrationTeams = await this.store.findAll('administration-team');
+    this.countries = await this.store.findAll('country');
   }
 
   get isManagingStudentAvailable() {
@@ -65,10 +67,23 @@ export default class OrganizationInformationSectionEditionMode extends Component
     return options;
   }
 
+  get countriesOptions() {
+    const options = this.countries.map((country) => ({
+      value: country.code,
+      label: `${country.name} (${country.code})`,
+    }));
+
+    return options;
+  }
+
   get translatedAdministrationTeamIdErrorMessage() {
     return this.form.administrationTeamIdError.message
       ? this.intl.t(this.form.administrationTeamIdError.message)
       : null;
+  }
+
+  get translatedCountryCodeErrorMessage() {
+    return this.form.countryCodeError.message ? this.intl.t(this.form.countryCodeError.message) : null;
   }
 
   @action
@@ -79,6 +94,11 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @action
   onChangeAdministrationTeam(newAdministrationTeamId) {
     this.form.administrationTeamId = newAdministrationTeamId;
+  }
+
+  @action
+  onChangeCountry(newCountryCode) {
+    this.form.countryCode = newCountryCode;
   }
 
   @action
@@ -121,6 +141,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
       (team) => team.id === this.form.administrationTeamId,
     )?.name;
 
+    const countryName = this.countries.find((country) => country.code === this.form.countryCode)?.name;
+
     this.args.organization.set('name', this.form.name);
     this.args.organization.set('externalId', this.form.externalId);
     this.args.organization.set('provinceCode', this.form.provinceCode);
@@ -134,6 +156,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('features', this.form.features);
     this.args.organization.set('administrationTeamId', this.form.administrationTeamId);
     this.args.organization.set('administrationTeamName', administrationTeamName);
+    this.args.organization.set('countryCode', this.form.countryCode);
+    this.args.organization.set('countryName', countryName ?? null);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -156,6 +180,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
       administrationTeamId: this.args.organization.administrationTeamId
         ? `${this.args.organization.administrationTeamId}`
         : null,
+      countryCode: this.args.organization.countryCode ? `${this.args.organization.countryCode}` : null,
     });
   }
 
@@ -213,6 +238,25 @@ export default class OrganizationInformationSectionEditionMode extends Component
             @placeholder={{t "components.organizations.editing.administration-team.selector.placeholder"}}
           >
             <:label>{{t "components.organizations.editing.administration-team.selector.label"}}</:label>
+          </PixSelect>
+        </div>
+
+        <div class="form-field">
+          <PixSelect
+            required
+            @aria-required={{true}}
+            @requiredLabel={{t "common.forms.mandatory"}}
+            @errorMessage={{this.translatedCountryCodeErrorMessage}}
+            @validationStatus={{this.form.countryCodeError.status}}
+            @options={{this.countriesOptions}}
+            @value={{this.form.countryCode}}
+            @onChange={{this.onChangeCountry}}
+            @hideDefaultOption={{true}}
+            @isSearchable={{true}}
+            class="admin-form__select"
+            @placeholder={{t "components.organizations.editing.country.selector.placeholder"}}
+          >
+            <:label>{{t "components.organizations.editing.country.selector.label"}}</:label>
           </PixSelect>
         </div>
 

--- a/admin/app/models/organization-form.js
+++ b/admin/app/models/organization-form.js
@@ -104,6 +104,14 @@ const Validations = buildValidations({
       }),
     ],
   },
+  countryCode: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        message: 'components.organizations.editing.country.selector.error-message',
+      }),
+    ],
+  },
 });
 
 export default class OrganizationForm extends Model.extend(Validations) {
@@ -118,6 +126,7 @@ export default class OrganizationForm extends Model.extend(Validations) {
   @attr('string') documentationUrl;
   @attr() identityProviderForCampaigns;
   @attr('string') administrationTeamId;
+  @attr('string') countryCode;
 
   #getErrorAttribute(name) {
     const nameAttribute = this.validations.attrs.get(name);
@@ -168,5 +177,9 @@ export default class OrganizationForm extends Model.extend(Validations) {
 
   get administrationTeamIdError() {
     return this.#getErrorAttribute('administrationTeamId');
+  }
+
+  get countryCodeError() {
+    return this.#getErrorAttribute('countryCode');
   }
 }

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -30,6 +30,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
           IS_MANAGING_STUDENTS: { active: false },
         },
         administrationTeamId: 456,
+        countryCode: 99100,
       });
       this.server.create('organization', { id: '1234' });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -624,6 +624,13 @@
             "placeholder": "Choose an administration team"
           }
         },
+        "country": {
+          "selector": {
+            "error-message": "Country is required",
+            "label": "Country",
+            "placeholder": "Choose a country"
+          }
+        },
         "name": {
           "label": "Name"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -625,6 +625,13 @@
             "placeholder": "Sélectionner une équipe en charge"
           }
         },
+        "country": {
+          "selector": {
+            "error-message": "Le pays est requis",
+            "label": "Pays",
+            "placeholder": "Sélectionner un pays"
+          }
+        },
         "name": {
           "label": "Nom"
         },


### PR DESCRIPTION
## 🍂 Problème

Suite à cette PR https://github.com/1024pix/pix/pull/14186, on veut maintenant permettre à un utilisateur de Pix Admin de sélectionner un pays lors de la modification d'une organisation.

## 🌰 Proposition

Ajouter un composant Select, nourri par la liste des pays stockée en BDD.

## 🍁 Remarques

Ce champs est obligatoire.

## 🪵 Pour tester

Sur Pix Admin:
- aller sur la page de détail d'une orga
- cliquer sur **Modifier**
- constater le champ Pays et la liste des pays
- modifier le pays et sauvegarder

Pour tester l'erreur du champs lorsqu'il n'y a pas de pays, il faut aller manuellement mettre le `countryCode` d'une orga à `null` en base. Ce ne sera plus possible dans le futur car le `countryCode` deviendra `notNullable`
