### PR TITLE
[TECH] Améliorer l'idendification des éléments dans generateItems (PIX-19095).

### DIFF
--- a/api/src/quest/domain/models/CombinedCourse.js
+++ b/api/src/quest/domain/models/CombinedCourse.js
@@ -5,8 +5,10 @@ import {
   CombinedCourseStatuses,
 } from '../../../prescription/shared/domain/constants.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
+import { Campaign } from './Campaign.js';
 import { COMBINED_COURSE_ITEM_TYPES, CombinedCourseItem } from './CombinedCourseItem.js';
 import { CombinedCourseParticipationDetails } from './CombinedCourseParticipationDetails.js';
+import { Module } from './Module.js';
 import { Quest } from './Quest.js';
 import { TYPES } from './Requirement.js';
 
@@ -238,7 +240,9 @@ export class CombinedCourseDetails extends CombinedCourse {
       const isLocked = this.#isCombinedCourseItemLocked(previousItem);
 
       if (requirement.requirement_type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
-        const campaign = itemDetails.find(({ id }) => id === requirement.data.campaignId.data);
+        const campaign = itemDetails.find(
+          (item) => item.id === requirement.data.campaignId.data && item instanceof Campaign,
+        );
         const isCompleted = dataForQuest ? requirement.isFulfilled(dataForQuest) : false;
 
         const associatedParticipation = dataForQuest?.campaignParticipations?.find(
@@ -267,7 +271,7 @@ export class CombinedCourseDetails extends CombinedCourse {
         );
       } else if (requirement.requirement_type === TYPES.OBJECT.PASSAGES) {
         const isCompleted = dataForQuest ? requirement.isFulfilled(dataForQuest) : false;
-        const module = itemDetails.find(({ id }) => id === requirement.data.moduleId.data);
+        const module = itemDetails.find((item) => item.id === requirement.data.moduleId.data && item instanceof Module);
 
         const recommandableModule = recommendableModuleIds.find(
           (potentiallyRecommendedModule) => potentiallyRecommendedModule.moduleId === module.id,

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -11,16 +11,13 @@ import {
 } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
 import { CombinedCourseParticipation } from '../../../../../src/quest/domain/models/CombinedCourseParticipation.js';
 import { CombinedCourseTemplate } from '../../../../../src/quest/domain/models/CombinedCourseTemplate.js';
+import { COMPARISONS as CRITERION_COMPARISONS } from '../../../../../src/quest/domain/models/CriterionProperty.js';
 import { DataForQuest } from '../../../../../src/quest/domain/models/DataForQuest.js';
 import { Eligibility } from '../../../../../src/quest/domain/models/Eligibility.js';
 import { Module } from '../../../../../src/quest/domain/models/Module.js';
-import {
-  CRITERION_COMPARISONS,
-  Quest,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
-import { domainBuilder, expect } from '../../../../test-helper.js';
+import { Quest, REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/Quest.js';
+import { COMPARISONS as REQUIREMENT_COMPARISONS } from '../../../../../src/quest/domain/models/Requirement.js';
+import { expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
   describe('CombinedCourseDetails', function () {
@@ -1108,7 +1105,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
         it('should not return module if it is recommandable, but not recommended for user', function () {
           // given
           const module = new Module({ id: 'module-id', title: 'module' });
-          const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+          const campaign = new Campaign({ id: 777, targetProfileId: 888 });
           const recommendableModuleIds = [{ moduleId: module.id, targetProfileIds: [campaign.targetProfileId] }];
           const recommendedModuleIdsForUser = [];
           const combinedCourseTemplate = new CombinedCourseTemplate({
@@ -1170,7 +1167,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           // given
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const module = new Module({ id: 'ebcde1', title: 'module' });
-          const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+          const campaign = new Campaign({ id: 777, targetProfileId: 888 });
 
           const recommendableModuleIds = [{ moduleId: module.id, targetProfileIds: [campaign.targetProfileId] }];
           const recommendedModuleIdsForUser = [{ moduleId: module.id }];
@@ -1248,7 +1245,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
             const firstModule = new Module({ id: 'abcdef1', title: 'module' });
             const secondModule = new Module({ id: 'abcdef2', title: 'module' });
-            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+            const campaign = new Campaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
               { moduleId: firstModule.id, targetProfileIds: [campaign.targetProfileId] },
@@ -1328,8 +1325,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
             const firstModule = new Module({ id: 'abcdef1', title: 'module' });
             const secondModule = new Module({ id: 'abcdef2', title: 'module' });
-            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
-            const secondCampaign = domainBuilder.buildCampaign({ id: 999, targetProfileId: 101 });
+            const campaign = new Campaign({ id: 777, targetProfileId: 888 });
+            const secondCampaign = new Campaign({ id: 999, targetProfileId: 101 });
 
             const recommendableModuleIds = [
               { moduleId: firstModule.id, targetProfileIds: [campaign.targetProfileId] },
@@ -1433,7 +1430,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
             const firstModule = new Module({ id: 'abcdef1', title: 'module' });
             const secondModule = new Module({ id: 'abcdef2', title: 'module' });
-            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+            const campaign = new Campaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
               { moduleId: firstModule.id, targetProfileIds: [campaign.targetProfileId] },
@@ -1498,8 +1495,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
             const module = new Module({ id: 'abcdef1', title: 'module' });
             const module2 = new Module({ id: 'abcdef3', title: 'module2' });
-            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888, code: 'campaign123' });
-            const campaign2 = domainBuilder.buildCampaign({ id: 333, targetProfileId: 666, code: 'campaign456' });
+            const campaign = new Campaign({ id: 777, targetProfileId: 888, code: 'campaign123' });
+            const campaign2 = new Campaign({ id: 333, targetProfileId: 666, code: 'campaign456' });
 
             const recommendableModuleIds = [
               { moduleId: module.id, targetProfileIds: [campaign2.targetProfileId, campaign.targetProfileId] },
@@ -1603,7 +1600,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
             const moduleFromTargetProfile = new Module({ id: 'abcdefgh1', title: 'module' });
             const moduleFromQuest = new Module({ id: 'abcdefgh3', title: 'module from quest' });
-            const campaign = domainBuilder.buildCampaign({ id: 777, targetProfileId: 888 });
+            const campaign = new Campaign({ id: 777, targetProfileId: 888 });
 
             const recommendableModuleIds = [
               { moduleId: moduleFromTargetProfile.id, targetProfileIds: [campaign.targetProfileId] },
@@ -1813,6 +1810,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           }),
         ]);
       });
+
       it('should evaluates if module is completed', function () {
         // given
         const module = new Module({ id: 'abc2de', title: 'title', slug: 'abcdef' });
@@ -2058,6 +2056,64 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             id: module11.id,
             reference: module11.slug,
             title: module11.title,
+            type: COMBINED_COURSE_ITEM_TYPES.MODULE,
+            redirection: redirectionUrl,
+            isCompleted: false,
+            isLocked: true,
+          }),
+        ]);
+      });
+
+      it('should identify module or campaign even if they  have a same id', function () {
+        const campaign = new Campaign({ id: '3', code: 'ABCDIAG2', title: 'diagnostique2', targetProfileId: 999 });
+        const module = new Module({ id: '3', title: 'module diag 1', slug: 'module-abcdef-1' });
+        const combinedCourseTemplate = new CombinedCourseTemplate({
+          name: 'combinix',
+          combinedCourseContent: [
+            {
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign.targetProfileId,
+            },
+            {
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module.id,
+            },
+          ],
+        });
+        const combinedCourseQuestFormat = combinedCourseTemplate.toCombinedCourseQuestFormat([campaign]);
+        const combinedCourse = new CombinedCourseDetails(
+          new CombinedCourse({ id, organizationId, name, code, questId }),
+          combinedCourseQuestFormat,
+        );
+        const dataForQuest = new DataForQuest({
+          eligibility: new Eligibility({
+            campaignParticipations: [{ campaignId: campaign.id, status: CampaignParticipationStatuses.STARTED }],
+            passages: [],
+          }),
+        });
+        const redirectionUrl = 'redirectionUrl';
+
+        // when
+        combinedCourse.generateItems({
+          itemDetails: [module, campaign],
+          encryptedCombinedCourseUrl: redirectionUrl,
+          dataForQuest,
+        });
+        // then
+        expect(combinedCourse.items).to.deep.equal([
+          new CombinedCourseItem({
+            id: campaign.id,
+            reference: campaign.code,
+            title: campaign.title,
+            type: COMBINED_COURSE_ITEM_TYPES.CAMPAIGN,
+            masteryRate: null,
+            isCompleted: false,
+            isLocked: false,
+          }),
+          new CombinedCourseItem({
+            id: module.id,
+            reference: module.slug,
+            title: module.title,
             type: COMBINED_COURSE_ITEM_TYPES.MODULE,
             redirection: redirectionUrl,
             isCompleted: false,

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-details.js
@@ -1,3 +1,4 @@
+import { Campaign } from '../../../../src/quest/domain/models/Campaign.js';
 import { CombinedCourse, CombinedCourseDetails } from '../../../../src/quest/domain/models/CombinedCourse.js';
 import { DataForQuest } from '../../../../src/quest/domain/models/DataForQuest.js';
 import { Eligibility } from '../../../../src/quest/domain/models/Eligibility.js';
@@ -62,7 +63,11 @@ function buildCombinedCourse({ combinedCourse, quest } = {}) {
 }
 
 function buildCombinedCourseDetails({ combinedCourse, quest, items } = {}) {
-  const campaign = domainBuilder.buildCampaign({ title: 'diagnostique', code: 'ABCDIAG1' });
+  const campaign = new Campaign({
+    id: quest !== undefined ? quest.successRequirements[0].data.campaignId.data : 1,
+    title: 'diagnostique',
+    code: 'ABCDIAG1',
+  });
   const module = new Module({
     id: 7,
     slug: 'slug',


### PR DESCRIPTION
## ❄️ Problème

Les find utilisés dans le generateItems ne se base que sur l'id et non pas sur le type  d'objet.
Cela pourrait poser problème par la suite dans le cas ou les id de modules deviendrait des id de bdd

## 🛷 Proposition

Utiliser aussi le type d'objet pour identifier un élément du parcours combiné

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Passer un parcours combiné
