### PR TITLE
[TECH] Mettre à jour  epreuves component en version 2.2.2.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.2.1",
+        "@1024pix/epreuves-components": "^2.2.2",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.1.tgz",
-      "integrity": "sha512-yezELaJDih4AGSjPJEqQicPgksu5YRwwA8EAy47L+r1bSZQiclKBr132hynaH/Pnx0gjd4Tl9eyIvrqPXRxeJQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
+      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.2.1",
+    "@1024pix/epreuves-components": "^2.2.2",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.1",
+        "@1024pix/epreuves-components": "^2.2.2",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.1.tgz",
-      "integrity": "sha512-yezELaJDih4AGSjPJEqQicPgksu5YRwwA8EAy47L+r1bSZQiclKBr132hynaH/Pnx0gjd4Tl9eyIvrqPXRxeJQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
+      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.2.1",
+    "@1024pix/epreuves-components": "^2.2.2",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.1",
+        "@1024pix/epreuves-components": "^2.2.2",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.1.tgz",
-      "integrity": "sha512-yezELaJDih4AGSjPJEqQicPgksu5YRwwA8EAy47L+r1bSZQiclKBr132hynaH/Pnx0gjd4Tl9eyIvrqPXRxeJQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
+      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -44,10 +44,10 @@
   },
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
-    "@1024pix/epreuves-components": "^2.2.1",
-    "@1024pix/pix-ui": "^55.32.2",
-    "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/ember-testing-library": "^3.0.25",
+    "@1024pix/epreuves-components": "^2.2.2",
+    "@1024pix/eslint-plugin": "^2.1.14",
+    "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.24.7",


### PR DESCRIPTION
## ❄️ Problème

Nous ne somme pas a jours sur le package `epreuves component`

## 🛷 Proposition

Mettre à jour le package

## ☃️ Remarques

ras

## 🧑‍🎄 Pour tester

Tests au vert
