### PR TITLE
[FEATURE] Permettre de sélectionner un pays lors de la création d'orga (PIX-20298)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -39,6 +39,15 @@ export default class OrganizationCreationForm extends Component {
     return options;
   }
 
+  get countriesOptions() {
+    const options = this.args.countries.map((country) => ({
+      value: country.code,
+      label: `${country.name} (${country.code})`,
+    }));
+
+    return options;
+  }
+
   get submitButtonText() {
     return this.args.parentOrganizationName
       ? 'components.organizations.creation.actions.add-child-organization'
@@ -58,6 +67,11 @@ export default class OrganizationCreationForm extends Component {
   @action
   handleAdministrationTeamSelectionChange(value) {
     this.args.organization.administrationTeamId = value;
+  }
+
+  @action
+  handleCountrySelectionChange(value) {
+    this.args.organization.countryCode = value;
   }
 
   @action
@@ -133,6 +147,21 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>
+
+          <PixSelect
+            @onChange={{this.handleCountrySelectionChange}}
+            @options={{this.countriesOptions}}
+            @placeholder={{t "components.organizations.creation.country.selector.placeholder"}}
+            @hideDefaultOption={{true}}
+            @value={{@organization.countryCode}}
+            required
+            @aria-required={{true}}
+            @requiredLabel={{t "common.fields.required-field"}}
+            @isSearchable={{true}}
+          >
+            <:label>{{t "components.organizations.creation.country.selector.label"}}</:label>
+          </PixSelect>
+
         </Card>
 
         <Card class="admin-form__card" @title="Configuration">

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -5,15 +5,12 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import Card from '../card';
 
 export default class OrganizationCreationForm extends Component {
   @service store;
-
-  @tracked administrationTeams = [];
 
   organizationTypes = [
     { value: 'PRO', label: 'Organisation professionnelle' },
@@ -22,17 +19,8 @@ export default class OrganizationCreationForm extends Component {
     { value: 'SCO-1D', label: 'Établissement scolaire du premier degré' },
   ];
 
-  constructor() {
-    super(...arguments);
-    this.#onMount();
-  }
-
-  async #onMount() {
-    this.administrationTeams = await this.store.findAll('administration-team');
-  }
-
   get administrationTeamsOptions() {
-    const options = this.administrationTeams.map((administrationTeam) => ({
+    const options = this.args.administrationTeams.map((administrationTeam) => ({
       value: administrationTeam.id,
       label: administrationTeam.name,
     }));

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -22,8 +22,9 @@ export default class NewController extends Controller {
   @action
   async addOrganization(event) {
     event.preventDefault();
+    const { name, type, administrationTeamId, countryCode } = this.model.organization;
 
-    if (!this.model.name || !this.model.type || !this.model.administrationTeamId) {
+    if (!name || !type || !administrationTeamId || !countryCode) {
       this.pixToast.sendErrorNotification({
         message: this.intl.t('components.organizations.creation.required-fields-error'),
       });
@@ -31,21 +32,24 @@ export default class NewController extends Controller {
     }
 
     if (this.parentOrganizationId) {
-      this.model.setProperties({
+      this.model.organization.setProperties({
         parentOrganizationId: this.parentOrganizationId,
       });
     }
 
     try {
-      await this.model.save();
+      await this.model.organization.save();
       this.pixToast.sendSuccessNotification({ message: 'L’organisation a été créée avec succès.' });
 
-      if (this.model.parentOrganizationId) {
-        const parentOrganization = await this.store.findRecord('organization', this.model.parentOrganizationId);
+      if (this.model.organization.parentOrganizationId) {
+        const parentOrganization = await this.store.findRecord(
+          'organization',
+          this.model.organization.parentOrganizationId,
+        );
         await parentOrganization.hasMany('children').reload();
       }
 
-      this.router.transitionTo('authenticated.organizations.get.all-tags', this.model.id);
+      this.router.transitionTo('authenticated.organizations.get.all-tags', this.model.organization.id);
     } catch {
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
     }

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -25,7 +25,7 @@ export default class NewController extends Controller {
 
     if (!this.model.name || !this.model.type || !this.model.administrationTeamId) {
       this.pixToast.sendErrorNotification({
-        message: this.intl.t('components.organizations.creation.administration-team.required-fields-error'),
+        message: this.intl.t('components.organizations.creation.required-fields-error'),
       });
       return;
     }

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -28,9 +28,11 @@ export default class NewRoute extends Route {
 
   async model() {
     const organization = await this.store.createRecord('organization');
+    const administrationTeams = await this.store.findAll('administration-team');
     const countries = await this.store.findAll('country');
     return RSVP.hash({
       organization,
+      administrationTeams,
       countries,
     });
   }

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default class NewRoute extends Route {
   @service router;
@@ -25,8 +26,13 @@ export default class NewRoute extends Route {
     }
   }
 
-  model() {
-    return this.store.createRecord('organization');
+  async model() {
+    const organization = await this.store.createRecord('organization');
+    const countries = await this.store.findAll('country');
+    return RSVP.hash({
+      organization,
+      countries,
+    });
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/templates/authenticated/organizations/new.hbs
+++ b/admin/app/templates/authenticated/organizations/new.hbs
@@ -9,7 +9,8 @@
 
 <main class="main-admin-form">
   <Organizations::CreationForm
-    @organization={{@model}}
+    @organization={{@model.organization}}
+    @countries={{@model.countries}}
     @onSubmit={{this.addOrganization}}
     @onCancel={{this.goBackToOrganizationList}}
     @parentOrganizationName={{this.parentOrganizationName}}

--- a/admin/app/templates/authenticated/organizations/new.hbs
+++ b/admin/app/templates/authenticated/organizations/new.hbs
@@ -10,6 +10,7 @@
 <main class="main-admin-form">
   <Organizations::CreationForm
     @organization={{@model.organization}}
+    @administrationTeams={{@model.administrationTeams}}
     @countries={{@model.countries}}
     @onSubmit={{this.addOrganization}}
     @onCancel={{this.goBackToOrganizationList}}

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -113,9 +113,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
       await clickByName('Ajouter');
 
       // then
-      assert
-        .dom(screen.getByText(t('components.organizations.creation.administration-team.required-fields-error')))
-        .exists();
+      assert.dom(screen.getByText(t('components.organizations.creation.required-fields-error'))).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -15,6 +15,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
+    server.create('country', { code: '99100', name: 'France' });
 
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
@@ -90,6 +91,14 @@ module('Acceptance | Organizations | Create', function (hooks) {
       );
       await screen.findByRole('listbox');
       await click(screen.getByText('Équipe 2'));
+
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.country.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByText('France (99100)'));
 
       await fillByLabel('Crédits', 120);
 

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -18,13 +18,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     { code: '99101', name: 'Danemark' },
   ];
 
+  const administrationTeams = [
+    { id: 'team-1', name: 'Équipe 1' },
+    { id: 'team-2', name: 'Équipe 2' },
+  ];
+
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
-    store.findAll = () =>
-      Promise.resolve([
-        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
-      ]);
   });
 
   test('it renders', async function (assert) {
@@ -36,6 +36,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       <template>
         <CreationForm
           @organization={{organization}}
+          @administrationTeams={{administrationTeams}}
           @countries={{countries}}
           @onSubmit={{onSubmit}}
           @onCancel={{onCancel}}
@@ -64,6 +65,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         <template>
           <CreationForm
             @organization={{organization}}
+            @administrationTeams={{administrationTeams}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
             @onCancel={{onCancel}}
@@ -90,6 +92,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         <template>
           <CreationForm
             @organization={{organization}}
+            @administrationTeams={{administrationTeams}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
             @onCancel={{onCancel}}
@@ -151,6 +154,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         <template>
           <CreationForm
             @organization={{organization}}
+            @administrationTeams={{administrationTeams}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
             @onCancel={{onCancel}}
@@ -180,6 +184,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       <template>
         <CreationForm
           @organization={{organization}}
+          @administrationTeams={{administrationTeams}}
           @countries={{countries}}
           @onSubmit={{onSubmit}}
           @onCancel={{onCancel}}
@@ -206,6 +211,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       <template>
         <CreationForm
           @organization={{organization}}
+          @administrationTeams={{administrationTeams}}
           @countries={{countries}}
           @onSubmit={{onSubmit}}
           @onCancel={{onCancel}}

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -11,19 +11,35 @@ module('Integration | Component | organizations/creation-form', function (hooks)
   const onSubmit = () => {};
   const onCancel = () => {};
 
-  test('it renders', async function (assert) {
-    const store = this.owner.lookup('service:store');
+  let store;
+
+  const countries = [
+    { code: '99100', name: 'France' },
+    { code: '99101', name: 'Danemark' },
+  ];
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
     store.findAll = () =>
       Promise.resolve([
         store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
         store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
       ]);
+  });
+
+  test('it renders', async function (assert) {
+    //given
     const organization = store.createRecord('organization', { type: '' });
 
     // when
     const screen = await render(
       <template>
-        <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+        <CreationForm
+          @organization={{organization}}
+          @countries={{countries}}
+          @onSubmit={{onSubmit}}
+          @onCancel={{onCancel}}
+        />
       </template>,
     );
 
@@ -34,24 +50,24 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     assert
       .dom(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')))
       .exists();
+    assert.ok(screen.getByLabelText(`${t('components.organizations.creation.country.selector.label')} *`));
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
   });
 
   module('#selectOrganizationType', function () {
     test('should update attribute organization.type', async function (assert) {
-      const store = this.owner.lookup('service:store');
-      store.findAll = () =>
-        Promise.resolve([
-          store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-          store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
-        ]);
+      // given
       const organization = store.createRecord('organization', { type: '' });
 
-      // given
       const screen = await render(
         <template>
-          <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+          <CreationForm
+            @organization={{organization}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
         </template>,
       );
 
@@ -65,20 +81,19 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     });
   });
 
-  module('#handlePixTeamSelectionChange', function () {
+  module('#handleAdministrationTeamSelectionChange', function () {
     test('should update attribute organization Administration team', async function (assert) {
-      const store = this.owner.lookup('service:store');
-      store.findAll = () =>
-        Promise.resolve([
-          store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-          store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
-        ]);
+      // given
       const organization = store.createRecord('organization', { type: '' });
 
-      // given
       const screen = await render(
         <template>
-          <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+          <CreationForm
+            @organization={{organization}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
         </template>,
       );
 
@@ -96,19 +111,79 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     });
   });
 
+  module('Country information', function () {
+    test('should render countries options in list', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', { type: '' });
+
+      const screen = await render(
+        <template>
+          <CreationForm
+            @organization={{organization}}
+            @administrationTeams={{administrationTeams}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.country.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      const options = await screen.getAllByRole('option');
+
+      // then
+      assert.strictEqual(options.length, 2);
+      assert.strictEqual(options[0].title, 'France (99100)');
+      assert.strictEqual(options[1].title, 'Danemark (99101)');
+    });
+
+    test('should update organization model with countryCode attribute when selecting a country', async function (assert) {
+      // given
+      const organization = store.createRecord('organization', { type: '' });
+
+      const screen = await render(
+        <template>
+          <CreationForm
+            @organization={{organization}}
+            @countries={{countries}}
+            @onSubmit={{onSubmit}}
+            @onCancel={{onCancel}}
+          />
+        </template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.country.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'France (99100)' }));
+
+      // then
+      assert.strictEqual(organization.countryCode, '99100');
+    });
+  });
+
   test('Adds data protection officer information', async function (assert) {
-    const store = this.owner.lookup('service:store');
-    store.findAll = () =>
-      Promise.resolve([
-        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
-      ]);
+    // given
     const organization = store.createRecord('organization', { type: '' });
 
-    // given
     await render(
       <template>
-        <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+        <CreationForm
+          @organization={{organization}}
+          @countries={{countries}}
+          @onSubmit={{onSubmit}}
+          @onCancel={{onCancel}}
+        />
       </template>,
     );
 
@@ -125,18 +200,16 @@ module('Integration | Component | organizations/creation-form', function (hooks)
 
   test('Credits can be added', async function (assert) {
     // given
-    const store = this.owner.lookup('service:store');
-    store.findAll = () =>
-      Promise.resolve([
-        store.createRecord('administration-team', { id: 'team-1', name: 'Équipe 1' }),
-        store.createRecord('administration-team', { id: 'team-2', name: 'Équipe 2' }),
-      ]);
     const organization = store.createRecord('organization', { type: '' });
 
-    //when
     await render(
       <template>
-        <CreationForm @organization={{organization}} @onSubmit={{onSubmit}} @onCancel={{onCancel}} />
+        <CreationForm
+          @organization={{organization}}
+          @countries={{countries}}
+          @onSubmit={{onSubmit}}
+          @onCancel={{onCancel}}
+        />
       </template>,
     );
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -614,13 +614,19 @@
           "add-child-organization": "Add child organization"
         },
         "administration-team": {
-          "required-fields-error": "Please fill in all required fields.",
           "selector": {
             "label": "Choose an administration team",
             "placeholder": "Administration team"
           }
         },
-        "parent-organization-name": "Parent organization: {parentOrganizationName}"
+        "country": {
+          "selector": {
+            "label": "Choose a country",
+            "placeholder": "Country (INSEE code)"
+          }
+        },
+        "parent-organization-name": "Parent organization: {parentOrganizationName}",
+        "required-fields-error": "Please fill in all required fields."
       },
       "editing": {
         "administration-team": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -615,13 +615,19 @@
           "add-child-organization": "Ajouter une organisation fille"
         },
         "administration-team": {
-          "required-fields-error": "Veuillez remplir tous les champs obligatoires.",
           "selector": {
             "label": "Sélectionner une équipe en charge",
             "placeholder": "Équipe en charge"
           }
         },
-        "parent-organization-name": "Organisation mère : {parentOrganizationName}"
+        "country": {
+          "selector": {
+            "label": "Sélectionner un pays",
+            "placeholder": "Pays (code INSEE)"
+          }
+        },
+        "parent-organization-name": "Organisation mère : {parentOrganizationName}",
+        "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "editing": {
         "administration-team": {


### PR DESCRIPTION
## 🍂 Problème

Dans le cadre de l'ajout du champs Pays aux organisations, on souhaite pouvoir sélectionner un pays lors de la création d'une organisation.

## 🌰 Proposition

Dans le formulaire de création d'orga, ajouter un Select, avec possibilité de recherche, alimenté par la liste des pays en base.

## 🍁 Remarques

- Ce champs est obligatoire pour pouvoir créer une orga.
- La clé de traduction du message d'erreur lorsque les champs obligatoires ne sont pas remplis a été déplacée un cran plus haut, pour être au niveau du formulaire de création et non au niveau de l'administration-team (cette erreur concerne tous les champs obligatoires et pas seulement l'équipe en charge)
- Le dernier commit est optionnel. Il vise à ré-écrire la manière d'aller requêter l'API pour récupérer la lsite des `administration-teams`. Auparavant, on faisait cette requête directement dans le composant du formulaire de création, on propose maintenant de le faire au niveau de la route.

## 🪵 Pour tester

Sur Pix Admin:
- aller sur la page de création d'orga
- constater la présence d'un nouveau champs **Pays**
- remplir toutes les infos obligatoires et créer l'organisation
- tester aussi de ne pas remplir le champs **Pays** pour constater l'erreur
