### PR TITLE
[FEATURE] Ajuster le temps d'apparition du bouton suivant dans un stepper horizontal (PIX-20521)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bac-a-sable.json
@@ -10,9 +10,7 @@
     "duration": 5,
     "level": "novice",
     "tabletSupport": "inconvenient",
-    "objectives": [
-      "Non régression fonctionnelle"
-    ]
+    "objectives": ["Non régression fonctionnelle"]
   },
   "sections": [
     {
@@ -62,6 +60,59 @@
                         }
                       ],
                       "solution": "1"
+                    }
+                  ]
+                },
+                {
+                  "elements": [
+                    {
+                      "id": "0f8eb663-be85-4cb1-9168-e5c39f4ec1bd",
+                      "type": "qrocm",
+                      "instruction": "<p>Compléter le texte suivant :</p>",
+                      "proposals": [
+                        {
+                          "type": "text",
+                          "content": "<span>Pix est un</span>"
+                        },
+                        {
+                          "input": "pix-name",
+                          "type": "input",
+                          "inputType": "text",
+                          "size": 10,
+                          "display": "inline",
+                          "placeholder": "",
+                          "ariaLabel": "Mot à trouver",
+                          "defaultValue": "",
+                          "tolerances": ["t1", "t3"],
+                          "solutions": ["Groupement"]
+                        },
+                        {
+                          "type": "text",
+                          "content": "<span>d'intérêt public qui a été créée en</span>"
+                        },
+                        {
+                          "input": "pix-birth",
+                          "type": "input",
+                          "inputType": "number",
+                          "size": 10,
+                          "display": "inline",
+                          "placeholder": "",
+                          "ariaLabel": "Année à trouver",
+                          "defaultValue": "",
+                          "tolerances": [],
+                          "solutions": [2016]
+                        }
+                      ],
+                      "feedbacks": {
+                        "valid": {
+                          "state": "Correct&#8239;!",
+                          "diagnosis": "<p> vous nous connaissez bien &nbsp; <span aria-hidden=\"true\">🎉</span></p>"
+                        },
+                        "invalid": {
+                          "state": "Incorrect&#8239;!",
+                          "diagnosis": "<p> vous y arriverez la prochaine fois&#8239;!</p>"
+                        }
+                      }
                     }
                   ]
                 },
@@ -128,11 +179,7 @@
                           "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "3",
-                        "4"
-                      ]
+                      "solutions": ["1", "3", "4"]
                     }
                   ]
                 },
@@ -941,11 +988,7 @@
                     "diagnosis": "<p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "3",
-                  "4"
-                ]
+                "solutions": ["1", "3", "4"]
               }
             }
           ]
@@ -1032,13 +1075,8 @@
                     "placeholder": "",
                     "ariaLabel": "Mot à trouver",
                     "defaultValue": "",
-                    "tolerances": [
-                      "t1",
-                      "t3"
-                    ],
-                    "solutions": [
-                      "Groupement"
-                    ]
+                    "tolerances": ["t1", "t3"],
+                    "solutions": ["Groupement"]
                   },
                   {
                     "type": "text",
@@ -1054,9 +1092,7 @@
                     "ariaLabel": "Année à trouver",
                     "defaultValue": "",
                     "tolerances": [],
-                    "solutions": [
-                      2016
-                    ]
+                    "solutions": [2016]
                   }
                 ],
                 "feedbacks": {
@@ -1110,14 +1146,8 @@
                     "placeholder": "",
                     "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
                     "defaultValue": "",
-                    "tolerances": [
-                      "t1",
-                      "t2",
-                      "t3"
-                    ],
-                    "solutions": [
-                      "Katie"
-                    ]
+                    "tolerances": ["t1", "t2", "t3"],
+                    "solutions": ["Katie"]
                   }
                 ],
                 "feedbacks": {
@@ -1190,12 +1220,8 @@
                     "placeholder": "",
                     "ariaLabel": "Nom de ce produit",
                     "defaultValue": "",
-                    "tolerances": [
-                      "t1"
-                    ],
-                    "solutions": [
-                      "Modulix"
-                    ]
+                    "tolerances": ["t1"],
+                    "solutions": ["Modulix"]
                   }
                 ],
                 "feedbacks": {

--- a/mon-pix/app/components/module/component/_stepper.scss
+++ b/mon-pix/app/components/module/component/_stepper.scss
@@ -159,6 +159,25 @@
   justify-self: start;
   width: fit-content;
   min-width: 140px;
+
+  @media (not (prefers-reduced-motion: reduce)) {
+    animation: 0.75s zoom-in-zoom-out ease;
+
+    @keyframes zoom-in-zoom-out {
+      0% {
+        scale: 100%;
+        overflow: hidden;
+      }
+
+      50% {
+        scale: 110%;
+      }
+
+      100% {
+        scale: 100%;
+      }
+    }
+  }
 }
 
 @include breakpoints.device-is('tablet') {

--- a/mon-pix/app/components/module/component/stepper.gjs
+++ b/mon-pix/app/components/module/component/stepper.gjs
@@ -17,7 +17,7 @@ import { TrackedSet } from 'tracked-built-ins';
 import didInsert from '../../../modifiers/modifier-did-insert';
 import { VERIFY_RESPONSE_DELAY } from './element';
 
-export const NEXT_STEP_BUTTON_DELAY = VERIFY_RESPONSE_DELAY + 500;
+export const NEXT_STEP_BUTTON_DELAY = VERIFY_RESPONSE_DELAY;
 
 export default class ModulixStepper extends Component {
   @tracked locallyAnsweredElements = new TrackedSet();

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -34,5 +34,24 @@
     color: var(--pix-neutral-0);
     background: var(--pix-neutral-800);
     border-radius: 0 0 var(--pix-spacing-4x) var(--pix-spacing-4x);
+
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.75s zoom-in-zoom-out ease;
+
+      @keyframes zoom-in-zoom-out {
+        0% {
+          scale: 100%;
+          overflow: hidden;
+        }
+
+        50% {
+          scale: 110%;
+        }
+
+        100% {
+          scale: 100%;
+        }
+      }
+    }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -22,5 +22,24 @@
   &__feedback {
     color: var(--pix-neutral-800);
     background: var(--pix-info-100);
+
+    @media (not (prefers-reduced-motion: reduce)) {
+      animation: 0.75s zoom-in-zoom-out ease;
+
+      @keyframes zoom-in-zoom-out {
+        0% {
+          scale: 100%;
+          overflow: hidden;
+        }
+
+        50% {
+          scale: 110%;
+        }
+
+        100% {
+          scale: 100%;
+        }
+      }
+    }
   }
 }

--- a/mon-pix/app/components/module/element/qcm.gjs
+++ b/mon-pix/app/components/module/element/qcm.gjs
@@ -79,9 +79,10 @@ export default class ModuleQcm extends ModuleElement {
     event.preventDefault();
     this.args.updateSkipButton(true);
     this.isAnswering = true;
+    super.onAnswer(event);
+
     await this.waitFor(VERIFY_RESPONSE_DELAY);
 
-    super.onAnswer(event);
     if (this.shouldDisplayRequiredMessage === true) {
       this.isAnswering = false;
       this.args.updateSkipButton(false);
@@ -97,13 +98,13 @@ export default class ModuleQcm extends ModuleElement {
       isKo: !this.answerIsValid,
     };
 
+    this.args.updateSkipButton(false);
+    this.isAnswering = false;
+
     this.passageEvents.record({
       type: 'QCM_ANSWERED',
       data: { answer: this.userResponse, elementId: this.element.id, status },
     });
-
-    this.isAnswering = false;
-    this.args.updateSkipButton(false);
   }
 
   waitFor(duration) {

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 import ProposalButton from 'mon-pix/components/module/component/proposal-button';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
 
 export default class ModuleQcuDeclarative extends ModuleElement {
@@ -30,6 +31,10 @@ export default class ModuleQcuDeclarative extends ModuleElement {
   async onAnswer(event) {
     event.preventDefault();
     this.selectedProposalId = event.submitter.value;
+
+    await this.waitFor(VERIFY_RESPONSE_DELAY);
+    await this.args.onAnswer({ element: this.element });
+
     this.shouldDisplayFeedback = true;
     this.passageEvents.record({
       type: 'QCU_DECLARATIVE_ANSWERED',
@@ -38,12 +43,14 @@ export default class ModuleQcuDeclarative extends ModuleElement {
         answer: this.selectedProposalAnswer,
       },
     });
-
-    await this.args.onAnswer({ element: this.element });
   }
 
   get isAnswered() {
     return this.selectedProposalId !== null;
+  }
+
+  waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
   <template>

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 import ProposalButton from 'mon-pix/components/module/component/proposal-button';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
+import { VERIFY_RESPONSE_DELAY } from '../component/element';
 import ModuleElement from './module-element';
 
 export default class ModuleQcuDiscovery extends ModuleElement {
@@ -30,6 +31,10 @@ export default class ModuleQcuDiscovery extends ModuleElement {
   async onAnswer(event) {
     event.preventDefault();
     this.selectedProposalId = event.submitter.value;
+
+    await this.waitFor(VERIFY_RESPONSE_DELAY);
+    await this.args.onAnswer({ element: this.element });
+
     this.shouldDisplayFeedback = true;
     this.passageEvents.record({
       type: 'QCU_DISCOVERY_ANSWERED',
@@ -39,12 +44,14 @@ export default class ModuleQcuDiscovery extends ModuleElement {
         status: this.selectedProposalId === this.element.solution ? 'ok' : 'ko',
       },
     });
-
-    await this.args.onAnswer({ element: this.element });
   }
 
   get isAnswered() {
     return this.selectedProposalId !== null;
+  }
+
+  waitFor(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
   }
 
   <template>

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -639,9 +639,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
           const passage = store.createRecord('passage');
           this.set('passage', passage);
 
+          const onElementAnswer = sinon.stub();
+          this.set('onElementAnswer', onElementAnswer);
+
           // when
           const screen = await render(hbs`
-            <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+            <Module::Grain::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @onElementAnswer={{this.onElementAnswer}} @passage={{this.passage}} />`);
           await click(screen.getByLabelText('checkbox1'));
           await click(screen.getByLabelText('checkbox2'));
           const verifyButton = screen.getByRole('button', { name: 'Vérifier ma réponse' });

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModuleQcuDeclarative from 'mon-pix/components/module/element/qcu-declarative';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -9,6 +10,16 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | QCUDeclarative', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
 
   test('it should display an instruction, a complementary instruction and a list of proposals', async function (assert) {
     // given
@@ -43,6 +54,8 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
 
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
       // then
       const button2 = screen.getByRole('button', { name: proposals[1].content });
       const button3 = screen.getByRole('button', { name: proposals[2].content });
@@ -74,6 +87,8 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       );
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
       // then
       sinon.assert.calledWithExactly(onAnswerStub, {

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -2,6 +2,7 @@ import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
+import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModuleQcuDiscovery from 'mon-pix/components/module/element/qcu-discovery';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -10,6 +11,16 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | QCUDiscovery', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
 
   test('it should display an instruction, a direction and a list of proposals', async function (assert) {
     // given
@@ -44,6 +55,7 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
 
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
       // then
       const button2 = screen.getByRole('button', { name: proposals[1].content });
       const button3 = screen.getByRole('button', { name: proposals[2].content });
@@ -76,6 +88,8 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
       );
       const button1 = screen.getByRole('button', { name: proposals[0].content });
       await click(button1);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
 
       // then
       sinon.assert.calledWithExactly(onAnswerStub, {


### PR DESCRIPTION
## 🍂 Problème

L’expérience utilisateur est assez mauvaise quand un élément avec feedback est répondu dans un stepper horizontal : le bouton “Suivant” du Stepper apparaît bien après, d’un coup. 

La raison principale est in délai de 1s pour l'apparition de ce bouton dans le stepper. Cela fait qu'il apparaît 500ms plus tard que le feedback ce qui donne le comportement décrit ci-dessus.

## 🌰 Proposition

On propose d'ajuster le temps d'apparition afin qu'il s'affiche en même temps que le feedback de chaque élément.
Pour éviter un effet bizarre car l'apparition du bouton suivant n'a pas d'animation, on a aussi mis la même animation que le feedback.
Enfin, l'apparition des feedbacks des éléments QCU déclarative et découverte ont été mise à jour pour avoir la même animation que les autres éléments répondables.

## 🍁 Remarques

On en profite pour ajouter un exemple de QROCM dans le stepper horizontal du bac à sable 😄 

## 🪵 Pour tester

- Aller sur le module [bac-a-sable](https://app-pr14253.review.pix.fr/modules/bac-a-sable/details)
- Tester le stepper horizontal dans le premier grain et vérifier que le bouton suivant apparaît bien en même temps que le feedback pour chaque élément répondable 🚀 
