### PR TITLE
[BUGFIX] Les liens vers des tutos Youtube ne fonctionnent pas (PIX-20617)

### DIFF
--- a/mon-pix/app/components/tutorials/card.gjs
+++ b/mon-pix/app/components/tutorials/card.gjs
@@ -16,7 +16,7 @@ export default class Card extends Component {
           <h4 class="tutorial-card-content__title">
             <a
               target="_blank"
-              rel={{this.linkRel}}
+              referrerpolicy="strict-origin"
               href="{{@tutorial.link}}"
               title="{{@tutorial.title}}"
               {{on "click" this.trackAccess}}
@@ -64,8 +64,6 @@ export default class Card extends Component {
   @tracked savingStatus;
   @tracked evaluationStatus;
 
-  static TUTORIAL_PIX_URL_HOST = 'tutorial.pix.fr';
-
   constructor(owner, args) {
     super(owner, args);
     this.savingStatus = args.tutorial.isSaved ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
@@ -98,12 +96,6 @@ export default class Card extends Component {
 
   get isTutorialSaved() {
     return this.savingStatus !== buttonStatusTypes.unrecorded;
-  }
-
-  get linkRel() {
-    const tutorialUrl = new URL(this.args.tutorial.link);
-    const isKnownHost = tutorialUrl.host === Card.TUTORIAL_PIX_URL_HOST;
-    return isKnownHost ? null : 'noreferrer';
   }
 
   @action

--- a/mon-pix/tests/integration/components/tutorials/card-test.js
+++ b/mon-pix/tests/integration/components/tutorials/card-test.js
@@ -77,8 +77,8 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
     });
   });
 
-  module('link rel', function () {
-    test('should set rel="noreferrer" on external links', async function (assert) {
+  module('link referrer policy', function () {
+    test('should set referrerpolicy="strict-origin" on external links', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       this.set(
@@ -99,7 +99,7 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
 
       // then
       const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
-      assert.strictEqual(link.getAttribute('rel'), 'noreferrer');
+      assert.strictEqual(link.getAttribute('referrerpolicy'), 'strict-origin');
     });
 
     test('should not set rel="noreferrer" on internal links', async function (assert) {

--- a/mon-pix/tests/unit/components/tutorials/card-test.js
+++ b/mon-pix/tests/unit/components/tutorials/card-test.js
@@ -180,32 +180,6 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
     });
   });
 
-  module('#linkRel', function () {
-    test('should return noreferrer if unknown destination link', function (assert) {
-      // given
-      component = createGlimmerComponent('tutorials/card', { tutorial: { ...tutorial, link: 'https://exemple.net/' } });
-
-      // when
-      const result = component.linkRel;
-
-      // then
-      assert.strictEqual(result, 'noreferrer');
-    });
-
-    test('should return empty string if tutorial.pix.fr', function (assert) {
-      // given
-      component = createGlimmerComponent('tutorials/card', {
-        tutorial: { ...tutorial, link: 'https://tutorial.pix.fr:443/known-link' },
-      });
-
-      // when
-      const result = component.linkRel;
-
-      // then
-      assert.strictEqual(result, null);
-    });
-  });
-
   module('#trackAccess', function () {
     test('should push event on click', function (assert) {
       // given


### PR DESCRIPTION
## ❄️ Problème

Le site youtube-nocookie.com utilisé pour accéder aux vidéos de tutos Youtube ne fonctionne pas si aucun header HTTP `Referer` ne lui est envoyé.
Les liens de tutos externes ont l’attribut `rel="noreferrer"` qui empêche le positionnement du header HTTP `Referer`.

## 🛷 Proposition

Remplacer l’attribut `rel="noreferrer"` par [l’attribut `referrerpolicy="strict-origin"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy).

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller sur https://app-pr14312.review.pix.fr/mes-tutos/enregistres en se connectant avec `a@example.net` et `Pix12345`.
Cliquer sur le lien du tuto Youtube et vérifier que la vidéo s’affiche bien.