### PR TITLE
[TECH] :recycle: Renommer `CertificationEndedBySupervisorError` avec `Invigilator` (pix-20575)

### DIFF
--- a/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
+++ b/api/src/evaluation/domain/usecases/save-and-correct-answer-for-certification.js
@@ -1,7 +1,7 @@
 import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ForbiddenAccess,
 } from '../../../shared/domain/errors.js';
@@ -22,8 +22,8 @@ const saveAndCorrectAnswerForCertification = withTransaction(async function ({
   if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
-  if (assessment.isEndedBySupervisor()) {
-    throw new CertificationEndedBySupervisorError();
+  if (assessment.isEndedByInvigilator()) {
+    throw new CertificationEndedByInvigilatorError();
   }
   if (assessment.hasBeenEndedDueToFinalization()) {
     throw new CertificationEndedByFinalizationError();

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -77,7 +77,7 @@ class CertificateVerificationCodeGenerationTooManyTrials extends DomainError {
   }
 }
 
-class CertificationEndedBySupervisorError extends DomainError {
+class CertificationEndedByInvigilatorError extends DomainError {
   constructor(message = 'Le surveillant a mis fin à votre test de certification.') {
     super(message);
   }
@@ -1055,7 +1055,7 @@ export {
   CertificationCenterMembershipCreationError,
   CertificationCenterMembershipDisableError,
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   CertificationRejectNotAllowedError,
   CertificationRescoringNotAllowedError,
   ChallengeAlreadyAnsweredError,

--- a/api/src/shared/domain/models/Assessment.js
+++ b/api/src/shared/domain/models/Assessment.js
@@ -103,7 +103,7 @@ class Assessment {
     return this.state === Assessment.states.STARTED;
   }
 
-  isEndedBySupervisor() {
+  isEndedByInvigilator() {
     return this.state === Assessment.states.ENDED_BY_SUPERVISOR;
   }
 

--- a/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/save-and-correct-answer-for-certification_test.js
@@ -5,7 +5,7 @@ import { saveAndCorrectAnswerForCertification } from '../../../../../src/evaluat
 import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import {
   CertificationEndedByFinalizationError,
-  CertificationEndedBySupervisorError,
+  CertificationEndedByInvigilatorError,
   ChallengeAlreadyAnsweredError,
   ChallengeNotAskedError,
 } from '../../../../../src/shared/domain/errors.js';
@@ -120,8 +120,8 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
     });
   });
 
-  context('when the assessment has been ended by supervisor', function () {
-    it('should throw a CertificationEndedBySupervisorError error', async function () {
+  context('when the assessment has been ended by invigilator', function () {
+    it('should throw a CertificationEndedByInvigilatorError error', async function () {
       // given
       assessment.state = Assessment.states.ENDED_BY_SUPERVISOR;
 
@@ -135,7 +135,7 @@ describe('Unit | Evaluation | Domain | Use Cases | save-and-correct-answer-for-c
       });
 
       // then
-      expect(error).to.be.an.instanceOf(CertificationEndedBySupervisorError);
+      expect(error).to.be.an.instanceOf(CertificationEndedByInvigilatorError);
     });
   });
 

--- a/api/tests/shared/unit/domain/models/Assessment_test.js
+++ b/api/tests/shared/unit/domain/models/Assessment_test.js
@@ -43,16 +43,16 @@ describe('Unit | Domain | Models | Assessment', function () {
     });
   });
 
-  describe('#isEndedBySupervisor', function () {
+  describe('#isEndedByInvigilator', function () {
     it('should return true when its state is endedBySupervisor', function () {
       // given
       const assessment = new Assessment({ state: 'endedBySupervisor' });
 
       // when
-      const isEndedBySupervisor = assessment.isEndedBySupervisor();
+      const isEndedByInvigilator = assessment.isEndedByInvigilator();
 
       // then
-      expect(isEndedBySupervisor).to.be.true;
+      expect(isEndedByInvigilator).to.be.true;
     });
 
     it('should return false when its state is not endedBySupervisor', function () {
@@ -60,10 +60,10 @@ describe('Unit | Domain | Models | Assessment', function () {
       const assessment = new Assessment({ state: '' });
 
       // when
-      const isEndedBySupervisor = assessment.isEndedBySupervisor();
+      const isEndedByInvigilator = assessment.isEndedByInvigilator();
 
       // then
-      expect(isEndedBySupervisor).to.be.false;
+      expect(isEndedByInvigilator).to.be.false;
     });
   });
 


### PR DESCRIPTION
## 🍂 Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/47690562-58ee-4b69-aec0-d49686e27e3f" />

Une erreur contient toujours le terme Supervisor

## 🌰 Proposition

 Renommer `CertificationEndedBySupervisorError` avec `Invigilator`

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
