### PR TITLE
[TECH] Ajouter le shortId dans le script listant les modules pour la réplication BDD (PIX-20468).

### DIFF
--- a/api/scripts/modulix/list-modules-for-db-replication.js
+++ b/api/scripts/modulix/list-modules-for-db-replication.js
@@ -1,14 +1,14 @@
 import moduleDatasource from '../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 
 /**
- * List all modules for DB replication with id, slug and title
+ * List all modules for DB replication with id, shortId, slug and title
  * @returns {Promise<void>}
  */
 async function listModulesForDBReplication() {
   const imports = await moduleDatasource.list();
   console.log('--- List of modules for DB replication ---');
   const moduleInformation = imports.map((module) => {
-    return { id: module.id, slug: module.slug, title: module.title };
+    return { id: module.id, shortId: module.shortId, slug: module.slug, title: module.title };
   });
   console.log(JSON.stringify(moduleInformation, null, 2).replace(/"([^"]+)": "([^"]+)"/g, "$1: '$2'"));
 }


### PR DESCRIPTION
## ❄️ Problème

On souhaite afficher les nouveaux `shortId` dans Metabase.

## 🛷 Proposition

Pour pouvoir mettre à jour la liste des modules dans la db-replication, on lance le script `list-modules-for-db-replication.js`. Il faut donc qu'on y ajoute shortId pour notre besoin.

## 🧑‍🎄 Pour tester
lancer le script  `node scripts/modulix/list-modules-for-db-replication.js` et constater que le shortId apparaît.
