### PR TITLE
[BUGFIX] Garder la configuration des attestations lors de la mise à jour d'une Organisation (PIX-20591).

### DIFF
--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -1,7 +1,8 @@
+import { withTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { AdministrationTeamNotFound, CountryNotFoundError } from '../errors.js';
 
-const updateOrganizationInformation = async function ({
+const updateOrganizationInformation = withTransaction(async function ({
   organization,
   organizationForAdminRepository,
   tagRepository,
@@ -26,7 +27,7 @@ const updateOrganizationInformation = async function ({
   await organizationForAdminRepository.update({ organization: existingOrganization });
 
   return organizationForAdminRepository.get({ organizationId: organization.id });
-};
+});
 
 async function _checkAdministrationTeamExists(administrationTeamId, administrationTeamRepository) {
   const existingAdministrationTeam = await administrationTeamRepository.getById(administrationTeamId);

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -397,6 +397,10 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
 }
 
 function _paramsForFeature(importFormats, key, value) {
+  if (key === ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key) {
+    return JSON.stringify(value.params);
+  }
+
   if (key === ORGANIZATION_FEATURE.LEARNER_IMPORT.key) {
     const learnerImportFormat = importFormats.find(({ name }) => name === value.params.name);
     return { organizationLearnerImportFormatId: learnerImportFormat.id };

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -1412,6 +1412,44 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
           expect(enabledFeatures[0].params).deep.equal({ enableMaximumPlacesLimit: true });
         });
       });
+
+      describe('ATTESTATIONS_MANAGEMENT', function () {
+        let organization;
+
+        beforeEach(async function () {
+          databaseBuilder.factory.buildFeature({
+            key: ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key,
+          });
+          const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
+          organization = databaseBuilder.factory.buildOrganization({
+            name: 'super orga',
+            createdBy: userId,
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('should insert new feature with given params', async function () {
+          // given && when
+          const organizationToUpdate = new OrganizationForAdmin({
+            id: organization.id,
+            documentationUrl: 'https://pix.fr/',
+            features: {
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
+              [ORGANIZATION_FEATURE.ATTESTATIONS_MANAGEMENT.key]: {
+                active: true,
+                params: ['my-reward', 'other-reward'],
+              },
+            },
+          });
+          await repositories.organizationForAdminRepository.update({ organization: organizationToUpdate });
+
+          //then
+          const enabledFeatures = await knex('organization-features');
+          expect(enabledFeatures).lengthOf(1);
+          expect(enabledFeatures[0].params).deep.equal(['my-reward', 'other-reward']);
+        });
+      });
     });
 
     it('should create data protection officer', async function () {

--- a/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/update-organization-information.usecase.test.js
@@ -1,5 +1,6 @@
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
@@ -7,6 +8,9 @@ describe('Unit | Organizational Entities | Domain | UseCase | update-organizatio
   let organizationForAdminRepository, tagRepository, administrationTeamRepository;
 
   beforeEach(function () {
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback();
+    });
     organizationForAdminRepository = {
       get: sinon.stub(),
       update: sinon.stub(),


### PR DESCRIPTION
## 🍂 Problème

La manière dont on fait la sauvegarde des features est trop spécifique dans le repository. il faut ajouter à chaque nouvelle feature la configuration

## 🌰 Proposition

Faire la correction pour la feature des attestations. 

## 🍁 Remarques

Mais il serait intéressant de pouvoir utiliser le model des OrganizationFeatures pour gérer ce que l'on doit mettre à jour ou non. ( à faire dans un second temps. là on corrige le bug qui débloquera le métier / support

## 🪵 Pour tester

Aller sur PixAdmin, faire une modification d'une organisation ayant une attestation. et vérifier que sa config n'a pas bougé. 