### PR TITLE
[TECH] :recycle: Renomme les constantes appelées `supervisor` pour utiliser `invigilator` (PIX-20573)

### DIFF
--- a/api/src/certification/session-management/domain/models/CertificationAssessment.js
+++ b/api/src/certification/session-management/domain/models/CertificationAssessment.js
@@ -17,7 +17,7 @@ import { NeutralizationAttempt } from './NeutralizationAttempt.js';
 const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
-  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
   ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 
@@ -29,7 +29,7 @@ const certificationAssessmentSchema = Joi.object({
   completedAt: Joi.date().allow(null),
   endedAt: Joi.date().allow(null),
   state: Joi.string()
-    .valid(states.COMPLETED, states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_DUE_TO_FINALIZATION)
+    .valid(states.COMPLETED, states.STARTED, states.ENDED_BY_INVIGILATOR, states.ENDED_DUE_TO_FINALIZATION)
     .required(),
   version: Joi.number()
     .integer()
@@ -98,7 +98,7 @@ class CertificationAssessment {
   }
 
   endByInvigilator({ now }) {
-    this.state = states.ENDED_BY_SUPERVISOR;
+    this.state = states.ENDED_BY_INVIGILATOR;
     this.endedAt = now;
   }
 
@@ -187,7 +187,7 @@ class CertificationAssessment {
   }
 
   static get uncompletedAssessmentStates() {
-    return [states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_DUE_TO_FINALIZATION];
+    return [states.STARTED, states.ENDED_BY_INVIGILATOR, states.ENDED_DUE_TO_FINALIZATION];
   }
 
   _getLastChallenge() {

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -1,7 +1,7 @@
 import { status as assessmentResultStatuses } from '../../../../shared/domain/models/AssessmentResult.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 const STARTED = 'started';
-const ENDED_BY_SUPERVISOR = 'endedBySupervisor';
+const ENDED_BY_INVIGILATOR = 'endedBySupervisor';
 const CORE_CERTIFICATION = 'CORE';
 const DOUBLE_CORE_CLEA_CERTIFICATION = 'DOUBLE_CORE_CLEA';
 
@@ -16,7 +16,7 @@ class JuryCertificationSummary {
     completedAt,
     abortReason,
     isPublished,
-    isEndedBySupervisor,
+    isEndedByInvigilator,
     complementaryCertificationLabelObtained,
     complementaryCertificationKeyObtained,
     certificationIssueReports,
@@ -24,7 +24,7 @@ class JuryCertificationSummary {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
-    this.status = _getStatus({ status, isEndedBySupervisor });
+    this.status = _getStatus({ status, isEndedByInvigilator });
     this.pixScore = pixScore;
     this.isFlaggedAborted = Boolean(abortReason) && !completedAt;
     this.certificationObtained = _getCertificationObtained({
@@ -64,9 +64,9 @@ class JuryCertificationSummary {
   }
 }
 
-function _getStatus({ status, isEndedBySupervisor }) {
-  if (isEndedBySupervisor) {
-    return ENDED_BY_SUPERVISOR;
+function _getStatus({ status, isEndedByInvigilator }) {
+  if (isEndedByInvigilator) {
+    return ENDED_BY_INVIGILATOR;
   }
 
   if (!Object.values(assessmentResultStatuses).includes(status)) {
@@ -86,7 +86,7 @@ function _getCertificationObtained({ complementaryCertificationLabelObtained, co
   return complementaryCertificationLabelObtained;
 }
 
-const statuses = { ...assessmentResultStatuses, STARTED, ENDED_BY_SUPERVISOR };
+const statuses = { ...assessmentResultStatuses, STARTED, ENDED_BY_INVIGILATOR };
 
 JuryCertificationSummary.statuses = statuses;
 

--- a/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
@@ -1,25 +1,23 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-const create = async function ({ sessionId, userId }) {
+export async function create({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('supervisor-accesses').insert({ sessionId, userId });
-};
+}
 
-const isUserInvigilatorForSession = async function ({ sessionId, userId }) {
+export async function isUserInvigilatorForSession({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn.select(1).from('supervisor-accesses').where({ sessionId, userId }).first();
   return Boolean(result);
-};
+}
 
-const isUserInvigilatorForSessionCandidate = async function ({ supervisorId, certificationCandidateId }) {
+export async function isUserInvigilatorForSessionCandidate({ invigilatorId, certificationCandidateId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn
     .select(1)
     .from('supervisor-accesses')
     .innerJoin('certification-candidates', 'supervisor-accesses.sessionId', 'certification-candidates.sessionId')
-    .where({ 'certification-candidates.id': certificationCandidateId, 'supervisor-accesses.userId': supervisorId })
+    .where({ 'certification-candidates.id': certificationCandidateId, 'supervisor-accesses.userId': invigilatorId })
     .first();
   return Boolean(result);
-};
-
-export { create, isUserInvigilatorForSession, isUserInvigilatorForSessionCandidate };
+}

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-summary-repository.js
@@ -139,7 +139,7 @@ function _toDomain(juryCertificationSummaryDTO) {
   return new JuryCertificationSummary({
     ...juryCertificationSummaryDTO,
     status: juryCertificationSummaryDTO.assessmentResultStatus,
-    isEndedBySupervisor: juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_SUPERVISOR,
+    isEndedByInvigilator: juryCertificationSummaryDTO.assessmentState === Assessment.states.ENDED_BY_INVIGILATOR,
     certificationIssueReports,
   });
 }

--- a/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/session-invigilator-authorization.js
@@ -2,14 +2,14 @@ import { extractUserIdFromRequest } from '../../../../shared/infrastructure/util
 import * as invigilatorAccessRepository from '../../../session-management/infrastructure/repositories/invigilator-access-repository.js';
 
 const verifyByCertificationCandidateId = async function (request, h, dependencies = { invigilatorAccessRepository }) {
-  const supervisorUserId = extractUserIdFromRequest(request);
+  const invigilatorUserId = extractUserIdFromRequest(request);
   const certificationCandidateId = request.params.certificationCandidateId;
-  const isSupervisorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
-    supervisorId: supervisorUserId,
+  const isInvigilatorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
+    invigilatorId: invigilatorUserId,
     certificationCandidateId,
   });
 
-  if (!isSupervisorForSession) {
+  if (!isInvigilatorForSession) {
     return h.response().code(401).takeover();
   }
 
@@ -20,12 +20,12 @@ const verifyBySessionId = async function (request, h, dependencies = { invigilat
   const userId = extractUserIdFromRequest(request);
   const sessionId = request.params.sessionId;
 
-  const isSupervisorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSession({
+  const isInvigilatorForSession = await dependencies.invigilatorAccessRepository.isUserInvigilatorForSession({
     sessionId,
     userId,
   });
 
-  if (!isSupervisorForSession) {
+  if (!isInvigilatorForSession) {
     return h.response().code(401).takeover();
   }
   return true;

--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -1,7 +1,7 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ForbiddenAccess,
 } from '../../../shared/domain/errors.js';
@@ -22,8 +22,8 @@ const saveAndCorrectAnswerForCertification = withTransaction(async function ({
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
-  if (assessment.isEndedBySupervisor()) {
-    throw new CertificationEndedBySupervisorError();
+  if (assessment.isEndedByInvigilator()) {
+    throw new CertificationEndedByInvigilatorError();
   }
   if (assessment.hasBeenEndedDueToFinalization()) {
     throw new CertificationEndedByFinalizationError();

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -77,7 +77,7 @@ class CertificateVerificationCodeGenerationTooManyTrials extends DomainError {
   }
 }
 
-class CertificationEndedBySupervisorError extends DomainError {
+class CertificationEndedByInvigilatorError extends DomainError {
   constructor(message = 'Le surveillant a mis fin à votre test de certification.') {
     super(message);
   }
@@ -1055,7 +1055,7 @@ export {
   CertificationCenterMembershipCreationError,
   CertificationCenterMembershipDisableError,
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   CertificationRejectNotAllowedError,
   CertificationRescoringNotAllowedError,
   ChallengeAlreadyAnsweredError,

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -16,7 +16,7 @@ const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
   ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
 };
 
@@ -103,8 +103,8 @@ class Assessment {
     return this.state === Assessment.states.STARTED;
   }
 
-  isEndedBySupervisor() {
-    return this.state === Assessment.states.ENDED_BY_SUPERVISOR;
+  isEndedByInvigilator() {
+    return this.state === Assessment.states.ENDED_BY_INVIGILATOR;
   }
 
   hasBeenEndedDueToFinalization() {

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -109,7 +109,7 @@ const completeByAssessmentId = function (assessmentId) {
 };
 
 const endBySupervisorByAssessmentId = function (assessmentId) {
-  return this._updateStateById({ id: assessmentId, state: Assessment.states.ENDED_BY_SUPERVISOR });
+  return this._updateStateById({ id: assessmentId, state: Assessment.states.ENDED_BY_INVIGILATOR });
 };
 
 const getByCertificationCandidateId = async function (certificationCandidateId) {

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -192,8 +192,8 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
         });
       });
 
-      context('when the session has been accessed by one or more supervisor', function () {
-        it('should remove supervisor accesses and delete the session', async function () {
+      context('when the session has been accessed by one or more invigilator', function () {
+        it('should remove invigilator accesses and delete the session', async function () {
           // given
           const sessionId = databaseBuilder.factory.buildSession().id;
           databaseBuilder.factory.buildSupervisorAccess({ sessionId });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -308,7 +308,7 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
           expect(candidateTimeline.events).to.deep.includes(
             new CertificationEndedEvent({
               when: assessment.endedAt,
-              assessmentState: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+              assessmentState: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
             }),
           );
         });

--- a/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/get-candidate-timeline_test.js
@@ -276,8 +276,8 @@ describe('Certification | Enrolment | Unit | Domain | UseCase | get-candidate-ti
         });
       });
 
-      context('when supervisor stops the test', function () {
-        it('should add an ended by supervisor event', async function () {
+      context('when invigilator stops the test', function () {
+        it('should add an ended by invigilator event', async function () {
           // given
           const sessionId = 1234;
           const certificationCandidateId = 4567;

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/session-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/session-serializer_test.js
@@ -49,7 +49,7 @@ describe('Unit | Certification | enrolment | Serializer | session-serializer', f
     });
 
     context('when session does not have a link to an existing certification center', function () {
-      it('should convert a SessionEnrolment model object into JSON API data including supervisor password', function () {
+      it('should convert a SessionEnrolment model object into JSON API data including invigilator password', function () {
         // when
         const json = serializer.serialize(session);
 

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -770,7 +770,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
               certificationCourseId: 789,
               createdAt: new Date('2020-01-01'),
               completedAt: new Date('2020-01-01'),
-              state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+              state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
               version: 2,
               certificationChallenges: [
                 domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false }),
@@ -837,7 +837,7 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
                 certificationCourseId: 789,
                 createdAt: new Date('2020-01-01'),
                 completedAt: new Date('2020-01-01'),
-                state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+                state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
                 version: 2,
                 certificationChallenges: [domainBuilder.buildCertificationChallengeWithType({ isNeutralized: false })],
                 certificationAnswersByDate: ['answer'],

--- a/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
@@ -14,7 +14,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
   describe('POST /api/certification-candidates/{certificationCandidateId}/authorize-to-start', function () {
     context('when user is authenticated', function () {
-      context('when the user is the supervisor of the session', function () {
+      context('when the user is the invigilator of the session', function () {
         it('should return a 204 status code', async function () {
           // given
           const candidateUserId = databaseBuilder.factory.buildUser({}).id;

--- a/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
@@ -40,11 +40,11 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         status: CertificationCompanionLiveAlertStatus.ONGOING,
       });
 
-      const { userId: supervisorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+      const { userId: invigilatorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId });
 
       await databaseBuilder.commit();
 
-      const headers = generateAuthenticatedUserRequestHeaders({ userId: supervisorId, source: 'pix-certif' });
+      const headers = generateAuthenticatedUserRequestHeaders({ userId: invigilatorId, source: 'pix-certif' });
 
       const options = {
         headers,
@@ -61,18 +61,18 @@ describe('Certification | Session Management | Acceptance | Application | Routes
       expect(alerts).to.deep.equal([{ assessmentId, status: CertificationCompanionLiveAlertStatus.CLEARED }]);
     });
 
-    describe('when user does NOT have supervisor access on session', function () {
+    describe('when user does NOT have invigilator access on session', function () {
       it('should return 401 unauthorized', async function () {
         // given
         const { id: certificationCenterId } = databaseBuilder.factory.buildCertificationCenter();
         const { id: sessionId } = databaseBuilder.factory.buildSession({ certificationCenterId });
         const { id: otherSessionId } = databaseBuilder.factory.buildSession({ certificationCenterId });
 
-        const { userId: supervisorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId: otherSessionId });
+        const { userId: invigilatorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId: otherSessionId });
 
         await databaseBuilder.commit();
 
-        const headers = generateAuthenticatedUserRequestHeaders({ userId: supervisorId, source: 'pix-certif' });
+        const headers = generateAuthenticatedUserRequestHeaders({ userId: invigilatorId, source: 'pix-certif' });
 
         const options = {
           headers,

--- a/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
@@ -15,7 +15,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
   });
 
   describe('PATCH /sessions/{sessionId}/candidates/{candidateId}/dismiss-live-alert', function () {
-    describe('when user has supervisor authorization', function () {
+    describe('when user has invigilator authorization', function () {
       it('should return 204 when the alert is ongoing', async function () {
         // given
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -23,8 +23,8 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
         });
-        const supervisorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: supervisorUserId, sessionId: session.id });
+        const invigilatorUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
@@ -43,7 +43,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
 
         await databaseBuilder.commit();
 
-        const headers = generateAuthenticatedUserRequestHeaders({ userId: supervisorUserId, source: 'pix-certif' });
+        const headers = generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' });
         const options = {
           headers,
           method: 'PATCH',
@@ -63,7 +63,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
       });
     });
 
-    describe('when user does not have supervisor authorization', function () {
+    describe('when user does not have invigilator authorization', function () {
       it('should return 401 when the alert is ongoing', async function () {
         // given
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -71,8 +71,8 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
         });
-        const supervisorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: supervisorUserId, sessionId: session.id });
+        const invigilatorUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const userNotLinkedToTheSessionId = databaseBuilder.factory.buildUser().id;
 
@@ -98,7 +98,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
   });
 
   describe('PATCH /sessions/{sessionId}/candidates/{candidateId}/validate-live-alert', function () {
-    describe('when user has supervisor authorization', function () {
+    describe('when user has invigilator authorization', function () {
       it('should return 204 when the alert is ongoing', async function () {
         // given
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -106,12 +106,12 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
         });
-        const supervisorUserId = databaseBuilder.factory.buildUser().id;
+        const invigilatorUserId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildIssueReportCategory({
           name: 'IMAGE_NOT_DISPLAYING',
           issueReportCategoryId: 5,
         });
-        databaseBuilder.factory.buildSupervisorAccess({ userId: supervisorUserId, sessionId: session.id });
+        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
@@ -130,7 +130,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
 
         await databaseBuilder.commit();
 
-        const headers = generateAuthenticatedUserRequestHeaders({ userId: supervisorUserId, source: 'pix-certif' });
+        const headers = generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' });
         const options = {
           headers,
           method: 'PATCH',
@@ -155,7 +155,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
       });
     });
 
-    describe('when user does not have supervisor authorization', function () {
+    describe('when user does not have invigilator authorization', function () {
       it('should return 401 when the alert is ongoing', async function () {
         // given
         const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -163,8 +163,8 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
         });
-        const supervisorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: supervisorUserId, sessionId: session.id });
+        const invigilatorUserId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const userNotLinkedToTheSessionId = databaseBuilder.factory.buildUser().id;
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
@@ -58,9 +58,9 @@ describe('Integration | Repository | invigilator-access-repository', function ()
   describe('#isUserInvigilatorForSessionCandidate', function () {
     it("should return true if the user is invigilating the candidate's session", async function () {
       // given
-      const supervisorId = databaseBuilder.factory.buildUser().id;
+      const invigilatorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: supervisorId });
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: invigilatorId });
       const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId });
       await databaseBuilder.commit();
@@ -68,7 +68,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // when
       const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
         certificationCandidateId,
-        supervisorId,
+        invigilatorId,
       });
 
       // then
@@ -77,9 +77,9 @@ describe('Integration | Repository | invigilator-access-repository', function ()
 
     it("should return false if the user is not invigilating the candidate's session", async function () {
       // given
-      const supervisorId = databaseBuilder.factory.buildUser().id;
+      const invigilatorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: supervisorId });
+      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: invigilatorId });
       const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate().id;
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId });
       await databaseBuilder.commit();
@@ -87,7 +87,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // when
       const isUserInvigilatorForSession = await invigilatorAccessRepository.isUserInvigilatorForSessionCandidate({
         certificationCandidateId,
-        supervisorId,
+        invigilatorId,
       });
 
       // then

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -153,7 +153,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         const assessmentId = dbf.buildAssessment({
           certificationCourseId: certificationCourse.id,
-          state: Assessment.states.ENDED_BY_SUPERVISOR,
+          state: Assessment.states.ENDED_BY_INVIGILATOR,
         }).id;
 
         dbf.buildAssessmentResult({ assessmentId, createdAt: new Date('2018-02-15T00:00:00Z') });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -164,7 +164,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({ sessionId });
 
         // then
-        expect(juryCertificationSummaries[0].status).to.equal('endedByinvigilator');
+        expect(juryCertificationSummaries[0].status).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
       });
     });
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -141,8 +141,8 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
       });
     });
 
-    context('when the session has an ended by supervisor assessment', function () {
-      it('should return a JuryCertificationSummary with a endedBySupervisor status', async function () {
+    context('when the session has an ended by invigilator assessment', function () {
+      it('should return a JuryCertificationSummary with a endedByInvigilator status', async function () {
         // given
         const dbf = databaseBuilder.factory;
         const sessionId = dbf.buildSession().id;
@@ -164,7 +164,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId({ sessionId });
 
         // then
-        expect(juryCertificationSummaries[0].status).to.equal('endedBySupervisor');
+        expect(juryCertificationSummaries[0].status).to.equal('endedByinvigilator');
       });
     });
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -670,7 +670,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulOne.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_SUPERVISOR,
+        state: states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -684,7 +684,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulTwo.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_SUPERVISOR,
+        state: states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -734,7 +734,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithReportNotImpactfulOne.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_SUPERVISOR,
+        state: states.ENDED_BY_INVIGILATOR,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -761,7 +761,7 @@ describe('Integration | Repository | JurySession', function () {
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseWithImpactfulSubCategory.id,
         type: Assessment.types.CERTIFICATION,
-        state: states.ENDED_BY_SUPERVISOR,
+        state: states.ENDED_BY_INVIGILATOR,
       });
       databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: certificationCourseWithImpactfulSubCategory.id,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
@@ -541,7 +541,7 @@ describe('Integration | Repository | Certification | session | SessionManagement
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 98,
-          state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+          state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
         });
 
         const userId3 = databaseBuilder.factory.buildUser().id;

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -467,18 +467,18 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
     });
 
-    describe('when the assessment is ENDED_BY_SUPERVISOR', function () {
+    describe('when the assessment is ENDED_BY_INVIGILATOR', function () {
       it('should NOT change the assessment state"', function () {
         // given
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+          state: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
         });
 
         // when
         certificationAssessment.endDueToFinalization();
 
         // when then
-        expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_SUPERVISOR);
+        expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
       });
     });
   });
@@ -495,7 +495,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       certificationAssessment.endByInvigilator({ now });
 
       // then
-      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_SUPERVISOR);
+      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
       expect(certificationAssessment.endedAt).to.deep.equal(now);
     });
   });
@@ -918,7 +918,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       // then
       expect(result).to.deep.equal([
         CertificationAssessment.states.STARTED,
-        CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+        CertificationAssessment.states.ENDED_BY_INVIGILATOR,
         CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
       ]);
     });

--- a/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/FinalizedSession_test.js
@@ -21,7 +21,7 @@ describe('Unit | Certification | Session-Management | Domain | Models | Finalize
       expect(finalizedSession.isPublishable).to.be.false;
     });
 
-    it('is publishable when session has no global comment, no started or error status, no issue report requiring action and supervisor was used', function () {
+    it('is publishable when session has no global comment, no started or error status, no issue report requiring action and invigilator was used', function () {
       // given / when
       const finalizedSession = FinalizedSession.from({
         sessionId: 1234,
@@ -37,7 +37,7 @@ describe('Unit | Certification | Session-Management | Domain | Models | Finalize
       expect(finalizedSession.isPublishable).to.be.true;
     });
 
-    context('when supervisor portal was used', function () {
+    context('when invigilator portal was used', function () {
       it('is publishable even if a test end screen has not been seen', function () {
         // when
         const finalizedSession = FinalizedSession.from({

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -62,10 +62,10 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
       });
     });
 
-    context('when assessment is ended by supervisor', function () {
-      it(`should returns "endedBySupervisor" status`, function () {
+    context('when assessment is ended by invigilator', function () {
+      it(`should returns "endedByInvigilator" status`, function () {
         // when
-        const juryCertificationSummary = new JuryCertificationSummary({ isEndedBySupervisor: true });
+        const juryCertificationSummary = new JuryCertificationSummary({ isEndedByInvigilator: true });
 
         // then
         expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['ENDED_BY_INVIGILATOR']);

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
         const juryCertificationSummary = new JuryCertificationSummary({ isEndedBySupervisor: true });
 
         // then
-        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['ENDED_BY_SUPERVISOR']);
+        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses['ENDED_BY_INVIGILATOR']);
       });
     });
 

--- a/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/end-assessment-by-invigilator_test.js
@@ -57,7 +57,7 @@ describe('Unit | UseCase | end-assessment-by-invigilator', function () {
 
       // then
       expect(startedCertificationAssessment.endedAt).to.be.instanceOf(Date);
-      expect(startedCertificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_SUPERVISOR);
+      expect(startedCertificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_INVIGILATOR);
       expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(startedCertificationAssessment);
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -683,7 +683,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
       });
     });
 
-    describe('when the certification was ended by the supervisor', function () {
+    describe('when the certification was ended by the invigilator', function () {
       it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({

--- a/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/process-auto-jury_test.js
@@ -687,7 +687,7 @@ describe('Unit | UseCase | process-auto-jury', function () {
       it('triggers a CertificationJuryDone rescoring event', async function () {
         // given
         const { certificationCourse } = _initializeV3CourseAndAssessment({
-          certificationState: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+          certificationState: CertificationAssessment.states.ENDED_BY_INVIGILATOR,
           certificationAssessmentRepository,
           certificationCourseRepository,
           certificationIssueReportRepository,

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
@@ -123,7 +123,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
   context('when the assessment has been ended by supervisor', function () {
     it('should throw a CertificationEndedBySupervisorError error', async function () {
       // given
-      assessment.state = Assessment.states.ENDED_BY_SUPERVISOR;
+      assessment.state = Assessment.states.ENDED_BY_INVIGILATOR;
 
       // when
       const error = await catchErr(saveAndCorrectAnswerForCertification)({

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
@@ -5,7 +5,7 @@ import { saveAndCorrectAnswerForCertification } from '../../../../../src/evaluat
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
 } from '../../../../../src/shared/domain/errors.js';
@@ -120,8 +120,8 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
     });
   });
 
-  context('when the assessment has been ended by supervisor', function () {
-    it('should throw a CertificationEndedBySupervisorError error', async function () {
+  context('when the assessment has been ended by invigilator', function () {
+    it('should throw a CertificationEndedByInvigilatorError error', async function () {
       // given
       assessment.state = Assessment.states.ENDED_BY_INVIGILATOR;
 
@@ -135,7 +135,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       });
 
       // then
-      expect(error).to.be.an.instanceOf(CertificationEndedBySupervisorError);
+      expect(error).to.be.an.instanceOf(CertificationEndedByInvigilatorError);
     });
   });
 

--- a/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/assessment-repository_test.js
@@ -557,7 +557,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
       // then
       const { state } = await knex('assessments').where('id', assessmentId).first('state');
-      expect(state).to.equal(Assessment.states.ENDED_BY_SUPERVISOR);
+      expect(state).to.equal(Assessment.states.ENDED_BY_INVIGILATOR);
     });
   });
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -43,27 +43,27 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
-  describe('#isEndedBySupervisor', function () {
-    it('should return true when its state is endedBySupervisor', function () {
+  describe('#isEndedByInvigilator', function () {
+    it('should return true when its state is endedByInvigilator', function () {
       // given
-      const assessment = new Assessment({ state: 'endedBySupervisor' });
+      const assessment = new Assessment({ state: Assessment.states.ENDED_BY_INVIGILATOR });
 
       // when
-      const isEndedBySupervisor = assessment.isEndedBySupervisor();
+      const isEndedByInvigilator = assessment.isEndedByInvigilator();
 
       // then
-      expect(isEndedBySupervisor).to.be.true;
+      expect(isEndedByInvigilator).to.be.true;
     });
 
-    it('should return false when its state is not endedBySupervisor', function () {
+    it('should return false when its state is not endedByInvigilator', function () {
       // given
       const assessment = new Assessment({ state: '' });
 
       // when
-      const isEndedBySupervisor = assessment.isEndedBySupervisor();
+      const isEndedByInvigilator = assessment.isEndedByInvigilator();
 
       // then
-      expect(isEndedBySupervisor).to.be.false;
+      expect(isEndedByInvigilator).to.be.false;
     });
   });
 

--- a/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
+++ b/api/tests/shared/unit/domain/usecases/update-assessment-with-next-challenge_test.js
@@ -76,7 +76,7 @@ describe('Shared | Unit | Domain | Use Cases | get-next-challenge', function () 
       [
         Assessment.states.ABORTED,
         Assessment.states.COMPLETED,
-        Assessment.states.ENDED_BY_SUPERVISOR,
+        Assessment.states.ENDED_BY_INVIGILATOR,
         Assessment.states.ENDED_DUE_TO_FINALIZATION,
       ].forEach((assessmentState) => {
         it(`should return an assessment with its answers`, async function () {

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -421,8 +421,8 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
         });
 
-        describe('when the are multiple different supervisors per session', function () {
-          it('should return the session with an array of supervisors', function () {
+        describe('when the are multiple different invigilators per session', function () {
+          it('should return the session with an array of invigilators', function () {
             // given
             const parsedCsvData = [
               _lineWithSessionAndNoCandidate({ sessionNumber: 1, examiner: 'Big' }),

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification-summary.js
@@ -11,7 +11,7 @@ const buildJuryCertificationSummary = function ({
   completedAt = new Date('2020-01-02'),
   abortReason = null,
   isPublished = true,
-  isEndedBySupervisor = false,
+  isEndedByInvigilator = false,
   certificationObtained,
   certificationIssueReports = [],
 } = {}) {
@@ -25,7 +25,7 @@ const buildJuryCertificationSummary = function ({
     completedAt,
     abortReason,
     isPublished,
-    isEndedBySupervisor,
+    isEndedByInvigilator,
     certificationObtained,
     certificationIssueReports,
   });

--- a/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-supervisor-authorization_test.js
@@ -27,7 +27,7 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
         invigilatorAccessRepository.isUserInvigilatorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
-            supervisorId: 100,
+            invigilatorId: 100,
           })
           .resolves(true);
 
@@ -49,7 +49,7 @@ describe('Unit | Pre-handler | Invigilator Authorization', function () {
         invigilatorAccessRepository.isUserInvigilatorForSessionCandidate
           .withArgs({
             certificationCandidateId: 8,
-            supervisorId: 100,
+            invigilatorId: 100,
           })
           .resolves(false);
 


### PR DESCRIPTION
## 🍂 Problème

La traduction  de surveillant en supervisor n’est  pas  approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/b038aeec-5e0a-478d-9a6c-70b595d8a8bf" />

Il y a plusieurs constantes qui portent le terme `SUPERVISOR`.

## 🌰 Proposition

Renommer les constantes appelées `supervisor` pour utiliser `invigilator`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Faire un tour sur l'interface de l'espace surveillant, tout doit continuer à fonctionner normalement.
