### PR TITLE
[BUGFIX] ne pas remonter tout les learners d'une orga lors de la suppression de learner (PIX-20609)"

### DIFF
--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerList.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerList.js
@@ -8,18 +8,14 @@ class OrganizationLearnerList {
   }
 
   getDeletableOrganizationLearners(organizationLearnerIdsToDelete, userId) {
-    const organizationLearnersInOrganization = this.organizationLearners.filter((organizationLearner) => {
-      return organizationLearnerIdsToDelete.includes(organizationLearner.id);
-    });
-
-    if (organizationLearnersInOrganization.length !== organizationLearnerIdsToDelete.length) {
+    if (this.organizationLearners.length !== organizationLearnerIdsToDelete.length) {
       logger.error(
         `User id ${userId} could not delete organization learners because some learner id in (${organizationLearnerIdsToDelete.join(',')}) don't belong to organization id ${this.organizationId}`,
       );
       throw new CouldNotDeleteLearnersError();
     }
 
-    return organizationLearnersInOrganization;
+    return this.organizationLearners;
   }
 }
 

--- a/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/delete-organization-learners.js
@@ -22,8 +22,9 @@ const deleteOrganizationLearners = withTransaction(async function ({
   }
 
   const organizationLearnersFromOrganization =
-    await organizationLearnerRepository.findOrganizationLearnersByOrganizationId({
+    await organizationLearnerRepository.findOrganizationLearnersByOrganizationIdAndLearnerIds({
       organizationId,
+      organizationLearnerIds,
     });
 
   const organizationLearnerList = new OrganizationLearnerList({

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -282,9 +282,17 @@ const findByUserId = async function ({ userId }) {
   return rawOrganizationLearners.map((rawOrganizationLearner) => new OrganizationLearner(rawOrganizationLearner));
 };
 
-const findOrganizationLearnersByOrganizationId = async function ({ organizationId }) {
+const findOrganizationLearnersByOrganizationIdAndLearnerIds = async function ({
+  organizationId,
+  organizationLearnerIds = [],
+}) {
+  if (organizationLearnerIds.length === 0) {
+    return [];
+  }
   const knexConnection = DomainTransaction.getConnection();
-  const organizationLearners = await knexConnection('view-active-organization-learners').where({ organizationId });
+  const organizationLearners = await knexConnection('view-active-organization-learners')
+    .whereIn('id', organizationLearnerIds)
+    .where({ organizationId });
   return organizationLearners.map((organizationLearner) => _toDomain(organizationLearner));
 };
 
@@ -392,7 +400,7 @@ export {
   findAllCommonOrganizationLearnerByReconciliationInfos,
   findByUserId,
   findOrganizationLearnerIdsBeforeImportFeatureFromOrganizationId,
-  findOrganizationLearnersByOrganizationId,
+  findOrganizationLearnersByOrganizationIdAndLearnerIds,
   getLearnerInfo,
   getOrganizationLearnerForAdmin,
   reconcileUserByNationalStudentIdAndOrganizationId,

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerList_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationLearnerList_test.js
@@ -29,32 +29,31 @@ describe('Unit | Models | OrganizationLearnerListFormat', function () {
         const organizationLearnerList = new OrganizationLearnerList(payload);
 
         // when
-        const result = organizationLearnerList.getDeletableOrganizationLearners([345]);
+        const result = organizationLearnerList.getDeletableOrganizationLearners([123, 345]);
 
         // then
-        expect(result).to.be.deep.equal([{ id: 345 }]);
+        expect(result).to.be.deep.equal([{ id: 123 }, { id: 345 }]);
       });
     });
 
     context('when some organizationLearnerIds belong to organization', function () {
       it('should throw', function () {
         sinon.stub(logger, 'error');
-        //when
-        const payload = {
-          organizationId: 777,
-          organizationLearners: [{ id: 123 }, { id: 345 }],
-        };
 
-        const organizationLearnerList = new OrganizationLearnerList(payload);
+        //when
+        const organizationLearnerList = new OrganizationLearnerList({
+          organizationId: 777,
+          organizationLearners: [{ id: 123 }],
+        });
 
         const result = catchErrSync(organizationLearnerList.getDeletableOrganizationLearners, organizationLearnerList)(
-          [456, 123],
+          [123, 453],
           'userIdSample',
         );
 
         expect(result).to.be.instanceof(CouldNotDeleteLearnersError);
         expect(logger.error).to.have.calledWithExactly(
-          "User id userIdSample could not delete organization learners because some learner id in (456,123) don't belong to organization id 777",
+          "User id userIdSample could not delete organization learners because some learner id in (123,453) don't belong to organization id 777",
         );
       });
     });


### PR DESCRIPTION

## ❄️ Problème

On a des container qui explosent quand on veut supprimer un learner d'orga avec plusieurs millions de learner
C'est pas ouf pour les captains

## 🛷 Proposition

Filtrer sur les id des learner à supprimer lorsqu'on souhaite vérifier que les learner appartiennent bien à l'orga

## ☃️ Remarques

On a profiter de la PR pour modifier le modele qu'on utilise étant donnée que la liste des learners récupérer et forcément un sous-ensemble de la liste des id fourni dans le payload

## 🧑‍🎄 Pour tester

Test de non régression
dans pix admin
- supprimer un learner d'une orga 
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
