### PR TITLE
[FEATURE] Mentionner l'oralisation dans la modale d'édition du candidat (PIX-20572).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -76,14 +76,19 @@
               </PixTag>
             {{/if}}
           </div>
-
-          {{#if @candidate.hasOngoingChallengeLiveAlert}}
-            <PixButton @triggerAction={{this.askUserToHandleLiveAlert}} @variant="error">
-              {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
-            </PixButton>
-          {{/if}}
         </div>
       {{/if}}
+
+      {{#if @candidate.hasOngoingChallengeLiveAlert}}
+        <PixButton
+          @triggerAction={{this.askUserToHandleLiveAlert}}
+          @variant="error"
+          class="session-supervising-candidate-in-list__live-alert-button"
+        >
+          {{t "pages.session-supervising.candidate-in-list.resume-test-modal.live-alerts.handle-challenge"}}
+        </PixButton>
+      {{/if}}
+
       {{#if this.isConfirmButtonToBeDisplayed}}
         <PixButton
           aria-label={{this.authorizationButtonAriaLabel}}

--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-edition-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-edition-modal.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
@@ -35,9 +36,12 @@ export default class CandidateEditionModal extends Component {
             <legend class='edit-candidate-modal-form-accessibility-adjustment__legend'>{{t
                 'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.title'
               }}</legend>
-            <span id='adjustment-details'>{{t
-                'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.details'
-              }}</span>
+            <PixNotificationAlert
+              @withIcon={{true}}
+              class='edit-candidate-modal-form-accessibility-adjustment__description'
+            >
+              {{t 'pages.sessions.detail.candidates.edit-modal.accessibility-adjustment.details' htmlSafe=true}}
+            </PixNotificationAlert>
             <PixCheckbox
               aria-describedby='adjustment-details'
               @checked={{@candidate.accessibilityAdjustmentNeeded}}

--- a/certif/app/styles/components/edit-candidate-modal.scss
+++ b/certif/app/styles/components/edit-candidate-modal.scss
@@ -18,8 +18,14 @@
   }
 }
 
-.edit-candidate-modal-form-accessibility-adjustment__legend {
-  color: var(--pix-neutral-900);
-  font-weight: var(--pix-font-medium);
-  font-size: 1rem;
+.edit-candidate-modal-form-accessibility-adjustment {
+  &__legend {
+    color: var(--pix-neutral-900);
+    font-weight: var(--pix-font-medium);
+    font-size: 1rem;
+  }
+
+  &__description {
+    margin-block: var(--pix-spacing-2x);
+  }
 }

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -74,6 +74,10 @@
     width: fit-content;
   }
 
+  &__live-alert-button {
+    margin-top: var(--pix-spacing-2x);
+  }
+
   &__menu {
     border-left: 1px solid var(--pix-neutral-100);
     padding: var(--pix-spacing-2x);

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-edition-modal-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-edition-modal-test.gjs
@@ -48,7 +48,6 @@ module(
         .dom(
           screen.getByRole('checkbox', {
             name: "Le candidat a besoin d'un aménagement",
-            description: "L'aménagement consiste à retirer les questions non accessibles",
             checked: false,
           }),
         )

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -627,7 +627,7 @@
           },
           "edit-modal": {
             "accessibility-adjustment": {
-              "details": "The adjustment involves removing questions that are not accessible",
+              "details": "The adjustment involves <b>removing questions that are not accessible</b> and <b>allowing the oral presentation of the challenges questions</b>",
               "label": "Candidate needs an adjustment",
               "title": "Digital accessibility adjustment"
             },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -627,7 +627,7 @@
           },
           "edit-modal": {
             "accessibility-adjustment": {
-              "details": "L'aménagement consiste à retirer les questions non accessibles",
+              "details": "L'aménagement consiste à <b>retirer les questions non accessibles</b> ainsi qu'à <b>permettre l'oralisation de l'énoncé des épreuves</b>.",
               "label": "Le candidat a besoin d'un aménagement",
               "title": "Aménagement d'accessibilité numérique"
             },


### PR DESCRIPTION
## 🍂 Problème

L'oralisation a été ajoutée pour la certif Pix coeur.
Mais aucune mention n'y était faite sur Pix certif.

## 🌰 Proposition

Dans la modale d'édition du candidat, ajouter l'information sur l'oralisation.

## 🍁 Remarques

J'ai profité de la PR pour améliorer le CSS dans l'espace surveillant.

#### Avant

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9a29869d-0806-4731-a770-9d57c00635a5" />

#### Après

<img width="700" alt="image" src="https://github.com/user-attachments/assets/bde33c3b-20e0-4279-b8b9-dafab4eeabb3" />


## 🪵 Pour tester

- Ajouter un candidat Pix coeur à une session
- Afficher sa modale d'édition
- Vérifier que l'info d'oralisation est bien indiquée
