### PR TITLE
[FEATURE] Afficher deux nouvelles colonnes dans le tableau d'historique de versions (PIX-20546)

### DIFF
--- a/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/framework-history.gjs
@@ -1,6 +1,7 @@
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
 
 <template>
   <section class="framework-details">
@@ -16,10 +17,28 @@ import { t } from 'ember-intl';
       <:columns as |version context|>
         <PixTableColumn @context={{context}}>
           <:header>
-            {{t "components.complementary-certifications.item.framework.history.label"}}
+            {{t "components.complementary-certifications.item.framework.history.table.columns.version-id"}}
           </:header>
           <:cell>
-            {{version}}
+            {{version.id}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.complementary-certifications.item.framework.history.table.columns.start-date"}}
+          </:header>
+          <:cell>
+            {{formatDate version.startDate}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "components.complementary-certifications.item.framework.history.table.columns.expiration-date"}}
+          </:header>
+          <:cell>
+            {{#if version.expirationDate}}
+              {{formatDate version.expirationDate}}
+            {{/if}}
           </:cell>
         </PixTableColumn>
       </:columns>

--- a/admin/tests/integration/components/complementary-certifications/item/framework/framework-history-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/framework-history-test.gjs
@@ -7,9 +7,18 @@ import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-ren
 module('Integration | Component | Complementary certifications/Item/Framework | Framework history', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  let intl;
+
+  hooks.beforeEach(function () {
+    intl = this.owner.lookup('service:intl');
+  });
+
   test('it should display the framework history', async function (assert) {
     // given
-    const frameworkHistory = ['20250101080000', '20240101080000', '20230101080000'];
+    const frameworkHistory = [
+      { id: 456, startDate: new Date('2023-10-10'), expirationDate: '' },
+      { id: 123, startDate: new Date('2020-01-01'), expirationDate: new Date('2023-10-10') },
+    ];
 
     // when
     const screen = await render(<template><FrameworkHistory @history={{frameworkHistory}} /></template>);
@@ -32,8 +41,12 @@ module('Integration | Component | Complementary certifications/Item/Framework | 
       .exists();
 
     assert.strictEqual(screen.getAllByRole('row').length, frameworkHistory.length + 1);
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0] })).exists();
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[1] })).exists();
-    assert.dom(screen.getByRole('cell', { name: frameworkHistory[2] })).exists();
+
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0].id })).exists();
+    assert.strictEqual(screen.getAllByRole('cell', { name: intl.formatDate(frameworkHistory[0].startDate) }).length, 2);
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[0].expirationDate })).exists();
+
+    assert.dom(screen.getByRole('cell', { name: frameworkHistory[1].id })).exists();
+    assert.dom(screen.getByRole('cell', { name: intl.formatDate(frameworkHistory[1].startDate) })).exists();
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -452,7 +452,12 @@
           "history": {
             "label": "Versions",
             "table": {
-              "caption": "Versions list in descending order"
+              "caption": "Versions list in descending order",
+              "columns": {
+                "expiration-date": "Expiration date",
+                "start-date": "Start date",
+                "version-id": "Version ID"
+              }
             },
             "title": "Framework versions history"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -453,7 +453,12 @@
           "history": {
             "label": "Versions",
             "table": {
-              "caption": "Liste des versions par ordre décroissant"
+              "caption": "Liste des versions par ordre décroissant",
+              "columns": {
+                "expiration-date": "Date d'expiration",
+                "start-date": "Date de début",
+                "version-id": "ID de version"
+              }
             },
             "title": "Historique des versions du référentiel"
           },

--- a/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/versions-repository.js
@@ -127,7 +127,10 @@ export async function update({ version }) {
 export async function getFrameworkHistory({ scope }) {
   const knexConn = DomainTransaction.getConnection();
 
-  return knexConn('certification_versions').where({ scope }).orderBy('startDate', 'desc').pluck('id');
+  return knexConn('certification_versions')
+    .select('id', 'startDate', 'expirationDate')
+    .where({ scope })
+    .orderBy('startDate', 'desc');
 }
 
 const _toDomain = ({

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -644,14 +644,16 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
       const otherComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification.clea({});
 
-      const olderVersion = databaseBuilder.factory.buildCertificationVersion({
-        scope: complementaryCertification.key,
-        startDate: new Date('2024-01-11'),
-      });
-
       const newerVersion = databaseBuilder.factory.buildCertificationVersion({
         scope: complementaryCertification.key,
         startDate: new Date('2025-01-11'),
+        expirationDate: null,
+      });
+
+      const olderVersion = databaseBuilder.factory.buildCertificationVersion({
+        scope: complementaryCertification.key,
+        startDate: new Date('2024-01-11'),
+        expirationDate: newerVersion.expirationDate,
       });
 
       databaseBuilder.factory.buildCertificationVersion({
@@ -677,7 +679,10 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
         type: 'framework-histories',
         attributes: {
           'complementary-certification-key': complementaryCertification.key,
-          history: [newerVersion.id, olderVersion.id],
+          history: [
+            { id: newerVersion.id, startDate: newerVersion.startDate, expirationDate: newerVersion.expirationDate },
+            { id: olderVersion.id, startDate: olderVersion.startDate, expirationDate: olderVersion.expirationDate },
+          ],
         },
       });
     });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
@@ -295,7 +295,11 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
       const frameworkHistory = await versionsRepository.getFrameworkHistory({ scope });
 
       // then
-      expect(frameworkHistory).to.deep.equal([version3.id, version2.id, version1.id]);
+      expect(frameworkHistory).to.deep.equal([
+        { id: version3.id, startDate: version3.startDate, expirationDate: version3.expirationDate },
+        { id: version2.id, startDate: version2.startDate, expirationDate: version2.expirationDate },
+        { id: version1.id, startDate: version1.startDate, expirationDate: version1.expirationDate },
+      ]);
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/get-framework-history_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/get-framework-history_test.js
@@ -10,10 +10,10 @@ describe('Certification | Configuration | Unit | UseCase | get-framework-history
       getFrameworkHistory: sinon.stub(),
     };
 
-    const currentVersionId = 456;
-    const previousVersionId = 123;
+    const currentVersion = { id: 456, startDate: new Date('2024-01-01'), expirationDate: new Date('2025-02-02') };
+    const previousVersion = { id: 123, startDate: new Date('2022-01-01'), expirationDate: new Date('2024-01-01') };
 
-    versionsRepository.getFrameworkHistory.resolves([currentVersionId, previousVersionId]);
+    versionsRepository.getFrameworkHistory.resolves([currentVersion, previousVersion]);
 
     // when
     const frameworkHistory = await getFrameworkHistory({
@@ -26,6 +26,6 @@ describe('Certification | Configuration | Unit | UseCase | get-framework-history
       scope: complementaryCertificationKey,
     });
 
-    expect(frameworkHistory).to.deep.equal([currentVersionId, previousVersionId]);
+    expect(frameworkHistory).to.deep.equal([currentVersion, previousVersion]);
   });
 });

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/framework-history-serializer_test.js
@@ -6,7 +6,7 @@ describe('Certification | Configuration | Unit | Serializer | framework-history-
   describe('#serialize', function () {
     it('should serialize a framework history to JSONAPI', function () {
       // given
-      const frameworkHistory = ['20250101080000', '20240101080000', '20230101080000'];
+      const frameworkHistory = [{ id: 456, startDate: new Date('2024-01-01'), expirationDate: new Date('2025-02-02') }];
       const complementaryCertificationKey = ComplementaryCertificationKeys.PIX_PLUS_DROIT;
 
       // when


### PR DESCRIPTION
## 🍂 Problème

Il faut afficher les dates des versions des référentiels dans le tableau d'historique des versions.

## 🌰 Proposition

Les 2 nouvelles colonnes sont :
   - date de début de la version
   - date de fin de la version (si existante) 

## 🍁 Remarques

:warning: il manque une colonne par rapport au ticket. Il s'agit de la version de l'algo (v2/v3) qui s'est appliquée aux candidats. (à étudier pour un prochain ticket)


## 🪵 Pour tester

Sur Pix Admin : 
- se connecter sur Pix Admin : https://admin-pr14268.review.pix.fr
- dans ` /complementary-certifications/list`, choisir un référentiel de certification 
- Constater que le tableau **Historique des versions du référentiel** contient bien un **ID de version**, une **Date de début e**t une **Date d'expiration** à null pour la version courante
- Créer une nouvelle version
Constater 
   -- que le tableau **Historique des versions du référentiel** affiche bien les deux versions avec les dates de début pour les deux, et d'expiration pour la plus ancienne
[NON REGRESSION]
   -- que la version la plus récente est affichée au dessus
   -- que la date de début de la plus récente correspond à la date de fin de la plus ancienne
