### PR TITLE
[FEATURE] Prendre en compte le pays (via son code INSEE) lors de la création d'une organisation (PIX-20297)

### DIFF
--- a/api/src/organizational-entities/domain/validators/organization-creation-validator.js
+++ b/api/src/organizational-entities/domain/validators/organization-creation-validator.js
@@ -21,6 +21,12 @@ const organizationValidationJoiSchema = Joi.object({
   administrationTeamId: Joi.number().required().messages({
     'any.required': 'L’équipe en charge n’est pas renseignée.',
   }),
+
+  countryCode: Joi.number().min(99000).max(99999).integer().required().messages({
+    'any.required': 'Le code pays n’est pas renseigné.',
+    'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+    'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+  }),
 });
 
 const validate = function (organizationCreationParams) {

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -339,6 +339,11 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           // given
           const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
           databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
+          databaseBuilder.factory.buildCertificationCpfCountry({
+            code: 99100,
+            commonName: 'France',
+            originalName: 'France',
+          });
           await databaseBuilder.commit();
 
           // when
@@ -354,6 +359,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   'documentation-url': 'https://kingArthur.com',
                   'data-protection-officer-email': 'justin.ptipeu@example.net',
                   'administration-team-id': 1234,
+                  'country-code': 99100,
                 },
               },
             },
@@ -369,6 +375,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           expect(createdOrganization['documentation-url']).to.equal('https://kingArthur.com');
           expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
           expect(createdOrganization['created-by']).to.equal(superAdminUserId);
+          expect(createdOrganization['country-code']).to.equal(99100);
         });
       });
 
@@ -377,6 +384,11 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           // given
           const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
           databaseBuilder.factory.buildAdministrationTeam({ id: 1234, name: 'Équipe 1' });
+          databaseBuilder.factory.buildCertificationCpfCountry({
+            code: 99100,
+            commonName: 'France',
+            originalName: 'France',
+          });
           const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
           await databaseBuilder.commit();
 
@@ -394,6 +406,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   'data-protection-officer-email': 'justin.ptipeu@example.net',
                   'administration-team-id': 1234,
                   'parent-organization-id': parentOrganizationId,
+                  'country-code': 99100,
                 },
               },
             },

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1093,6 +1093,9 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     it('saves the given organization', async function () {
       // given
       const superAdminUserId = databaseBuilder.factory.buildUser.withRole().id;
+      databaseBuilder.factory.buildCertificationCpfCountry({
+        code: 99100,
+      });
       await insertMultipleSendingFeatureForNewOrganization();
 
       await databaseBuilder.commit();
@@ -1102,6 +1105,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         type: 'SCO',
         createdBy: superAdminUserId,
         administrationTeamId: administrationTeam.id,
+        countryCode: 99100,
       });
 
       // when
@@ -1112,11 +1116,13 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(savedOrganization.name).to.equal('Organization SCO');
       expect(savedOrganization.type).to.equal('SCO');
       expect(savedOrganization.createdBy).to.equal(superAdminUserId);
+      expect(savedOrganization.countryCode).to.equal(99100);
     });
 
     context('when the organization type is SCO-1D', function () {
       it('adds mission_management, oralization and learner_import features to the organization', async function () {
         const superAdminUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCpfCountry({ countryCode: 99100 });
         const missionManagementFeatureId = databaseBuilder.factory.buildFeature(
           ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT,
         ).id;
@@ -1136,6 +1142,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           type: 'SCO-1D',
           createdBy: superAdminUserId,
           administrationTeamId: administrationTeam.id,
+          countryCode: 99100,
         });
 
         const savedOrganization = await repositories.organizationForAdminRepository.save({ organization });

--- a/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
+++ b/api/tests/organizational-entities/unit/domain/validators/organization-creation-validator_test.js
@@ -20,6 +20,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           type: 'PRO',
           documentationUrl: 'https://kingArthur.com',
           administrationTeamId: 1234,
+          countryCode: 99123,
         };
 
         // when/then
@@ -35,7 +36,12 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             attribute: 'name',
             message: 'Le nom n’est pas renseigné.',
           };
-          const organizationCreationParams = { name: MISSING_VALUE, type: 'PRO', administrationTeamId: 1234 };
+          const organizationCreationParams = {
+            name: MISSING_VALUE,
+            type: 'PRO',
+            administrationTeamId: 1234,
+            countryCode: 99123,
+          };
 
           try {
             // when
@@ -62,7 +68,12 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             },
           ];
 
-          const organizationCreationParams = { name: 'ACME', type: MISSING_VALUE, administrationTeamId: 1234 };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: MISSING_VALUE,
+            administrationTeamId: 1234,
+            countryCode: 99123,
+          };
 
           try {
             // when
@@ -81,7 +92,12 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             attribute: 'type',
             message: 'Le type de l’organisation doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.',
           };
-          const organizationCreationParams = { name: 'ACME', type: 'PTT', administrationTeamId: 1234 };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PTT',
+            administrationTeamId: 1234,
+            countryCode: 99123,
+          };
 
           try {
             // when
@@ -96,7 +112,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
         ['SUP', 'SCO', 'PRO', 'SCO-1D'].forEach((type) => {
           it(`should not throw with ${type} as type`, function () {
             // given
-            const organizationCreationParams = { name: 'ACME', type, administrationTeamId: 1234 };
+            const organizationCreationParams = { name: 'ACME', type, administrationTeamId: 1234, countryCode: 99123 };
 
             // when/then
             return expect(() => organizationCreationValidator.validate(organizationCreationParams)).to.not.throw();
@@ -112,6 +128,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             type: 'PRO',
             documentationUrl: 'invalidUrl',
             administrationTeamId: 1234,
+            countryCode: 99123,
           };
           const error = await catchErr(organizationCreationValidator.validate)(organizationCreationParams);
 
@@ -128,7 +145,83 @@ describe('Unit | Domain | Validators | organization-validator', function () {
             attribute: 'administrationTeamId',
             message: 'L’équipe en charge n’est pas renseignée.',
           };
-          const organizationCreationParams = { name: 'ACME', type: 'PRO', administrationTeamId: undefined };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            countryCode: 99123,
+            administrationTeamId: undefined,
+          };
+
+          try {
+            // when
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+      });
+
+      context('on countryCode attribute', function () {
+        it('should reject with error when countryCode is missing', function () {
+          // given
+          const expectedError = {
+            attribute: 'countryCode',
+            message: 'Le code pays n’est pas renseigné.',
+          };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            administrationTeamId: 1234,
+            countryCode: undefined,
+          };
+
+          try {
+            // when
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
+        it('should reject with error when countryCode is below minimum', function () {
+          // given
+          const expectedError = {
+            attribute: 'countryCode',
+            message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+          };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            administrationTeamId: 1234,
+            countryCode: 98999,
+          };
+
+          try {
+            // when
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
+        it('should reject with error when countryCode is above maximum', function () {
+          // given
+          const expectedError = {
+            attribute: 'countryCode',
+            message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+          };
+          const organizationCreationParams = {
+            name: 'ACME',
+            type: 'PRO',
+            administrationTeamId: 1234,
+            countryCode: 100000,
+          };
 
           try {
             // when
@@ -147,6 +240,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           name: MISSING_VALUE,
           type: MISSING_VALUE,
           administrationTeamId: MISSING_VALUE,
+          countryCode: MISSING_VALUE,
         };
 
         try {
@@ -155,7 +249,7 @@ describe('Unit | Domain | Validators | organization-validator', function () {
           expect.fail('should have thrown an error');
         } catch (errors) {
           // then
-          expect(errors.invalidAttributes).to.have.lengthOf(4);
+          expect(errors.invalidAttributes).to.have.lengthOf(5);
         }
       });
     });


### PR DESCRIPTION
## 🍂 Problème

On veut pouvoir enregistrer le code pays d'une organisation à sa création 

## 🌰 Proposition

Récupérer la propriété countryCode (code INSEE) dans la route de création d’une orga, et l’ajouter jusqu’au save d’une organisation en base

## 🍁 Remarques

RAS

## 🪵 Pour tester

- utiliser un client HTTP pour requêter la route POST https://admin-pr14246.review.pix.fr/api/admin/organizations
passer le payload suivant (country code de la France):
```
{
  "data": {
    "attributes": {
      "name":"Orga Test Country",
      "type":"SCO",
      "administration-team-id": "1000",
      "country-code": "99100"
    },
    "type": "organizations"
  }
}
```
- constater dans la réponse que l'organisation a bien été crée avec le countryCode

<img width="1402" height="530" alt="image" src="https://github.com/user-attachments/assets/e1c33d5c-fd5e-4a9e-87f2-f2daf2582f72" />

