### PR TITLE
[TECH] Réaliser un script pour changer le domaine des urls de badges et de logos en BDD (PIX-20463).

### DIFF
--- a/api/scripts/modulix/modify-urls-domain-for-pix-assets.js
+++ b/api/scripts/modulix/modify-urls-domain-for-pix-assets.js
@@ -1,0 +1,81 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+const OLD_DOMAIN = 'images.pix.fr';
+const NEW_DOMAIN = 'assets.pix.org';
+const REGEX_FOR_DUPLICATE_PROTOCOL = /https:\/\/[^/]+\/.*?(https:\/\/[^"]+)$/;
+
+export class ModifyBadgeAndTrainingLogoUrlsDomain extends Script {
+  constructor() {
+    super({
+      description: "Change the domain of training's logo and badge URLs for Pix Assets",
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const trainingsToBeUpdated = await trx('trainings').whereLike('editorLogoUrl', `%${OLD_DOMAIN}%`);
+      logger.info(`Number of trainings with a editorLogoUrl containing the old domain: ${trainingsToBeUpdated.length}`);
+
+      const badgesToBeUpdated = await trx('badges').whereLike('imageUrl', `%${OLD_DOMAIN}%`);
+      logger.info(`Number of badges with a imageUrl containing the old domain: ${badgesToBeUpdated.length}`);
+
+      for (const training of trainingsToBeUpdated) {
+        training.editorLogoUrl = modifyUrlWithNewDomain(training.editorLogoUrl);
+        await trx('trainings')
+          .update({ editorLogoUrl: training.editorLogoUrl, updatedAt: new Date() })
+          .where({ id: training.id });
+      }
+
+      for (const badge of badgesToBeUpdated) {
+        badge.imageUrl = modifyUrlWithNewDomain(badge.imageUrl);
+        await trx('badges').update({ imageUrl: badge.imageUrl }).where({ id: badge.id });
+      }
+
+      if (dryRun) {
+        const trainings = await trx('trainings').select('editorLogoUrl').whereLike('editorLogoUrl', `%${OLD_DOMAIN}%`);
+        const trainingsUrlUpdated = trainings.map((item) => item.editorLogoUrl);
+
+        const badges = await trx('badges').select('imageUrl').whereLike('imageUrl', `%${OLD_DOMAIN}%`);
+        const badgesUrlUpdated = badges.map((item) => item.imageUrl);
+
+        logger.info(`Trainings list with old domain after update : ${trainingsUrlUpdated}`);
+        logger.info(`Badges list with old domain after update : ${badgesUrlUpdated}`);
+
+        await trx.rollback();
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`${trainingsToBeUpdated.length} trainings have been successfully updated`);
+      logger.info(`${badgesToBeUpdated.length} badges have been successfully updated`);
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+function modifyUrlWithNewDomain(url) {
+  const invalidUrlWithDuplicateProtocol = url.match(REGEX_FOR_DUPLICATE_PROTOCOL);
+  if (invalidUrlWithDuplicateProtocol) {
+    url = invalidUrlWithDuplicateProtocol[1];
+  }
+  return url.replace(`https://${OLD_DOMAIN}`, `https://${NEW_DOMAIN}`);
+}
+
+await ScriptRunner.execute(import.meta.url, ModifyBadgeAndTrainingLogoUrlsDomain);

--- a/api/tests/modulix/integration/scripts/modify-urls-domain-for-pix-assets.script_test.js
+++ b/api/tests/modulix/integration/scripts/modify-urls-domain-for-pix-assets.script_test.js
@@ -1,0 +1,155 @@
+import { ModifyBadgeAndTrainingLogoUrlsDomain } from '../../../../scripts/modulix/modify-urls-domain-for-pix-assets.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+const OLD_DOMAIN = 'images.pix.fr';
+const NEW_DOMAIN = 'assets.pix.org';
+
+describe('integration | modulix | scripts | modify-urls-domain-for-pix-assets', function () {
+  describe('#handle', function () {
+    let file;
+    let script;
+    let logger;
+    let clock;
+    let now;
+
+    beforeEach(function () {
+      now = new Date('2025-10-10');
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      script = new ModifyBadgeAndTrainingLogoUrlsDomain();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('runs the script with dryRun', async function () {
+      // given
+      databaseBuilder.factory.buildTraining({
+        id: 1,
+        editorLogoUrl: `https://${OLD_DOMAIN}/contenu-formatif/editeur/url-updated.svg`,
+        updatedAt: new Date('2020-09-10'),
+      });
+      databaseBuilder.factory.buildTraining({
+        id: 2,
+        editorLogoUrl: `https://${NEW_DOMAIN}/contenu-formatif/editeur/same-url.svg`,
+        updatedAt: new Date('2022-04-10'),
+      });
+      databaseBuilder.factory.buildBadge({
+        id: 1,
+        imageUrl: `https://${OLD_DOMAIN}/badges/url-updated.svg`,
+      });
+      databaseBuilder.factory.buildBadge({
+        id: 2,
+        imageUrl: `https://${NEW_DOMAIN}/badges/same-url.svg`,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file, dryRun: true },
+        logger,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith('Trainings list with old domain after update : ');
+      expect(logger.info).to.have.been.calledWith('Badges list with old domain after update : ');
+
+      const trainings = await knex('trainings').orderBy('id');
+      expect(trainings[0].editorLogoUrl).to.equal(`https://${OLD_DOMAIN}/contenu-formatif/editeur/url-updated.svg`);
+    });
+
+    describe('For trainings editorLogoUrl', function () {
+      it('modify the urls domain', async function () {
+        // given
+        databaseBuilder.factory.buildTraining({
+          id: 1,
+          editorLogoUrl: `https://${OLD_DOMAIN}/contenu-formatif/editeur/url-updated.svg`,
+          updatedAt: new Date('2020-09-10'),
+        });
+        databaseBuilder.factory.buildTraining({
+          id: 2,
+          editorLogoUrl: `https://${NEW_DOMAIN}/contenu-formatif/editeur/same-url.svg`,
+          updatedAt: new Date('2022-04-10'),
+        });
+        databaseBuilder.factory.buildTraining({
+          id: 3,
+          editorLogoUrl: `https://${OLD_DOMAIN}/contenu-formatif/editeur/autre-dossier-surprise/dave-comp-url-updated.svg`,
+          updatedAt: new Date('2021-01-10'),
+        });
+        databaseBuilder.factory.buildTraining({
+          id: 4,
+          editorLogoUrl: `https://${OLD_DOMAIN}/contenu-formatif/https://${OLD_DOMAIN}/contenu-formatif/logo.svg`,
+          updatedAt: new Date('2023-11-10'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({
+          options: { file },
+          logger,
+        });
+
+        // then
+        const trainings = await knex('trainings').orderBy('id');
+        expect(trainings[0].editorLogoUrl).to.equal(`https://${NEW_DOMAIN}/contenu-formatif/editeur/url-updated.svg`);
+        expect(trainings[0].updatedAt).to.deep.equal(now);
+
+        expect(trainings[1].editorLogoUrl).to.equal(`https://${NEW_DOMAIN}/contenu-formatif/editeur/same-url.svg`);
+        expect(trainings[1].updatedAt).to.deep.equal(new Date('2022-04-10'));
+
+        expect(trainings[2].editorLogoUrl).to.equal(
+          `https://${NEW_DOMAIN}/contenu-formatif/editeur/autre-dossier-surprise/dave-comp-url-updated.svg`,
+        );
+        expect(trainings[2].updatedAt).to.deep.equal(now);
+
+        expect(trainings[3].editorLogoUrl).to.equal(`https://${NEW_DOMAIN}/contenu-formatif/logo.svg`);
+        expect(trainings[3].updatedAt).to.deep.equal(now);
+
+        expect(logger.info).to.have.been.calledWith(
+          'Number of trainings with a editorLogoUrl containing the old domain: 3',
+        );
+      });
+    });
+
+    describe('For badges imageUrl', function () {
+      it('modify the urls domain', async function () {
+        // given
+        databaseBuilder.factory.buildBadge({
+          id: 1,
+          imageUrl: `https://${OLD_DOMAIN}/badges/url-updated.svg`,
+        });
+        databaseBuilder.factory.buildBadge({
+          id: 2,
+          imageUrl: `https://${NEW_DOMAIN}/badges/same-url.svg`,
+        });
+        databaseBuilder.factory.buildBadge({
+          id: 3,
+          imageUrl: `https://${OLD_DOMAIN}/badges/autre-dossier-surprise/dave-comp-url-updated.svg`,
+        });
+        databaseBuilder.factory.buildBadge({
+          id: 4,
+          imageUrl: `https://${OLD_DOMAIN}/https://${OLD_DOMAIN}/logo.svg`,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({
+          options: { file },
+          logger,
+        });
+
+        // then
+        const badges = await knex('badges').orderBy('id');
+        expect(badges[0].imageUrl).to.equal(`https://${NEW_DOMAIN}/badges/url-updated.svg`);
+        expect(badges[1].imageUrl).to.equal(`https://${NEW_DOMAIN}/badges/same-url.svg`);
+        expect(badges[2].imageUrl).to.equal(
+          `https://${NEW_DOMAIN}/badges/autre-dossier-surprise/dave-comp-url-updated.svg`,
+        );
+        expect(badges[3].imageUrl).to.equal(`https://${NEW_DOMAIN}/logo.svg`);
+
+        expect(logger.info).to.have.been.calledWith('Number of badges with a imageUrl containing the old domain: 3');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🍂 Problème

Actuellement en BDD, les tables badges et trainings possèdent des colonnes enregistrant des urls de badges et de logos de CF avec le domaine `images.pix.fr`

## 🌰 Proposition

Réaliser un script pour récupérer ces urls et changer leur domaine avec `assets.pix.org`

## 🍁 Remarques

En faisant un check des données en amont sur Metabase, j'ai constaté que des urls incorrectes sont présentes.

<img width="549" height="151" alt="Capture d’écran 2025-11-27 à 09 21 04" src="https://github.com/user-attachments/assets/6b84b935-2724-421a-9ab5-58eec09e8726" />

On va en profiter pour les clean.

> [!NOTE]
> Les questions Metabase sont disponibles dans le ticket JIRA, partie commentaires 


## 🪵 Pour tester

En local, modifier des urls coté badges (`imageUrl`) et logos (`editorLogoUrl`) avec les formats suivants : 

`https://images.pix.fr/badges/https://images.pix.fr./badges/logo.svg`
`https://images.pix.fr/badges/logo.svg`
`https://images.pix.fr/badges/dossier1/dossier2/logo.svg`

Modifier les `updatedAt` des trainings modifiés.

---

=> Lancer le script en DRYRUN

```shell
node --env-file-if-exists=api/.env api/scripts/modulix/modify-urls-domain-for-pix-assets.js --dryRun
```

Constater que les logs listent les urls corrigées mais que votre BDD n'a pas été impactée.

---

=> Lancer le script

```shell
LOG_LEVEL=debug LOG_ENABLED=true node api/scripts/modulix/modify-urls-domain-for-pix-assets.js
```

Constater : 
- Que les urls possèdent le domaine `assets.pix.org `
- Que la colonne `updatedAt` des trainings à été mis à jour (pas de colonne coté badges)
- Que les urls incorrects ont été corrigées.
