### PR TITLE
[TECH] Utiliser les nouvelles URLs de modules dans les contenus formatifs des seeds (PIX-20388)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -54,7 +54,7 @@ export function buildTrainings(databaseBuilder) {
     id: trainingId++,
     title: 'Bac à sable Pix',
     internalTitle: 'Bac à sable Pix',
-    link: '/modules/bac-a-sable/details',
+    link: '/modules/6a68bf32/bac-a-sable/details',
     duration: '00:10:00',
     editorName: 'Pix',
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',

--- a/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-combined-course.js
@@ -64,7 +64,7 @@ export const PRO_COMBINED_COURSE = {
     trainings: [
       {
         title: 'Demo combinix 1',
-        link: '/modules/demo-combinix-1',
+        link: '/modules/27d6ca4f/demo-combinix-1',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 1 mins 0.0 secs',
         locale: 'fr',
@@ -76,7 +76,7 @@ export const PRO_COMBINED_COURSE = {
       },
       {
         title: 'Demo combinix 2',
-        link: '/modules/demo-combinix-2',
+        link: '/modules/df82ec66/demo-combinix-2',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 1 mins 0.0 secs',
         locale: 'fr',
@@ -88,7 +88,7 @@ export const PRO_COMBINED_COURSE = {
       },
       {
         title: 'Demo combinix 1',
-        link: '/modules/demo-combinix-1',
+        link: '/modules/27d6ca4f/demo-combinix-1',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 1 mins 0.0 secs',
         locale: 'fr-fr',
@@ -100,7 +100,7 @@ export const PRO_COMBINED_COURSE = {
       },
       {
         title: 'Demo combinix 2',
-        link: '/modules/demo-combinix-2',
+        link: '/modules/df82ec66/demo-combinix-2',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 1 mins 0.0 secs',
         locale: 'fr-fr',

--- a/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
@@ -139,7 +139,7 @@ export const MAXI_COMBINED_COURSE = {
     trainings: [
       {
         title: 'Mon premier prompt !',
-        link: '/modules/tmp-ia-premier-prompt/details',
+        link: '/modules/4920d56c/tmp-ia-premier-prompt/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -150,7 +150,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "J'améliore mon prompt !",
-        link: '/modules/tmp-prompt-intermediaire',
+        link: '/modules/4eacd0c3/tmp-prompt-intermediaire',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -161,7 +161,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Elles hallucinent, ces IA génératives !',
-        link: '/modules/tmp-ia-hallu/details',
+        link: '/modules/9be9cfae/tmp-ia-hallu/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -172,7 +172,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les deepfakes (hypertrucages) : c’est quoi ?',
-        link: '/modules/tmp-ia-deepfakes/passage',
+        link: '/modules/05b24fee/tmp-ia-deepfakes/passage',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -183,7 +183,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "J'améliore mon prompt !",
-        link: '/modules/tmp-prompt-intermediaire',
+        link: '/modules/4eacd0c3/tmp-prompt-intermediaire',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -194,7 +194,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Elles hallucinent, ces IA génératives !',
-        link: '/modules/tmp-ia-hallu/details',
+        link: '/modules/9be9cfae/tmp-ia-hallu/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -205,7 +205,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les deepfakes : c’est quoi ?',
-        link: '/modules/tmp-ia-deepfakes/passage',
+        link: '/modules/05b24fee/tmp-ia-deepfakes/passage',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -216,7 +216,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment font les IA génératives pour répondre à nos demandes ?',
-        link: '/modules/tmp-ia-fonctionnement-debut/details',
+        link: '/modules/797ea8fb/tmp-ia-fonctionnement-debut/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -227,7 +227,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment font les IA génératives pour répondre à nos demandes ?',
-        link: '/modules/tmp-ia-fonctionnement-debut/details',
+        link: '/modules/797ea8fb/tmp-ia-fonctionnement-debut/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -239,7 +239,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment une IA générative a-t-elle appris à discuter ?',
-        link: '/modules/tmp-ia-fonctionnement-ind/details',
+        link: '/modules/76961c86/tmp-ia-fonctionnement-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -250,7 +250,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment une IA générative a-t-elle appris à discuter ?',
-        link: '/modules/tmp-ia-fonctionnement-ind/details',
+        link: '/modules/76961c86/tmp-ia-fonctionnement-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -262,7 +262,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les biais des IA',
-        link: '/modules/tmp-ia-bias-ind/details',
+        link: '/modules/163b520e/tmp-ia-bias-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -273,7 +273,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les biais des IA',
-        link: '/modules/tmp-ia-bias-ind/details',
+        link: '/modules/163b520e/tmp-ia-bias-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -284,7 +284,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "L'IA générative, ça consomme !",
-        link: '/modules/les-ia-generatives-consomment/details',
+        link: '/modules/6bf111e0/les-ia-generatives-consomment/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -295,7 +295,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "L'IA générative, ça consomme !",
-        link: '/modules/les-ia-generatives-consomment/details',
+        link: '/modules/6bf111e0/les-ia-generatives-consomment/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -306,7 +306,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'IA, vous avez dit IA ?',
-        link: '/modules/tmp-ia-dit-ia/details',
+        link: '/modules/cc0cbab7/tmp-ia-dit-ia/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -317,7 +317,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'IA, vous avez dit IA ?',
-        link: '/modules/tmp-ia-dit-ia/details',
+        link: '/modules/cc0cbab7/tmp-ia-dit-ia/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -328,7 +328,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Mon premier prompt !',
-        link: '/modules/tmp-ia-premier-prompt/details',
+        link: '/modules/4920d56c/tmp-ia-premier-prompt/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',


### PR DESCRIPTION
⚠️ Bloqué en attendant le merge de https://github.com/1024pix/pix/pull/14238

## 🍂 Problème

Les contenus formatifs dans les seeds utilisent les anciennes URLs de module.

## 🌰 Proposition

Par souci de réalisme, utiliser les nouvelles URLs de modules contenant un `shortId`.

## 🍁 Remarques

⚠️ Avant de merger, il faut que [cette PR](https://github.com/1024pix/pix/pull/14238) soit mergée.

## 🪵 Pour tester

1. Se connecter à [Pix Admin](https://admin-pr14259.review.pix.fr/) avec superadmin@example.net
2. Aller à la section Contenus formatifs
3. Constater que les urls des modules contiennent un identifiant court avant le slug
