### PR TITLE
[BUGFIX] Erreur de transaction sur la neutralisation / deneutralisation (PIX-20543).

### DIFF
--- a/api/src/certification/evaluation/application/certification-admin-controller.js
+++ b/api/src/certification/evaluation/application/certification-admin-controller.js
@@ -1,32 +1,34 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { usecases } from '../domain/usecases/index.js';
 
 const neutralizeChallenge = async function (request, h) {
-  const challengeRecId = request.payload.data.attributes.challengeRecId;
-  const certificationCourseId = request.payload.data.attributes.certificationCourseId;
-  const juryId = request.auth.credentials.userId;
+  const { challengeRecId, certificationCourseId } = request.payload.data.attributes;
+  const { userId: juryId } = request.auth.credentials;
 
-  const event = await usecases.neutralizeChallenge({
-    challengeRecId,
-    certificationCourseId,
-    juryId,
+  await DomainTransaction.execute(async () => {
+    const event = await usecases.neutralizeChallenge({
+      challengeRecId,
+      certificationCourseId,
+      juryId,
+    });
+    await usecases.rescoreV2Certification({ event });
   });
-  await usecases.rescoreV2Certification({ event });
 
   return h.response().code(204);
 };
 
 const deneutralizeChallenge = async function (request, h) {
-  const challengeRecId = request.payload.data.attributes.challengeRecId;
-  const certificationCourseId = request.payload.data.attributes.certificationCourseId;
-  const juryId = request.auth.credentials.userId;
+  const { challengeRecId, certificationCourseId } = request.payload.data.attributes;
+  const { userId: juryId } = request.auth.credentials;
 
-  const event = await usecases.deneutralizeChallenge({
-    challengeRecId,
-    certificationCourseId,
-    juryId,
+  await DomainTransaction.execute(async () => {
+    const event = await usecases.deneutralizeChallenge({
+      challengeRecId,
+      certificationCourseId,
+      juryId,
+    });
+    await usecases.rescoreV2Certification({ event });
   });
-
-  await usecases.rescoreV2Certification({ event });
 
   return h.response().code(204);
 };

--- a/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/deneutralize-challenge.js
@@ -1,6 +1,18 @@
+/**
+ * @typedef {import('../../../shared/infrastructure/repositories/certification-assessment-repository.js')} CertificationAssessmentRepository
+ * @typedef {import('../events/ChallengeDeneutralized.js').ChallengeDeneutralized} ChallengeDeneutralizedEvent
+ */
 import { ChallengeDeneutralized } from '../events/ChallengeDeneutralized.js';
 
-const deneutralizeChallenge = async function ({
+/**
+ * @param {Object} params
+ * @param {string} params.certificationCourseId
+ * @param {string} params.challengeRecId
+ * @param {string} params.juryId
+ * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
+ * @returns {Promise<ChallengeDeneutralizedEvent>}
+ */
+export const deneutralizeChallenge = async function ({
   certificationCourseId,
   challengeRecId,
   juryId,
@@ -13,5 +25,3 @@ const deneutralizeChallenge = async function ({
   await certificationAssessmentRepository.save(certificationAssessment);
   return new ChallengeDeneutralized({ certificationCourseId, juryId });
 };
-
-export { deneutralizeChallenge };

--- a/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
+++ b/api/src/certification/evaluation/domain/usecases/neutralize-challenge.js
@@ -1,6 +1,18 @@
+/**
+ * @typedef {import('../../../shared/infrastructure/repositories/certification-assessment-repository.js')} CertificationAssessmentRepository
+ * @typedef {import('../events/ChallengeNeutralized.js').ChallengeNeutralized} ChallengeNeutralizedEvent
+ */
 import { ChallengeNeutralized } from '../events/ChallengeNeutralized.js';
 
-const neutralizeChallenge = async function ({
+/**
+ * @param {Object} params
+ * @param {string} params.certificationCourseId
+ * @param {string} params.challengeRecId
+ * @param {string} params.juryId
+ * @param {CertificationAssessmentRepository} params.certificationAssessmentRepository
+ * @returns {Promise<ChallengeNeutralizedEvent>}
+ */
+export const neutralizeChallenge = async function ({
   certificationCourseId,
   challengeRecId,
   juryId,
@@ -13,5 +25,3 @@ const neutralizeChallenge = async function ({
   await certificationAssessmentRepository.save(certificationAssessment);
   return new ChallengeNeutralized({ certificationCourseId, juryId });
 };
-
-export { neutralizeChallenge };

--- a/api/tests/certification/evaluation/acceptance/application/certification-admin-route_test.js
+++ b/api/tests/certification/evaluation/acceptance/application/certification-admin-route_test.js
@@ -1,0 +1,236 @@
+import { AlgorithmEngineVersion } from '../../../../../src/certification/shared/domain/models/AlgorithmEngineVersion.js';
+import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
+import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  knex,
+} from '../../../../test-helper.js';
+
+describe('Certification | Evaluation | Acceptance | Application | certification admin routes', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/admin/certification/neutralize-challenge', function () {
+    it('should neutralize the challenge and return 204 when user is SUPER_ADMIN', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser.withRole({ role: 'SUPER_ADMIN' });
+
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'recArea0',
+        code: '66',
+        competenceIds: ['recCompetence0'],
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'recCompetence0',
+        name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
+        index: '1.1',
+        areaId: 'recArea0',
+        skillIds: ['recSkill0_0'],
+        origin: 'Pix',
+      });
+      databaseBuilder.factory.learningContent.buildTube({
+        id: 'recTube0_0',
+      });
+      databaseBuilder.factory.learningContent.buildSkill({
+        id: 'recSkill0_0',
+        name: '@recSkill0_0',
+        tubeId: 'recTube0_0',
+        status: 'actif',
+        level: 1,
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'recChallenge0_0_0',
+        competenceId: 'recCompetence0',
+        skillId: 'recSkill0_0',
+      });
+
+      const candidate = databaseBuilder.factory.buildUser();
+      const sessionId = databaseBuilder.factory.buildSession({
+        date: '2020/01/01',
+        time: '12:00',
+        finalizedAt: new Date('2020-01-01'),
+        version: AlgorithmEngineVersion.V3,
+      }).id;
+
+      const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+        sessionId,
+        userId: candidate.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        sessionId,
+        userId: candidate.id,
+        version: AlgorithmEngineVersion.V3,
+        createdAt: new Date('2025-01-01'),
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourse.id,
+        userId: candidate.id,
+        type: Assessment.types.CERTIFICATION,
+        state: Assessment.states.STARTED,
+      });
+
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessment.id,
+        pixScore: 200,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResult.id,
+      });
+
+      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourse.id,
+        isNeutralized: false,
+        challengeId: 'recChallenge0_0_0',
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        challengeId: certificationChallenge.challengeId,
+        result: AnswerStatus.KO.status,
+      });
+
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'POST',
+        url: '/api/admin/certification/neutralize-challenge',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: certificationCourse.id,
+              challengeRecId: certificationChallenge.challengeId,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const updatedChallenge = await knex('certification-challenges').where({ id: certificationChallenge.id }).first();
+      expect(updatedChallenge.isNeutralized).to.be.true;
+    });
+  });
+
+  describe('POST /api/admin/certification/deneutralize-challenge', function () {
+    it('should deneutralize the challenge and return 204 when user is SUPER_ADMIN', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser.withRole({ role: 'SUPER_ADMIN' });
+
+      databaseBuilder.factory.learningContent.buildArea({
+        id: 'recArea0',
+        code: '66',
+        competenceIds: ['recCompetence0'],
+      });
+      databaseBuilder.factory.learningContent.buildCompetence({
+        id: 'recCompetence0',
+        name_i18n: { fr: 'Construire un flipper', en: 'Build a pinball' },
+        index: '1.1',
+        areaId: 'recArea0',
+        skillIds: ['recSkill0_0'],
+        origin: 'Pix',
+      });
+      databaseBuilder.factory.learningContent.buildTube({
+        id: 'recTube0_0',
+      });
+      databaseBuilder.factory.learningContent.buildSkill({
+        id: 'recSkill0_0',
+        name: '@recSkill0_0',
+        tubeId: 'recTube0_0',
+        status: 'actif',
+        level: 1,
+      });
+      databaseBuilder.factory.learningContent.buildChallenge({
+        id: 'recChallenge0_0_0',
+        competenceId: 'recCompetence0',
+        skillId: 'recSkill0_0',
+      });
+
+      const candidate = databaseBuilder.factory.buildUser();
+      const sessionId = databaseBuilder.factory.buildSession({
+        date: '2020/01/01',
+        time: '12:00',
+        finalizedAt: new Date('2020-01-01'),
+        version: AlgorithmEngineVersion.V3,
+      }).id;
+
+      const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+        sessionId,
+        userId: candidate.id,
+      });
+      databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: certificationCandidate.id });
+
+      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        sessionId,
+        userId: candidate.id,
+        version: AlgorithmEngineVersion.V3,
+        createdAt: new Date('2025-01-01'),
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        certificationCourseId: certificationCourse.id,
+        userId: candidate.id,
+        type: Assessment.types.CERTIFICATION,
+        state: Assessment.states.STARTED,
+      });
+
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessment.id,
+        pixScore: 200,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResult.id,
+      });
+
+      const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourse.id,
+        isNeutralized: false,
+        challengeId: 'recChallenge0_0_0',
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        challengeId: certificationChallenge.challengeId,
+        result: AnswerStatus.KO.status,
+      });
+
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'POST',
+        url: '/api/admin/certification/deneutralize-challenge',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: certificationCourse.id,
+              challengeRecId: certificationChallenge.challengeId,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const updatedChallenge = await knex('certification-challenges').where({ id: certificationChallenge.id }).first();
+      expect(updatedChallenge.isNeutralized).to.be.false;
+    });
+  });
+});

--- a/api/tests/certification/evaluation/unit/application/certification-admin-controller_test.js
+++ b/api/tests/certification/evaluation/unit/application/certification-admin-controller_test.js
@@ -2,9 +2,16 @@ import { certificationAdminController } from '../../../../../src/certification/e
 import { ChallengeDeneutralized } from '../../../../../src/certification/evaluation/domain/events/ChallengeDeneutralized.js';
 import { ChallengeNeutralized } from '../../../../../src/certification/evaluation/domain/events/ChallengeNeutralized.js';
 import { usecases } from '../../../../../src/certification/evaluation/domain/usecases/index.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Certification | Evaluation | Unit | Application | Controller | certification', function () {
+  beforeEach(async function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
+  });
+
   describe('#neutralizeChallenge', function () {
     it('neutralizes the challenge and dispatches the event', async function () {
       // given


### PR DESCRIPTION
## 🍂 Problème

La PO a tente une neutralisation pour declencher un rescoring sur une certif V2 => erreur 400 (cas métier prévu)
et pourtant la question est neutralisee en base SANS etre rescoree.

## 🌰 Proposition

* Il y avait aucun test d'acceptance sur cette route (même en remontant jusqu'a fevrier 2024 dans git)
  * création des tests
* Ajout de la transaction + cerification du rollback

## 🍁 Remarques

* En raison du fait que on seed pas de la V2, **on ne sera pas capable de tester de neutraliser sur une certif depubliee** ; mais c'est le meme endpoint et au pire cela sera un autre JIRA

## 🪵 Pour tester

* Sur Pix Admin, trouver une certification **V2 publiée**
  * https://admin-pr14254.review.pix.fr/sessions/7401
  * vous trouverez une question deja neutralized sur la certification : https://admin-pr14254.review.pix.fr/certifications/6/neutralization
* Aller dans les détails des questions, cliquer sur neutraliser
  * Vérifier que une erreur de seproduit (cas métier, on ne peut pas neutraliser sur une certif publiée)
  * Faire un rafraichissement de la page : la question doit **pas** être neutralisée
    * (pour les techs) J'invite grandement à le confirmer en vérifiant "isNeutralized" sur le challenge dans la table "certification-challenges"
* Faire pareil pour la deneutralisation (https://admin-pr14254.review.pix.fr/certifications/6/neutralization) 
