### PR TITLE
[TECH] Permettre au métier d'entrer une URL complète de logo dans le formulaire du contenu formatif sur Pix Admin (PIX-20548).

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -35,7 +35,7 @@ class Form {
     this.type = type || null;
     this.duration = duration || { days: 0, hours: 0, minutes: 0 };
     this.locale = locale || null;
-    this.editorLogoUrl = editorLogoUrl?.split('/').at(-1) || null;
+    this.editorLogoUrl = editorLogoUrl || null;
     this.editorName = editorName || null;
     this.isDisabled = isDisabled || false;
   }
@@ -79,8 +79,8 @@ export default class CreateOrUpdateTrainingForm extends Component {
       locale: this.form.locale,
       editorName: this.form.editorName,
       isDisabled: this.form.isDisabled,
+      editorLogoUrl: this.form.editorLogoUrl,
     };
-    training.editorLogoUrl = `https://assets.pix.org/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
 
     try {
       this.submitting = true;
@@ -183,14 +183,13 @@ export default class CreateOrUpdateTrainingForm extends Component {
           <div class="admin-form--training__logo-url-input">
             <PixInput
               @id="trainingEditorLogoUrl"
-              @subLabel="Exemple : logo-ministere-education-nationale-et-jeunesse.svg"
+              @subLabel="Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg"
               required={{true}}
               aria-required={{true}}
-              placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
               @value={{this.form.editorLogoUrl}}
               {{on "change" (fn this.updateForm "editorLogoUrl")}}
             >
-              <:label>Nom du fichier du logo éditeur (.svg)</:label>
+              <:label>Url du logo de l'éditeur (.svg)</:label>
             </PixInput>
             <small>
               <a

--- a/admin/app/components/trainings/create-or-update-training-form.gjs
+++ b/admin/app/components/trainings/create-or-update-training-form.gjs
@@ -180,28 +180,24 @@ export default class CreateOrUpdateTrainingForm extends Component {
           >
             <:label>Langue localisée</:label>
           </PixSelect>
-          <div class="admin-form--training__logo-url-input">
-            <PixInput
-              @id="trainingEditorLogoUrl"
-              @subLabel="Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg"
-              required={{true}}
-              aria-required={{true}}
-              @value={{this.form.editorLogoUrl}}
-              {{on "change" (fn this.updateForm "editorLogoUrl")}}
-            >
-              <:label>Url du logo de l'éditeur (.svg)</:label>
-            </PixInput>
-            <small>
-              <a
-                href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/contenu-formatif/editeur"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="training__logo-url-link"
-              >
-                Voir la liste des logos éditeur
-              </a>
-            </small>
-          </div>
+          <PixInput
+            @id="trainingEditorLogoUrl"
+            @subLabel="Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg"
+            required={{true}}
+            aria-required={{true}}
+            @value={{this.form.editorLogoUrl}}
+            {{on "change" (fn this.updateForm "editorLogoUrl")}}
+          >
+            <:label>Url du logo de l'éditeur (.svg)</:label>
+          </PixInput>
+          <a
+            href="https://pix-assets-manager-tmp-poc.osc-fr1.scalingo.io/list/contenu-formatif/editeur"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="training__logo-url-link"
+          >
+            Voir la liste des logos éditeur
+          </a>
           <PixInput
             @id="trainingEditorName"
             @subLabel="Exemple: Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité"

--- a/admin/app/controllers/authenticated/trainings/new.js
+++ b/admin/app/controllers/authenticated/trainings/new.js
@@ -6,6 +6,7 @@ export default class NewController extends Controller {
   @service pixToast;
   @service store;
   @service router;
+  @service intl;
 
   @action
   goToTrainingDetails(trainingId) {
@@ -30,13 +31,17 @@ export default class NewController extends Controller {
 
   _handleResponseError({ errors }) {
     if (!errors) {
-      return this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     }
     errors.forEach((error) => {
       if (['400', '404', '412', '422'].includes(error.status)) {
-        return this.pixToast.sendErrorNotification({ message: error.detail });
+        let message = error.detail;
+        if (message.includes('data.attributes.editor-logo-url')) {
+          message = this.intl.t('pages.trainings.training.error-messages.incorrect-editor-logo-url-format');
+        }
+        return this.pixToast.sendErrorNotification({ message });
       }
-      return this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      return this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     });
   }
 }

--- a/admin/app/styles/components/trainings/create-or-update-training-form.scss
+++ b/admin/app/styles/components/trainings/create-or-update-training-form.scss
@@ -1,20 +1,5 @@
 @use 'pix-design-tokens/typography';
 
-.admin-form--training__logo-url-input {
-  @extend %pix-body-s;
-
-  strong {
-    font-weight: 500;
-  }
-
-  small {
-    display: block;
-    margin-top: var(--pix-spacing-2x);
-    color: var(--pix-neutral-500);
-    font-size: 0.813rem;
-  }
-}
-
 .admin-form--training__duration {
   display: flex;
   gap: 2rem;
@@ -26,6 +11,9 @@
 }
 
 .training__logo-url-link {
+  @extend %pix-body-xs;
+
+  display: block;
   color: var(--pix-primary-700);
   text-decoration: underline;
 }

--- a/admin/app/templates/authenticated/trainings/training.gjs
+++ b/admin/app/templates/authenticated/trainings/training.gjs
@@ -41,8 +41,15 @@ export default class Training extends Component {
       await this.args.model.save();
       this.pixToast.sendSuccessNotification({ message: 'Le contenu formatif a été mis à jour avec succès.' });
       this.toggleEditMode();
-    } catch {
-      this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+    } catch (error) {
+      const errorStatus = error.errors?.[0]?.status;
+      const errorMessage = error.errors?.[0]?.detail;
+
+      let message = this.intl.t('common.notifications.generic-error');
+      if (errorStatus === '400' && errorMessage.includes('data.attributes.editor-logo-url')) {
+        message = this.intl.t('pages.trainings.training.error-messages.incorrect-editor-logo-url-format');
+      }
+      this.pixToast.sendErrorNotification({ message });
     }
   }
 

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -1,5 +1,5 @@
 import { clickByName, fillByLabel, screen, visit } from '@1024pix/ember-testing-library';
-import { click, currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -89,7 +89,12 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await fillByLabel('Heures (HH)', 0);
         await fillByLabel('Minutes (MM)', 0);
         await click(screen.getByText('Francophone (fr)'));
-        await fillByLabel('Nom du fichier du logo éditeur', 'Logo.svg', { exact: false });
+        await fillIn(
+          screen.getByRole('textbox', {
+            name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+          }),
+          'https://assets.pix.org/contenu-formatif/editeur/logo.svg',
+        );
         await fillByLabel("Nom de l'éditeur", 'Editeur', { exact: false });
         await click(screen.getByRole('button', { name: 'Créer le contenu formatif' }));
 

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -1,5 +1,5 @@
 import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
-import { click, triggerEvent } from '@ember/test-helpers';
+import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import CreateOrUpdateTrainingForm from 'pix-admin/components/trainings/create-or-update-training-form';
 import { localeCategories, typeCategories } from 'pix-admin/models/training';
 import { module, test } from 'qunit';
@@ -28,7 +28,13 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
     assert.dom(screen.getByLabelText('Heures (HH)')).exists();
     assert.dom(screen.getByLabelText('Minutes (MM)')).exists();
     assert.dom(screen.getByLabelText('Langue localisée')).exists();
-    assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur', { exact: false })).exists();
+    assert
+      .dom(
+        screen.getByRole('textbox', {
+          name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+        }),
+      )
+      .exists();
     assert.dom(screen.queryByLabelText('Mettre en pause')).doesNotExist();
     assert
       .dom(
@@ -64,7 +70,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
   module('when model is provided', function () {
     test('it should display the items with model values', async function (assert) {
       // given
-      const editorLogo = 'un-logo.svg';
+      const editorLogo = 'https://example.net/un-logo.svg';
       const model = {
         title: 'Un contenu formatif',
         internalTitle: 'Mon titre interne',
@@ -72,7 +78,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         type: 'webinaire',
         locale: 'fr-fr',
         editorName: 'Un éditeur de contenu formatif',
-        editorLogoUrl: `https://example.net/${editorLogo}`,
+        editorLogoUrl: editorLogo,
         duration: { days: 0, hours: 0, minutes: 0 },
         isDisabled: false,
       };
@@ -93,7 +99,13 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.dom(screen.getByLabelText('Heures (HH)')).hasValue(model.duration.hours.toString());
       assert.dom(screen.getByLabelText('Minutes (MM)')).hasValue(model.duration.minutes.toString());
       assert.strictEqual(screen.getByLabelText('Langue localisée').innerText, localeCategories[model.locale]);
-      assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur', { exact: false })).hasValue(editorLogo);
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+          }),
+        )
+        .hasValue(editorLogo);
       assert.strictEqual(screen.getByLabelText('Mettre en pause').checked, model.isDisabled);
       assert
         .dom(
@@ -125,15 +137,20 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
       assert.strictEqual(submittedData.title, 'New Title');
     });
 
-    test('should format editor logo URL with base URL on form submission', async function (assert) {
+    test('should save editor logo URL on form submission', async function (assert) {
       // given
       const onSubmitStub = sinon.stub();
-      await render(
+      const screen = await render(
         <template><CreateOrUpdateTrainingForm @onSubmit={{onSubmitStub}} @onCancel={{onCancel}} /></template>,
       );
 
       // when
-      await fillByLabel('Nom du fichier du logo éditeur', 'new-logo.svg', { exact: false });
+      await fillIn(
+        screen.getByRole('textbox', {
+          name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+        }),
+        'https://assets.pix.org/contenu-formatif/editeur/new-logo.svg',
+      );
       await triggerEvent('form', 'submit');
 
       // then

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     type: 'webinaire',
     locale: 'fr-fr',
     editorName: 'Un éditeur de contenu formatif',
-    editorLogoUrl: 'un-logo.svg',
+    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/un-logo.svg',
     duration: {
       days: 2,
     },
@@ -34,7 +34,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     assert.dom(screen.getByText('2j')).exists();
     assert.dom(screen.getByText('Franco-français (fr-fr)')).exists();
     assert.dom(screen.getByText('Un éditeur de contenu formatif')).exists();
-    assert.dom(screen.getByText('un-logo.svg')).exists();
+    assert.dom(screen.getByText('https://assets.pix.org/contenu-formatif/editeur/un-logo.svg')).exists();
     assert.dom(screen.getByAltText('Un éditeur de contenu formatif')).exists();
   });
 
@@ -93,7 +93,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
           type: 'webinaire',
           locale: 'fr-fr',
           editorName: 'Un éditeur de contenu formatif',
-          editorLogoUrl: 'un-logo.svg',
+          editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/un-logo.svg',
           duration,
           isRecommendable: true,
         };

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -25,7 +25,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
       type: 'type',
       locale: 'fr-fr',
       editorName: 'Albert',
-      editorLogoUrl: 'my-logo-url',
+      editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/my-logo-url',
       isRecommendable: true,
       isDisabled: false,
     });

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -1,7 +1,7 @@
 /* eslint-disable ember/template-no-let-reference */
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import Training from 'pix-admin/templates/authenticated/trainings/training';
 import { module, test } from 'qunit';
@@ -130,6 +130,68 @@ module('Integration | Component | Trainings | Training', function (hooks) {
       assert.ok(deleteTriggerAdapterStub.calledOnce);
       assert.ok(reloadStub.calledOnce);
       assert.ok(notificationSuccessStub.calledOnce);
+    });
+  });
+
+  module('error cases', function () {
+    module('when editorLogoURl format is incorrect', function () {
+      test('should display an error', async function (assert) {
+        // given
+        sinon.stub(model, 'save').rejects({ errors: [{ status: '400', detail: 'data.attributes.editor-logo-url' }] });
+
+        const notificationErrorStub = sinon.stub();
+        class NotificationsStub extends Service {
+          sendErrorNotification = notificationErrorStub;
+        }
+        this.owner.register('service:pixToast', NotificationsStub);
+
+        // when
+        const screen = await render(<template><Training @model={{model}} /></template>);
+        await click(screen.getByRole('button', { name: 'Modifier' }));
+        await fillIn(
+          screen.getByRole('textbox', {
+            name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+          }),
+          'bonjour!',
+        );
+        await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
+
+        // then
+        sinon.assert.calledWith(notificationErrorStub, {
+          message: t('pages.trainings.training.error-messages.incorrect-editor-logo-url-format'),
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('for other errors', function () {
+      test('should display a default error', async function (assert) {
+        // given
+        sinon.stub(model, 'save').rejects();
+
+        const notificationErrorStub = sinon.stub();
+        class NotificationsStub extends Service {
+          sendErrorNotification = notificationErrorStub;
+        }
+        this.owner.register('service:pixToast', NotificationsStub);
+
+        // when
+        const screen = await render(<template><Training @model={{model}} /></template>);
+        await click(screen.getByRole('button', { name: 'Modifier' }));
+        await fillIn(
+          screen.getByRole('textbox', {
+            name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
+          }),
+          'bonjour!',
+        );
+        await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
+
+        // then
+        sinon.assert.calledWith(notificationErrorStub, {
+          message: 'Une erreur est survenue.',
+        });
+        assert.ok(true);
+      });
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/trainings/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/new-test.js
@@ -1,9 +1,13 @@
+import { t } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../../../helpers/setup-intl';
+
 module('Unit | Controller | authenticated/trainings/new', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let controller;
 
@@ -67,21 +71,69 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
       assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.training', trainingData.id));
     });
 
-    test('it should display error notification when training cannot be saved', async function (assert) {
-      controller.pixToast = {
-        sendErrorNotification: sinon.stub(),
-      };
+    module('when training cannot be saved', function () {
+      module('when the editorLogoUrl format is incorrect', function () {
+        test('it should display a specific error message', async function (assert) {
+          controller.pixToast = {
+            sendErrorNotification: sinon.stub(),
+          };
 
-      const saveStub = sinon.stub().rejects();
+          const saveStub = sinon
+            .stub()
+            .rejects({ errors: [{ status: '400', detail: 'data.attributes.editor-logo-url' }] });
 
-      controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+          controller.store.createRecord = sinon.stub().returns({ save: saveStub });
 
-      // when
-      await controller.createOrUpdateTraining();
+          // when
+          await controller.createOrUpdateTraining();
 
-      // then
-      assert.ok(saveStub.called);
-      assert.ok(controller.pixToast.sendErrorNotification.calledWith({ message: 'Une erreur est survenue.' }));
+          // then
+          assert.ok(saveStub.called);
+          assert.ok(
+            controller.pixToast.sendErrorNotification.calledWith({
+              message: t('pages.trainings.training.error-messages.incorrect-editor-logo-url-format'),
+            }),
+          );
+        });
+      });
+
+      module('for 400, 404, 412, 422 HTTP errors', function () {
+        test('it should display the error detail message', async function (assert) {
+          controller.pixToast = {
+            sendErrorNotification: sinon.stub(),
+          };
+
+          const saveStub = sinon.stub().rejects({ errors: [{ status: '404', detail: 'Ressource introuvable.' }] });
+
+          controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+
+          // when
+          await controller.createOrUpdateTraining();
+
+          // then
+          assert.ok(saveStub.called);
+          assert.ok(controller.pixToast.sendErrorNotification.calledWith({ message: 'Ressource introuvable.' }));
+        });
+      });
+
+      module('for other errors', function () {
+        test('it should display the default error message', async function (assert) {
+          controller.pixToast = {
+            sendErrorNotification: sinon.stub(),
+          };
+
+          const saveStub = sinon.stub().rejects();
+
+          controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+
+          // when
+          await controller.createOrUpdateTraining();
+
+          // then
+          assert.ok(saveStub.called);
+          assert.ok(controller.pixToast.sendErrorNotification.calledWith({ message: 'Une erreur est survenue.' }));
+        });
+      });
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/trainings/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/new-test.js
@@ -39,7 +39,7 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
         link: 'https://mon-lien',
         type: 'webinaire',
         locale: 'fr-fr',
-        editorLogoUrl: 'https//images.fr/mon-logo.svg',
+        editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
         editorName: 'Un éditeur de contenu formatif',
         duration: '6h',
       };

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1390,19 +1390,19 @@
           }
         },
         "details": {
-          "contentType": "Content type : ",
-          "duration": "Duration : ",
-          "editorLogo": "Editor logo : ",
-          "editorName": "Editor name : ",
-          "internalTitle": "Internal title : ",
-          "localizedLanguage": "Localized language : ",
-          "publishedOn": "Published on : ",
-          "status": "Status : ",
+          "contentType": "Content type: ",
+          "duration": "Duration: ",
+          "editorLogo": "Editor logo url: ",
+          "editorName": "Editor name: ",
+          "internalTitle": "Internal title: ",
+          "localizedLanguage": "Localized language: ",
+          "publishedOn": "Published on: ",
+          "status": "Status: ",
           "status-label": {
             "disabled": "Non-triggerable",
             "enabled": "Triggerable"
           },
-          "title": "Public title : "
+          "title": "Public title: "
         },
         "duplicate": {
           "button": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1416,6 +1416,9 @@
             "success": "The formative content has been duplicated!"
           }
         },
+        "error-messages": {
+          "incorrect-editor-logo-url-format": "The url format of the editor's logo is incorrect."
+        },
         "list": {
           "caption": "Trainings list",
           "goalThreshold": "Goal Threshold",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1417,6 +1417,9 @@
             "success": "Le contenu formatif a bien été dupliqué !"
           }
         },
+        "error-messages": {
+          "incorrect-editor-logo-url-format": "Le format de l'url du logo de l'éditeur est incorrect."
+        },
         "list": {
           "caption": "Liste des contenus formatifs",
           "goalThreshold": "Objectif à ne pas dépasser",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1393,7 +1393,7 @@
         "details": {
           "contentType": "Type de contenu :",
           "duration": "Durée :",
-          "editorLogo": "Logo de l'éditeur :",
+          "editorLogo": "Url du logo de l'éditeur :",
           "editorName": "Nom d'éditeur :",
           "internalTitle": "Titre interne :",
           "localizedLanguage": "Langue localisée :",

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -144,7 +144,7 @@ const register = async function (server) {
                   .valid(...lowerCaseSupportedLocales)
                   .required(),
                 'editor-name': Joi.string().required(),
-                'editor-logo-url': Joi.string().uri().required(),
+                'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/src/devcomp/application/trainings/training-route.js
+++ b/api/src/devcomp/application/trainings/training-route.js
@@ -3,7 +3,11 @@ import Joi from 'joi';
 import { BadRequestError, NotFoundError, sendJsonApiError } from '../../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { getSupportedLocales } from '../../../shared/domain/services/locale-service.js';
-import { identifiersType, optionalIdentifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import {
+  editorLogoUrlValidation,
+  identifiersType,
+  optionalIdentifiersType,
+} from '../../../shared/domain/types/identifiers-type.js';
 import { trainingController as trainingsController } from './training-controller.js';
 
 const lowerCaseSupportedLocales = getSupportedLocales().map((supportedLocale) => supportedLocale.toLowerCase());
@@ -212,7 +216,7 @@ const register = async function (server) {
                   .valid(...lowerCaseSupportedLocales)
                   .allow(null),
                 'editor-name': Joi.string().allow(null),
-                'editor-logo-url': Joi.string().allow(null),
+                'editor-logo-url': Joi.string().regex(editorLogoUrlValidation).required(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -14,6 +14,7 @@ const implementationType = {
 };
 
 const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
+const editorLogoUrlValidation = new RegExp('^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$');
 
 const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
 const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');
@@ -105,6 +106,7 @@ paramsToExport.positiveInteger32bits = {
 
 export {
   certificationVerificationCodeType,
+  editorLogoUrlValidation,
   paramsToExport as identifiersType,
   queryToExport as optionalIdentifiersType,
   queriesType,

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -165,7 +165,7 @@ describe('Acceptance | Controller | training-controller', function () {
           },
           locale: 'fr',
           'editor-name': 'Un ministère',
-          'editor-logo-url': 'https://mon-logo.svg',
+          'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
         },
       };
 
@@ -185,7 +185,7 @@ describe('Acceptance | Controller | training-controller', function () {
                 hours: 6,
               },
               locale: 'fr',
-              'editor-logo-url': 'https://mon-logo.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/mon-logo.svg',
               'editor-name': 'Un ministère',
             },
           },

--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -123,7 +123,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
             type: 'webinaire',
             locale: 'fr-fr',
             'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
           },
         },
       };
@@ -270,7 +270,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               type: 'webinaire',
               locale: 'fr-fr',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -307,7 +307,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               type: 'webinaire',
               locale: 'fr-fr',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -342,7 +342,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               type: 'webinaire',
               locale: 'fr-fr',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -377,7 +377,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               type: 'webinaire',
               locale: 'fr-fr',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -412,7 +412,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
                 type: 'webinaire',
                 locale: 'fr-fr',
                 'editor-name': 'ministère',
-                'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+                'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
               },
             },
           };
@@ -479,7 +479,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               duration: { days: 2, hours: 2, minutes: 2 },
               locale: 'fr-fr',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -513,7 +513,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',
               'editor-name': 'ministère',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -547,7 +547,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
               duration: { days: 2, hours: 2, minutes: 2 },
               type: 'webinaire',
               locale: 'fr-fr',
-              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
             },
           },
         };
@@ -617,7 +617,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
                 type: 'webinaire',
                 locale: 'fr-BE',
                 'editor-name': 'ministère',
-                'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+                'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
               },
             },
           };
@@ -652,7 +652,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
                 type: 'webinaire',
                 locale: 'ja-Jpan-JP-u-ca-japanese-hc-h12',
                 'editor-name': 'ministère',
-                'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+                'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
               },
             },
           };
@@ -778,7 +778,10 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
-          const payloadAttributes = { title: 'new title' };
+          const payloadAttributes = {
+            title: 'new title',
+            'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
+          };
           const payload = { data: { attributes: payloadAttributes } };
 
           // when
@@ -804,7 +807,10 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
-        const payloadAttributes = { title: 'new title' };
+        const payloadAttributes = {
+          title: 'new title',
+          'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
+        };
         const payload = { data: { attributes: payloadAttributes } };
 
         // when
@@ -941,7 +947,10 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
                 .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleMetier);
               const validPayload = {
                 data: {
-                  attributes: { duration },
+                  attributes: {
+                    duration,
+                    'editor-logo-url': 'https://assets.pix.org/contenu-formatif/editeur/image.svg',
+                  },
                 },
               };
               const httpTestServer = new HttpTestServer();
@@ -996,6 +1005,40 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
 
           // then
           expect(result.statusCode).to.equal(400);
+        });
+      });
+
+      describe('when editorLogoUrl is not a valid url', function () {
+        it('should return 400', async function () {
+          // given
+          const invalidPayload = {
+            data: {
+              attributes: {
+                link: 'http://www.example.net',
+                title: 'ma formation',
+                'internal-title': 'Ma formation',
+                duration: { days: 2, hours: 2, minutes: 2 },
+                type: 'webinaire',
+                locale: 'fr-fr',
+                'editor-name': 'ministère',
+                'editor-logo-url': 'image.svg',
+              },
+            },
+          };
+          sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('PATCH', '/api/admin/trainings/1', invalidPayload);
+
+          // then
+          expect(JSON.parse(response.payload).errors[0].detail).to.equal(
+            '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
+          );
+          expect(response.statusCode).to.equal(400);
         });
       });
     });

--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -253,7 +253,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
 
         // then
         expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-          '"data.attributes.editor-logo-url" must be a valid uri',
+          '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
         );
         expect(response.statusCode).to.equal(400);
       });


### PR DESCRIPTION
## 🍂 Problème

Aujourd’hui, lorsque le métier souhaite enregistrer un contenu formatif sur Admin, il doit fournir le nom de l’image du logo.

Seulement, depuis le changement du lien de la liste, Pix Assets donne la possibilité de copier coller l’url complet à la différence de Pix Image qui proposait un copier-coller du nom de l’image uniquement.

Cette différence a provoqué des erreurs, car les personnes ont mis l’url complète et se sont retrouvé avec l'url + un prefix de domaine qui se faisait coté front, qu'on fini par enregistrer en BDD.

## 🌰 Proposition

- Remplacer le label du champ “nom du” en “url du”
- Retirer le préfixe en dur dans le front pour permettre l'ajout de l'url complète
- Lors de la modification d’un contenu formatif, faire en sorte que ce soit l’url complète qui se retrouve dans le champ et pas juste le nom

## 🍁 Remarques

Les derniers commits, avec la regex, permettent la vérification stricte de l'url. Si on ne migre pas la BDD, le métier se trouvera bloqué s'ils souhaitent modifier un contenu formatif et que l'url pointe sur `images.pix.fr`.

En réalisant le script pour la migration BDD en parallèle, j'ai pu trouver 4 occurrences d'urls au format incorrect, suite à un mauvais copier-coller. La regex peut faire sens pour s'éviter ce type d'erreur. 

## 🪵 Pour tester

- Se connecter sur Pix Admin
- Aller dans le contenu formatif
- Créer un nouveau contenu https://admin-pr14261.review.pix.fr/trainings/new
- Remplir les champs
- Sur le champ des urls de logo, constater : 
  - que le label à changé pour "url du logo"
  - le sublabel présente un exemple complet avec l'url

<img width="419" height="113" alt="Capture d’écran 2025-11-28 à 16 52 58" src="https://github.com/user-attachments/assets/3860c749-f0a3-4de7-a590-3b9c3233dcae" />

- Mettre un mot au pif et valider le formulaire
- Constater qu'une notif indique que le format est incorrect
- Mettre une url avec `images.pix.fr` et recevoir la même erreur
- Mettre l'url suivante `https://assets.pix.org/badges/logo.svg` et recevoir la même erreur
- Mettre une url valide (récupéré via le lien en dessous dirigeant vers Pix Assets) et constater que c'est tout bon
- En BDD, dans la table `trainings`, voir que l'enregistrement est bon
- Sur Admin, modifier le contenu formatif que vous venez de créer
- L'url doit s'afficher au complet sur le champ
- Modifier l'url pour mettre n'importe quoi (ou l'effacer) et recevoir une erreur.