### PR TITLE
[FEATURE] Créer en masse des organisations en leurs spécifiant leurs pays (PIX-20344)

### DIFF
--- a/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
+++ b/api/src/organizational-entities/domain/validators/organization-with-tags-and-target-profiles.js
@@ -57,6 +57,11 @@ const schema = Joi.object({
     'any.required': "L'id de l'équipe en charge est manquant",
     'number.base': "L'id de l'équipe en charge n'est pas un nombre",
   }),
+  countryCode: Joi.number().min(99000).max(99999).integer().required().messages({
+    'any.required': 'Le code pays n’est pas renseigné.',
+    'number.min': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+    'number.max': 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+  }),
 });
 
 const validate = function (organization) {

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -121,6 +121,7 @@ const requiredFieldNamesForOrganizationsImport = [
   'DPOEmail',
   'administrationTeamId',
   'parentOrganizationId',
+  'countryCode',
 ];
 
 async function deserializeForOrganizationsImport(file) {
@@ -170,6 +171,9 @@ async function deserializeForOrganizationsImport(file) {
           value = 'fr-fr';
         }
         if (columnName === 'adminstrationTeamId') {
+          value = parseInt(value, 10);
+        }
+        if (columnName === 'countryCode') {
           value = parseInt(value, 10);
         }
       }

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -54,15 +54,20 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       databaseBuilder.factory.buildTag({ name: 'GARBURE' });
       databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
       databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
+      databaseBuilder.factory.buildCertificationCpfCountry({
+        code: 99100,
+        commonName: 'France',
+        originalName: 'France',
+      });
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       const parentOrganizationId = databaseBuilder.factory.buildOrganization().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organizationId }).id;
       await databaseBuilder.commit();
 
       const buffer =
-        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId\n' +
-        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,\n` +
-        `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId}`;
+        'type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles,administrationTeamId,parentOrganizationId,countryCode\n' +
+        `SCO,ANNEGRAELLE,Orga des Anne-Graelle,33700,666,${superAdminUserId},url.com,,true,,Anne,Graelle,anne-graelle@example.net,,ADMIN,fr,GRAS_GARGOUILLE,${targetProfileId},1234,,99100\n` +
+        `PRO,ANNEGARBURE,Orga des Anne-Garbure,33700,999,${superAdminUserId},,,,,Anne,Garbure,anne-garbure@example.net,,ADMIN,fr,GARBURE,${targetProfileId},1234,${parentOrganizationId},99100`;
 
       // when
       const response = await server.inject({
@@ -90,6 +95,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         identityProviderForCampaigns: null,
         isManagingStudents: true,
         parentOrganizationId: null,
+        countryCode: 99100,
       });
 
       const secondOrganizationCreated = organizations.find((organization) => organization.externalId === 'ANNEGARBURE');
@@ -103,6 +109,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         identityProviderForCampaigns: null,
         isManagingStudents: false,
         parentOrganizationId,
+        countryCode: 99100,
       });
 
       const dataProtectionOfficers = await knex('data-protection-officers');

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.test.js
@@ -2,6 +2,7 @@ import lodash from 'lodash';
 
 import {
   AdministrationTeamNotFound,
+  CountryNotFoundError,
   UnableToAttachChildOrganizationToParentOrganizationError,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
@@ -31,7 +32,8 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     ondeImportFormat,
     userId,
     byDefaultFeatureId,
-    administrationTeamId;
+    administrationTeamId,
+    countryCode;
 
   beforeEach(async function () {
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
@@ -39,6 +41,10 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     oralizationFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.ORALIZATION_MANAGED_BY_PRESCRIBER);
     importStudentsFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
     administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
+    countryCode = databaseBuilder.factory.buildCertificationCpfCountry({
+      originalName: 'Lalaland',
+      commonName: 'Lalaland',
+    }).code;
     ondeImportFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
       name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE,
     });
@@ -82,6 +88,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             targetProfiles: '',
             organizationInvitationRole: '',
             administrationTeamId: '',
+            countryCode: undefined,
           },
         ];
 
@@ -129,6 +136,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             attribute: 'administrationTeamId',
             message: "L'id de l'équipe en charge est manquant",
           },
+          { attribute: 'countryCode', message: 'Le code pays n’est pas renseigné.' },
         ]);
       });
     });
@@ -151,6 +159,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             targetProfiles: '1_2_3',
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
+            countryCode,
           },
           {
             type: 'PRO',
@@ -166,6 +175,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             targetProfiles: '1_2_3',
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
+            countryCode,
           },
           {
             type: 'PRO',
@@ -181,6 +191,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             targetProfiles: '1_2_3',
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
+            countryCode,
           },
         ];
 
@@ -221,6 +232,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             documentationUrl: 'http://www.pix.fr',
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
+            countryCode,
           },
           {
             type: 'PRO',
@@ -236,6 +248,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             documentationUrl: 'http://www.pix.fr',
             organizationInvitationRole: 'MEMBER',
             administrationTeamId,
+            countryCode,
           },
           {
             type: 'PRO',
@@ -251,6 +264,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             documentationUrl: 'http://www.pix.fr',
             organizationInvitationRole: 'ADMIN',
             administrationTeamId,
+            countryCode,
           },
         ];
 
@@ -294,6 +308,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -309,6 +324,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -324,6 +340,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -354,6 +371,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             'emailInvitations',
             'targetProfiles',
             'administrationTeamId',
+            'countryCode',
           ),
         );
 
@@ -387,6 +405,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -402,6 +421,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'MEMBER',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -417,6 +437,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -453,6 +474,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -468,6 +490,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'MEMBER',
           administrationTeamId: 9999,
+          countryCode,
         },
       ];
 
@@ -507,6 +530,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -522,6 +546,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'MEMBER',
           administrationTeamId: anotherAdministrationTeamId,
+          countryCode,
         },
       ];
 
@@ -535,6 +560,78 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
       expect(organizationsInDB).to.have.lengthOf(2);
       expect(organizationsInDB[0].administrationTeamId).to.equal(administrationTeamId);
       expect(organizationsInDB[1].administrationTeamId).to.equal(anotherAdministrationTeamId);
+    });
+  });
+
+  describe('when one provided country code is not found in database', function () {
+    it('should rollback', async function () {
+      // given
+      const invalidCountryCode = 99998;
+      const organizationsWithNonExistingCountryCode = [
+        {
+          type: 'PRO',
+          externalId: 'b400',
+          name: 'Mathieu Bâtiment',
+          provinceCode: '567',
+          credit: 20,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'ADMIN',
+          administrationTeamId,
+          countryCode: invalidCountryCode,
+        },
+      ];
+
+      // when
+      const error = await catchErr(usecases.createOrganizationsWithTagsAndTargetProfiles)({
+        organizations: organizationsWithNonExistingCountryCode,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(CountryNotFoundError);
+      expect(error.meta).to.deep.equal({
+        countryCode: invalidCountryCode,
+      });
+      const organizationsInDB = await knex('organizations').select();
+      expect(organizationsInDB).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when provided country code is found in database', function () {
+    it('should save the organizations', async function () {
+      // given
+      const organizationsWithExistingCountryCode = [
+        {
+          type: 'PRO',
+          externalId: 'b400',
+          name: 'Mathieu Bâtiment',
+          provinceCode: '567',
+          credit: 20,
+          emailInvitations: '',
+          locale: 'fr-fr',
+          tags: '',
+          targetProfiles: '',
+          createdBy: userId,
+          documentationUrl: 'http://www.pix.fr',
+          organizationInvitationRole: 'ADMIN',
+          administrationTeamId,
+          countryCode,
+        },
+      ];
+
+      // when
+      await usecases.createOrganizationsWithTagsAndTargetProfiles({
+        organizations: organizationsWithExistingCountryCode,
+      });
+
+      // then
+      const organizationsInDB = await knex('organizations').select();
+      expect(organizationsInDB).to.have.lengthOf(1);
+      expect(organizationsInDB[0].countryCode).to.equal(Number(countryCode));
     });
   });
 
@@ -562,6 +659,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -577,6 +675,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -592,6 +691,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           documentationUrl: 'http://www.pix.fr',
           organizationInvitationRole: 'ADMIN',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -622,6 +722,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             'emailInvitations',
             'targetProfiles',
             'administrationTeamId',
+            'countryCode',
           ),
         );
 
@@ -657,6 +758,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           createdBy: userId,
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -672,6 +774,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           createdBy: userId,
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -712,6 +815,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           createdBy: userId,
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -764,6 +868,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           createdBy: userId,
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'PRO',
@@ -778,6 +883,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           createdBy: userId,
           documentationUrl: 'http://www.pix.fr',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -820,6 +926,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           credit: 10,
           provinceCode: '123',
           administrationTeamId,
+          countryCode,
         },
         {
           type: 'SCO-1D',
@@ -832,6 +939,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           credit: 1230,
           provinceCode: '123',
           administrationTeamId,
+          countryCode,
         },
       ];
 
@@ -867,6 +975,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             createdBy: userId,
             administrationTeamId,
             parentOrganizationId,
+            countryCode,
           },
         ];
 
@@ -892,6 +1001,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             createdBy: userId,
             administrationTeamId,
             parentOrganizationId: 12345,
+            countryCode,
           },
         ];
 
@@ -923,6 +1033,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             createdBy: userId,
             administrationTeamId,
             parentOrganizationId,
+            countryCode,
           },
         ];
 

--- a/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
+++ b/api/tests/organizational-entities/integration/domain/validators/organization-with-tags-and-target-profiles.test.js
@@ -18,6 +18,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
     tags: 'TAG1',
     type: 'SCO',
     administrationTeamId: 1,
+    countryCode: 99123,
   };
 
   context('success', function () {
@@ -50,6 +51,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
               name: 'Organization Name',
               createdBy: 0,
               administrationTeamId: 1,
+              countryCode: 99123,
             };
 
             // when
@@ -81,6 +83,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
           { attribute: 'name', message: '"name" is required' },
           { attribute: 'createdBy', message: "L'id du créateur est manquant" },
           { attribute: 'administrationTeamId', message: "L'id de l'équipe en charge est manquant" },
+          { attribute: 'countryCode', message: 'Le code pays n’est pas renseigné.' },
         ]);
       });
     });
@@ -102,6 +105,48 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'locale',
           message: `La locale doit avoir l'une des valeurs suivantes : en, es, es-419, fr, nl, fr-be, fr-fr, nl-be`,
+        });
+      });
+    });
+
+    context('when country code is below minimum value', function () {
+      it('returns an EntityValidation error', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          countryCode: 98000,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'countryCode',
+          message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
+        });
+      });
+    });
+
+    context('when country code is above maximum value', function () {
+      it('returns an EntityValidation error', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          countryCode: 100000,
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'countryCode',
+          message: 'Le code pays doit être un nombre entier compris entre 99000 et 99999.',
         });
       });
     });


### PR DESCRIPTION
## ☔ Problème

On doit pouvoir renseigner un pays lors de la création en masse via csv.

## 🧥 Proposition

- Créer  la colonne dans le fichier csv : countryCode
- En tenir compte lors de la création en masse

## 🎃 Pour tester

- Depuis pix-admin
- Se connecter avec le compte [superadmin@example.net](mailto:superadmin@example.net)
- Dans l'onglet Administration > Déploiement
- Télécharger le template
- Importer un csv de création en masse selon l'exemple ci dessous complété avec les infos d'une orga et un countryCode valide
- Constater que l'organisation a bien été crée et que le pays a bien été prise en compte
