### PR TITLE
[TECH] Corriger les erreurs de la console de tests Pix Admin

### DIFF
--- a/admin/app/adapters/certification-candidate-timeline.js
+++ b/admin/app/adapters/certification-candidate-timeline.js
@@ -9,6 +9,6 @@ export default class CertificationCandidateTimelineAdapter extends ApplicationAd
       delete query.candidateId;
       return `${this.host}/${this.namespace}/certification-candidates/${candidateId}/timeline`;
     }
-    return super.urlForQuery(...arguments);
+    return super.urlForQueryRecord(...arguments);
   }
 }

--- a/admin/app/components/administration/common/create-combined-courses.gjs
+++ b/admin/app/components/administration/common/create-combined-courses.gjs
@@ -50,8 +50,7 @@ export default class CreateCombinedCourses extends Component {
           this.errorResponseHandler.notify(responseJson, undefined, true);
         }
       }
-    } catch (err) {
-      console.error(err);
+    } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     } finally {
       this.isLoading = false;

--- a/admin/app/components/administration/common/upsert-quests-in-batch.gjs
+++ b/admin/app/components/administration/common/upsert-quests-in-batch.gjs
@@ -52,8 +52,7 @@ export default class UpsertQuestsInBatch extends Component {
           this.errorResponseHandler.notify(responseJson, undefined, true);
         }
       }
-    } catch (err) {
-      console.error(err);
+    } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     } finally {
       this.isLoading = false;

--- a/admin/app/components/certifications/certification/informations/issue-reports/resolve-issue-report-modal.gjs
+++ b/admin/app/components/certifications/certification/informations/issue-reports/resolve-issue-report-modal.gjs
@@ -31,7 +31,6 @@ export default class CertificationIssueReportModal extends Component {
 
       this.pixToast.sendSuccessNotification({ message: 'Le signalement a été résolu.' });
     } catch (error) {
-      console.log('error', error);
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue :\n' + error?.errors[0]?.detail });
     } finally {
       this.args.toggleResolveModal();

--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -13,7 +13,6 @@ import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { not } from 'ember-truth-helpers';
 
 export default class ActionsOnUsersRoleInOrganization extends Component {
   @tracked showModal = false;
@@ -165,7 +164,6 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
       @title="Détacher l'organisation du profil cible"
       @onCloseButtonClick={{this.closeModal}}
       @showModal={{this.showModal}}
-      aria-hidden="{{not this.showModal}}"
     >
       <:content>
         <p>

--- a/admin/app/components/organizations/target-profiles-section.gjs
+++ b/admin/app/components/organizations/target-profiles-section.gjs
@@ -11,7 +11,6 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import { not } from 'ember-truth-helpers';
 import uniq from 'lodash/uniq';
 
 export default class OrganizationTargetProfilesSectionComponent extends Component {
@@ -214,7 +213,6 @@ export default class OrganizationTargetProfilesSectionComponent extends Componen
       @title="Détacher le profil cible de l'organisation"
       @onCloseButtonClick={{this.closeModal}}
       @showModal={{this.showModal}}
-      aria-hidden="{{not this.showModal}}"
     >
       <:content>
         <p>

--- a/admin/app/components/sessions/session-informations.gjs
+++ b/admin/app/components/sessions/session-informations.gjs
@@ -121,15 +121,17 @@ import JuryComment from './jury-comment';
       {{#if @accessControl.hasAccessToCertificationActionsScope}}
         <div class="session-info__actions">
           {{#if @sessionModel.finalizedAt}}
-            {{#if @isCurrentUserAssignedToSession}}
-              <PixButton @size="large" @isDisabled={{true}}>{{t
-                  "pages.sessions.informations.buttons.assigned-to-session"
-                }}</PixButton>
-            {{else}}
-              <PixButton @size="large" @triggerAction={{@checkForAssignment}}>{{t
-                  "pages.sessions.informations.buttons.assign-session"
-                }}</PixButton>
-            {{/if}}
+            <PixButton
+              @size="large"
+              @isDisabled={{@isCurrentUserAssignedToSession}}
+              @triggerAction={{@checkForAssignment}}
+            >
+              {{#if @isCurrentUserAssignedToSession}}
+                {{t "pages.sessions.informations.buttons.assigned-to-session"}}
+              {{else}}
+                {{t "pages.sessions.informations.buttons.assign-session"}}
+              {{/if}}
+            </PixButton>
             {{#if @sessionModel.isPublished}}
               <PixTooltip @position="right" @isWide={{true}}>
                 <:triggerElement>

--- a/admin/app/components/target-profiles/stages.gjs
+++ b/admin/app/components/target-profiles/stages.gjs
@@ -84,7 +84,7 @@ export default class Stages extends Component {
 
   get isLevelType() {
     const zeroStage = this.stages.find((stage) => stage.isZeroStage);
-    return zeroStage?.isTypeLevel;
+    return Boolean(zeroStage?.isTypeLevel);
   }
 
   get columnNameByStageType() {
@@ -103,7 +103,7 @@ export default class Stages extends Component {
   }
 
   get isAddFirstSkillStageDisabled() {
-    return this.stages.find((stage) => stage.isFirstSkill);
+    return this.stages.some((stage) => stage.isFirstSkill);
   }
 
   get isStageTypeLevelChecked() {

--- a/admin/app/models/certification-consolidated-framework.js
+++ b/admin/app/models/certification-consolidated-framework.js
@@ -3,5 +3,5 @@ import Model, { belongsTo, hasMany } from '@ember-data/model';
 export default class CertificationConsolidatedFramework extends Model {
   @belongsTo('complementary-certification', { async: false, inverse: null }) complementaryCertification;
   @hasMany('area', { async: true, inverse: null }) areas;
-  @hasMany('tubes', { async: false, inverse: null }) tubes;
+  @hasMany('tube', { async: false, inverse: null }) tubes;
 }

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -120,7 +120,6 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Modifier');
-      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
       await fillByLabel('Nom du centre', 'nouveau nom', { exact: false });
@@ -159,7 +158,6 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Modifier');
-      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
       await fillByLabel('Nom du centre', 'Centre des réussites', { exact: false });
@@ -183,7 +181,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         externalId: 'ABCDEF',
         type: 'SCO',
       });
-      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
+      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response(422));
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Modifier');
 

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item/attach-target-profile-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item/attach-target-profile-test.js
@@ -250,7 +250,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           await fillIn(within(table).getByRole('spinbutton', { name: '200 Badge Arène Feu Niveau' }), '1');
           await fillIn(
             within(table).getByRole('textbox', { name: '200 Badge Arène Feu Image svg certificat Pix App' }),
-            'IMAGE1.svg',
+            'logo-placeholder.png',
           );
           await fillIn(
             within(table).getByRole('textbox', { name: '200 Badge Arène Feu Label du certificat' }),
@@ -326,7 +326,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           const ariaLabel = '200 Badge Arène Feu';
           await fillIn(
             within(table).getByRole('textbox', { name: `${ariaLabel} Image svg certificat Pix App` }),
-            'IMAGE1.svg',
+            'logo-placeholder.png',
           );
           await fillIn(within(table).getByRole('textbox', { name: `${ariaLabel} Label du certificat` }), 'LABEL');
           await fillIn(

--- a/admin/tests/acceptance/authenticated/sessions/certification/details-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/certification/details-test.js
@@ -48,7 +48,7 @@ module('Acceptance | authenticated/sessions/certification/details', function (ho
     test('renders the V3 details page', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      const certificationId = this.server.create('certification', { id: 2, version: 3 }).id;
+      const certificationId = this.server.create('certification', { id: '2', version: 3 }).id;
       this.server.create('v3-certification-course-details-for-administration', {
         id: certificationId,
         certificationChallengesForAdministration: [],

--- a/admin/tests/acceptance/authenticated/sessions/certification/informations-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/certification/informations-test.js
@@ -556,7 +556,6 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | infor
                       certificationIssueReport.id,
                     );
                     certificationIssueReportToUpdate.update({ resolvedAt: new Date(), resolution });
-                    return new Response({});
                   },
                   204,
                 );

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
         duration: '10:00:00',
         locale: 'fr-fr',
         editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
-        editorLogoUrl: 'https://mon-logo.svg',
+        editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
         prerequisiteThreshold: null,
         goalThreshold: null,
       },

--- a/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/target-profiles-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
       duration: '10:00:00',
       locale: 'fr-fr',
       editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
-      editorLogoUrl: 'https://mon-logo.svg',
+      editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
       prerequisiteThreshold: null,
       goalThreshold: null,
       targetProfileSummaries: [targetProfileSummary],

--- a/admin/tests/acceptance/authenticated/trainings/training-test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training-test.js
@@ -39,7 +39,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         duration: { days: 0, hours: 10, minutes: 0 },
         locale: 'fr-fr',
         editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
-        editorLogoUrl: 'https://mon-logo.svg',
+        editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
         prerequisiteThreshold: null,
         goalThreshold: null,
       });
@@ -53,7 +53,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         duration: { days: 0, hours: 10, minutes: 0 },
         locale: 'fr-fr',
         editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
-        editorLogoUrl: 'https://mon-logo.svg',
+        editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
         prerequisiteThreshold: null,
         goalThreshold: null,
         targetProfileSummaries: [

--- a/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
+++ b/admin/tests/integration/components/administration/access/anonymize-gar-import-test.gjs
@@ -47,7 +47,9 @@ module('Integration | Component |  administration/anonymize-gar-import', functio
       );
 
       // when
-      const screen = await render(<template><AnonymizeGarImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><AnonymizeGarImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(t('components.administration.anonymize-gar-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -81,7 +83,9 @@ module('Integration | Component |  administration/anonymize-gar-import', functio
       );
 
       // when
-      const screen = await render(<template><AnonymizeGarImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><AnonymizeGarImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(t('components.administration.anonymize-gar-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -111,7 +115,9 @@ module('Integration | Component |  administration/anonymize-gar-import', functio
         );
 
         // when
-        const screen = await render(<template><AnonymizeGarImport /><PixToastContainer /></template>);
+        const screen = await render(
+          <template><AnonymizeGarImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
         const input = await screen.findByLabelText(t('components.administration.anonymize-gar-import.upload-button'));
         await triggerEvent(input, 'change', { files: [file] });
 
@@ -132,7 +138,9 @@ module('Integration | Component |  administration/anonymize-gar-import', functio
         window.fetch.resolves(fetchMock({ status: 500 }));
 
         // when
-        const screen = await render(<template><AnonymizeGarImport /><PixToastContainer /></template>);
+        const screen = await render(
+          <template><AnonymizeGarImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
         const input = await screen.findByLabelText(t('components.administration.anonymize-gar-import.upload-button'));
         await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/access/oidc-providers-import-test.gjs
+++ b/admin/tests/integration/components/administration/access/oidc-providers-import-test.gjs
@@ -19,7 +19,9 @@ module('Integration | Component | administration/oidc-providers-import', functio
       const file = new Blob(['foo'], { type: `valid-file` });
 
       // when
-      const screen = await render(<template><OidcProvidersImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OidcProvidersImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.oidc-providers-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -44,7 +46,9 @@ module('Integration | Component | administration/oidc-providers-import', functio
       const file = new Blob(['foo'], { type: `invalid-file` });
 
       // when
-      const screen = await render(<template><OidcProvidersImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OidcProvidersImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.oidc-providers-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/certification/sco-blocked-access-dates_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-blocked-access-dates_test.gjs
@@ -80,7 +80,9 @@ module('Integration | Component | administration/certification/sco-blocked-acces
 
     // when
     const screen = await render(
-      <template><ScoBlockedAccessDates @scoBlockedAccessDates={{model}} /><PixToastContainer /></template>,
+      <template>
+        <ScoBlockedAccessDates @scoBlockedAccessDates={{model}} /><PixToastContainer @closeButtonAriaLabel="Close" />
+      </template>,
     );
 
     const modifyButtons = await screen.getAllByText(
@@ -108,7 +110,9 @@ module('Integration | Component | administration/certification/sco-blocked-acces
 
     // when
     const screen = await render(
-      <template><ScoBlockedAccessDates @scoBlockedAccessDates={{model}} /><PixToastContainer /></template>,
+      <template>
+        <ScoBlockedAccessDates @scoBlockedAccessDates={{model}} /><PixToastContainer @closeButtonAriaLabel="Close" />
+      </template>,
     );
 
     const modifyButtons = await screen.getAllByText(

--- a/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
+++ b/admin/tests/integration/components/administration/certification/sco-whitelist-configuration_test.gjs
@@ -45,7 +45,9 @@ module('Integration | Component | administration/certification/sco-whitelist-con
         // given
         fileSaverStub.resolves();
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+        const screen = await render(
+          <template><ScoWhitelistConfiguration /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
         const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
         await triggerEvent(input, 'click');
 
@@ -61,7 +63,9 @@ module('Integration | Component | administration/certification/sco-whitelist-con
         // given
         fileSaverStub.rejects();
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+        const screen = await render(
+          <template><ScoWhitelistConfiguration /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
         const input = await screen.findByText(t('pages.administration.certification.sco-whitelist.export.button'));
         await triggerEvent(input, 'click');
 
@@ -89,7 +93,9 @@ module('Integration | Component | administration/certification/sco-whitelist-con
 
       test('it displays a success notification', async function (assert) {
         // when
-        const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+        const screen = await render(
+          <template><ScoWhitelistConfiguration /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+        );
         const input = await screen.getByLabelText(t('pages.administration.certification.sco-whitelist.import.button'));
         await triggerEvent(input, 'change', { files: [file] });
 
@@ -116,7 +122,9 @@ module('Integration | Component | administration/certification/sco-whitelist-con
             })
             .rejects();
           // when
-          const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+          const screen = await render(
+            <template><ScoWhitelistConfiguration /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+          );
           const input = await screen.findByLabelText(
             t('pages.administration.certification.sco-whitelist.import.button'),
           );
@@ -156,7 +164,9 @@ module('Integration | Component | administration/certification/sco-whitelist-con
             );
 
           // when
-          const screen = await render(<template><ScoWhitelistConfiguration /><PixToastContainer /></template>);
+          const screen = await render(
+            <template><ScoWhitelistConfiguration /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+          );
           const input = await screen.findByLabelText(
             t('pages.administration.certification.sco-whitelist.import.button'),
           );

--- a/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/add-organization-features-in-batch-test.gjs
@@ -49,7 +49,9 @@ module('Integration | Component |  administration/add-organization-features-in-b
 
     test('it displays a success notification', async function (assert) {
       // when
-      const screen = await render(<template><AddOrganizationFeaturesInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><AddOrganizationFeaturesInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(
         t('components.administration.add-organization-features-in-batch.upload-button'),
       );
@@ -87,7 +89,9 @@ module('Integration | Component |  administration/add-organization-features-in-b
         );
 
       // when
-      const screen = await render(<template><AddOrganizationFeaturesInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><AddOrganizationFeaturesInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.add-organization-features-in-batch.upload-button'),
       );
@@ -111,7 +115,9 @@ module('Integration | Component |  administration/add-organization-features-in-b
         })
         .rejects();
       // when
-      const screen = await render(<template><AddOrganizationFeaturesInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><AddOrganizationFeaturesInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.add-organization-features-in-batch.upload-button'),
       );

--- a/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
+++ b/admin/tests/integration/components/administration/common/create-combined-courses-test.gjs
@@ -49,7 +49,9 @@ module('Integration | Component | administration/create-combined-courses', funct
 
     test('it displays a success notification', async function (assert) {
       // when
-      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><CreateCombinedCourses /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(t('components.administration.create-combined-courses.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -89,7 +91,9 @@ module('Integration | Component | administration/create-combined-courses', funct
         );
 
       // when
-      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><CreateCombinedCourses /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.create-combined-courses.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -111,7 +115,9 @@ module('Integration | Component | administration/create-combined-courses', funct
         })
         .rejects();
       // when
-      const screen = await render(<template><CreateCombinedCourses /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><CreateCombinedCourses /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.create-combined-courses.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/common/upsert-quests-in-batch-test.gjs
@@ -49,7 +49,9 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
 
     test('it displays a success notification', async function (assert) {
       // when
-      const screen = await render(<template><UpsertQuestsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpsertQuestsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(t('components.administration.upsert-quests-in-batch.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -89,7 +91,9 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
         );
 
       // when
-      const screen = await render(<template><UpsertQuestsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpsertQuestsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.upsert-quests-in-batch.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -121,7 +125,9 @@ module('Integration | Component |  administration/upsert-quests-in-batch', funct
         })
         .rejects();
       // when
-      const screen = await render(<template><UpsertQuestsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpsertQuestsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.upsert-quests-in-batch.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/certification-centers-batch-archive-test.gjs
@@ -30,7 +30,9 @@ module('Integration | Component | administration/certification-centers-batch-arc
       );
 
       // when
-      const screen = await render(<template><CertificationCentersBatchArchive /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><CertificationCentersBatchArchive /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.certification-centers-batch-archive.upload-button'),
       );
@@ -71,7 +73,9 @@ module('Integration | Component | administration/certification-centers-batch-arc
       );
 
       // when
-      const screen = await render(<template><CertificationCentersBatchArchive /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><CertificationCentersBatchArchive /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.certification-centers-batch-archive.upload-button'),
       );

--- a/admin/tests/integration/components/administration/deployment/organization-tags-import_test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organization-tags-import_test.gjs
@@ -19,7 +19,9 @@ module('Integration | Component | administration/organization-tags-import', func
       const file = new Blob(['foo'], { type: `valid-file` });
 
       // when
-      const screen = await render(<template><OrganizationTagsImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OrganizationTagsImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.organization-tags-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 
@@ -44,7 +46,9 @@ module('Integration | Component | administration/organization-tags-import', func
       const file = new Blob(['foo'], { type: `invalid-file` });
 
       // when
-      const screen = await render(<template><OrganizationTagsImport /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OrganizationTagsImport /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(t('components.administration.organization-tags-import.upload-button'));
       await triggerEvent(input, 'change', { files: [file] });
 

--- a/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/organizations-batch-archive-test.gjs
@@ -29,7 +29,9 @@ module('Integration | Component | administration/organizations-batch-archive', f
       requestManagerService.request.resolves({ response: { ok: true, status: 204 } });
 
       // when
-      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OrganizationsBatchArchive /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.organizations-batch-archive.upload-button'),
       );
@@ -63,7 +65,9 @@ module('Integration | Component | administration/organizations-batch-archive', f
       });
 
       // when
-      const screen = await render(<template><OrganizationsBatchArchive /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><OrganizationsBatchArchive /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.organizations-batch-archive.upload-button'),
       );

--- a/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
@@ -34,7 +34,9 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       window.fetch.resolves(fetchResponse({ status: 204 }));
 
       // when
-      const screen = await render(<template><UpdateOrganizationsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.getByLabelText(
         t('components.administration.update-organizations-in-batch.upload-button'),
       );
@@ -60,7 +62,9 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(<template><UpdateOrganizationsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.update-organizations-in-batch.upload-button'),
       );
@@ -93,7 +97,9 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(<template><UpdateOrganizationsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.update-organizations-in-batch.upload-button'),
       );
@@ -127,7 +133,9 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(<template><UpdateOrganizationsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.update-organizations-in-batch.upload-button'),
       );
@@ -156,7 +164,9 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(<template><UpdateOrganizationsInBatch /><PixToastContainer /></template>);
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
       const input = await screen.findByLabelText(
         t('components.administration.update-organizations-in-batch.upload-button'),
       );

--- a/admin/tests/integration/components/badges/badge-test.gjs
+++ b/admin/tests/integration/components/badges/badge-test.gjs
@@ -18,7 +18,7 @@ module('Integration | Component | badges/badge', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const badge = store.createRecord('badge', {
-      id: 42,
+      id: '42',
       title: 'mon titre',
       message: 'mon message',
       imageUrl: 'data:,',
@@ -29,7 +29,7 @@ module('Integration | Component | badges/badge', function (hooks) {
       criteria: [],
     });
     const targetProfile = store.createRecord('target-profile', {
-      id: 1,
+      id: '1',
       internalName: 'Profil cible',
     });
 
@@ -51,24 +51,24 @@ module('Integration | Component | badges/badge', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const targetProfile = store.createRecord('target-profile', {
-      id: 1,
+      id: '1',
       internalName: 'Profil cible',
       areas: [],
     });
     const criterionCampaignParticipation = store.createRecord('badge-criterion', {
-      id: 123,
+      id: '123',
       threshold: 25,
       scope: 'CampaignParticipation',
       cappedTubes: [],
     });
     const criterionCappedTubes = store.createRecord('badge-criterion', {
-      id: 456,
+      id: '456',
       threshold: 95,
       scope: 'CappedTubes',
       cappedTubes: [],
     });
     const badge = store.createRecord('badge', {
-      id: 42,
+      id: '42',
       title: 'mon titre',
       message: 'mon message',
       imageUrl: 'data:,',
@@ -96,13 +96,13 @@ module('Integration | Component | badges/badge', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const targetProfile = store.createRecord('target-profile', {
-      id: 1,
+      id: '1',
       internalName: 'Profil cible',
       areas: [],
     });
 
     const badge = store.createRecord('badge', {
-      id: 42,
+      id: '42',
       title: 'mon titre',
       message: 'mon message',
       imageUrl: 'data:,',

--- a/admin/tests/integration/components/badges/campaign-criterion-test.gjs
+++ b/admin/tests/integration/components/badges/campaign-criterion-test.gjs
@@ -21,7 +21,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const criterion = store.createRecord('badge-criterion', {
-      id: 123,
+      id: '123',
       threshold: 60,
     });
 
@@ -41,7 +41,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
         // when
         const store = this.owner.lookup('service:store');
         const criterion = store.createRecord('badge-criterion', {
-          id: 123,
+          id: '123',
           threshold: 60,
         });
 

--- a/admin/tests/integration/components/certification-centers/information-edit-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-edit-test.gjs
@@ -27,7 +27,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's name is empty", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -40,7 +42,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's name is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -53,7 +57,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's type is empty", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -68,7 +74,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's externalId is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -81,7 +89,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's data protection officer first name is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -94,7 +104,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's data protection officer last name is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -107,7 +119,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's data protection officer email is longer than 255 characters", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when
@@ -122,7 +136,9 @@ module('Integration | Component | certification-centers/information-edit', funct
     test("it should show an error message if certification center's dataProtectionOfficerEmail is not valid", async function (assert) {
       // given
       const screen = await render(
-        <template><InformationEdit @certificationCenter={{certificationCenter}} /></template>,
+        <template>
+          <InformationEdit @certificationCenter={{certificationCenter}} @toggleEditMode={{toggleEditModeStub}} />
+        </template>,
       );
 
       // when

--- a/admin/tests/integration/components/certification-centers/information-edit-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-edit-test.gjs
@@ -227,7 +227,7 @@ module('Integration | Component | certification-centers/information-edit', funct
         const store = this.owner.lookup('service:store');
         const availableHabilitations = [
           store.createRecord('complementary-certification', {
-            id: 0,
+            id: '0',
             key: 'DROIT',
             label: 'Pix+Droit',
           }),
@@ -272,7 +272,7 @@ module('Integration | Component | certification-centers/information-edit', funct
         const store = this.owner.lookup('service:store');
         const availableHabilitations = [
           store.createRecord('complementary-certification', {
-            id: 0,
+            id: '0',
             key: 'DROIT',
             label: 'Pix+Droit',
           }),

--- a/admin/tests/integration/components/certification-centers/information-view-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-view-test.gjs
@@ -15,11 +15,11 @@ module('Integration | Component | certification-centers/information-view', funct
     // given
     const store = this.owner.lookup('service:store');
     const pixDroitHabilitation = store.createRecord('complementary-certification', {
-      id: 0,
+      id: '0',
       key: 'DROIT',
       label: 'Pix+Droit',
     });
-    const cleaHabilitation = store.createRecord('complementary-certification', { id: 1, key: 'CLEA', label: 'Cléa' });
+    const cleaHabilitation = store.createRecord('complementary-certification', { id: '1', key: 'CLEA', label: 'Cléa' });
     const availableHabilitations = [pixDroitHabilitation, cleaHabilitation];
 
     const certificationCenter = store.createRecord('certification-center', {

--- a/admin/tests/integration/components/certification-centers/information-view-test.gjs
+++ b/admin/tests/integration/components/certification-centers/information-view-test.gjs
@@ -1,11 +1,15 @@
 import { render } from '@1024pix/ember-testing-library';
 import InformationView from 'pix-admin/components/certification-centers/information-view';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-centers/information-view', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  const toggleEditMode = sinon.stub();
+  const toggleShowArchiveModal = sinon.stub();
 
   test('it should display label and values in read mode', async function (assert) {
     // given
@@ -34,6 +38,8 @@ module('Integration | Component | certification-centers/information-view', funct
         <InformationView
           @availableHabilitations={{availableHabilitations}}
           @certificationCenter={{certificationCenter}}
+          @toggleEditMode={{toggleEditMode}}
+          @toggleShowArchiveModal={{toggleShowArchiveModal}}
         />
       </template>,
     );
@@ -60,7 +66,15 @@ module('Integration | Component | certification-centers/information-view', funct
     });
 
     // when
-    const screen = await render(<template><InformationView @certificationCenter={{certificationCenter}} /></template>);
+    const screen = await render(
+      <template>
+        <InformationView
+          @certificationCenter={{certificationCenter}}
+          @toggleEditMode={{toggleEditMode}}
+          @toggleShowArchiveModal={{toggleShowArchiveModal}}
+        />
+      </template>,
+    );
 
     // then
     assert.dom(screen.getByText('Tableau de bord')).exists();

--- a/admin/tests/integration/components/certification-centers/membership-item-actions-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-actions-test.gjs
@@ -8,6 +8,11 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component |  certification-centers/membership-item-actions', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  const onSaveRoleButtonClicked = sinon.stub();
+  const onModifyRoleButtonClicked = sinon.stub();
+  const onDeactivateMembershipButtonClicked = sinon.stub();
+  const onCancelButtonClicked = sinon.stub();
+
   module('when edition mode is deactivated', function () {
     test('displays 2 buttons, "Modifier le rôle" and "Désactiver"', async function (assert) {
       // given
@@ -15,7 +20,13 @@ module('Integration | Component |  certification-centers/membership-item-actions
 
       //  when
       const screen = await renderScreen(
-        <template><MembershipItemActions @isEditionMode={{isEditionMode}} /></template>,
+        <template>
+          <MembershipItemActions
+            @isEditionMode={{isEditionMode}}
+            @onModifyRoleButtonClicked={{onModifyRoleButtonClicked}}
+            @onDeactivateMembershipButtonClicked={{onDeactivateMembershipButtonClicked}}
+          />
+        </template>,
       );
 
       // then
@@ -26,9 +37,7 @@ module('Integration | Component |  certification-centers/membership-item-actions
     module('when "Modifier le rôle" button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onModifyRoleButtonClicked = sinon.stub();
         const isEditionMode = false;
-        const onDeactivateMembershipButtonClicked = sinon.stub();
 
         //  when
         await renderScreen(
@@ -51,8 +60,6 @@ module('Integration | Component |  certification-centers/membership-item-actions
     module('when "Désactiver" button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onDeactivateMembershipButtonClicked = sinon.stub();
-        const onModifyRoleButtonClicked = sinon.stub();
         const isEditionMode = false;
 
         //  when
@@ -81,7 +88,13 @@ module('Integration | Component |  certification-centers/membership-item-actions
 
       //  when
       const screen = await renderScreen(
-        <template><MembershipItemActions @isEditionMode={{isEditionMode}} /></template>,
+        <template>
+          <MembershipItemActions
+            @isEditionMode={{isEditionMode}}
+            @onSaveRoleButtonClicked={{onSaveRoleButtonClicked}}
+            @onCancelButtonClicked={{onCancelButtonClicked}}
+          />
+        </template>,
       );
 
       // then
@@ -94,8 +107,6 @@ module('Integration | Component |  certification-centers/membership-item-actions
     module('when "Enregistrer" button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onSaveRoleButtonClicked = sinon.stub();
-        const onCancelButtonClicked = sinon.stub();
         const isEditionMode = true;
 
         //  when
@@ -119,8 +130,6 @@ module('Integration | Component |  certification-centers/membership-item-actions
     module('when "Annuler" button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onCancelButtonClicked = sinon.stub();
-        const onSaveRoleButtonClicked = sinon.stub();
         const isEditionMode = true;
 
         //  when

--- a/admin/tests/integration/components/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/certification-centers/membership-item-test.gjs
@@ -26,13 +26,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
     test('with last access date if exists', async function (assert) {
       // given
       const user = store.createRecord('user', {
-        id: 1,
+        id: '1',
         firstName: 'Jojo',
         lastName: 'La Gringue',
         email: 'jojo@example.net',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         user,
         role: 'MEMBER',
         createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -69,13 +69,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
     test('with default last access date when there is none', async function (assert) {
       // given
       const user = store.createRecord('user', {
-        id: 1,
+        id: '1',
         firstName: 'Jojo',
         lastName: 'La Gringue',
         email: 'jojo@example.net',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         user,
         role: 'MEMBER',
         createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -104,13 +104,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
     test('displays a role selector input, save and cancel buttons instead of "Modifier le rôle" button', async function (assert) {
       // given
       const user = store.createRecord('user', {
-        id: 1,
+        id: '1',
         firstName: 'Jojo',
         lastName: 'La Gringue',
         email: 'jojo@example.net',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         user,
         role: 'MEMBER',
         createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -141,13 +141,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
       test('deactivates edition mode and saves the new role', async function (assert) {
         // given
         const user = store.createRecord('user', {
-          id: 1,
+          id: '1',
           firstName: 'Jojo',
           lastName: 'La Gringue',
           email: 'jojo@example.net',
         });
         const certificationCenterMembership = store.createRecord('certification-center-membership', {
-          id: 1,
+          id: '1',
           user,
           role: 'MEMBER',
           createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -186,13 +186,13 @@ module('Integration | Component |  certification-centers/membership-item', funct
       test('hides role selector input, displays current role, "Modifier le rôle" and "Désactiver" buttons', async function (assert) {
         // given
         const user = store.createRecord('user', {
-          id: 1,
+          id: '1',
           firstName: 'Jojo',
           lastName: 'La Gringue',
           email: 'jojo@example.net',
         });
         const certificationCenterMembership = store.createRecord('certification-center-membership', {
-          id: 1,
+          id: '1',
           user,
           role: 'MEMBER',
           createdAt: new Date('2023-09-13T10:47:07Z'),

--- a/admin/tests/integration/components/certification-centers/memberships-section-test.gjs
+++ b/admin/tests/integration/components/certification-centers/memberships-section-test.gjs
@@ -28,13 +28,13 @@ module('Integration | Component | certification-centers/memberships-section', fu
       email: 'froufrou@example.net',
     });
     const certificationCenterMembership1 = store.createRecord('certification-center-membership', {
-      id: 1,
+      id: '1',
       user: user1,
       role: 'ADMIN',
       createdAt: new Date('2018-02-15T05:06:07Z'),
     });
     const certificationCenterMembership2 = store.createRecord('certification-center-membership', {
-      id: 2,
+      id: '2',
       user: user2,
       role: 'MEMBER',
       createdAt: new Date('2018-02-15T05:06:07Z'),

--- a/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/details-v3-test.gjs
@@ -8,7 +8,7 @@ import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 const answers = [
   {
-    id: 1,
+    id: '1',
     questionNumber: '1',
     answerStatus: 'ok',
     answerStatusName: 'OK',
@@ -19,7 +19,7 @@ const answers = [
     skillName: '@rec123',
   },
   {
-    id: 2,
+    id: '2',
     questionNumber: '2',
     answerStatus: 'ko',
     answerStatusName: 'KO',
@@ -30,7 +30,7 @@ const answers = [
     skillName: '@rec124',
   },
   {
-    id: 3,
+    id: '3',
     questionNumber: '[3]',
     answerStatus: null,
     answerStatusName: 'Signalement validé',
@@ -41,7 +41,7 @@ const answers = [
     skillName: '@rec125',
   },
   {
-    id: 4,
+    id: '4',
     questionNumber: '3',
     answerStatus: 'aband',
     answerStatusName: 'Abandonnée',
@@ -52,7 +52,7 @@ const answers = [
     skillName: '@rec124',
   },
   {
-    id: 5,
+    id: '5',
     questionNumber: '4',
     answerStatus: 'timedout',
     answerStatusName: 'Temps écoulé',
@@ -63,7 +63,7 @@ const answers = [
     skillName: '@rec124',
   },
   {
-    id: 6,
+    id: '6',
     questionNumber: '5',
     answerStatus: 'focusedOut',
     answerStatusName: 'Focus out',
@@ -74,7 +74,7 @@ const answers = [
     skillName: '@rec124',
   },
   {
-    id: 8,
+    id: '8',
     questionNumber: '7',
     answerStatus: 'unimplemented',
     answerStatusName: 'Non implémentée',
@@ -517,7 +517,7 @@ module('Integration | Component | Certifications | certification > details v3', 
             const model = store.createRecord('v3-certification-course-details-for-administration', {
               certificationChallengesForAdministration: [
                 store.createRecord('certification-challenges-for-administration', {
-                  id: 1,
+                  id: '1',
                   questionNumber: 1,
                   answerStatus: 'aband',
                 }),
@@ -626,11 +626,11 @@ function createCertificationCourseDetailsRecord({ certificationChallengesForAdmi
 function createChallengesForAdministration(answerStatuses, store) {
   return answerStatuses.map((answerStatus, index) =>
     store.createRecord('certification-challenges-for-administration', {
-      id: index,
+      id: String(index),
       questionNumber: index + 1,
       answerStatus,
       answerValue: answerStatus ? `Réponse ${index + 1}` : null,
-      validatedLiveAlert: !answerStatus ? { id: index + 10, issueReportSubcategory: 'WEBSITE_BLOCKED' } : false,
+      validatedLiveAlert: !answerStatus ? { id: String(index + 10), issueReportSubcategory: 'WEBSITE_BLOCKED' } : false,
     }),
   );
 }

--- a/admin/tests/integration/components/certifications/certification/informations-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations-test.gjs
@@ -24,7 +24,7 @@ module('Integration | Component | Certifications | Certification | Informations'
   test('should display the global actions block', async function (assert) {
     // given
     const certification = store.createRecord('certification', { userId: 1, competencesWithMark: [] });
-    const session = store.createRecord('session', { id: 7404 });
+    const session = store.createRecord('session', { id: '7404' });
 
     // when
     const screen = await render(
@@ -38,7 +38,7 @@ module('Integration | Component | Certifications | Certification | Informations'
   test('should display certification state card', async function (assert) {
     // given
     const certification = store.createRecord('certification', { competencesWithMark: [] });
-    const session = store.createRecord('session', { id: 7404 });
+    const session = store.createRecord('session', { id: '7404' });
 
     // when
     const screen = await render(
@@ -52,7 +52,7 @@ module('Integration | Component | Certifications | Certification | Informations'
   test('should display the certification candidate card', async function (assert) {
     // given
     const certification = store.createRecord('certification', { competencesWithMark: [] });
-    const session = store.createRecord('session', { id: 7404 });
+    const session = store.createRecord('session', { id: '7404' });
 
     // when
     const screen = await render(
@@ -68,7 +68,7 @@ module('Integration | Component | Certifications | Certification | Informations'
       test('should not display issue reports card', async function (assert) {
         // given
         const certification = store.createRecord('certification', { competencesWithMark: [] });
-        const session = store.createRecord('session', { id: 7404 });
+        const session = store.createRecord('session', { id: '7404' });
         const issueReports = [];
 
         // when
@@ -91,7 +91,7 @@ module('Integration | Component | Certifications | Certification | Informations'
       test('should display issue reports card', async function (assert) {
         // given
         const certification = store.createRecord('certification', { competencesWithMark: [] });
-        const session = store.createRecord('session', { id: 7404 });
+        const session = store.createRecord('session', { id: '7404' });
         const issueReports = [store.createRecord('certification-issue-report')];
 
         // when

--- a/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
@@ -26,7 +26,7 @@ module('Integration | Component | Certifications | Certification | Information |
     const certification = store.createRecord('certification', {
       firstName: 'Jane',
       lastName: 'Doe',
-      birthdate: new Date(),
+      birthdate: '2000-12-15',
       sex: 'F',
       birthplace: 'Paris',
       birthPostalCode: '75001',
@@ -92,7 +92,7 @@ module('Integration | Component | Certifications | Certification | Information |
         id: '1',
         firstName: 'Jane',
         lastName: 'Doe',
-        birthdate: new Date(),
+        birthdate: '2000-12-15',
         sex: 'F',
         birthplace: 'Paris',
         birthPostalCode: '75001',

--- a/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/candidate-test.gjs
@@ -89,7 +89,7 @@ module('Integration | Component | Certifications | Certification | Information |
       this.owner.register('service:pixToast', NotificationsStub);
 
       const certification = store.createRecord('certification', {
-        id: 1,
+        id: '1',
         firstName: 'Jane',
         lastName: 'Doe',
         birthdate: new Date(),

--- a/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/global-actions-test.gjs
@@ -191,7 +191,7 @@ module('Integration | Component | Certifications | Certification | Information |
       hooks.beforeEach(async function () {
         // given
         const certification = store.createRecord('certification', {
-          id: 1,
+          id: '1',
           userId: 1,
           status: assessmentResultStatus.VALIDATED,
           isPublished: false,
@@ -292,7 +292,7 @@ module('Integration | Component | Certifications | Certification | Information |
       hooks.beforeEach(async function () {
         // given
         const certification = store.createRecord('certification', {
-          id: 1,
+          id: '1',
           userId: 1,
           status: assessmentResultStatus.CANCELLED,
           isPublished: false,
@@ -531,7 +531,7 @@ module('Integration | Component | Certifications | Certification | Information |
       hooks.beforeEach(async function () {
         // given
         const certification = store.createRecord('certification', {
-          id: 1,
+          id: '1',
           userId: 1,
           status: assessmentResultStatus.VALIDATED,
           isPublished: false,
@@ -632,7 +632,7 @@ module('Integration | Component | Certifications | Certification | Information |
       hooks.beforeEach(async function () {
         // given
         const certification = store.createRecord('certification', {
-          id: 1,
+          id: '1',
           userId: 1,
           status: assessmentResultStatus.REJECTED,
           isRejectedForFraud: true,
@@ -872,7 +872,7 @@ module('Integration | Component | Certifications | Certification | Information |
 
         // given
         const certification = store.createRecord('certification', {
-          id: 123,
+          id: '123',
           userId: 1,
           status: assessmentResultStatus.VALIDATED,
           isPublished: false,
@@ -912,7 +912,7 @@ module('Integration | Component | Certifications | Certification | Information |
 
         // given
         const certification = store.createRecord('certification', {
-          id: 123,
+          id: '123',
           userId: 1,
           status: assessmentResultStatus.VALIDATED,
           isPublished: false,

--- a/admin/tests/integration/components/certifications/certification/informations/state-test.gjs
+++ b/admin/tests/integration/components/certifications/certification/informations/state-test.gjs
@@ -20,7 +20,7 @@ module('Integration | Component | Certifications | Certification | Information |
       status: 'rejected',
       isPublished: false,
     });
-    const session = store.createRecord('session', { id: 7404 });
+    const session = store.createRecord('session', { id: '7404' });
 
     // when
     const screen = await render(
@@ -59,7 +59,7 @@ module('Integration | Component | Certifications | Certification | Information |
       const certification = store.createRecord('certification', {
         isPublished: true,
       });
-      const session = store.createRecord('session', { id: 7404 });
+      const session = store.createRecord('session', { id: '7404' });
 
       // when
       const screen = await render(
@@ -81,7 +81,7 @@ module('Integration | Component | Certifications | Certification | Information |
         isPublished: false,
         status: assessmentResultStatus.CANCELLED,
       });
-      const session = store.createRecord('session', { id: 7404 });
+      const session = store.createRecord('session', { id: '7404' });
 
       // when
       const screen = await render(

--- a/admin/tests/integration/components/complementary-certifications/attach-badges-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges-test.gjs
@@ -13,6 +13,7 @@ module('Integration | Component | complementary-certifications/attach-badges', f
 
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
+    sinon.stub(store, 'queryRecord');
   });
 
   test('should reset state when target profile selector is changed', async function (assert) {

--- a/admin/tests/integration/components/complementary-certifications/attach-badges-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges-test.gjs
@@ -26,7 +26,7 @@ module('Integration | Component | complementary-certifications/attach-badges', f
       name: 'Current Profile',
     });
     const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-      id: 12,
+      id: '12',
       name: 'New Target Profile',
     });
     sinon.stub(store, 'query').resolves([attachableTargetProfile]);
@@ -69,7 +69,7 @@ module('Integration | Component | complementary-certifications/attach-badges', f
       name: 'Current Profile',
     });
     const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-      id: 12,
+      id: '12',
       name: 'Target Profile',
       badges: [{ id: 1, label: 'Badge 1' }],
     });

--- a/admin/tests/integration/components/complementary-certifications/attach-badges/badges/index-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges/badges/index-test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
       store.queryRecord = sinon.stub().returns(new Promise(() => {}));
       const attachableTargetProfile = store.createRecord('attachable-target-profile', {
         name: 'ALEX TARGET',
-        id: 1,
+        id: '1',
       });
       const noop = () => {};
 
@@ -43,7 +43,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
 
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
           name: 'ALEX TARGET',
-          id: 1,
+          id: '1',
         });
         const noop = () => {};
 
@@ -72,7 +72,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
           hasMany: sinon.stub().returns({
             value: sinon.stub().returns([
               {
-                id: 1000,
+                id: '1000',
                 title: 'canards',
                 isCertifiable: true,
               },
@@ -81,7 +81,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
         });
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
           name: 'ALEX TARGET',
-          id: 1,
+          id: '1',
         });
         const noop = () => {};
 

--- a/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector-test.gjs
@@ -50,7 +50,7 @@ module(
         const onChangeStub = sinon.stub();
         const onErrorStub = sinon.stub();
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-          id: 12,
+          id: '12',
           name: 'target-profile',
         });
         sinon.stub(store, 'query').resolves([attachableTargetProfile]);
@@ -80,7 +80,7 @@ module(
         const onChangeStub = sinon.stub();
         const onErrorStub = sinon.stub();
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-          id: 12,
+          id: '12',
           name: 'target-profile',
         });
         sinon.stub(store, 'query').resolves([attachableTargetProfile]);
@@ -188,7 +188,7 @@ module(
         const onChangeStub = sinon.stub();
         const onErrorStub = sinon.stub();
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-          id: 12,
+          id: '12',
           name: 'target-profile',
         });
         sinon.stub(store, 'query').resolves([attachableTargetProfile]);
@@ -218,7 +218,7 @@ module(
         const onChangeStub = sinon.stub();
         const onErrorStub = sinon.stub();
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-          id: 12,
+          id: '12',
           name: 'target-profile',
         });
         sinon.stub(store, 'query').resolves([attachableTargetProfile]);
@@ -251,7 +251,7 @@ module(
         const onChangeStub = sinon.stub();
         const onErrorStub = sinon.stub();
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
-          id: 12,
+          id: '12',
           name: 'target-profile',
         });
         sinon.stub(store, 'query').resolves([attachableTargetProfile]);

--- a/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/index-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/index-test.gjs
@@ -74,7 +74,7 @@ module(
         const store = this.owner.lookup('service:store');
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
           name: 'ALEX TARGET',
-          id: 1,
+          id: '1',
         });
         store.query = sinon.stub().resolves([attachableTargetProfile]);
         const noop = () => {};

--- a/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile-test.gjs
@@ -7,6 +7,8 @@ import sinon from 'sinon';
 module('Integration | Component | selected-target-profile', function (hooks) {
   setupRenderingTest(hooks);
 
+  const onResetStub = sinon.stub();
+
   test('it should display a link to the provided target profile', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -17,7 +19,9 @@ module('Integration | Component | selected-target-profile', function (hooks) {
 
     // when
     const screen = await renderScreen(
-      <template><SelectedTargetProfile @attachableTargetProfile={{attachableTargetProfile}} /></template>,
+      <template>
+        <SelectedTargetProfile @attachableTargetProfile={{attachableTargetProfile}} @onChange={{onResetStub}} />
+      </template>,
     );
 
     // then
@@ -28,7 +32,6 @@ module('Integration | Component | selected-target-profile', function (hooks) {
   module('when change button is clicked', function () {
     test("it should call onReset arg's method", async function (assert) {
       // given
-      const onResetStub = sinon.stub();
       const screen = await renderScreen(<template><SelectedTargetProfile @onChange={{onResetStub}} /></template>);
 
       // when

--- a/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/attach-badges/target-profile-selector/selected-target-profile-test.gjs
@@ -14,7 +14,7 @@ module('Integration | Component | selected-target-profile', function (hooks) {
     const store = this.owner.lookup('service:store');
     const attachableTargetProfile = store.createRecord('attachable-target-profile', {
       name: 'ALEX TARGET',
-      id: 1,
+      id: '1',
     });
 
     // when

--- a/admin/tests/integration/components/complementary-certifications/common/link-to-current-target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/common/link-to-current-target-profile-test.gjs
@@ -13,7 +13,7 @@ module(
       const store = this.owner.lookup('service:store');
       const currentTargetProfile = store.createRecord('target-profile', {
         name: 'ALEX TARGET',
-        id: 1,
+        id: '1',
       });
 
       // when

--- a/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
@@ -17,7 +17,7 @@ module('Integration | Component | complementary-certifications/item/framework/cr
     sinon.stub(store, 'findAll').withArgs('framework').resolves(frameworks);
 
     const complementaryCertification = store.createRecord('complementary-certification', {
-      id: 0,
+      id: '0',
       key: 'DROIT',
       label: 'Pix+Droit',
     });

--- a/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/header-test.gjs
@@ -12,7 +12,7 @@ module('Integration | Component | complementary-certifications/item/header', fun
       // given
       const store = this.owner.lookup('service:store');
       const complementaryCertification = store.createRecord('complementary-certification', {
-        id: 0,
+        id: '0',
         key: 'DROIT',
         label: 'Pix+Droit',
         hasComplementaryReferential: true,
@@ -36,7 +36,7 @@ module('Integration | Component | complementary-certifications/item/header', fun
       // given
       const store = this.owner.lookup('service:store');
       const complementaryCertification = store.createRecord('complementary-certification', {
-        id: 0,
+        id: '0',
         key: 'CLEA',
         label: 'CléA Numérique',
         hasComplementaryReferential: false,

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
@@ -16,7 +16,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.adminMember = { isSuperAdmin: true };
       const complementaryCertification = store.createRecord('complementary-certification', {
-        id: 10,
+        id: '10',
         key: 'CLEA',
         label: 'CléA Numérique',
         hasComplementaryReferential: false,
@@ -24,10 +24,10 @@ module('Integration | Component | complementary-certifications/item/target-profi
           {
             detachedAt: null,
             name: 'ALEX TARGET',
-            id: 3,
+            id: '3',
             badges: [
-              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
-              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: '1023', label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: '1025', label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
             ],
           },
         ],
@@ -69,7 +69,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.adminMember = { isSuperAdmin: true };
       const complementaryCertification = store.createRecord('complementary-certification', {
-        id: 10,
+        id: '10',
         key: 'DROIT',
         label: 'Pix+Droit',
         hasComplementaryReferential: true,
@@ -77,10 +77,10 @@ module('Integration | Component | complementary-certifications/item/target-profi
           {
             detachedAt: null,
             name: 'ALEX TARGET',
-            id: 3,
+            id: '3',
             badges: [
-              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
-              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: '1023', label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: '1025', label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
             ],
           },
         ],

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
@@ -26,8 +26,8 @@ module('Integration | Component | complementary-certifications/item/target-profi
             name: 'ALEX TARGET',
             id: 3,
             badges: [
-              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
-              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
+              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
             ],
           },
         ],
@@ -55,6 +55,59 @@ module('Integration | Component | complementary-certifications/item/target-profi
       assert
         .dom(
           screen.getByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.history-list.title'),
+          }),
+        )
+        .exists();
+    });
+  });
+  module('Complementary V2', function () {
+    test('it should only display target profile history', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const serviceRouter = this.owner.lookup('service:router');
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const complementaryCertification = store.createRecord('complementary-certification', {
+        id: 10,
+        key: 'DROIT',
+        label: 'Pix+Droit',
+        hasComplementaryReferential: true,
+        targetProfilesHistory: [
+          {
+            detachedAt: null,
+            name: 'ALEX TARGET',
+            id: 3,
+            badges: [
+              { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+              { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+            ],
+          },
+        ],
+      });
+
+      sinon
+        .stub(serviceRouter, 'currentRoute')
+        .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
+
+      // when
+      const screen = await render(<template><TargetProfile /></template>);
+
+      // then
+      assert.dom(screen.queryByText('Rattacher un nouveau profil cible')).doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('heading', {
+            name: t('components.complementary-certifications.target-profiles.badges-list.title'),
+          }),
+        )
+        .doesNotExist();
+      assert.dom(screen.queryByText('Badge Cascade')).doesNotExist();
+      assert.dom(screen.queryByText('Badge Volcan')).doesNotExist();
+
+      assert
+        .dom(
+          screen.queryByRole('heading', {
             name: t('components.complementary-certifications.target-profiles.history-list.title'),
           }),
         )

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile/badges-list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile/badges-list-test.gjs
@@ -16,10 +16,10 @@ module('Integration | Component | complementary-certifications/item/target-profi
         {
           detachedAt: null,
           name: 'ALEX TARGET',
-          id: 3,
+          id: '3',
           badges: [
-            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
-            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+            { id: '1023', label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+            { id: '1025', label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
           ],
         },
       ],
@@ -50,8 +50,8 @@ module('Integration | Component | complementary-certifications/item/target-profi
         {
           detachedAt: null,
           name: 'TARGET PROFILE',
-          id: 85,
-          badges: [{ id: 75, label: 'Badge Feu', level: 3 }],
+          id: '85',
+          badges: [{ id: '75', label: 'Badge Feu', level: 3 }],
         },
       ],
     });
@@ -73,8 +73,8 @@ module('Integration | Component | complementary-certifications/item/target-profi
         {
           detachedAt: null,
           name: 'TARGET PROFILE',
-          id: 85,
-          badges: [{ id: 75, label: 'Badge Feu', level: 3, minimumEarnedPix: 0 }],
+          id: '85',
+          badges: [{ id: '75', label: 'Badge Feu', level: 3, minimumEarnedPix: 0 }],
         },
       ],
     });
@@ -100,8 +100,8 @@ module('Integration | Component | complementary-certifications/item/target-profi
         {
           detachedAt: null,
           name: 'TARGET PROFILE',
-          id: 85,
-          badges: [{ id: 75, label: 'Badge Feu', level: 3, minimumEarnedPix: 120 }],
+          id: '85',
+          badges: [{ id: '75', label: 'Badge Feu', level: 3, minimumEarnedPix: 120 }],
         },
       ],
     });

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile/badges-list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile/badges-list-test.gjs
@@ -18,8 +18,8 @@ module('Integration | Component | complementary-certifications/item/target-profi
           name: 'ALEX TARGET',
           id: 3,
           badges: [
-            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://badge-cascade.net' },
-            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://badge-volcan.net' },
+            { id: 1023, label: 'Badge Cascade', level: 3, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
+            { id: 1025, label: 'Badge Volcan', level: 1, imageUrl: 'http://localhost:4202/logo-placeholder.png' },
           ],
         },
       ],

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile/history-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile/history-test.gjs
@@ -12,9 +12,9 @@ module('Integration | Component | complementary-certifications/item/target-profi
     const store = this.owner.lookup('service:store');
     const complementaryCertification = store.createRecord('complementary-certification', {
       targetProfilesHistory: [
-        { id: 1023, name: 'Target Cascade', attachedAt: new Date('2023-10-10T10:50:00Z'), detachedAt: null },
+        { id: '1023', name: 'Target Cascade', attachedAt: new Date('2023-10-10T10:50:00Z'), detachedAt: null },
         {
-          id: 1025,
+          id: '1025',
           name: 'Target Volcan',
           attachedAt: new Date('2019-10-08T10:50:00Z'),
           detachedAt: new Date('2020-10-08T10:50:00Z'),

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile/information-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile/information-test.gjs
@@ -13,7 +13,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
     currentUser.adminMember = { isSuperAdmin: true };
     const complementaryCertification = store.createRecord('complementary-certification', {
       label: 'Pix+ Droit',
-      targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+      targetProfilesHistory: [{ name: 'ALEX TARGET', id: '3' }],
     });
     const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
 
@@ -39,7 +39,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       const store = this.owner.lookup('service:store');
       const complementaryCertification = store.createRecord('complementary-certification', {
         label: 'MARIANNE CERTIF',
-        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+        targetProfilesHistory: [{ name: 'ALEX TARGET', id: '3' }],
       });
       const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
 
@@ -66,7 +66,7 @@ module('Integration | Component | complementary-certifications/item/target-profi
       currentUser.adminMember = { isSuperAdmin: true };
       const complementaryCertification = store.createRecord('complementary-certification', {
         label: 'MARIANNE CERTIF',
-        targetProfilesHistory: [{ name: 'ALEX TARGET', id: 3 }],
+        targetProfilesHistory: [{ name: 'ALEX TARGET', id: '3' }],
       });
       const currentTargetProfile = complementaryCertification.currentTargetProfiles[0];
 

--- a/admin/tests/integration/components/complementary-certifications/list-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/list-test.gjs
@@ -11,8 +11,8 @@ module('Integration | Component | complementary-certifications/list', function (
     // given
     const store = this.owner.lookup('service:store');
     const complementaryCertifications = [
-      store.createRecord('complementary-certification', { id: 0, key: 'DROIT', label: 'Pix+Droit' }),
-      store.createRecord('complementary-certification', { id: 1, key: 'CLEA', label: 'Cléa' }),
+      store.createRecord('complementary-certification', { id: '0', key: 'DROIT', label: 'Pix+Droit' }),
+      store.createRecord('complementary-certification', { id: '1', key: 'CLEA', label: 'Cléa' }),
     ];
 
     // when
@@ -36,9 +36,9 @@ module('Integration | Component | complementary-certifications/list', function (
     // given
     const store = this.owner.lookup('service:store');
     const complementaryCertifications = [
-      store.createRecord('complementary-certification', { id: 1, label: 'Certif+ B' }),
-      store.createRecord('complementary-certification', { id: 2, label: 'Certif+ C' }),
-      store.createRecord('complementary-certification', { id: 3, label: 'Certif+ A' }),
+      store.createRecord('complementary-certification', { id: '1', label: 'Certif+ B' }),
+      store.createRecord('complementary-certification', { id: '2', label: 'Certif+ C' }),
+      store.createRecord('complementary-certification', { id: '3', label: 'Certif+ A' }),
     ];
 
     // when

--- a/admin/tests/integration/components/confirm-popup-test.gjs
+++ b/admin/tests/integration/components/confirm-popup-test.gjs
@@ -8,10 +8,15 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | confirm-popup', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  const confirm = sinon.stub();
+  const cancel = sinon.stub();
+
   test('should display confirm', async function (assert) {
     // given & when
     const display = true;
-    const screen = await render(<template><ConfirmPopup @show={{display}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Merci de confirmer' })).exists();
@@ -23,7 +28,9 @@ module('Integration | Component | confirm-popup', function (hooks) {
     // given & when
     const display = false;
 
-    const screen = await render(<template><ConfirmPopup @show={{display}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.queryByRole('heading', { name: 'Merci de confirmer' })).doesNotExist();
@@ -34,9 +41,8 @@ module('Integration | Component | confirm-popup', function (hooks) {
   test('should call cancel action on click on cancel button', async function (assert) {
     // given
     const display = true;
-    const cancel = sinon.stub();
 
-    await render(<template><ConfirmPopup @show={{display}} @cancel={{cancel}} /></template>);
+    await render(<template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>);
 
     // when
     await clickByName('Annuler');
@@ -48,8 +54,7 @@ module('Integration | Component | confirm-popup', function (hooks) {
   test('should call confirm action on click on confirm button', async function (assert) {
     // given
     const display = true;
-    const confirm = sinon.stub();
-    await render(<template><ConfirmPopup @show={{display}} @confirm={{confirm}} /></template>);
+    await render(<template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>);
 
     // when
     await clickByName('Confirmer');
@@ -63,7 +68,9 @@ module('Integration | Component | confirm-popup', function (hooks) {
     const display = true;
 
     // when
-    const screen = await render(<template><ConfirmPopup @show={{display}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByText('Merci de confirmer')).exists();
@@ -75,7 +82,9 @@ module('Integration | Component | confirm-popup', function (hooks) {
     const title = 'Titre de test';
 
     // when
-    const screen = await render(<template><ConfirmPopup @show={{display}} @title={{title}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @title={{title}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByText(title)).exists();
@@ -84,7 +93,9 @@ module('Integration | Component | confirm-popup', function (hooks) {
   test('should display default closeTitle if it is not defined', async function (assert) {
     // given & when
     const display = true;
-    const screen = await render(<template><ConfirmPopup @show={{display}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
@@ -96,7 +107,11 @@ module('Integration | Component | confirm-popup', function (hooks) {
     const closeTitle = "Titre du bouton d'annulation";
 
     // when
-    const screen = await render(<template><ConfirmPopup @show={{display}} @closeTitle={{closeTitle}} /></template>);
+    const screen = await render(
+      <template>
+        <ConfirmPopup @show={{display}} @closeTitle={{closeTitle}} @confirm={{confirm}} @cancel={{cancel}} />
+      </template>,
+    );
 
     // then
     assert.dom(screen.getByText(closeTitle)).exists();
@@ -105,7 +120,9 @@ module('Integration | Component | confirm-popup', function (hooks) {
   test('should display default submitTitle if it is not defined', async function (assert) {
     // given & when
     const display = true;
-    const screen = await render(<template><ConfirmPopup @show={{display}} /></template>);
+    const screen = await render(
+      <template><ConfirmPopup @show={{display}} @confirm={{confirm}} @cancel={{cancel}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByRole('button', { name: 'Confirmer' })).exists();
@@ -117,7 +134,11 @@ module('Integration | Component | confirm-popup', function (hooks) {
     const submitTitle = 'Titre du bouton dde confirmation';
 
     // when
-    const screen = await render(<template><ConfirmPopup @show={{display}} @submitTitle={{submitTitle}} /></template>);
+    const screen = await render(
+      <template>
+        <ConfirmPopup @show={{display}} @submitTitle={{submitTitle}} @confirm={{confirm}} @cancel={{cancel}} />
+      </template>,
+    );
 
     // then
     assert.dom(screen.getByText(submitTitle)).exists();

--- a/admin/tests/integration/components/organizations/campaigns-section-test.gjs
+++ b/admin/tests/integration/components/organizations/campaigns-section-test.gjs
@@ -29,7 +29,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
     test('it should display campaign columns', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: '1',
         name: 'Nom de campagne 1',
         archivedAt: new Date('2021-01-01'),
         type: 'ASSESSMENT',
@@ -60,7 +60,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
 
     test('it should display a list of campaigns', async function (assert) {
       const campaign1 = store.createRecord('campaign', {
-        id: 1,
+        id: '1',
         name: 'Nom de campagne 1',
         archivedAt: new Date('2021-01-01'),
         type: 'ASSESSMENT',
@@ -72,7 +72,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
         targetProfileName: 'Nom du profil cible',
       });
       const campaign2 = store.createRecord('campaign', {
-        id: 2,
+        id: '2',
         name: 'Nom de campagne 2',
         archivedAt: new Date('2021-01-03'),
         type: 'PROFILES_COLLECTION',
@@ -95,7 +95,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
 
     test('it should display information of each campaigns', async function (assert) {
       const campaign1 = store.createRecord('campaign', {
-        id: 1,
+        id: '1',
         name: 'Nom de campagne 1',
         archivedAt: new Date('2021-01-01'),
         deletedAt: new Date('2023-12-31'),
@@ -110,7 +110,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
         targetProfileName: 'Nom du profil cible',
       });
       const campaign2 = store.createRecord('campaign', {
-        id: 2,
+        id: '2',
         name: 'Nom de campagne 2',
         archivedAt: new Date('2021-01-03'),
         type: 'PROFILES_COLLECTION',
@@ -154,7 +154,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
     test('it should display - when there is no archivedAt date', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: '1',
         name: 'Nom de campagne 1',
         archivedAt: null,
         deletedAt: new Date('2021-01-02'),
@@ -177,7 +177,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
     test('it should display - when there is no deletedAt date', async function (assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
+        id: '1',
         name: 'Nom de campagne 1',
         archivedAt: new Date('2021-01-02'),
         deletedAt: null,

--- a/admin/tests/integration/components/organizations/children/actions-on-children-in-organization-test.gjs
+++ b/admin/tests/integration/components/organizations/children/actions-on-children-in-organization-test.gjs
@@ -30,7 +30,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
     test('it should display confirmation modal with orga id in modal text', async function (assert) {
       // given
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         name: 'Orga 1',
       });
 
@@ -58,7 +58,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
       test('it should close modal, detach organization, send success notification and refresh model', async function (assert) {
         // given
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           name: 'Orga 1',
         });
 
@@ -107,7 +107,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
         test('it should send error notification for UNABLE_TO_DETACH_PARENT_ORGANIZATION_FROM_CHILD_ORGANIZATION error', async function (assert) {
           // given
           const organization = store.createRecord('organization', {
-            id: 1,
+            id: '1',
             name: 'Orga 1',
           });
 
@@ -140,7 +140,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
         test('it should send generic error notification for any other code', async function (assert) {
           // given
           const organization = store.createRecord('organization', {
-            id: 1,
+            id: '1',
             name: 'Orga 1',
           });
 
@@ -171,7 +171,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
         test('it should send generic error notification if error has no code', async function (assert) {
           // given
           const organization = store.createRecord('organization', {
-            id: 1,
+            id: '1',
             name: 'Orga 1',
           });
 
@@ -204,7 +204,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
         test('it should send generic error notification if error response has no errors array', async function (assert) {
           // given
           const organization = store.createRecord('organization', {
-            id: 1,
+            id: '1',
             name: 'Orga 1',
           });
 
@@ -238,7 +238,7 @@ module('Integration | Component | organizations/children/actions-on-children-in-
       test('it should close modal and not detach organization', async function (assert) {
         // given
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           name: 'Orga 1',
         });
 

--- a/admin/tests/integration/components/organizations/children/actions-section-test.gjs
+++ b/admin/tests/integration/components/organizations/children/actions-section-test.gjs
@@ -24,7 +24,7 @@ module('Integration | Component | organizations/children/actions-section', funct
     test('it should display create child organization button', async function (assert) {
       // given
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         name: 'Orga 1',
       });
 
@@ -45,7 +45,7 @@ module('Integration | Component | organizations/children/actions-section', funct
     test('it should not display create child organization button if organization is already a child', async function (assert) {
       // given
       const childOrganization = store.createRecord('organization', {
-        id: 2,
+        id: '2',
         name: 'Orga 2',
         parentOrganizationId: '1234',
       });
@@ -77,7 +77,7 @@ module('Integration | Component | organizations/children/actions-section', funct
       this.owner.register('service:access-control', AccessControlStub);
 
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         name: 'Orga 1',
       });
 
@@ -102,7 +102,7 @@ module('Integration | Component | organizations/children/actions-section', funct
         this.owner.register('service:access-control', AccessControlStub);
 
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           name: 'Orga 1',
         });
 

--- a/admin/tests/integration/components/organizations/children/list-item-test.gjs
+++ b/admin/tests/integration/components/organizations/children/list-item-test.gjs
@@ -19,7 +19,7 @@ module('Integration | Component | organizations/children/list-item', function (h
       // given
       const store = this.owner.lookup('service:store');
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         name: 'Collège The Night Watch',
         externalId: 'UA123456',
       });
@@ -47,7 +47,7 @@ module('Integration | Component | organizations/children/list-item', function (h
       // given
       const store = this.owner.lookup('service:store');
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         name: 'Collège The Night Watch',
         externalId: 'UA123456',
       });

--- a/admin/tests/integration/components/organizations/children/list-test.gjs
+++ b/admin/tests/integration/components/organizations/children/list-test.gjs
@@ -18,12 +18,12 @@ module('Integration | Component | organizations/children/list', function (hooks)
     // given
     const store = this.owner.lookup('service:store');
     const organization1 = store.createRecord('organization', {
-      id: 1,
+      id: '1',
       name: 'Collège The Night Watch',
       externalId: 'UA123456',
     });
     const organization2 = store.createRecord('organization', {
-      id: 2,
+      id: '2',
       name: 'Lycée KingsLanding',
       externalId: 'UB64321',
     });

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -111,7 +111,7 @@ module('Integration | Component | organizations/information-section', function (
         //given
         const store = this.owner.lookup('service:store');
         const parentOrganization = store.createRecord('organization', {
-          id: 5,
+          id: '5',
           type: 'SCO',
         });
         const organization = store.createRecord('organization', {

--- a/admin/tests/integration/components/organizations/information-section-view-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-view-test.gjs
@@ -5,11 +5,15 @@ import { t } from 'ember-intl/test-support';
 import InformationSectionView from 'pix-admin/components/organizations/information-section-view';
 import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | organizations/information-section-view', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  const toggleEditMode = sinon.stub();
+  const toggleArchivingConfirmationModal = sinon.stub();
 
   module('when user has access', function (hooks) {
     let originalDashboardUrl;
@@ -53,7 +57,15 @@ module('Integration | Component | organizations/information-section-view', funct
       };
 
       // when
-      const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+      const screen = await render(
+        <template>
+          <InformationSectionView
+            @organization={{organization}}
+            @toggleEditMode={{toggleEditMode}}
+            @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+          />
+        </template>,
+      );
 
       // then
       assert
@@ -125,7 +137,15 @@ module('Integration | Component | organizations/information-section-view', funct
       };
 
       // when
-      const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+      const screen = await render(
+        <template>
+          <InformationSectionView
+            @organization={{organization}}
+            @toggleEditMode={{toggleEditMode}}
+            @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+          />
+        </template>,
+      );
 
       // then
       assert
@@ -142,7 +162,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -161,7 +189,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -198,7 +234,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -231,7 +275,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -248,7 +300,15 @@ module('Integration | Component | organizations/information-section-view', funct
       const organization = EmberObject.create({ type: 'SUP', name: 'SUPer Orga' });
 
       // when
-      const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+      const screen = await render(
+        <template>
+          <InformationSectionView
+            @organization={{organization}}
+            @toggleEditMode={{toggleEditMode}}
+            @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+          />
+        </template>,
+      );
 
       // then
       assert.dom(screen.getByRole('button', { name: t('common.actions.edit') })).exists();
@@ -266,7 +326,15 @@ module('Integration | Component | organizations/information-section-view', funct
       const organization = EmberObject.create({});
 
       // when
-      const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+      const screen = await render(
+        <template>
+          <InformationSectionView
+            @organization={{organization}}
+            @toggleEditMode={{toggleEditMode}}
+            @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+          />
+        </template>,
+      );
 
       // then
       assert
@@ -285,7 +353,15 @@ module('Integration | Component | organizations/information-section-view', funct
         const organization = store.createRecord('organization', { archivistFullName: 'Rob Lochon', archivedAt });
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -311,7 +387,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         assert
           .dom(
@@ -331,7 +415,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -356,7 +448,15 @@ module('Integration | Component | organizations/information-section-view', funct
         };
 
         // when
-        const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+        const screen = await render(
+          <template>
+            <InformationSectionView
+              @organization={{organization}}
+              @toggleEditMode={{toggleEditMode}}
+              @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+            />
+          </template>,
+        );
 
         // then
         assert
@@ -381,7 +481,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByLabelText(
@@ -403,7 +511,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
 
             // then
             assert.ok(
@@ -428,7 +544,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByLabelText(
@@ -458,7 +582,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByLabelText(
@@ -482,7 +614,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByText(
@@ -501,7 +641,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByText(
@@ -523,7 +671,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
             // then
             assert.ok(
               screen.getByLabelText(
@@ -546,7 +702,15 @@ module('Integration | Component | organizations/information-section-view', funct
           });
 
           // when
-          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+          const screen = await render(
+            <template>
+              <InformationSectionView
+                @organization={{organization}}
+                @toggleEditMode={{toggleEditMode}}
+                @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+              />
+            </template>,
+          );
           // then
           assert.ok(
             screen.getByText(
@@ -565,7 +729,15 @@ module('Integration | Component | organizations/information-section-view', funct
           });
 
           // when
-          const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+          const screen = await render(
+            <template>
+              <InformationSectionView
+                @organization={{organization}}
+                @toggleEditMode={{toggleEditMode}}
+                @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+              />
+            </template>,
+          );
 
           // then
           assert.ok(
@@ -590,7 +762,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
 
             // then
             assert.ok(
@@ -615,7 +795,15 @@ module('Integration | Component | organizations/information-section-view', funct
             });
 
             // when
-            const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+            const screen = await render(
+              <template>
+                <InformationSectionView
+                  @organization={{organization}}
+                  @toggleEditMode={{toggleEditMode}}
+                  @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+                />
+              </template>,
+            );
 
             // then
             assert.ok(
@@ -641,7 +829,15 @@ module('Integration | Component | organizations/information-section-view', funct
       this.owner.register('service:access-control', AccessControlStub);
 
       // when
-      const screen = await render(<template><InformationSectionView @organization={{organization}} /></template>);
+      const screen = await render(
+        <template>
+          <InformationSectionView
+            @organization={{organization}}
+            @toggleEditMode={{toggleEditMode}}
+            @toggleArchivingConfirmationModal={{toggleArchivingConfirmationModal}}
+          />
+        </template>,
+      );
 
       // then
       assert.dom(screen.queryByRole('button', { name: t('common.actions.edit') })).doesNotExist();

--- a/admin/tests/integration/components/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/organizations/list-items-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, fillIn } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import ListItems from 'pix-admin/components/organizations/list-items';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -21,8 +21,9 @@ module('Integration | Component | ListItems', function (hooks) {
   const organizations = [organization1, organization2];
   organizations.meta = { page: 1, pageSize: 1 };
 
-  const triggerFiltering = () => {};
-  const goToOrganizationPage = () => {};
+  const triggerFiltering = sinon.stub();
+  const resetFilter = sinon.stub();
+  const goToOrganizationPage = sinon.stub();
   const detachOrganizations = sinon.stub();
 
   test('it should not display an Actions column to detach organizations', async function (assert) {
@@ -35,6 +36,7 @@ module('Integration | Component | ListItems', function (hooks) {
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilter}}
           @showDetachColumn={{false}}
         />
       </template>,
@@ -56,6 +58,7 @@ module('Integration | Component | ListItems', function (hooks) {
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
             @detachOrganizations={{detachOrganizations}}
+            @onResetFilter={{resetFilter}}
             @showDetachColumn={{true}}
           />
         </template>,
@@ -80,6 +83,7 @@ module('Integration | Component | ListItems', function (hooks) {
             @triggerFiltering={{triggerFiltering}}
             @detachOrganizations={{detachOrganizations}}
             @targetProfileName={{targetProfileName}}
+            @onResetFilter={{resetFilter}}
             @showDetachColumn={{true}}
           />
         </template>,
@@ -104,6 +108,7 @@ module('Integration | Component | ListItems', function (hooks) {
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
             @detachOrganizations={{detachOrganizations}}
+            @onResetFilter={{resetFilter}}
             @showDetachColumn={{true}}
           />
         </template>,
@@ -124,6 +129,7 @@ module('Integration | Component | ListItems', function (hooks) {
   module('filters', () => {
     module('internal identifier', () => {
       test('it should not allow to search text in id input', async function (assert) {
+        //when
         const screen = await render(
           <template>
             <ListItems
@@ -131,21 +137,19 @@ module('Integration | Component | ListItems', function (hooks) {
               @externalId="123"
               @goToOrganizationPage={{goToOrganizationPage}}
               @triggerFiltering={{triggerFiltering}}
+              @onResetFilter={{resetFilter}}
             />
           </template>,
         );
         const input = screen.getByLabelText('Identifiant');
 
-        await fillIn(input, 'not allowed text');
-
-        assert.strictEqual(input.value, '');
+        // then
+        assert.dom(input).hasAttribute('type', 'number');
       });
     });
 
     test('when one filter is active, clic on reset filter button should trigger onResetFilters method', async function (assert) {
       // given
-      const onResetFilters = sinon.stub();
-
       const screen = await render(
         <template>
           <ListItems
@@ -153,7 +157,7 @@ module('Integration | Component | ListItems', function (hooks) {
             @externalId="123"
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
-            @onResetFilter={{onResetFilters}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );
@@ -163,7 +167,7 @@ module('Integration | Component | ListItems', function (hooks) {
       await click(button);
 
       // then
-      assert.true(onResetFilters.calledOnce);
+      assert.true(resetFilter.calledOnce);
     });
 
     test('when no filter is active, reset filter button should be disabled', async function (assert) {
@@ -174,6 +178,7 @@ module('Integration | Component | ListItems', function (hooks) {
             @organizations={{organizations}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );

--- a/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
+++ b/admin/tests/integration/components/organizations/target-profiles-section-test.gjs
@@ -25,7 +25,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
     test('it disables the button when the input is empty', async function (assert) {
       // given
       const organization = EmberObject.create({
-        id: 1,
+        id: '1',
         targetProfiles: [],
       });
 
@@ -45,11 +45,11 @@ module('Integration | Component | organizations/target-profiles-section', functi
       const attachTargetProfileStub = sinon.stub(adapter, 'attachTargetProfile').resolves();
       this.owner.register('service:pixToast', NotificationsStub);
       const targetProfileSummary = store.createRecord('target-profile-summary', {
-        id: 666,
+        id: '666',
         internalName: 'Number of The Beast',
       });
       const organization = EmberObject.create({
-        id: 1,
+        id: '1',
         targetProfiles: [],
       });
 
@@ -66,19 +66,19 @@ module('Integration | Component | organizations/target-profiles-section', functi
       await clickByName('Valider');
 
       // then
-      assert.ok(attachTargetProfileStub.calledWith({ organizationId: 1, targetProfileIds: ['1'] }));
+      assert.ok(attachTargetProfileStub.calledWith({ organizationId: '1', targetProfileIds: ['1'] }));
     });
 
     test('it should have a link to redirect on target profile page', async function (assert) {
       const targetProfileSummary = store.createRecord('target-profile-summary', {
-        id: 666,
+        id: '666',
         internalName: 'Number of The Beast',
       });
 
       const targetProfileSummaries = [targetProfileSummary];
 
       const organization = store.createRecord('organization', {
-        id: 1,
+        id: '1',
         targetProfiles: [],
       });
 
@@ -98,17 +98,17 @@ module('Integration | Component | organizations/target-profiles-section', functi
       test('it should display an Actions column with a detach button', async function (assert) {
         // given
         const publicTargetProfileSummary = store.createRecord('target-profile-summary', {
-          id: 666,
+          id: '666',
           internalName: 'Number of The Beast',
           canDetach: false,
         });
         const privateTargetProfileSummary = store.createRecord('target-profile-summary', {
-          id: 777,
+          id: '777',
           internalName: 'Super Lucky',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           targetProfiles: [],
         });
         const targetProfileSummaries = [publicTargetProfileSummary, privateTargetProfileSummary];
@@ -129,12 +129,12 @@ module('Integration | Component | organizations/target-profiles-section', functi
       test('it should open confirm modal when click on "Détacher" button', async function (assert) {
         // given
         const targetProfileSummary = store.createRecord('target-profile-summary', {
-          id: 666,
+          id: '666',
           internalName: 'Number of The Beast',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           targetProfiles: [],
         });
         const targetProfileSummaries = [targetProfileSummary];
@@ -161,12 +161,12 @@ module('Integration | Component | organizations/target-profiles-section', functi
         const adapter = store.adapterFor('target-profile');
         const detachOrganizationsTargetProfileStub = sinon.stub(adapter, 'detachOrganizations').resolves();
         const targetProfileSummary = store.createRecord('target-profile-summary', {
-          id: 666,
+          id: '666',
           internalName: 'Number of The Beast',
           canDetach: true,
         });
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           targetProfiles: [],
           get: sinon.stub().returns({ reload: sinon.stub() }),
         });
@@ -195,12 +195,12 @@ module('Integration | Component | organizations/target-profiles-section', functi
         sinon.stub(adapter, 'detachOrganizations').resolves();
 
         const organization = store.createRecord('organization', {
-          id: 1,
+          id: '1',
           targetProfiles: [],
         });
         const targetProfileSummaries = [
           store.createRecord('target-profile-summary', {
-            id: 666,
+            id: '666',
             internalName: 'Number of The Beast',
             canDetach: true,
           }),
@@ -228,7 +228,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
     test('it should not allow to add target profiles', async function (assert) {
       // given
       const organization = EmberObject.create({
-        id: 1,
+        id: '1',
         targetProfiles: [],
       });
 

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -14,6 +14,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
   });
 
   const triggerFiltering = function () {};
+  const resetFilter = function () {};
 
   test('it should display header with id, name, type, team and externalId', async function (assert) {
     // given
@@ -29,7 +30,13 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
     // when
     const screen = await render(
-      <template><ListItems @organizations={{organizations}} @triggerFiltering={{triggerFiltering}} /></template>,
+      <template>
+        <ListItems
+          @organizations={{organizations}}
+          @triggerFiltering={{triggerFiltering}}
+          @onResetFilter={{resetFilter}}
+        />
+      </template>,
     );
 
     // then
@@ -49,7 +56,9 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   test('if should display search inputs', async function (assert) {
     // when
-    const screen = await render(<template><ListItems @triggerFiltering={{triggerFiltering}} /></template>);
+    const screen = await render(
+      <template><ListItems @triggerFiltering={{triggerFiltering}} @onResetFilter={{resetFilter}} /></template>,
+    );
 
     // then
     assert.dom(screen.getByRole('spinbutton', { name: 'Identifiant' })).exists();
@@ -72,7 +81,13 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
     // when
     const screen = await render(
-      <template><ListItems @organizations={{organizations}} @triggerFiltering={{triggerFiltering}} /></template>,
+      <template>
+        <ListItems
+          @organizations={{organizations}}
+          @triggerFiltering={{triggerFiltering}}
+          @onResetFilter={{resetFilter}}
+        />
+      </template>,
     );
 
     // then

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-summary-items-test.gjs
@@ -8,13 +8,18 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
   setupIntlRenderingTest(hooks);
 
   const triggerFiltering = function () {};
+  const resetFilter = function () {};
   const goToTargetProfilePage = function () {};
 
   test('it should display search inputs (name, id and status)', async function (assert) {
     // when
     const screen = await render(
       <template>
-        <ListSummaryItems @triggerFiltering={{triggerFiltering}} @goToTargetProfilePage={{goToTargetProfilePage}} />
+        <ListSummaryItems
+          @triggerFiltering={{triggerFiltering}}
+          @goToTargetProfilePage={{goToTargetProfilePage}}
+          @onResetFilter={{resetFilter}}
+        />
       </template>,
     );
 
@@ -43,6 +48,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
           @summaries={{summaries}}
           @triggerFiltering={{triggerFiltering}}
           @goToTargetProfilePage={{goToTargetProfilePage}}
+          @onResetFilter={{resetFilter}}
         />
       </template>,
     );
@@ -68,6 +74,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
           @summaries={{summaries}}
           @triggerFiltering={{triggerFiltering}}
           @goToTargetProfilePage={{goToTargetProfilePage}}
+          @onResetFilter={{resetFilter}}
         />
       </template>,
     );
@@ -93,6 +100,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
           @summaries={{summaries}}
           @triggerFiltering={{triggerFiltering}}
           @goToTargetProfilePage={{goToTargetProfilePage}}
+          @onResetFilter={{resetFilter}}
         />
       </template>,
     );
@@ -116,6 +124,7 @@ module('Integration | Component | routes/authenticated/target-profiles | list-su
           @summaries={{summaries}}
           @triggerFiltering={{triggerFiltering}}
           @goToTargetProfilePage={{goToTargetProfilePage}}
+          @onResetFilter={{resetFilter}}
         />
       </template>,
     );

--- a/admin/tests/integration/components/sessions/certifications/list-test.gjs
+++ b/admin/tests/integration/components/sessions/certifications/list-test.gjs
@@ -17,7 +17,7 @@ module('Integration | Component | certifications/list', function (hooks) {
     // given
     const juryCertificationSummaries = [
       store.createRecord('jury-certification-summary', {
-        id: 1,
+        id: '1',
         numberOfCertificationIssueReportsWithRequiredAction: 2,
       }),
     ];

--- a/admin/tests/integration/components/stages/stage-test.gjs
+++ b/admin/tests/integration/components/stages/stage-test.gjs
@@ -203,6 +203,7 @@ module('Integration | Component | Stage', function (hooks) {
         <Stage
           @stage={{stage}}
           @isEditMode={{true}}
+          @toggleEditMode={{toggleEditMode}}
           @hasLinkedCampaign={{hasLinkedCampaign}}
           @onUpdate={{update}}
           @targetProfileName={{targetProfileName}}

--- a/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/target-profiles/list-summary-items-test.gjs
@@ -11,6 +11,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
   setupIntlRenderingTest(hooks);
 
   const triggerFiltering = () => {};
+  const resetFilter = () => {};
 
   test('it should display target profile summary', async function (assert) {
     // given
@@ -30,7 +31,13 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
     // when
     const screen = await render(
       <template>
-        <ListSummaryItems @id={{id}} @summaries={{summaries}} @name={{name}} @triggerFiltering={{triggerFiltering}} />
+        <ListSummaryItems
+          @id={{id}}
+          @summaries={{summaries}}
+          @name={{name}}
+          @triggerFiltering={{triggerFiltering}}
+          @onResetFilter={{resetFilter}}
+        />
       </template>,
     );
 
@@ -59,6 +66,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
             @name={{name}}
             @categories={{categories}}
             @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );
@@ -87,6 +95,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
             @name={{name}}
             @categories={{categories}}
             @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );
@@ -112,6 +121,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
             @name={{name}}
             @categories={{categories}}
             @triggerFiltering={{triggerFiltering}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );
@@ -143,6 +153,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
             @name={{name}}
             @categories={{categories}}
             @triggerFiltering={{triggerFilteringSpy}}
+            @onResetFilter={{resetFilter}}
           />
         </template>,
       );

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -12,6 +12,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
   const triggerFiltering = () => {};
   const goToOrganizationPage = () => {};
   const detachOrganizations = () => {};
+  const resetFilters = () => {};
   const queryParams = { hideArchived: false };
 
   hooks.beforeEach(function () {
@@ -35,6 +36,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -59,6 +61,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -84,6 +87,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -104,6 +108,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -126,6 +131,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -150,6 +156,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -176,6 +183,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -202,6 +210,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -224,6 +233,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
           @detachOrganizations={{detachOrganizations}}
+          @onResetFilter={{resetFilters}}
         />
       </template>,
     );
@@ -257,6 +267,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @triggerFiltering={{triggerFiltering}}
             @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
+            @onResetFilter={{resetFilters}}
           />
         </template>,
       );
@@ -285,6 +296,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @triggerFiltering={{triggerFiltering}}
             @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
+            @onResetFilter={{resetFilters}}
           />
         </template>,
       );
@@ -310,6 +322,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
             @triggerFiltering={{triggerFiltering}}
             @hideArchived={{queryParams.hideArchived}}
             @detachOrganizations={{detachOrganizations}}
+            @onResetFilter={{resetFilters}}
           />
         </template>,
       );

--- a/admin/tests/integration/components/target-profiles/stages-test.gjs
+++ b/admin/tests/integration/components/target-profiles/stages-test.gjs
@@ -83,7 +83,7 @@ module('Integration | Component | Stages', function (hooks) {
     test('it should NOT display stage type radio buttons', async function (assert) {
       // given
       const stage = store.createRecord('stage', {
-        id: 1,
+        id: '1',
         level: 0,
         title: 'stage 1',
       });
@@ -107,7 +107,7 @@ module('Integration | Component | Stages', function (hooks) {
     test('it should display delete button on a stage', async function (assert) {
       // given
       const stage = store.createRecord('stage', {
-        id: 1,
+        id: '1',
         level: 1,
       });
       const stageCollection = store.createRecord('stage-collection', {
@@ -130,7 +130,7 @@ module('Integration | Component | Stages', function (hooks) {
     test('it should display modal when deleting a stage', async function (assert) {
       // given
       const stage = store.createRecord('stage', {
-        id: 1,
+        id: '1',
         level: 1,
       });
       const stageCollection = store.createRecord('stage-collection', {
@@ -212,7 +212,7 @@ module('Integration | Component | Stages', function (hooks) {
     test('it should display the items', async function (assert) {
       // given
       const stage = store.createRecord('stage', {
-        id: 1,
+        id: '1',
         threshold: 100,
         level: null,
         title: 'My title',
@@ -254,7 +254,7 @@ module('Integration | Component | Stages', function (hooks) {
     test('it should display the items', async function (assert) {
       // given
       const stage = store.createRecord('stage', {
-        id: 1,
+        id: '1',
         level: 0,
         threshold: null,
         title: 'My title',
@@ -325,7 +325,7 @@ module('Integration | Component | Stages', function (hooks) {
       hooks.beforeEach(async function () {
         // given
         const stage = store.createRecord('stage', {
-          id: 1,
+          id: '1',
           threshold: 50,
           level: null,
           title: 'My title',

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -70,7 +70,6 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
   module('when model is provided', function () {
     test('it should display the items with model values', async function (assert) {
       // given
-      const editorLogo = 'logo-placeholder.png';
       const model = {
         title: 'Un contenu formatif',
         internalTitle: 'Mon titre interne',
@@ -78,7 +77,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         type: 'webinaire',
         locale: 'fr-fr',
         editorName: 'Un éditeur de contenu formatif',
-        editorLogoUrl: `http://localhost:4202/${editorLogo}`,
+        editorLogoUrl: `http://localhost:4202/logo-placeholder.png`,
         duration: { days: 0, hours: 0, minutes: 0 },
         isDisabled: false,
       };
@@ -105,7 +104,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
             name: "Url du logo de l'éditeur (.svg) Exemple : https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg",
           }),
         )
-        .hasValue(editorLogo);
+        .hasValue(model.editorLogoUrl);
       assert.strictEqual(screen.getByLabelText('Mettre en pause').checked, model.isDisabled);
       assert
         .dom(

--- a/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form-test.gjs
@@ -70,7 +70,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
   module('when model is provided', function () {
     test('it should display the items with model values', async function (assert) {
       // given
-      const editorLogo = 'https://example.net/un-logo.svg';
+      const editorLogo = 'logo-placeholder.png';
       const model = {
         title: 'Un contenu formatif',
         internalTitle: 'Mon titre interne',
@@ -78,7 +78,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         type: 'webinaire',
         locale: 'fr-fr',
         editorName: 'Un éditeur de contenu formatif',
-        editorLogoUrl: editorLogo,
+        editorLogoUrl: `http://localhost:4202/${editorLogo}`,
         duration: { days: 0, hours: 0, minutes: 0 },
         isDisabled: false,
       };
@@ -168,7 +168,7 @@ module('Integration | Component | trainings | CreateOrUpdateTrainingForm', funct
         type: 'webinaire',
         locale: 'fr-fr',
         editorName: 'Un éditeur de contenu formatif',
-        editorLogoUrl: 'https://example.net/un-logo.svg',
+        editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
         duration: { days: 0, hours: 0, minutes: 0 },
         isDisabled: false,
       };

--- a/admin/tests/integration/components/trainings/create-training-triggers-test.gjs
+++ b/admin/tests/integration/components/trainings/create-training-triggers-test.gjs
@@ -27,22 +27,22 @@ const buildTrainingTrigger = (store) => {
     practicalTitle: 'tube4Thematic2Competence1Area1 practicalTitle',
   });
   const trainingTriggerTube1 = store.createRecord('trigger-tube', {
-    id: 1,
+    id: '1',
     tube: tube1Thematic1Competence1Area1,
     level: 3,
   });
   const trainingTriggerTube2 = store.createRecord('trigger-tube', {
-    id: 2,
+    id: '2',
     tube: tube2Thematic1Competence1Area1,
     level: 1,
   });
   const trainingTriggerTube3 = store.createRecord('trigger-tube', {
-    id: 3,
+    id: '3',
     tube: tube3Thematic1Competence1Area1,
     level: 5,
   });
   const trainingTriggerTube4 = store.createRecord('trigger-tube', {
-    id: 4,
+    id: '4',
     tube: tube4Thematic2Competence1Area1,
     level: 8,
   });
@@ -90,7 +90,7 @@ const buildTrainingTrigger = (store) => {
     practicalTitle: 'tube1Thematic1Competence1Area2 practicalTitle',
   });
   const trainingTriggerTubeForArea2 = store.createRecord('trigger-tube', {
-    id: 5,
+    id: '5',
     tube: tube1Thematic1Competence1Area2,
     level: 3,
   });

--- a/admin/tests/integration/components/trainings/training-details-card-test.gjs
+++ b/admin/tests/integration/components/trainings/training-details-card-test.gjs
@@ -15,7 +15,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     type: 'webinaire',
     locale: 'fr-fr',
     editorName: 'Un éditeur de contenu formatif',
-    editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/un-logo.svg',
+    editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
     duration: {
       days: 2,
     },
@@ -34,7 +34,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     assert.dom(screen.getByText('2j')).exists();
     assert.dom(screen.getByText('Franco-français (fr-fr)')).exists();
     assert.dom(screen.getByText('Un éditeur de contenu formatif')).exists();
-    assert.dom(screen.getByText('https://assets.pix.org/contenu-formatif/editeur/un-logo.svg')).exists();
+    assert.dom(screen.getByText('http://localhost:4202/logo-placeholder.png')).exists();
     assert.dom(screen.getByAltText('Un éditeur de contenu formatif')).exists();
   });
 
@@ -93,7 +93,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
           type: 'webinaire',
           locale: 'fr-fr',
           editorName: 'Un éditeur de contenu formatif',
-          editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/un-logo.svg',
+          editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
           duration,
           isRecommendable: true,
         };

--- a/admin/tests/integration/components/users/certification-centers/membership-item-actions-test.gjs
+++ b/admin/tests/integration/components/users/certification-centers/membership-item-actions-test.gjs
@@ -5,13 +5,26 @@ import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
+const onEditRoleButtonClicked = sinon.stub();
+const onDeactivateMembershipButtonClicked = sinon.stub();
+const onSaveRoleButtonClicked = sinon.stub();
+const onCancelButtonClicked = sinon.stub();
+
 module('Integration | Component | users | certification-centers | membership-item-actions', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('When edition mode is deactivated', function () {
     test('it displays 2 buttons to edit the user role and deactivate the membership', async function (assert) {
       //  when
-      const screen = await renderScreen(<template><MembershipItemActions @isEditionMode={{false}} /></template>);
+      const screen = await renderScreen(
+        <template>
+          <MembershipItemActions
+            @isEditionMode={{false}}
+            @onEditRoleButtonClicked={{onEditRoleButtonClicked}}
+            @onDeactivateMembershipButtonClicked={{onDeactivateMembershipButtonClicked}}
+          />
+        </template>,
+      );
 
       // then
       assert
@@ -23,9 +36,7 @@ module('Integration | Component | users | certification-centers | membership-ite
     module('when the edit role button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onEditRoleButtonClicked = sinon.stub();
         const isEditionMode = false;
-        const onDeactivateMembershipButtonClicked = sinon.stub();
 
         //  when
         await renderScreen(
@@ -48,9 +59,7 @@ module('Integration | Component | users | certification-centers | membership-ite
     module('when the deactivate button is clicked', function () {
       test('it emits an event without any data', async function (assert) {
         // given
-        const onDeactivateMembershipButtonClicked = sinon.stub();
         const isEditionMode = false;
-        const onEditRoleButtonClicked = sinon.stub();
 
         //  when
         await renderScreen(
@@ -78,7 +87,13 @@ module('Integration | Component | users | certification-centers | membership-ite
 
       //  when
       const screen = await renderScreen(
-        <template><MembershipItemActions @isEditionMode={{isEditionMode}} /></template>,
+        <template>
+          <MembershipItemActions
+            @isEditionMode={{isEditionMode}}
+            @onSaveRoleButtonClicked={{onSaveRoleButtonClicked}}
+            @onCancelButtonClicked={{onCancelButtonClicked}}
+          />
+        </template>,
       );
 
       // then
@@ -95,9 +110,7 @@ module('Integration | Component | users | certification-centers | membership-ite
     module('when the save button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onSaveRoleButtonClicked = sinon.stub();
         const isEditionMode = true;
-        const onCancelButtonClicked = sinon.stub();
 
         //  when
         await renderScreen(
@@ -120,9 +133,7 @@ module('Integration | Component | users | certification-centers | membership-ite
     module('when the cancel button is clicked', function () {
       test('emits an event without any data', async function (assert) {
         // given
-        const onCancelButtonClicked = sinon.stub();
         const isEditionMode = true;
-        const onSaveRoleButtonClicked = sinon.stub();
 
         //  when
         await renderScreen(

--- a/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
+++ b/admin/tests/integration/components/users/certification-centers/membership-item-test.gjs
@@ -23,13 +23,13 @@ module('Integration | Component | users | certification-centers | membership-ite
     test('with last access date if there is one', async function (assert) {
       // given
       const certificationCenter = store.createRecord('certification-center', {
-        id: 2,
+        id: '2',
         name: 'Centre Jean-Bonboeur',
         type: 'SUP',
         externalId: 'PAIN123',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         certificationCenter,
         role: 'MEMBER',
         lastAccessedAt: new Date('2020-01-01'),
@@ -66,13 +66,13 @@ module('Integration | Component | users | certification-centers | membership-ite
     test('with default access date if there is none', async function (assert) {
       // given
       const certificationCenter = store.createRecord('certification-center', {
-        id: 2,
+        id: '2',
         name: 'Centre Jean-Bonboeur',
         type: 'SUP',
         externalId: 'PAIN123',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         certificationCenter,
         role: 'MEMBER',
       });
@@ -104,13 +104,13 @@ module('Integration | Component | users | certification-centers | membership-ite
     test('displays a role selector input, save and cancel buttons instead of "Modifier le rôle" button', async function (assert) {
       // given
       const certificationCenter = store.createRecord('certification-center', {
-        id: 2,
+        id: '2',
         name: 'Centre Tristan-Douille',
         type: 'SUP',
         externalId: 'PAIN123',
       });
       const certificationCenterMembership = store.createRecord('certification-center-membership', {
-        id: 1,
+        id: '1',
         certificationCenter,
         role: 'MEMBER',
         createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -145,13 +145,13 @@ module('Integration | Component | users | certification-centers | membership-ite
       test('deactivates edition mode and saves the new role', async function (assert) {
         // given
         const certificationCenter = store.createRecord('certification-center', {
-          id: 2,
+          id: '2',
           name: 'Centre John-Doeuf',
           type: 'SCO',
           externalId: 'BRUNCH888',
         });
         const certificationCenterMembership = store.createRecord('certification-center-membership', {
-          id: 1,
+          id: '1',
           certificationCenter,
           role: 'MEMBER',
           createdAt: new Date('2023-09-13T10:47:07Z'),
@@ -194,7 +194,7 @@ module('Integration | Component | users | certification-centers | membership-ite
         store.push({
           data: [
             {
-              id: 1,
+              id: '1',
               type: 'certification-center',
               attributes: {
                 name: 'Centre Emma-Carena',
@@ -204,7 +204,7 @@ module('Integration | Component | users | certification-centers | membership-ite
               relationships: {},
             },
             {
-              id: 1,
+              id: '1',
               type: 'certification-center-membership',
               attributes: {
                 role: 'MEMBER',
@@ -213,7 +213,7 @@ module('Integration | Component | users | certification-centers | membership-ite
               relationships: {
                 certificationCenter: {
                   data: {
-                    id: 1,
+                    id: '1',
                     type: 'certification-center',
                   },
                 },

--- a/admin/tests/integration/components/users/user-certification-courses-test.gjs
+++ b/admin/tests/integration/components/users/user-certification-courses-test.gjs
@@ -48,7 +48,7 @@ module('Integration | Component | Users | User certification courses', function 
     test('displays a table with a table of certification courses', async function (assert) {
       // given
       const certificationCourse = store.createRecord('user-certification-course', {
-        id: 1,
+        id: '1',
         sessionId: 23,
         createdAt: new Date('2025-04-01'),
         isPublished: true,

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -18,7 +18,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
     this.owner.lookup('service:router');
     store = this.owner.lookup('service:store');
     model = store.createRecord('training', {
-      id: 12,
+      id: '12',
       title: 'title',
       internalTitle: 'internalTitle',
       link: 'my-training-link',
@@ -83,14 +83,14 @@ module('Integration | Component | Trainings | Training', function (hooks) {
   module('when trigger is defined', function (hooks) {
     hooks.beforeEach(function () {
       store.createRecord('training-trigger', {
-        id: 6,
+        id: '6',
         type: 'goal',
         threshold: '80',
         areas: [],
         training: model,
       });
       store.createRecord('training-trigger', {
-        id: 7,
+        id: '7',
         type: 'prerequisite',
         threshold: '80',
         areas: [],

--- a/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
+++ b/admin/tests/integration/templates/authenticated/trainings/training-test.gjs
@@ -25,7 +25,7 @@ module('Integration | Component | Trainings | Training', function (hooks) {
       type: 'type',
       locale: 'fr-fr',
       editorName: 'Albert',
-      editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/my-logo-url',
+      editorLogoUrl: 'http://localhost:4202/logo-placeholder.png',
       isRecommendable: true,
       isDisabled: false,
     });

--- a/admin/tests/mirage/factories/target-profile.js
+++ b/admin/tests/mirage/factories/target-profile.js
@@ -16,7 +16,7 @@ export default Factory.extend({
   },
 
   imageUrl() {
-    return 'mon_image.png';
+    return 'logo-placeholder.png';
   },
 
   outdated() {

--- a/admin/tests/mirage/models/certification-consolidated-framework.js
+++ b/admin/tests/mirage/models/certification-consolidated-framework.js
@@ -3,5 +3,5 @@ import { belongsTo, hasMany, Model } from 'miragejs';
 export default Model.extend({
   complementaryCertification: belongsTo('complementaryCertification'),
   areas: hasMany('area'),
-  tubes: hasMany('tubes'),
+  tubes: hasMany('tube'),
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -273,6 +273,7 @@ export default function routes() {
 
   this.get('/admin/certification-centers', findPaginatedFilteredCertificationCenters);
   this.get('/admin/certification-centers/:id');
+  this.patch('/admin/certification-centers/:id');
   this.get('/admin/certification-centers/:id/certification-center-memberships', (schema, request) => {
     const certificationCenterId = request.params.id;
     return schema.certificationCenterMemberships.where({ certificationCenterId });
@@ -453,7 +454,7 @@ export default function routes() {
     return new Response(204);
   });
   this.get('/admin/certification-candidates/:id/timeline', (schema, request) => {
-    return { data: { type: 'certification-candidates-timeline', id: request.id, attributes: { events: [] } } };
+    return schema.certificationCandidateTimelines.find(request.params.id);
   });
 
   this.post('/admin/organizations/:id/invitations', (schema, request) => {

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -452,6 +452,9 @@ export default function routes() {
   this.post('/admin/certification/deneutralize-challenge', () => {
     return new Response(204);
   });
+  this.get('/admin/certification-candidates/:id/timeline', (schema, request) => {
+    return { data: { type: 'certification-candidates-timeline', id: request.id, attributes: { events: [] } } };
+  });
 
   this.post('/admin/organizations/:id/invitations', (schema, request) => {
     const params = JSON.parse(request.requestBody);

--- a/admin/tests/unit/adapters/v3-certification-course-details-for-administration-test.js
+++ b/admin/tests/unit/adapters/v3-certification-course-details-for-administration-test.js
@@ -8,7 +8,7 @@ module('Unit | Adapter | v3-certification-course-details-for-administration', fu
     test('should build get url from certification details id', function (assert) {
       // when
       const adapter = this.owner.lookup('adapter:v3-certification-course-details-for-administration');
-      const url = adapter.urlForFindRecord(123, 'v3-certification-course-details-for-administration');
+      const url = adapter.urlForFindRecord('123', 'v3-certification-course-details-for-administration');
 
       // then
       assert.ok(url.endsWith('/admin/certification-courses-v3/123/details'));

--- a/admin/tests/unit/controllers/authenticated/autonomous-courses/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/autonomous-courses/new-test.js
@@ -41,7 +41,7 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
     test('it should save autonomous course and redirect to autonomous course details', async function (assert) {
       // given
       const autonomousCourse = {
-        id: 2,
+        id: '2',
         internalTitle: 'un nom interne',
         publicTitle: 'un nom public',
         targetProfileId: 32,

--- a/admin/tests/unit/controllers/authenticated/organizations/get/team-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/team-test.js
@@ -25,7 +25,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
         store.query = sinon.stub().resolves([]);
 
         controller.model = {
-          organization: { id: 1 },
+          organization: { id: '1' },
         };
         controller.userEmailToAdd = 'a-user-not-in-store@example.net';
 
@@ -42,12 +42,12 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
       test('it should return an error (even if searched email is in uppercase)', async function (assert) {
         // given
         const emailInLowerCase = 'a-user-already-in-organization@example.net';
-        const user = store.createRecord('user', { email: emailInLowerCase, id: 5 });
+        const user = store.createRecord('user', { email: emailInLowerCase, id: '5' });
 
         store.query = sinon.stub().resolves([user]);
         controller.model = {
           organization: {
-            id: 1,
+            id: '1',
             hasMember: sinon.stub().resolves(true),
           },
         };
@@ -66,7 +66,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
       test('it should give access to the organization', async function (assert) {
         // given
         const email = 'a-user-not-in-organization@example.net';
-        const user = store.createRecord('user', { email, id: 5 });
+        const user = store.createRecord('user', { email, id: '5' });
 
         store.query = sinon.stub().resolves([user]);
         store.createRecord = sinon.stub().returns({ save: sinon.stub() });
@@ -76,7 +76,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
             reload: sinon.stub().resolves(true),
           },
           organization: {
-            id: 1,
+            id: '1',
             hasMember: sinon.stub().resolves(false),
           },
         };
@@ -97,7 +97,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
       test('it should notify when error', async function (assert) {
         // given
         const email = 'a-user-not-in-organization@example.net';
-        const user = store.createRecord('user', { email, id: 5 });
+        const user = store.createRecord('user', { email, id: '5' });
 
         store.query = sinon.stub().resolves([user]);
         store.createRecord = sinon.stub().returns({ save: sinon.stub() });
@@ -107,7 +107,7 @@ module('Unit | Controller | authenticated/organizations/get/team', function (hoo
           },
           organization: {
             hasMember: sinon.stub().resolves(false),
-            id: 1,
+            id: '1',
           },
         };
         controller.userEmailToAdd = email;

--- a/admin/tests/unit/controllers/authenticated/sessions/certification/details-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/certification/details-test.js
@@ -37,7 +37,7 @@ module('Unit | Controller | authenticated/sessions/certification/details', funct
 function createChallengesForAdministration(answerStatuses, store) {
   return answerStatuses.map((answerStatus, index) =>
     store.createRecord('certification-challenges-for-administration', {
-      id: index,
+      id: String(index),
       answerStatus,
       validatedLiveAlert: !answerStatus,
     }),

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -49,7 +49,7 @@ module('Unit | Model | certification', function (hooks) {
       const certification = store.createRecord('certification', {
         competencesWithMark: [
           {
-            id: 1,
+            id: '1',
             area_code: '1',
             competence_code: '1.1',
             competenceId: 'rec11',
@@ -58,7 +58,7 @@ module('Unit | Model | certification', function (hooks) {
             assessmentResultId: 123,
           },
           {
-            id: 2,
+            id: '2',
             area_code: '2',
             competence_code: '2.1',
             competenceId: 'rec21',
@@ -94,7 +94,7 @@ module('Unit | Model | certification', function (hooks) {
       const certification = store.createRecord('certification', {
         competencesWithMark: [
           {
-            id: 1,
+            id: '1',
             area_code: '1',
             competence_code: '1.1',
             competenceId: 'rec11',
@@ -103,7 +103,7 @@ module('Unit | Model | certification', function (hooks) {
             assessmentResultId: 123,
           },
           {
-            id: 2,
+            id: '2',
             area_code: '2',
             competence_code: '2.1',
             competenceId: 'rec21',

--- a/admin/tests/unit/models/complementary-certification-test.js
+++ b/admin/tests/unit/models/complementary-certification-test.js
@@ -11,20 +11,20 @@ module('Unit | Model | complementaryCertification', function (hooks) {
       const complementaryCertification = store.createRecord('complementary-certification', {
         targetProfilesHistory: [
           {
-            id: 66,
+            id: '66',
             name: 'STEPHEN TARGET',
             attachedAt: '2020-01-01T00:00:00.000Z',
             detachedAt: null,
             badges: [
               {
-                id: 68,
+                id: '68',
                 label: 'badge Glacier',
                 level: 1,
               },
             ],
           },
           {
-            id: 67,
+            id: '67',
             name: 'BAD TARGET',
             attachedAt: '2020-01-02T00:00:00.000Z',
             detachedAt: '2020-01-02T00:00:00.000Z',
@@ -39,13 +39,13 @@ module('Unit | Model | complementaryCertification', function (hooks) {
       // then
       assert.deepEqual(currentTargetProfiles, [
         {
-          id: 66,
+          id: '66',
           name: 'STEPHEN TARGET',
           attachedAt: '2020-01-01T00:00:00.000Z',
           detachedAt: null,
           badges: [
             {
-              id: 68,
+              id: '68',
               label: 'badge Glacier',
               level: 1,
             },

--- a/admin/tests/unit/models/v3-certification-course-details-for-administration-test.js
+++ b/admin/tests/unit/models/v3-certification-course-details-for-administration-test.js
@@ -127,7 +127,7 @@ module('Unit | Model | v3-certification-course-details-for-administration', func
 function createChallengesForAdministration(answerStatuses, store) {
   return answerStatuses.map((answerStatus, index) =>
     store.createRecord('certification-challenges-for-administration', {
-      id: index,
+      id: String(index),
       answerStatus,
       validatedLiveAlert: !answerStatus,
     }),

--- a/admin/tests/unit/routes/authenticated/organizations/all-tags-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/all-tags-test.js
@@ -109,11 +109,11 @@ module('Unit | Route | authenticated/organizations/get/all-tags', function (hook
     const route = this.owner.lookup('route:authenticated/organizations/get/all-tags');
     const store = this.owner.lookup('service:store');
 
-    const tag1 = store.createRecord('tag', { id: 1, name: 'MEDNUM' });
-    const tag2 = store.createRecord('tag', { id: 2, name: 'AEFE' });
-    const tag3 = store.createRecord('tag', { id: 3, name: 'CFA' });
-    const tag4 = store.createRecord('tag', { id: 4, name: 'POLE EMPLOI' });
-    const organization = store.createRecord('organization', { id: 7, tags: [tag1, tag2] });
+    const tag1 = store.createRecord('tag', { id: '1', name: 'MEDNUM' });
+    const tag2 = store.createRecord('tag', { id: '2', name: 'AEFE' });
+    const tag3 = store.createRecord('tag', { id: '3', name: 'CFA' });
+    const tag4 = store.createRecord('tag', { id: '4', name: 'POLE EMPLOI' });
+    const organization = store.createRecord('organization', { id: '7', tags: [tag1, tag2] });
     route.modelFor = sinon.stub().returns(organization);
     store.query = sinon.stub().resolves([tag1, tag2, tag3, tag4]);
 


### PR DESCRIPTION
## ❄️ Problème

La console de test de Pix Admin est remplie de message d'erreurs (92 erreurs) quand on exécute les tests. 

## 🛷 Proposition

Les erreurs sont liées à :
- des liens vers des ressources inaccessibles (ex: images)
- des stubs ou config mirage manquantes qui déclenches des requêtes réseaux non mockées
- des consoles logs

**Avant:**
<img width="263" height="232" alt="SCR-20251127-pslh" src="https://github.com/user-attachments/assets/37501993-8e72-498d-b41a-db9aeb4656e0" />

**Après la correction des erreurs:**
<img width="260" height="239" alt="SCR-20251127-pvbm" src="https://github.com/user-attachments/assets/2178d9b7-606f-49b5-939b-a8d45a844f5a" />

**Après la correction des warnings:**
<img width="300" height="167" alt="image" src="https://github.com/user-attachments/assets/11f7e543-54e4-43d3-8497-77bd3e66adb0" />


## ☃️ Remarques

Les 12 warnings restants concernent:
- des warnings venant de PixUI
- des warnings liés à la librarie `ember-cp-validations` qui contient des déprecations `ember-data`
- des warnings liés à la montée de `ember-data` vers `warp-drive`

## 🧑‍🎄 Pour tester

La CI doit être verte.