### PR TITLE
[BUGFIX] Les images vectorielles doivent prendre toute la place du conteneur dans les modules (PIX-20554)

### DIFF
--- a/mon-pix/app/utils/resize-image.js
+++ b/mon-pix/app/utils/resize-image.js
@@ -27,6 +27,13 @@ export function resizeImage(imageInformation, options) {
 }
 
 function _resizeByHeight(imageInformation, MAX_HEIGHT) {
+  if (imageInformation.height <= MAX_HEIGHT && imageInformation.type !== 'vector') {
+    return {
+      width: imageInformation.width,
+      height: imageInformation.height,
+    };
+  }
+
   const width = Math.round((MAX_HEIGHT * imageInformation.width) / imageInformation.height);
   const height = MAX_HEIGHT;
   return {
@@ -36,7 +43,7 @@ function _resizeByHeight(imageInformation, MAX_HEIGHT) {
 }
 
 function _resizeByWidth(imageInformation, MAX_WIDTH) {
-  if (imageInformation.width <= MAX_WIDTH) {
+  if (imageInformation.width <= MAX_WIDTH && imageInformation.type !== 'vector') {
     return {
       width: imageInformation.width,
       height: imageInformation.height,

--- a/mon-pix/tests/unit/utils/resize-image-test.js
+++ b/mon-pix/tests/unit/utils/resize-image-test.js
@@ -47,32 +47,63 @@ module('Unit | Utility | Resize Image', function () {
       assert.deepEqual(imageInformation, dimensions);
     });
 
-    test('should return accurate result when MAX_HEIGHT option is provided', function (assert) {
-      // given
-      const imageInformation = { height: 50, width: 100 };
-      const options = {
-        MAX_HEIGHT: 100,
-      };
+    module('when provided image is raster', function () {
+      test('should return current height when MAX_HEIGHT option is provided', function (assert) {
+        // given
+        const imageInformation = { height: 50, width: 100, type: 'raster' };
+        const options = {
+          MAX_HEIGHT: 100,
+        };
 
-      // when
-      const dimensions = resizeImage(imageInformation, options);
+        // when
+        const dimensions = resizeImage(imageInformation, options);
 
-      //then
-      assert.deepEqual(dimensions, { height: 100, width: 200 });
+        //then
+        assert.deepEqual(dimensions, { height: 50, width: 100 });
+      });
+      test('should return current width if MAX_WIDTH option is provided and larger than width', function (assert) {
+        // given
+        const imageInformation = { height: 100, width: 50, type: 'raster' };
+        const options = {
+          MAX_WIDTH: 100,
+        };
+
+        // when
+        const dimensions = resizeImage(imageInformation, options);
+
+        //then
+        assert.deepEqual(dimensions, { height: 100, width: 50 });
+      });
     });
 
-    test('should return current width if MAX_WIDTH option is provided and larger than width', function (assert) {
-      // given
-      const imageInformation = { height: 100, width: 50 };
-      const options = {
-        MAX_WIDTH: 100,
-      };
+    module('when provided image is vector', function () {
+      test('should return accurate result when MAX_HEIGHT option is provided', function (assert) {
+        // given
+        const imageInformation = { height: 50, width: 100, type: 'vector' };
+        const options = {
+          MAX_HEIGHT: 100,
+        };
 
-      // when
-      const dimensions = resizeImage(imageInformation, options);
+        // when
+        const dimensions = resizeImage(imageInformation, options);
 
-      //then
-      assert.deepEqual(dimensions, { height: 100, width: 50 });
+        //then
+        assert.deepEqual(dimensions, { height: 100, width: 200 });
+      });
+
+      test('should return accurate result if MAX_WIDTH option is provided and larger than width', function (assert) {
+        // given
+        const imageInformation = { height: 100, width: 50, type: 'vector' };
+        const options = {
+          MAX_WIDTH: 100,
+        };
+
+        // when
+        const dimensions = resizeImage(imageInformation, options);
+
+        //then
+        assert.deepEqual(dimensions, { height: 200, width: 100 });
+      });
     });
 
     test('should return MAX_WIDTH if MAX_WIDTH option is provided and smaller than width', function (assert) {


### PR DESCRIPTION
## 🍂 Problème

Lisa nous remonte des soucis sur les images vectorielles dans les modules. Elles sont riquiquis.
**Exemple 1 :**
<img width="491" height="531" alt="image (1)" src="https://github.com/user-attachments/assets/b76a3ad2-436d-4698-b651-0925b41a36fc" />

**Exemple 2:**
<img width="516" height="525" alt="image" src="https://github.com/user-attachments/assets/a359758f-d96e-4a33-bc17-bf1314de4e12" />

## 🌰 Proposition

Récemment nous avons traité les dimensions des images si elles sont plus petites que le conteneur. 
On a ajouté coté front une condition pour traiter les dimensions des images `raster` uniquement.

## 🍁 Remarques

On a ajouté la condition aussi pour le cas où on fournit une hauteur maximum.

## 🪵 Pour tester

- Parcourir le module [cyber-arnaque](https://app-pr14244.review.pix.fr/modules/cyber-message-arnaque/details)
- Vérifier que toutes les images sont lisibles (notamment les captures de téléphone et les infographies)
