### PR TITLE
[TECH] Ajouter une contrainte not-nullable sur le champ CountryCode de la table organizations (PIX-20348)

### DIFF
--- a/api/db/migrations/20251201141329_add-not-nullable-constraint-on-countryCode-in-organizations-table.js
+++ b/api/db/migrations/20251201141329_add-not-nullable-constraint-on-countryCode-in-organizations-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'countryCode';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable().alter();
+  });
+};
+
+export { down, up };

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -296,6 +296,7 @@ export async function createOrganizationInDB({
       identityProviderForCampaigns: null,
       parentOrganizationId: null,
       administrationTeamId,
+      countryCode: 99100,
     })
     .returning('id');
   return id;

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -3,20 +3,23 @@
     "id": 1,
     "type": "PRO",
     "name": "Dragon & Co",
-    "administrationTeamId": 1
+    "administrationTeamId": 1,
+    "countryCode": 99100
   },
   {
     "id": 2,
     "type": "SCO",
     "name": "The Night Watch",
     "isManagingStudents": true,
-    "administrationTeamId": 2
+    "administrationTeamId": 2,
+    "countryCode": 99100
   },
   {
     "id": 3,
     "type": "SUP",
     "name": "The Order of Maesters",
     "isManagingStudents": true,
-    "administrationTeamId": 1
+    "administrationTeamId": 1,
+    "countryCode": 99100
   }
 ]


### PR DESCRIPTION
## ❄️ Problème

Désormais, le countryCode n'est plus optionnel dans les informations d'une organisation.

## 🛷 Proposition

Créer une migration pour rendre ce champs `non nullable `en base de données

## ☃️ Remarques

Tous les seeds d'organisations ont précédemment été mis à jour pour qu'elles aient un code pays.
On a ajouté le countryCode dans les builders des tests e2e car sinon ils ne passaient pas la migration

## 🧑‍🎄 Pour tester

- Tests au vert
- vérifier en base (RA et Recette) que toutes les organisations ont bien un code pays
