### PR TITLE
[FEATURE] [Pix Orga] Inscription via SSO - association d'un compte existant (PIX-20539)

### DIFF
--- a/orga/app/authenticators/oidc.js
+++ b/orga/app/authenticators/oidc.js
@@ -1,0 +1,94 @@
+import { service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import ENV from 'pix-orga/config/environment';
+import { decodeToken } from 'pix-orga/helpers/jwt';
+
+export default class OidcAuthenticator extends BaseAuthenticator {
+  @service oidcIdentityProviders;
+  @service session;
+  @service locale;
+
+  async authenticate({ code, state, iss, identityProviderSlug, authenticationKey, hostSlug }) {
+    const request = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Accept-Language': this.locale.currentLanguage, // todo(locale): should be accept language
+        'Content-Type': 'application/json',
+      },
+    };
+    const host = `${ENV.APP.API_HOST}/api/oidc/`;
+    let body;
+    const identityProvider = this.oidcIdentityProviders.findBySlug(identityProviderSlug);
+
+    if (authenticationKey) {
+      body = {
+        identity_provider: identityProvider.code,
+        authentication_key: authenticationKey,
+      };
+    } else {
+      body = {
+        identity_provider: identityProvider.code,
+        code,
+        state,
+        iss,
+      };
+
+      if (this.session.isAuthenticated) {
+        this.session.set('skipRedirectAfterSessionInvalidation', true);
+        await this.session.invalidate();
+      }
+    }
+
+    request.body = JSON.stringify({ data: { attributes: body } });
+    const response = await fetch(host + hostSlug, request);
+
+    const data = await response.json();
+    if (!response.ok) {
+      return Promise.reject(data);
+    }
+
+    const decodedAccessToken = decodeToken(data.access_token);
+
+    return {
+      access_token: data.access_token,
+      logoutUrlUuid: data.logout_url_uuid,
+      user_id: decodedAccessToken.user_id,
+      source: identityProvider.source,
+      shouldCloseSession: identityProvider.shouldCloseSession,
+      identityProviderCode: identityProvider.code,
+    };
+  }
+
+  restore(data) {
+    return new Promise((resolve, reject) => {
+      if (!isEmpty(data['access_token'])) {
+        resolve(data);
+      }
+      reject();
+    });
+  }
+
+  /**
+   * @param {Object} data - The current authenticated session data
+   */
+  async invalidate(data) {
+    const { access_token, shouldCloseSession, identityProviderCode, logoutUrlUuid } = data || {};
+    if (!shouldCloseSession) {
+      return;
+    }
+
+    const response = await fetch(
+      `${ENV.APP.API_HOST}/api/oidc/redirect-logout-url?identity_provider=${identityProviderCode}&logout_url_uuid=${logoutUrlUuid}`,
+      {
+        headers: {
+          Authorization: `Bearer ${access_token}`,
+        },
+      },
+    );
+    const { redirectLogoutUrl } = await response.json();
+
+    this.session.alternativeRootURL = redirectLogoutUrl;
+  }
+}

--- a/orga/app/components/authentication/sso-selection-form.gjs
+++ b/orga/app/components/authentication/sso-selection-form.gjs
@@ -31,7 +31,7 @@ export default class SsoSelectionForm extends Component {
   @action
   goToOidcProviderLoginPage() {
     this.oidcIdentityProviders.isOidcProviderAuthenticationInProgress = true;
-    this.router.transitionTo('authentication.login-oidc', this.selectedProviderSlug);
+    this.router.transitionTo('authentication.oidc.flow', this.selectedProviderSlug);
   }
 
   <template>

--- a/orga/app/controllers/authentication/oidc/login.js
+++ b/orga/app/controllers/authentication/oidc/login.js
@@ -1,0 +1,32 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
+
+export default class OidcLoginController extends Controller {
+  @service currentDomain;
+  @service featureToggles;
+  @service session;
+
+  get currentInvitation() {
+    const invitationStorage = new SessionStorageEntry('joinInvitationData');
+    return invitationStorage.get();
+  }
+
+  @action
+  async reconcile() {
+    this.isLoading = true;
+
+    try {
+      await this.session.authenticate('authenticator:oidc', {
+        authenticationKey: this.args.authenticationKey,
+        identityProviderSlug: this.args.identityProviderSlug,
+        hostSlug: 'user/reconcile',
+      });
+    } catch (responseError) {
+      this.reconcileErrorMessage = this.errorMessages.getAuthenticationErrorMessage(responseError);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}

--- a/orga/app/helpers/jwt.js
+++ b/orga/app/helpers/jwt.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { jwtDecode } from 'jwt-decode';
+
+export function decodeToken(accessToken) {
+  return jwtDecode(accessToken);
+}
+
+export default helper(decodeToken);

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -20,6 +20,9 @@ Router.map(function () {
   this.route('authentication', { path: 'connexion' }, function () {
     this.route('login', { path: '' });
     this.route('sso-selection');
+    this.route('oidc.flow', { path: '/:identity_provider_slug' });
+    this.route('oidc.login', { path: '/:identity_provider_slug/login' });
+    this.route('oidc.signup', { path: '/:identity_provider_slug/signup' });
   });
 
   this.route('join', { path: 'rejoindre' }, function () {

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -1,0 +1,125 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import get from 'lodash/get';
+import ENV from 'pix-orga/config/environment';
+
+import Location from '../../../utils/location';
+import { SessionStorageEntry } from '../../../utils/session-storage-entry';
+
+const oidcUserAuthenticationStorage = new SessionStorageEntry('oidcUserAuthentication');
+
+export default class LoginOidcRoute extends Route {
+  @service intl;
+  @service oidcIdentityProviders;
+  @service router;
+  @service session;
+
+  async beforeModel(transition) {
+    const queryParams = transition.to.queryParams;
+    if (queryParams.error) {
+      throw queryParams.error;
+    }
+
+    const identityProviderSlug = transition.to.params.identity_provider_slug;
+    const identityProvider = this.oidcIdentityProviders.findBySlug(identityProviderSlug);
+    if (!identityProvider) {
+      this.router.transitionTo('authentication.login');
+      return;
+    }
+
+    // Preventing OIDC authentication replay errors when doing history back and reload
+    // when the user is already authenticated with the same OIDC Provider.
+    if (this.session.isAuthenticated) {
+      if (identityProvider.code == this.session.data.authenticated.identityProviderCode) {
+        this.router.transitionTo('authenticated');
+        return;
+      }
+    }
+
+    if (!queryParams.code) {
+      transition.abort();
+      await this._makeOidcAuthenticationRequest(identityProvider);
+    }
+  }
+
+  async model(params, transition) {
+    const { code, state, iss } = transition.to.queryParams;
+    const identityProviderSlug = params.identity_provider_slug;
+    const identityProvider = this.oidcIdentityProviders.findBySlug(identityProviderSlug);
+
+    const model = await this._handleOidcCallbackRequest({ identityProvider, code, state, iss });
+    return model;
+  }
+
+  redirect(model) {
+    const { identityProviderSlug, shouldCreateUserAccount } = model;
+
+    if (shouldCreateUserAccount) {
+      this.router.transitionTo('authentication.oidc.login', identityProviderSlug);
+    }
+  }
+
+  async _makeOidcAuthenticationRequest(identityProvider) {
+    this.session.set('data.nextURL', undefined);
+
+    // Storing the `attemptedTransition` in the localstorage so that when the user returns after
+    // the login he can be sent to the initial destination.
+    if (this.session.get('attemptedTransition')) {
+      // cf. https://github.com/tildeio/router.js/blob/master/ARCHITECTURE.md#transitionintent
+      // there are 2 types of TransitionIntents:
+      // - URLTransitionIntent: for example when the route is accessed by url (/campagnes/:code), the url is provided
+      // - NamedTransitionIntent: for example when the route is accessed by the submit of the campaign code
+      //   the route name (organizations.access) and contexts ([Campaign]) are provided.
+      const { url, name, contexts } = this.session.get('attemptedTransition.intent');
+      let nextURL;
+      if (url) {
+        nextURL = url;
+      } else {
+        if (contexts[0]) {
+          nextURL = this.router.urlFor(name, contexts[0]);
+        } else {
+          nextURL = this.router.urlFor(name);
+        }
+      }
+
+      this.session.set('data.nextURL', nextURL);
+    }
+
+    const response = await fetch(
+      `${ENV.APP.API_HOST}/api/oidc/authorization-url?identity_provider=${identityProvider.code}`,
+    );
+    const { redirectTarget: authorizationUrl } = await response.json();
+    Location.assign(authorizationUrl);
+  }
+
+  async _handleOidcCallbackRequest({ identityProvider, code, state, iss }) {
+    const identityProviderSlug = identityProvider.slug;
+    try {
+      await this.session.authenticate('authenticator:oidc', {
+        code,
+        state,
+        iss,
+        identityProviderSlug,
+        hostSlug: 'token',
+      });
+
+      return { identityProviderSlug, shouldCreateUserAccount: false };
+    } catch (response) {
+      const apiError = get(response, 'errors[0]');
+
+      if (apiError.code == 'MISSING_OIDC_STATE') {
+        this.router.transitionTo('authentication.login');
+        return;
+      }
+
+      const shouldValidateCgu = apiError.code === 'SHOULD_VALIDATE_CGU';
+      if (shouldValidateCgu && apiError.meta.authenticationKey) {
+        oidcUserAuthenticationStorage.set(apiError.meta);
+
+        return { identityProviderSlug, shouldCreateUserAccount: true };
+      }
+
+      throw apiError;
+    }
+  }
+}

--- a/orga/app/routes/join/index.js
+++ b/orga/app/routes/join/index.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
 
 export default class JoinRoute extends Route {
   @service router;
@@ -15,22 +16,32 @@ export default class JoinRoute extends Route {
     this.session.prohibitAuthentication(this.routeIfAlreadyAuthenticated);
   }
 
-  model(params) {
-    return this.store
-      .queryRecord('organization-invitation', {
-        invitationId: params.invitationId,
-        code: params.code,
-      })
-      .catch((errorResponse) => {
-        errorResponse.errors.forEach((error) => {
-          if (error.status === '403') {
-            this.isInvitationCancelled = true;
-          }
-          if (error.status === '412') {
-            this.hasInvitationAlreadyBeenAccepted = true;
-          }
-        });
+  async model(params) {
+    const { code, invitationId } = params;
+
+    try {
+      const model = await this.store.queryRecord('organization-invitation', { invitationId, code });
+
+      const joinInvitationData = {
+        invitationId,
+        code,
+        organizationName: model.organizationName,
+      };
+
+      const invitationStorage = new SessionStorageEntry('joinInvitationData');
+      invitationStorage.set(joinInvitationData);
+
+      return model;
+    } catch (errorResponse) {
+      errorResponse.errors.forEach((error) => {
+        if (error.status === '403') {
+          this.isInvitationCancelled = true;
+        }
+        if (error.status === '412') {
+          this.hasInvitationAlreadyBeenAccepted = true;
+        }
       });
+    }
   }
 
   async redirect(model) {

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -1,0 +1,34 @@
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import t from 'ember-intl/helpers/t';
+import pageTitle from 'ember-page-title/helpers/page-title';
+import LoginForm from 'pix-orga/components/authentication/login-form';
+import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+
+<template>
+  {{pageTitle (t "pages.login.title")}}
+
+  <AuthenticationLayout class="signin-page-layout">
+    <:header>
+    </:header>
+
+    <:content>
+      {{#if @controller.currentInvitation}}
+        <PixNotificationAlert @type="communication-orga">
+          {{t "pages.login.join-invitation" organizationName=@controller.currentInvitation.organizationName}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      <div>
+        <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>
+        <h3 class="pix-body-l">{{t "pages.login.with-pix-account"}}</h3>
+      </div>
+
+      <LoginForm
+        @isWithInvitation={{false}}
+        @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
+        @isInvitationCancelled={{@controller.isInvitationCancelled}}
+        @onLogin={{@controller.reconcile}}
+      />
+    </:content>
+  </AuthenticationLayout>
+</template>

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -1,0 +1,3 @@
+<template>
+  <div>SIGNUP PAGE TO BE DONE</div>
+</template>

--- a/orga/app/utils/location.js
+++ b/orga/app/utils/location.js
@@ -2,8 +2,28 @@ function getHref() {
   return window.location.href;
 }
 
+function getOrigin() {
+  return window.location.origin;
+}
+
+function replace(url) {
+  window.location.replace(url);
+}
+
+function reload() {
+  window.location.reload(true);
+}
+
+function assign(url) {
+  window.location.assign(url);
+}
+
 const Location = {
   getHref,
+  getOrigin,
+  replace,
+  reload,
+  assign,
 };
 
 export default Location;

--- a/orga/app/utils/session-storage-entry.js
+++ b/orga/app/utils/session-storage-entry.js
@@ -1,0 +1,18 @@
+export class SessionStorageEntry {
+  constructor(key) {
+    this.key = key;
+  }
+
+  set(value) {
+    sessionStorage.setItem(this.key, JSON.stringify({ value }));
+  }
+
+  get() {
+    const result = JSON.parse(sessionStorage.getItem(this.key)) || {};
+    return result.value;
+  }
+
+  remove() {
+    sessionStorage.removeItem(this.key);
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -716,4 +716,105 @@ function routes() {
       ],
     };
   });
+
+  this.post('/oidc/token', (schema, request) => {
+    if (!request.requestHeaders.Authorization) {
+      return new Response(
+        401,
+        {},
+        {
+          errors: [
+            {
+              code: 'SHOULD_VALIDATE_CGU',
+              meta: { authenticationKey: 'key', userClaims: { lastName: 'PIX', firstName: 'test' } },
+            },
+          ],
+        },
+      );
+    }
+
+    const createdUser = schema.users.create({
+      firstName: 'Lloyd',
+      lastName: 'Cé',
+      lang: 'fr',
+    });
+
+    return {
+      access_token:
+        'aaa.' +
+        btoa(
+          `{"user_id":${createdUser.id},"source":"oidc-externe","iat":1545321469,"exp":4702193958,"identity_provider":"OIDC_PARTNER"}`,
+        ) +
+        '.bbb',
+      logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+      user_id: createdUser.id,
+    };
+  });
+
+  this.get('/oidc/identity-providers/:cache_buster', () => {
+    return {
+      data: [
+        {
+          type: 'oidc-identity-providers',
+          id: 'oidc-partner',
+          attributes: {
+            code: 'OIDC_PARTNER',
+            'organization-name': 'Partenaire OIDC',
+            slug: 'oidc-partner',
+            'should-close-session': false,
+            source: 'oidc-externe',
+            'is-visible': true,
+          },
+        },
+      ],
+    };
+  });
+
+  this.get('/oidc/authorization-url', () => {
+    return {
+      redirectTarget: `https://oidc/connexion/oauth2/authorize`,
+    };
+  });
+
+  this.post('/oidc/users', (schema, request) => {
+    const payload = JSON.parse(request.requestBody);
+    const identityProvider = payload.data.attributes.identity_provider;
+    const profile = schema.profiles.create({ pixScore: 1 });
+    const createdUser = schema.users.create({
+      firstName: 'Lloyd',
+      lastName: 'Cé',
+      lang: 'fr',
+      profile,
+    });
+
+    return {
+      access_token:
+        'aaa.' +
+        btoa(
+          `{"user_id":${createdUser.id},"source":"oidc-externe","identity_provider":"${identityProvider}","iat":1545321469,"exp":4702193958}`,
+        ) +
+        '.bbb',
+      user_id: createdUser.id,
+    };
+  });
+
+  this.get('/oidc/redirect-logout-url', () => {
+    return {
+      redirectLogoutUrl:
+        'http://identity_provider_base_url/deconnexion?id_token_hint=ID_TOKEN&redirect_uri=http%3A%2F%2Flocalhost.fr%3A4200%2Fconnexion',
+    };
+  });
+
+  this.post('/oidc/user/check-reconciliation', () => {
+    return {
+      data: {
+        attributes: {
+          'full-name-from-pix': 'LLoyd Cé',
+          'full-name-from-external-identity-provider': 'LLoyd Idp',
+          email: 'lloyd.ce@example.net',
+          'authentication-methods': [{ identityProvider: 'PIX' }],
+        },
+      },
+    };
+  });
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -69,6 +69,7 @@
         "eslint-plugin-qunit": "^8.1.2",
         "globals": "^16.0.0",
         "i18next-browser-languagedetector": "^8.2.0",
+        "jwt-decode": "^4.0.0",
         "loader.js": "^4.7.0",
         "npm-run-all2": "^8.0.0",
         "p-queue": "^8.0.0",
@@ -28631,6 +28632,16 @@
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -113,6 +113,7 @@
     "eslint-plugin-qunit": "^8.1.2",
     "globals": "^16.0.0",
     "i18next-browser-languagedetector": "^8.2.0",
+    "jwt-decode": "^4.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all2": "^8.0.0",
     "p-queue": "^8.0.0",

--- a/orga/tests/acceptance/join-and-login-test.js
+++ b/orga/tests/acceptance/join-and-login-test.js
@@ -5,6 +5,7 @@ import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
 import { module, test } from 'qunit';
 
 import setupIntl from '../helpers/setup-intl';
@@ -19,8 +20,16 @@ module('Acceptance | join and login', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  let invitationStorage;
+
   hooks.beforeEach(function () {
     server.create('feature-toggle', { id: 0, usePixOrgaNewAuthDesign: true });
+    invitationStorage = new SessionStorageEntry('joinInvitationData');
+  });
+
+  hooks.afterEach(function () {
+    server.create('feature-toggle', { id: 0, usePixOrgaNewAuthDesign: true });
+    invitationStorage.remove();
   });
 
   module('When the invitation is valid', function (hooks) {
@@ -54,6 +63,11 @@ module('Acceptance | join and login', function (hooks) {
       assert.strictEqual(currentURL(), '/');
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       assert.ok(screen.getByText('Harry Cover'));
+      assert.deepEqual(invitationStorage.get(), {
+        code: 'ABCD',
+        invitationId: '1',
+        organizationName: 'College BRO & Evil Associates',
+      });
     });
 
     module('When user has not accepted terms of service yet', function (hooks) {
@@ -149,6 +163,7 @@ module('Acceptance | join and login', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/connexion');
+      assert.strictEqual(invitationStorage.get(), undefined);
     });
   });
 

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -1,0 +1,119 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn, settled } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import Location from 'pix-orga/utils/location';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntl from '../../helpers/setup-intl';
+import { unabortedVisit } from '../../helpers/unaborted-visit';
+
+module('Acceptance | OIDC | authentication flow', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function () {
+    sinon.stub(Location, 'assign');
+  });
+
+  hooks.afterEach(function () {
+    Location.assign.restore();
+  });
+
+  module('when the user has not performed an authentication to the OIDC Provider', function () {
+    module('when the wanted OIDC Provider is not enabled/ready/existing', function () {
+      test('it redirects the user to the login page', async function (assert) {
+        // when
+        await unabortedVisit('/connexion/some-oidc-provider-not-enabled-ready-existing');
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+      });
+    });
+
+    module('when the wanted OIDC Provider is enabled and ready', function () {
+      test('it redirects the user to the OIDC provider authentication page', async function (assert) {
+        // when
+        await unabortedVisit('/connexion/oidc-partner');
+
+        // then
+        assert.ok(Location.assign.calledWith('https://oidc/connexion/oauth2/authorize'));
+      });
+    });
+  });
+
+  module('when the user has performed an authentication to the OIDC Provider', function () {
+    module('when the wanted OIDC Provider is not enabled/ready/existing', function () {
+      test('it redirects the user to the login page', async function (assert) {
+        // when
+        await unabortedVisit('/connexion/some-oidc-provider-not-enabled-ready-existing?code=code&state=state');
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+      });
+    });
+
+    module('when the wanted OIDC Provider is enabled and ready', function () {
+      test('it redirects the user to the SSO login page', async function (assert) {
+        // when
+        await unabortedVisit('/connexion/oidc-partner?code=code&state=state');
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion/oidc-partner/login');
+      });
+
+      module('when the user has a Pix account', function () {
+        test('the user can log in their account', async function (assert) {
+          // given
+          server.create('user', {
+            email: 'lloyd.ce@example.net',
+            password: 'pix123',
+            cgu: true,
+            mustValidateTermsOfService: false,
+            lastTermsOfServiceValidatedAt: new Date(),
+          });
+          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+          // when
+          await fillIn(
+            screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
+            'lloyd.ce@example.net',
+          );
+          await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'pix123');
+
+          await click(screen.getByRole('button', { name: 'Je me connecte' }));
+          // eslint-disable-next-line ember/no-settled-after-test-helper
+          await settled();
+
+          // then
+          assert.ok(screen.getByRole('button', { name: t('pages.login-form.login') }));
+        });
+      });
+
+      // TODO: Uncomment and make those tests work when the signup template is done
+      // module('when the user creates an account', function () {
+      //   module('when the user logs out', function () {
+      //     toRenameToTest('it redirects the user to the logout URL', async function (assert) {
+      //       // given
+      //       const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+      //       await click(screen.getByLabelText(t('common.cgu.label')));
+      //       await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+      //       // eslint-disable-next-line ember/no-settled-after-test-helper
+      //       await settled();
+
+      //       await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+
+      //       // when
+      //       await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+
+      //       // then
+      //       assert.strictEqual(currentURL(), '/deconnexion');
+      //     });
+      //   });
+      // });
+    });
+  });
+});

--- a/orga/tests/helpers/unaborted-visit.js
+++ b/orga/tests/helpers/unaborted-visit.js
@@ -1,0 +1,21 @@
+import { getScreen, visit } from '@1024pix/ember-testing-library';
+import { settled } from '@ember/test-helpers';
+
+// Lorsqu'on souhaite tester un transitionTo, on doit utiliser un try/catch en attendant l'évolution attendue dans Ember :
+// https://github.com/emberjs/ember-test-helpers/issues/332
+export async function unabortedVisit(url) {
+  try {
+    await visit(url);
+  } catch (error) {
+    if (!_isEmberTransitionAborted(error)) {
+      throw error;
+    }
+
+    await settled();
+  }
+  return getScreen();
+}
+
+function _isEmberTransitionAborted(error) {
+  return error.message == 'TransitionAborted';
+}

--- a/orga/tests/unit/helpers/jwt-test.js
+++ b/orga/tests/unit/helpers/jwt-test.js
@@ -1,0 +1,60 @@
+import { decodeToken } from 'pix-orga/helpers/jwt';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Unit | Helpers | decodeToken', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('decodeToken', function () {
+    test('should decode valid token', async function (assert) {
+      const accessToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiRmlyc3QiLCJsYXN0X25hbWUiOiJMYXN0Iiwic2FtbF9pZCI6InNhbWxJRDEyMzQ1NjciLCJpYXQiOjE1OTc5Mjk0NDgsImV4cCI6MTU5NzkzMzA0OH0.bk7HPPwoa0bx6uxE92HXj1ak8DintQx5Id_1wyudZkg';
+      const decodedToken = decodeToken(accessToken);
+      const expectedResult = {
+        first_name: 'First',
+        last_name: 'Last',
+        saml_id: 'samlID1234567',
+        iat: 1597929448,
+        exp: 1597933048,
+      };
+      assert.deepEqual(decodedToken, expectedResult);
+    });
+
+    test('should decode valid token with accented characters in firstName, lastName', async function (assert) {
+      const accessToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiTm_DqW1pZSIsImxhc3RfbmFtZSI6IkHDrmnDr21hbsOoIiwic2FtbF9pZCI6InNhbWxJRDEyMzQ1NjciLCJpYXQiOjE1OTc5Mjk0NDgsImV4cCI6MTU5NzkzMzA0OH0.XZJCiDE73sTqHrSmVc99ynypQHzxw3wwZahLUvxgdZY';
+      const decodedToken = decodeToken(accessToken);
+      const expectedResult = {
+        first_name: 'Noémie',
+        last_name: 'Aîiïmanè',
+        saml_id: 'samlID1234567',
+        iat: 1597929448,
+        exp: 1597933048,
+      };
+      assert.deepEqual(decodedToken, expectedResult);
+    });
+
+    test('should extract userId and source from token', function (assert) {
+      // given
+      const user_id = 1;
+      const source = 'mon-pix';
+      const token =
+        'aaa.' +
+        btoa(`{
+        "user_id": ${user_id},
+        "source": "${source}",
+        "iat": 1545321469,
+        "exp": 4702193958
+      }`) +
+        '.bbb';
+
+      // when
+      const dataFromToken = decodeToken(token);
+
+      // then
+      assert.strictEqual(dataFromToken.user_id, user_id);
+      assert.strictEqual(dataFromToken.source, source);
+    });
+  });
+});

--- a/orga/tests/unit/utils/location-test.js
+++ b/orga/tests/unit/utils/location-test.js
@@ -20,4 +20,48 @@ module('Unit | Utility | location', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
   });
+
+  module('#replace', function () {
+    test('should replace the current URL', function (assert) {
+      // given
+      const newUrl = 'https://example.com/new-path';
+      const replaceStub = sinon.stub(Location, 'replace');
+
+      // when
+      Location.replace(newUrl);
+
+      // then
+      sinon.assert.calledWith(replaceStub, newUrl);
+      assert.ok(true);
+    });
+  });
+
+  module('#reload', function () {
+    test('should reload the current page', function (assert) {
+      // given
+      const reloadStub = sinon.stub(Location, 'reload');
+
+      // when
+      Location.reload();
+
+      // then
+      sinon.assert.calledOnce(reloadStub);
+      assert.ok(true);
+    });
+  });
+
+  module('#assign', function () {
+    test('should assign a new URL', function (assert) {
+      // given
+      const newUrl = 'https://example.com/new-path';
+      const assignStub = sinon.stub(Location, 'assign');
+
+      // when
+      Location.assign(newUrl);
+
+      // then
+      sinon.assert.calledWith(assignStub, newUrl);
+      assert.ok(true);
+    });
+  });
 });

--- a/orga/tests/unit/utils/session-storage-entry-test.js
+++ b/orga/tests/unit/utils/session-storage-entry-test.js
@@ -1,0 +1,76 @@
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
+import { module, test } from 'qunit';
+
+module('Unit | Utilities | SessionStorageEntry', function () {
+  test('sets and gets a string value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('testKey');
+    const value = 'testValue';
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a number value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('numberKey');
+    const value = 123;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a boolean value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('booleanKey');
+    const value = true;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('sets and gets a null value', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('nullKey');
+    const value = null;
+
+    // when
+    entry.set(value);
+
+    // then
+    assert.strictEqual(entry.get(), value);
+  });
+
+  test('returns undefined for a non-existing key', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('nonExistingKey');
+
+    // when
+    const result = entry.get();
+
+    // then
+    assert.strictEqual(result, undefined);
+  });
+
+  test('removes a key', function (assert) {
+    // given
+    const entry = new SessionStorageEntry('testKey');
+    const value = 'testValue';
+    entry.set(value);
+
+    // when
+    entry.remove();
+
+    // then
+    assert.strictEqual(entry.get(), undefined);
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Dans Pix Orga, afin de s’inscrire via SSO, il est nécessaire de mettre en place le mécanisme d’inscription par SSO sur l’URL `/connexion/:oidc/login`.

## 🌰 Proposition

<img width="2544" height="1167" alt="invitation-route-display-flow" src="https://github.com/user-attachments/assets/80c2cbe1-88d7-45c2-b1aa-8059d6df1abd" />

Cette PR gère la partie du schéma en bleu.

Cette PR traite uniquement le cas où le compte SSO n’est pas associé à un compte Pix existant (via `sub`) et où l’utilisateur va se mettre en position de les associer avec un formulaire de login / password.

:bulb: Cette PR ajoute la route `/:identity_provider_slug/signup` mais en créant juste une template avec `<div>SIGNUP PAGE TO BE DONE</div>` dedans. C’est pour démontrer et valider la bonne logique de l’architecture des routes mises en place.

## 🍁 Remarques

N/A

## 🪵 Pour tester

1. Dans Pix Orga, se connecter avec un admin d’organisation
2. Inviter un utilisateur ayant déjà un compte Pix
3. Avec cet utilisateur invité suivre le lien de l’invitation
4. Sur la page de connexion constater que le bandeau _« Vous êtes invité à rejoindre "le nom de l’orga" »_ s‘affiche
5. Cliquer sur _« Choisir une autre organisation »_
6. Réaliser l’authentification auprès du SSO
7. Constater l’arrivée sur la page de connexion où s’affiche toujours le bandeau _« Vous êtes invité à rejoindre "le nom de l’orga" »_
8. Cliquer sur _« Je me connecte »_ et constater l‘affichage du message d’erreur disant que l’utilisateur n’est pas encore membre de cet organisation (ce qui est normal car l’ajout de membership n’a pas été réalisé dans cette PR)