### PR TITLE
[FEATURE] Ajouter les paliers et résultats thématiques aux participations MADDO (PIX-19098)

### DIFF
--- a/api/src/maddo/application/campaigns-routes.js
+++ b/api/src/maddo/application/campaigns-routes.js
@@ -57,6 +57,29 @@ const register = async function (server) {
                     masteryRate: Joi.number().description(
                       "Taux de réussite, i.e. pourcentage d'acquis validés dans la campagne",
                     ),
+                    stages: Joi.object({
+                      reachedStage: Joi.number().description('Palier atteint dans la campagne'),
+                      numberOfStages: Joi.number().description('Nombre total de paliers dans la campagne'),
+                    })
+                      .description(
+                        'Paliers associés à la participation à la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                      )
+                      .label('CampaignParticipationStages'),
+                    badges: Joi.array()
+                      .items(
+                        Joi.object({
+                          id: Joi.number().description('ID du badge'),
+                          altMessage: Joi.string().description('Message alternatif du badge'),
+                          imageUrl: Joi.string().description("URL de l'image du badge"),
+                          key: Joi.string().description('Clé unique du badge'),
+                          title: Joi.string().description('Titre du badge'),
+                          isAcquired: Joi.boolean().description('Indique si le badge a été obtenu'),
+                        }).label('CampaignParticipationBadge'),
+                      )
+                      .description(
+                        'Badges associés à la participation à la campagne, null si le type de la campagne est `PROFILES_COLLECTION`',
+                      )
+                      .label('CampaignParticipationBadges'),
                     tubes: Joi.array()
                       .items(
                         Joi.object({

--- a/api/src/maddo/domain/models/CampaignParticipation.js
+++ b/api/src/maddo/domain/models/CampaignParticipation.js
@@ -15,6 +15,8 @@ class CampaignParticipation {
     clientId,
     masteryRate,
     tubes,
+    badges,
+    stages,
     pixScore,
   } = {}) {
     this.id = id;
@@ -30,6 +32,8 @@ class CampaignParticipation {
     this.participantId = crypto.hash('sha1', `${userId}_${clientId}`);
     this.masteryRate = masteryRate;
     this.tubes = tubes;
+    this.badges = badges;
+    this.stages = stages;
     this.pixScore = pixScore;
   }
 }

--- a/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/maddo/infrastructure/repositories/campaign-participation-repository.js
@@ -24,6 +24,8 @@ function toDomain(rawCampaignParticipation, clientId, campaignId) {
     masteryRate: rawCampaignParticipation.masteryRate,
     tubes: rawCampaignParticipation.tubes?.map((tube) => new TubeCoverage(tube)),
     pixScore: rawCampaignParticipation.pixScore,
+    stages: rawCampaignParticipation.stages,
+    badges: rawCampaignParticipation.badges,
     clientId,
     campaignId,
   });

--- a/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/application/api/models/CampaignParticipation.js
@@ -63,6 +63,8 @@ class AssessmentCampaignParticipation extends CampaignParticipation {
     super(args);
     this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
     this.tubes = args.tubes?.map((tube) => new TubeCoverage(tube));
+    this.stages = args.stages;
+    this.badges = args.badges;
   }
 }
 

--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipation.js
@@ -50,6 +50,11 @@ class CampaignParticipation {
  * @extends CampaignParticipationArgs
  * @property {number} masteryRate
  * @property {Object} tubes
+ * @property {{
+ *  reachedStage: number
+ *  numberOfStages: number
+ * }} stages
+ * @property {Badge[]} badges
  */
 
 /**
@@ -63,6 +68,8 @@ class AssessmentCampaignParticipation extends CampaignParticipation {
     super(args);
     this.masteryRate = !_.isNil(args.masteryRate) ? Number(args.masteryRate) : null;
     this.tubes = args.tubes;
+    this.stages = args.stages;
+    this.badges = args.badges;
   }
 }
 
@@ -79,6 +86,17 @@ class ProfilesCollectionCampaignParticipation extends CampaignParticipation {
   constructor(args) {
     super(args);
     this.pixScore = args.pixScore;
+  }
+}
+
+class Badge {
+  constructor({ id, key, title, imageUrl, altMessage, isAcquired }) {
+    this.id = id;
+    this.key = key;
+    this.title = title;
+    this.imageUrl = imageUrl;
+    this.altMessage = altMessage;
+    this.isAcquired = isAcquired;
   }
 }
 
@@ -116,6 +134,7 @@ class TubeCoverage {
 
 export {
   AssessmentCampaignParticipation,
+  Badge,
   CampaignParticipation,
   ProfilesCollectionCampaignParticipation,
   TubeCoverage,

--- a/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
+++ b/api/src/prescription/campaign/domain/usecases/get-campaign-participations.js
@@ -1,17 +1,82 @@
+import * as stageAndStageAcquisitionComparisonService from '../../../../evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
 import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 import { CampaignResultLevelsPerTubesAndCompetences } from '../models/CampaignResultLevelsPerTubesAndCompetences.js';
 import {
   AssessmentCampaignParticipation,
+  Badge,
   ProfilesCollectionCampaignParticipation,
   TubeCoverage,
 } from '../read-models/CampaignParticipation.js';
 
-const getCampaignParticipations = async function ({
+const getStagesAndStageAcquisitions = async (
+  stageRepository,
+  campaignId,
+  stageAcquisitionRepository,
+  participationIds,
+) => {
+  const stages = await stageRepository.getByCampaignId(campaignId);
+  const stageAcquisitions = stages.length
+    ? await stageAcquisitionRepository.getByCampaignParticipations(participationIds)
+    : [];
+  const acquiredStagesByParticipation = stageAcquisitions.reduce((acquiredStagesByParticipation, acquisition) => {
+    if (!acquiredStagesByParticipation[acquisition.campaignParticipationId]) {
+      acquiredStagesByParticipation[acquisition.campaignParticipationId] = [];
+    }
+    acquiredStagesByParticipation[acquisition.campaignParticipationId].push(acquisition);
+    return acquiredStagesByParticipation;
+  }, {});
+  return { stages, acquiredStagesByParticipation };
+};
+
+const getBadgesAndBadesAcquisitions = async (
+  badgeRepository,
+  campaignId,
+  badgeAcquisitionRepository,
+  participationIds,
+) => {
+  const badges = await badgeRepository.findByCampaignId(campaignId);
+  const badgeAcquisitions =
+    await badgeAcquisitionRepository.getAcquiredBadgesForCampaignParticipations(participationIds);
+  const acquiredBadgesByParticipation = badgeAcquisitions.reduce((acquiredBadgesByParticipation, acquisition) => {
+    if (!acquiredBadgesByParticipation[acquisition.campaignParticipationId]) {
+      acquiredBadgesByParticipation[acquisition.campaignParticipationId] = [];
+    }
+    acquiredBadgesByParticipation[acquisition.campaignParticipationId].push(acquisition);
+    return acquiredBadgesByParticipation;
+  }, {});
+  return { badges, acquiredBadgesByParticipation };
+};
+
+const computeTubes = (campaignId, campaignParticipation, learningContent, knowledgeElementsByParticipation) => {
+  if (campaignParticipation.status !== CampaignParticipationStatuses.SHARED) {
+    return;
+  }
+
+  const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
+    campaignId,
+    learningContent,
+  });
+
+  campaignResultLevelPerTubesAndCompetences.addKnowledgeElementSnapshots(knowledgeElementsByParticipation);
+
+  return campaignResultLevelPerTubesAndCompetences.levelsPerTube.map((tube) => {
+    return new TubeCoverage({
+      ...tube,
+      reachedLevel: tube.meanLevel,
+    });
+  });
+};
+
+export const getCampaignParticipations = async function ({
   campaignId,
   locale,
   page,
   since,
   campaignRepository,
+  badgeRepository,
+  badgeAcquisitionRepository,
+  stageRepository,
+  stageAcquisitionRepository,
   campaignParticipationRepository,
   knowledgeElementSnapshotRepository,
   learningContentRepository,
@@ -22,6 +87,7 @@ const getCampaignParticipations = async function ({
     page,
     since,
   });
+  const participationIds = participations.map(({ id }) => id);
 
   if (campaign.isProfilesCollection) {
     return {
@@ -31,45 +97,56 @@ const getCampaignParticipations = async function ({
       meta,
     };
   }
+  const { stages, acquiredStagesByParticipation } = await getStagesAndStageAcquisitions(
+    stageRepository,
+    campaignId,
+    stageAcquisitionRepository,
+    participationIds,
+  );
+
+  const { badges, acquiredBadgesByParticipation } = await getBadgesAndBadesAcquisitions(
+    badgeRepository,
+    campaignId,
+    badgeAcquisitionRepository,
+    participationIds,
+  );
 
   const learningContent = await learningContentRepository.findByCampaignId(campaignId, locale);
   const knowledgeElementsByParticipations = await knowledgeElementSnapshotRepository.findByCampaignParticipationIds(
     participations.map((participation) => participation.id),
   );
+
   return {
     models: participations.map((participation) => {
       const tubes = computeTubes(campaignId, participation, learningContent, {
         [participation.id]: knowledgeElementsByParticipations[participation.id],
       });
-      return new AssessmentCampaignParticipation({ ...participation, tubes });
+
+      const acquiredStagesForParticipation = acquiredStagesByParticipation[participation.id] || [];
+
+      const { reachedStageNumber } = stageAndStageAcquisitionComparisonService.compare(
+        stages,
+        acquiredStagesForParticipation,
+      );
+
+      const badgesAcquisitionsForParticipation = acquiredBadgesByParticipation[participation.id] || [];
+
+      return new AssessmentCampaignParticipation({
+        ...participation,
+        tubes,
+        stages: {
+          reachedStage: reachedStageNumber === 0 ? 0 : reachedStageNumber - 1, // exclude stage 0
+          numberOfStages: stages.length === 0 ? 0 : stages.length - 1, // exclude stage 0
+        },
+        badges: badges.map(
+          (badge) =>
+            new Badge({
+              ...badge,
+              isAcquired: badgesAcquisitionsForParticipation.some(({ badgeId }) => badgeId === badge.id),
+            }),
+        ),
+      });
     }),
     meta,
   };
 };
-
-function computeTubes(campaignId, campaignParticipation, learningContent, knowledgeElementsByParticipation) {
-  if (campaignParticipation.status !== CampaignParticipationStatuses.SHARED) {
-    return undefined;
-  }
-
-  const campaignResultLevelPerTubesAndCompetences = new CampaignResultLevelsPerTubesAndCompetences({
-    campaignId,
-    learningContent,
-  });
-  campaignResultLevelPerTubesAndCompetences.addKnowledgeElementSnapshots(knowledgeElementsByParticipation);
-  return campaignResultLevelPerTubesAndCompetences.levelsPerTube.map(
-    ({ id, competenceId, competenceName, title, description, meanLevel, maxLevel }) => {
-      return new TubeCoverage({
-        id,
-        competenceId,
-        title,
-        description,
-        maxLevel,
-        reachedLevel: meanLevel,
-        competenceName,
-      });
-    },
-  );
-}
-
-export { getCampaignParticipations };

--- a/api/tests/maddo/application/acceptance/campaigns-routes_test.js
+++ b/api/tests/maddo/application/acceptance/campaigns-routes_test.js
@@ -121,12 +121,23 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
                 practicalTitle: tube.practicalTitle_i18n['fr'],
               }),
             ],
+            stages: {
+              numberOfStages: 0,
+              reachedStage: 0,
+            },
+            badges: [],
           }),
           domainBuilder.maddo.buildCampaignParticipation({
             ...participation2,
             participantFirstName: organizationLearner2.firstName,
             participantLastName: organizationLearner2.lastName,
             clientId,
+            stages: {
+              numberOfStages: 0,
+              reachedStage: 0,
+            },
+            tubes: undefined,
+            badges: [],
           }),
         ]);
         expect(response.result.page).to.deep.equal({
@@ -304,6 +315,11 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
                 practicalTitle: tube.practicalTitle_i18n['fr'],
               }),
             ],
+            stages: {
+              numberOfStages: 0,
+              reachedStage: 0,
+            },
+            badges: [],
           }),
         ]);
         expect(response.result.page).to.deep.equal({
@@ -490,12 +506,23 @@ describe('Acceptance | Maddo | Route | Campaigns', function () {
                 practicalTitle: tube.practicalTitle_i18n['fr'],
               }),
             ],
+            stages: {
+              numberOfStages: 0,
+              reachedStage: 0,
+            },
+            badges: [],
           }),
           domainBuilder.maddo.buildCampaignParticipation({
             ...participationCreatedAfterDate,
             participantFirstName: organizationLearner.firstName,
             participantLastName: organizationLearner.lastName,
             clientId,
+            stages: {
+              numberOfStages: 0,
+              reachedStage: 0,
+            },
+            tubes: undefined,
+            badges: [],
           }),
         ]);
         expect(response.result.page).to.deep.equal({

--- a/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
+++ b/api/tests/prescription/campaign/integration/application/api/campaigns-api_test.js
@@ -138,6 +138,11 @@ describe('Integration | Application | campaign-api', function () {
           masteryRate: null,
           status: CampaignParticipationStatuses.STARTED,
           tubes: undefined,
+          stages: {
+            numberOfStages: 0,
+            reachedStage: 0,
+          },
+          badges: [],
         },
         {
           campaignParticipationId: participation1.id,
@@ -159,6 +164,11 @@ describe('Integration | Application | campaign-api', function () {
               practicalTitle: 'practicalTitle FR Tube A',
             },
           ],
+          stages: {
+            numberOfStages: 0,
+            reachedStage: 0,
+          },
+          badges: [],
         },
       ]);
       expect(result.meta).to.deep.equal({

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign-participations_test.js
@@ -12,20 +12,46 @@ import { KnowledgeElement } from '../../../../../../src/shared/domain/models/Kno
 import { FRENCH_SPOKEN } from '../../../../../../src/shared/domain/services/locale-service.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
+const {
+  buildStage,
+  buildBadge,
+  buildCampaign,
+  learningContent,
+  buildCampaignSkill,
+  buildTargetProfile,
+  buildBadgeAcquisition,
+  buildKnowledgeElement,
+  buildStageAcquisition,
+  buildOrganizationLearner,
+  buildCampaignParticipation,
+  buildKnowledgeElementSnapshot,
+} = databaseBuilder.factory;
+
 describe('Integration | UseCase | get-campaign-participations', function () {
   context('when campaign type is assessment', function () {
     it('should return all participations for given campaign', async function () {
       // given
-      const frameworkId = databaseBuilder.factory.learningContent.buildFramework().id;
-      const areaId = databaseBuilder.factory.learningContent.buildArea({ frameworkId }).id;
-      const competence = databaseBuilder.factory.learningContent.buildCompetence({ areaId });
-      const tube = databaseBuilder.factory.learningContent.buildTube({ competenceId: competence.id });
-      const skillId = databaseBuilder.factory.learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+      const frameworkId = learningContent.buildFramework().id;
+      const areaId = learningContent.buildArea({ frameworkId }).id;
+      const competence = learningContent.buildCompetence({ areaId });
+      const tube = learningContent.buildTube({ competenceId: competence.id });
+      const skillId = learningContent.buildSkill({ tubeId: tube.id, status: 'actif' }).id;
+      const organizationLearner1 = buildOrganizationLearner({ lastName: 'Albert' });
 
-      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ lastName: 'Albert' });
-      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
-      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId });
-      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+      const targetProfile = buildTargetProfile();
+
+      // Build stages
+      const stage0 = buildStage({ targetProfileId: targetProfile.id, threshold: 0 });
+      const stage1 = buildStage({ targetProfileId: targetProfile.id, threshold: 20 });
+      const stage2 = buildStage({ targetProfileId: targetProfile.id, threshold: 21 });
+      buildStage({ targetProfileId: targetProfile.id, threshold: 22 });
+
+      const badge1 = buildBadge({ targetProfileId: targetProfile.id, key: 'BADGE1' });
+      const badge2 = buildBadge({ targetProfileId: targetProfile.id, key: 'BADGE2' });
+
+      const campaign = buildCampaign({ type: CampaignTypes.ASSESSMENT, targetProfileId: targetProfile.id });
+      buildCampaignSkill({ campaignId: campaign.id, skillId });
+      const participation1 = buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.SHARED,
         organizationLearnerId: organizationLearner1.id,
@@ -35,22 +61,28 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         createdAt: new Date('2020-01-03'),
         sharedAt: new Date('2020-01-03'),
       });
-      const ke = databaseBuilder.factory.buildKnowledgeElement({
+      buildStageAcquisition({ campaignParticipationId: participation1.id, stageId: stage0.id });
+      buildStageAcquisition({ campaignParticipationId: participation1.id, stageId: stage1.id });
+      buildStageAcquisition({ campaignParticipationId: participation1.id, stageId: stage2.id });
+
+      buildBadgeAcquisition({ campaignParticipationId: participation1.id, badgeId: badge1.id });
+
+      const ke = buildKnowledgeElement({
         status: KnowledgeElement.StatusType.VALIDATED,
         skillId,
         userId: participation1.userId,
       });
 
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+      buildKnowledgeElementSnapshot({
         campaignParticipationId: participation1.id,
         snapshot: new KnowledgeElementCollection([ke]).toSnapshot(),
       });
 
-      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+      const organizationLearner2 = buildOrganizationLearner({
         lastName: 'Michele',
         organizationId: organizationLearner1.organizationId,
       });
-      databaseBuilder.factory.buildCampaignParticipation({
+      buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.STARTED,
         organizationLearnerId: organizationLearner2.id,
@@ -59,13 +91,14 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         validatedSkillsCount: null,
         createdAt: new Date('2020-01-03'),
       });
-      databaseBuilder.factory.buildCampaignParticipation({
+
+      buildCampaignParticipation({
         status: CampaignParticipationStatuses.STARTED,
         masteryRate: 0.5,
         createdAt: new Date('2020-01-04'),
       });
 
-      databaseBuilder.factory.buildCampaignParticipation({
+      buildCampaignParticipation({
         status: CampaignParticipationStatuses.STARTED,
         masteryRate: 0.5,
         createdAt: new Date('2020-01-01'),
@@ -88,7 +121,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
 
       // then
       expect(models).to.have.lengthOf(1);
-      expect(models).to.deep.members([
+      expect(models[0]).to.deep.equal(
         new AssessmentCampaignParticipation({
           campaignParticipationId: participation1.id,
           userId: participation1.userId,
@@ -110,8 +143,30 @@ describe('Integration | UseCase | get-campaign-participations', function () {
               title: tube.practicalTitle_i18n[FRENCH_SPOKEN],
             },
           ],
+          stages: {
+            reachedStage: 2,
+            numberOfStages: 3,
+          },
+          badges: [
+            {
+              id: badge1.id,
+              key: badge1.key,
+              title: badge1.title,
+              imageUrl: badge1.imageUrl,
+              altMessage: badge1.altMessage,
+              isAcquired: true,
+            },
+            {
+              id: badge2.id,
+              key: badge2.key,
+              title: badge2.title,
+              imageUrl: badge2.imageUrl,
+              altMessage: badge2.altMessage,
+              isAcquired: false,
+            },
+          ],
         }),
-      ]);
+      );
       expect(meta).to.deep.equal({
         page: 1,
         pageCount: 2,
@@ -124,9 +179,9 @@ describe('Integration | UseCase | get-campaign-participations', function () {
   context('when campaign type is profile collection', function () {
     it('should return all participations for given campaign', async function () {
       // given
-      const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
-      const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner();
-      const participation1 = databaseBuilder.factory.buildCampaignParticipation({
+      const campaign = buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+      const organizationLearner1 = buildOrganizationLearner();
+      const participation1 = buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.SHARED,
         organizationLearnerId: organizationLearner1.id,
@@ -134,10 +189,10 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         pixScore: 42,
         validatedSkillsCount: 10,
       });
-      const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({
+      const organizationLearner2 = buildOrganizationLearner({
         organizationId: organizationLearner1.organizationId,
       });
-      const participation2 = databaseBuilder.factory.buildCampaignParticipation({
+      const participation2 = buildCampaignParticipation({
         campaignId: campaign.id,
         status: CampaignParticipationStatuses.STARTED,
         organizationLearnerId: organizationLearner2.id,
@@ -145,7 +200,7 @@ describe('Integration | UseCase | get-campaign-participations', function () {
         pixScore: 21,
         validatedSkillsCount: 10,
       });
-      databaseBuilder.factory.buildCampaignParticipation({
+      buildCampaignParticipation({
         status: CampaignParticipationStatuses.STARTED,
         masteryRate: 0.5,
       });

--- a/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/maddo/build-campaign-participation.js
@@ -13,6 +13,8 @@ export function buildCampaignParticipation({
   clientId,
   masteryRate,
   tubes,
+  badges,
+  stages,
   pixScore,
 } = {}) {
   return new CampaignParticipation({
@@ -28,6 +30,8 @@ export function buildCampaignParticipation({
     clientId,
     masteryRate,
     tubes,
+    badges,
+    stages,
     pixScore,
   });
 }


### PR DESCRIPTION
## 🍂 Problème

L'API MADDO de récupération des participations à une campagne ne retournait pas les informations concernant les paliers atteints et les résultats thématiques obtenus par les participants.

## 🌰 Proposition

Ajout de deux nouvelles propriétés dans la réponse de la route `/api/campaigns/{campaignId}/participations` :

- **`stages`** : Objet contenant :
  - `reachedStage` : Palier atteint par le participant
  - `numberOfStages` : Nombre total de paliers dans la campagne
  
- **`badges`** : Tableau des badges de la campagne contenant pour chaque badge :
  - `id`, `altMessage`, `imageUrl`, `key`, `title`
  - `isAcquired` : Indique si le participant a obtenu le badge

Ces informations sont retournées uniquement pour les campagnes d'évaluation (type `ASSESSMENT`), et restent `null` pour les campagnes de collecte de profils (type `PROFILES_COLLECTION`).

## 🍁 Remarques

- La logique de récupération des stages et badges a été enrichie dans le use case `getCampaignParticipations`
- Les modèles de données et la documentation OpenAPI ont été mis à jour en conséquence
- Les tests d'acceptance et d'intégration ont été complétés

## 🪵 Pour tester

```sh
API_URL="https://pix-api-maddo-review-pr14245.osc-fr1.scalingo.io"
CAMPAIGN_ID=104920

# Get AUTH SECRET
SECRET=$(scalingo --app pix-api-maddo-review-pr14245 env-get 'AUTH_SECRET')
EXPIRY=$(($(date +%s) + 3600))  # 1 hour from now

# JWT Header
HEADER='{"alg":"HS256","typ":"JWT"}'
HEADER_B64=$(echo -n "$HEADER" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Payload
PAYLOAD="{\"client_id\":\"maddo-client\",\"source\":\"pix-client\",\"scope\":\"campaigns\",\"exp\":$EXPIRY}"
PAYLOAD_B64=$(echo -n "$PAYLOAD" | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# JWT Signature
SIGNATURE_B64=$(echo -n "${HEADER_B64}.${PAYLOAD_B64}" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64 -w 0 | tr -d '=' | tr '+/' '-_')

# Complete JWT token
TOKEN="${HEADER_B64}.${PAYLOAD_B64}.${SIGNATURE_B64}"

curl -X GET "${API_URL}/api/campaigns/${CAMPAIGN_ID}/participations" \
  -H "Authorization: Bearer ${TOKEN}" \
  -H "Content-Type: application/json" | jq
```

