### PR TITLE
[TECH] :recycle: Renomme ce qui tourne autour du kit de supervision pour utiliser le terme `invigilator` (pix-20619)

### DIFF
--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -70,10 +70,10 @@ export async function remove({ id }) {
     const certificationCandidateIdsInSession = await knex('certification-candidates')
       .where({ sessionId: id })
       .pluck('id');
-    const supervisorAccessIds = await knex('supervisor-accesses').where({ sessionId: id }).pluck('id');
+    const invigilatorAccessIds = await knex('supervisor-accesses').where({ sessionId: id }).pluck('id');
 
-    if (supervisorAccessIds) {
-      await trx('supervisor-accesses').whereIn('id', supervisorAccessIds).del();
+    if (invigilatorAccessIds) {
+      await trx('supervisor-accesses').whereIn('id', invigilatorAccessIds).del();
     }
 
     if (certificationCandidateIdsInSession.length) {

--- a/api/src/certification/session-management/application/invigilator-kit-route.js
+++ b/api/src/certification/session-management/application/invigilator-kit-route.js
@@ -9,7 +9,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/sessions/{sessionId}/supervisor-kit',
+      path: '/api/sessions/{sessionId}/invigilator-kit',
       config: {
         validate: {
           params: Joi.object({

--- a/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
@@ -5,14 +5,14 @@ import {
   generateAuthenticatedUserRequestHeaders,
 } from '../../../test-helper.js';
 
-describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', function () {
+describe('Acceptance | Controller | session-controller-get-invigilator-kit-pdf', function () {
   let server;
 
   beforeEach(async function () {
     server = await createServer();
   });
 
-  describe('GET /api/sessions/{id}/supervisor-kit', function () {
+  describe('GET /api/sessions/{id}/invigilator-kit', function () {
     let user, sessionIdAllowed;
 
     beforeEach(async function () {
@@ -38,7 +38,7 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
       // when
       const options = {
         method: 'GET',
-        url: `/api/sessions/${sessionIdAllowed}/supervisor-kit`,
+        url: `/api/sessions/${sessionIdAllowed}/invigilator-kit`,
         payload: {},
         headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
       };

--- a/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
@@ -40,9 +40,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             certificationCourseId,
           });
 
-          const supervisorUserId = databaseBuilder.factory.buildUser({}).id;
+          const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
           databaseBuilder.factory.buildSupervisorAccess({
-            userId: supervisorUserId,
+            userId: invigilatorUserId,
             sessionId,
           });
 
@@ -51,7 +51,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           const options = {
             method: 'POST',
             url: `/api/certification-candidates/${candidate.id}/authorize-to-start`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: supervisorUserId, source: 'pix-certif' }),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' }),
             payload: { 'authorized-to-start': true },
           };
 
@@ -67,7 +67,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
   describe('POST /api/certification-candidates/{certificationCandidateId}/authorize-to-resume', function () {
     context('when user is authenticated', function () {
-      context('when the user is the supervisor of the session', function () {
+      context('when the user is the invigilator of the session', function () {
         it('should return a 204 status code', async function () {
           // given
           const server = await createServer();
@@ -94,9 +94,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             certificationCourseId,
           });
 
-          const supervisorUserId = databaseBuilder.factory.buildUser({}).id;
+          const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
           databaseBuilder.factory.buildSupervisorAccess({
-            userId: supervisorUserId,
+            userId: invigilatorUserId,
             sessionId,
           });
 
@@ -105,7 +105,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           const options = {
             method: 'POST',
             url: `/api/certification-candidates/${candidate.id}/authorize-to-resume`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: supervisorUserId, source: 'pix-certif' }),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' }),
           };
 
           // when
@@ -120,7 +120,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
 
   describe('PATCH /api/certification-candidates/{certificationCandidateId}/end-assessment-by-supervisor', function () {
     context('when user is authenticated', function () {
-      context('when the user is the supervisor of the session', function () {
+      context('when the user is the invigilator of the session', function () {
         it('should return a 204 status code', async function () {
           // given
           const server = await createServer();
@@ -154,9 +154,9 @@ describe('Certification | Session Management | Acceptance | Application | Routes
             skillId: 'skillId',
           });
 
-          const supervisorUserId = databaseBuilder.factory.buildUser({}).id;
+          const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
           databaseBuilder.factory.buildSupervisorAccess({
-            userId: supervisorUserId,
+            userId: invigilatorUserId,
             sessionId,
           });
 
@@ -164,7 +164,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           const options = {
             method: 'PATCH',
             url: `/api/certification-candidates/1001/end-assessment-by-supervisor`,
-            headers: generateAuthenticatedUserRequestHeaders({ userId: supervisorUserId, source: 'pix-certif' }),
+            headers: generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' }),
           };
 
           // when

--- a/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
+++ b/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
@@ -17,7 +17,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
           server.route([
             {
               method: 'GET',
-              path: '/api/test/sessions/{sessionId}/supervisor-kit',
+              path: '/api/test/sessions/{sessionId}/invigilator-kit',
               handler: (r, h) => h.response().code(200),
               config: {
                 pre: [
@@ -53,7 +53,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
 
           const options = {
             method: 'GET',
-            url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+            url: `/api/test/sessions/${sessionId}/invigilator-kit`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -80,7 +80,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
 
           const options = {
             method: 'GET',
-            url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+            url: `/api/test/sessions/${sessionId}/invigilator-kit`,
             headers: generateAuthenticatedUserRequestHeaders({ userId }),
           };
 
@@ -104,7 +104,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
           server.route([
             {
               method: 'GET',
-              path: '/api/test/sessions/{sessionId}/supervisor-kit',
+              path: '/api/test/sessions/{sessionId}/invigilator-kit',
               handler: (r, h) => h.response().code(200),
               config: {
                 pre: [
@@ -122,7 +122,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
       httpServerTest.setupAuthentication();
     });
 
-    context('when the user is authenticated and has supervisor access to the given session', function () {
+    context('when the user is authenticated and has invigilator access to the given session', function () {
       it('should return 200', async function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
@@ -135,7 +135,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
 
         const options = {
           method: 'GET',
-          url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+          url: `/api/test/sessions/${sessionId}/invigilator-kit`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 
@@ -147,7 +147,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
       });
     });
 
-    context('when the user is authenticated and has no supervisor access to the given session', function () {
+    context('when the user is authenticated and has no invigilator access to the given session', function () {
       it('should return 403', async function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
@@ -159,7 +159,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
 
         const options = {
           method: 'GET',
-          url: `/api/test/sessions/${sessionId}/supervisor-kit`,
+          url: `/api/test/sessions/${sessionId}/invigilator-kit`,
           headers: generateAuthenticatedUserRequestHeaders({ userId }),
         };
 

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
@@ -13,9 +13,9 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       await invigilatorAccessRepository.create({ sessionId, userId });
 
       // then
-      const supervisorAccessInDB = await knex.from('supervisor-accesses').first();
-      expect(supervisorAccessInDB.sessionId).to.equal(sessionId);
-      expect(supervisorAccessInDB.userId).to.equal(userId);
+      const invigilatorAccessInDB = await knex.from('supervisor-accesses').first();
+      expect(invigilatorAccessInDB.sessionId).to.equal(sessionId);
+      expect(invigilatorAccessInDB.userId).to.equal(userId);
     });
   });
 

--- a/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
+++ b/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
@@ -5,7 +5,7 @@ import { securityPreHandlers } from '../../../../../src/shared/application/secur
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Certification | Session Management | Unit | Application | Routes | Invigilator Kit', function () {
-  describe('GET /api/sessions/{sessionId}/supervisor-kit', function () {
+  describe('GET /api/sessions/{sessionId}/invigilator-kit', function () {
     it('should return 200', async function () {
       // when
       sinon.stub(authorization, 'checkUserHaveCertificationCenterMembershipForSession').resolves(true);
@@ -15,7 +15,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Inv
 
       const auth = { credentials: { userId: 99 }, strategy: {} };
 
-      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
+      const response = await httpTestServer.request('GET', '/api/sessions/3/invigilator-kit', {}, auth);
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -31,7 +31,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Inv
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
-        const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
+        const response = await httpTestServer.request('GET', '/api/sessions/3/invigilator-kit', {}, auth);
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/certif/app/components/sessions/session-details/index.gjs
+++ b/certif/app/components/sessions/session-details/index.gjs
@@ -21,7 +21,7 @@ export default class SessionDetails extends Component {
   async fetchInvigilatorKit() {
     try {
       const token = this.session.data.authenticated.access_token;
-      await this.fileSaver.save({ url: this.args.model.sessionManagement.urlToDownloadSupervisorKitPdf, token });
+      await this.fileSaver.save({ url: this.args.model.sessionManagement.urlToDownloadInvigilatorKitPdf, token });
     } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('common.api-error-messages.internal-server-error') });
     }

--- a/certif/app/controllers/session-supervising.js
+++ b/certif/app/controllers/session-supervising.js
@@ -26,7 +26,7 @@ export default class SessionSupervisingController extends Controller {
   @action
   async fetchInvigilatorKit() {
     const token = this.session.data.authenticated.access_token;
-    const url = `/api/sessions/${this.model.id}/supervisor-kit`;
+    const url = `/api/sessions/${this.model.id}/invigilator-kit`;
 
     try {
       await this.fileSaver.save({ url, token });

--- a/certif/app/models/session-management.js
+++ b/certif/app/models/session-management.js
@@ -23,8 +23,8 @@ export default class Session extends Model {
     return this.status === FINALIZED || this.status === IN_PROCESS || this.status === PROCESSED;
   }
 
-  get urlToDownloadSupervisorKitPdf() {
-    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/supervisor-kit`;
+  get urlToDownloadInvigilatorKitPdf() {
+    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/invigilator-kit`;
   }
 
   get completedCertificationReports() {

--- a/certif/tests/unit/controllers/session-supervising-test.js
+++ b/certif/tests/unit/controllers/session-supervising-test.js
@@ -52,7 +52,7 @@ module('Unit | Controller | session-supervising', function (hooks) {
       assert.ok(
         controller.fileSaver.save.calledWith({
           token,
-          url: '/api/sessions/456/supervisor-kit',
+          url: '/api/sessions/456/invigilator-kit',
         }),
       );
     });

--- a/certif/tests/unit/models/session-management-test.js
+++ b/certif/tests/unit/models/session-management-test.js
@@ -8,8 +8,8 @@ import config from '../../../config/environment';
 module('Unit | Model | sessionManagement', function (hooks) {
   setupTest(hooks);
 
-  module('#urlToDownloadSupervisorKitPdf', function () {
-    test('it should return the correct urlToDownloadSupervisorKitPdf', function (assert) {
+  module('#urlToDownloadInvigilatorKitPdf', function () {
+    test('it should return the correct urlToDownloadInvigilatorKitPdf', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('session-management', { id: '1' });
@@ -24,7 +24,7 @@ module('Unit | Model | sessionManagement', function (hooks) {
       this.owner.register('service:session', SessionStub);
 
       // when/then
-      assert.strictEqual(model.urlToDownloadSupervisorKitPdf, `${config.APP.API_HOST}/api/sessions/1/supervisor-kit`);
+      assert.strictEqual(model.urlToDownloadInvigilatorKitPdf, `${config.APP.API_HOST}/api/sessions/1/invigilator-kit`);
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/6f99e6d3-4319-4f8d-8f88-943613abf704" />

Ce qui tourne autour du kit de supervision (URL, variables, etc) utilise encore le terme `supervisor`.

## 🛷 Proposition

Renommer les éléments autour du kit de supervision (URL, variables, etc) pour utiliser le terme `invigilator`

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Se connecter à Pix Certif avec le compte certif-prescriptor@example.net ;
- Entrer dans le détail d'une session de certification ;
<img width="1376" height="629" alt="image" src="https://github.com/user-attachments/assets/b8cac951-da1c-4994-9494-62fd2ec4747d" />
- cliquer sur le bouton de téléchargement du kit surveillant.
- constater que lekit est bien récupéré avec le bon nom de fichier
<img width="845" height="610" alt="image" src="https://github.com/user-attachments/assets/4e5569c5-7815-4f3b-b40f-5dad90c652c3" />

- aller  sur l'espace  surveillant
<img width="1031" height="758" alt="image" src="https://github.com/user-attachments/assets/20151e22-4e00-44f0-8623-130d6f4c4f01" />

- télécharger le kit surveillant
- constater que le kit est bien récupéré

<img width="545" height="665" alt="image" src="https://github.com/user-attachments/assets/55976797-e89a-404c-b4df-1f46b92fbfaf" />

Récupérer le kit surveillant depuis l'interface de pix certif
