### PR TITLE
[FEATURE] Ajouter un encart d'info pour l'email de convocation (PIX-6278).

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-creation-modal.gjs
@@ -432,6 +432,10 @@ export default class CandidateCreationModal extends Component {
             </PixInput>
           </div>
 
+          <PixNotificationAlert class='new-candidate-modal-form__info-panel' @withIcon={{true}}>
+            {{t 'pages.sessions.detail.candidates.add-modal.email-convocation-info'}}
+          </PixNotificationAlert>
+
           {{#if @shouldDisplayPaymentOptions}}
             <div class='new-candidate-modal-form__field'>
               <PixSelect

--- a/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-creation-modal-test.gjs
+++ b/certif/tests/integration/components/sessions/session-details/enrolled-candidates/candidate-creation-modal-test.gjs
@@ -88,6 +88,13 @@ module(
         )
         .exists();
       assert.dom(screen.getByRole('textbox', { name: 'E-mail de convocation' })).exists();
+      assert
+        .dom(
+          screen.getByText(
+            "L'envoi automatique de convocation par Pix n'est pas encore disponible. Le centre de certification se charge de convoquer les candidats.",
+          ),
+        )
+        .exists();
     });
 
     test('it should have some inputs required', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -605,6 +605,7 @@
               "enrol-the-candidate": "Enrol the candidate"
             },
             "complementary-certification-none": "None",
+            "email-convocation-info": "Automatic sending of exam invitations via Pix is not yet available. The certification center is responsible for inviting candidates.",
             "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
             "notifications": {
               "error-add-duplicate": "This candidate is already in the list, you can't add them again.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -605,6 +605,7 @@
               "enrol-the-candidate": "Inscrire le candidat"
             },
             "complementary-certification-none": "Aucune",
+            "email-convocation-info": "L'envoi automatique de convocation par Pix n'est pas encore disponible. Le centre de certification se charge de convoquer les candidats.",
             "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
             "notifications": {
               "error-add-duplicate": "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.",


### PR DESCRIPTION
## 🍂 Problème

Lors de l’inscription de candidats dans Pix Certif à une session de certification, on propose un champ “E-mail de convocation” pour chaque candidat.

La fonctionnalité d’envoi de convocations automatiques par Pix via ces adresses mail renseignées dans le champ “E-mail de convocation” dans Pix Certif n’est pas encore disponible.

## 🌰 Proposition

- Garder le champ "E-mail de convocation" : en effet, certaines structures se basent sur notre fichier ODS d'import de candidats pour gérer leurs inscriptions avant d'ajouter les candidats dans Pix Certif : dès qu'on modifie le procédé d'inscription d'un candidat, cela les impacte en interne (vba ou autre...).
Certaines structures utilisent également ce champs pour avoir à disposition toutes les informations des candidats, y compris leur adresse mail, pour les convoquer à leur façon par la suite.
- Pour l’inscription individuelle dans Pix Certif, rajouter une info en bleu en dessous (comme pour l'email du destinataire des résultats) qui indiquerait le message suivant : "L'envoi automatique de convocation par Pix n'est pas encore disponible. Le centre de certification se charge de convoquer les candidats."

## 🪵 Pour tester

- Aller sur PixCertif en RA
- Ajouter un candidat à une session
- Visualiser le nouvel encart d'info en dessous du champ `E-mail de convocation`
