### PR TITLE
[TECH] :recycle: Renomme l'URL `end-assessment-by-supervisor` pour utiliser le terme `invigilator` (pix-20625)

### DIFF
--- a/api/src/certification/session-management/application/certification-candidate-route.js
+++ b/api/src/certification/session-management/application/certification-candidate-route.js
@@ -60,7 +60,7 @@ const register = async function (server) {
     },
     {
       method: 'PATCH',
-      path: '/api/certification-candidates/{certificationCandidateId}/end-assessment-by-supervisor',
+      path: '/api/certification-candidates/{certificationCandidateId}/end-assessment-by-invigilator',
       config: {
         pre: [
           {

--- a/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
@@ -118,7 +118,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
     });
   });
 
-  describe('PATCH /api/certification-candidates/{certificationCandidateId}/end-assessment-by-supervisor', function () {
+  describe('PATCH /api/certification-candidates/{certificationCandidateId}/end-assessment-by-invigilator', function () {
     context('when user is authenticated', function () {
       context('when the user is the invigilator of the session', function () {
         it('should return a 204 status code', async function () {
@@ -163,7 +163,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           await databaseBuilder.commit();
           const options = {
             method: 'PATCH',
-            url: `/api/certification-candidates/1001/end-assessment-by-supervisor`,
+            url: `/api/certification-candidates/1001/end-assessment-by-invigilator`,
             headers: generateAuthenticatedUserRequestHeaders({ userId: invigilatorUserId, source: 'pix-certif' }),
           };
 

--- a/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-candidate-route_test.js
@@ -84,7 +84,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
     });
   });
 
-  describe('PATCH certification-candidates/{certificationCandidateId}/end-assessment-by-supervisor', function () {
+  describe('PATCH certification-candidates/{certificationCandidateId}/end-assessment-by-invigilator', function () {
     it('should return 200 if the user is an invigilator of the session linked to the candidate', async function () {
       // given
       sinon
@@ -97,7 +97,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       // when
       const response = await httpTestServer.request(
         'PATCH',
-        '/api/certification-candidates/1/end-assessment-by-supervisor',
+        '/api/certification-candidates/1/end-assessment-by-invigilator',
       );
 
       // then
@@ -115,7 +115,7 @@ describe('Certification | Session Management | Unit | Application | Routes | Cer
       // when
       const response = await httpTestServer.request(
         'PATCH',
-        '/api/certification-candidates/1/end-assessment-by-supervisor',
+        '/api/certification-candidates/1/end-assessment-by-invigilator',
       );
 
       // then

--- a/certif/app/adapters/certification-candidate-for-supervising.js
+++ b/certif/app/adapters/certification-candidate-for-supervising.js
@@ -10,8 +10,8 @@ export default class CertificationCandidateForSupervisingAdapter extends Applica
       return `${this.host}/${this.namespace}/certification-candidates/${id}/authorize-to-resume`;
     }
 
-    if (requestType === 'endAssessmentBySupervisor') {
-      return `${this.host}/${this.namespace}/certification-candidates/${id}/end-assessment-by-supervisor`;
+    if (requestType === 'endAssessmentByInvigilator') {
+      return `${this.host}/${this.namespace}/certification-candidates/${id}/end-assessment-by-invigilator`;
     }
 
     return super.buildURL(modelName, id, snapshot, requestType, query);

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -281,7 +281,7 @@ export default class CandidateInList extends Component {
   async endAssessmentForCandidate() {
     this.closeConfirmationModal();
     try {
-      await this.args.onSupervisorEndAssessment(this.args.candidate);
+      await this.args.onInvigilatorEndAssessment(this.args.candidate);
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('pages.session-supervising.candidate-in-list.test-end-modal.success', {
           firstName: this.args.candidate.firstName,

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -36,7 +36,7 @@
             @candidate={{candidate}}
             @toggleCandidate={{this.toggleCandidate}}
             @onCandidateTestResumeAuthorization={{this.authorizeTestResume}}
-            @onSupervisorEndAssessment={{this.endAssessmentBySupervisor}}
+            @onInvigilatorEndAssessment={{this.endAssessmentByInvigilator}}
             @sessionId={{@sessionId}}
           />
         {{/each}}

--- a/certif/app/components/session-supervising/candidate-list.js
+++ b/certif/app/components/session-supervising/candidate-list.js
@@ -16,8 +16,8 @@ export default class CandidateList extends Component {
   }
 
   @action
-  async endAssessmentBySupervisor(candidate) {
-    await this.args.endAssessmentBySupervisor(candidate);
+  async endAssessmentByInvigilator(candidate) {
+    await this.args.endAssessmentByInvigilator(candidate);
   }
 
   @action

--- a/certif/app/controllers/session-supervising.js
+++ b/certif/app/controllers/session-supervising.js
@@ -19,8 +19,8 @@ export default class SessionSupervisingController extends Controller {
   }
 
   @action
-  async endAssessmentBySupervisor(candidate) {
-    await candidate.endAssessmentBySupervisor();
+  async endAssessmentByInvigilator(candidate) {
+    await candidate.endAssessmentByInvigilator();
   }
 
   @action

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -5,7 +5,7 @@ const assessmentStates = {
   COMPLETED: 'completed',
   STARTED: 'started',
   ABORTED: 'aborted',
-  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_BY_INVIGILATOR: 'endedBySupervisor',
 };
 
 export default class CertificationCandidateForSupervising extends Model {
@@ -33,7 +33,7 @@ export default class CertificationCandidateForSupervising extends Model {
   }
 
   get hasCompleted() {
-    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_SUPERVISOR].includes(this.assessmentStatus);
+    return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_INVIGILATOR].includes(this.assessmentStatus);
   }
 
   get hasOngoingChallengeLiveAlert() {
@@ -64,8 +64,8 @@ export default class CertificationCandidateForSupervising extends Model {
     urlType: 'authorizeToResume',
   });
 
-  endAssessmentBySupervisor = memberAction({
+  endAssessmentByInvigilator = memberAction({
     type: 'patch',
-    urlType: 'endAssessmentBySupervisor',
+    urlType: 'endAssessmentByInvigilator',
   });
 }

--- a/certif/app/templates/session-supervising.hbs
+++ b/certif/app/templates/session-supervising.hbs
@@ -4,7 +4,7 @@
   <SessionSupervising::Header @session={{@model}} @fetchInvigilatorKit={{this.fetchInvigilatorKit}} />
   <SessionSupervising::CandidateList
     @authorizeTestResume={{this.authorizeTestResume}}
-    @endAssessmentBySupervisor={{this.endAssessmentBySupervisor}}
+    @endAssessmentByInvigilator={{this.endAssessmentByInvigilator}}
     @toggleCandidate={{this.toggleCandidate}}
     @candidates={{@model.certificationCandidates}}
     @sessionId={{@model.id}}

--- a/certif/tests/unit/adapters/certification-candidate-for-supervising-test.js
+++ b/certif/tests/unit/adapters/certification-candidate-for-supervising-test.js
@@ -34,13 +34,13 @@ module('Unit | Adapters | certification-candidate-for-supervising', function (ho
       });
     });
 
-    module('when request type is endAssessmentBySupervisor', function () {
+    module('when request type is endAssessmentByInvigilator', function () {
       test('should build url', async function (assert) {
         // when
-        const url = await adapter.buildURL(undefined, 2, undefined, 'endAssessmentBySupervisor', undefined);
+        const url = await adapter.buildURL(undefined, 2, undefined, 'endAssessmentByInvigilator', undefined);
 
         // then
-        assert.true(url.endsWith('certification-candidates/2/end-assessment-by-supervisor'));
+        assert.true(url.endsWith('certification-candidates/2/end-assessment-by-invigilator'));
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/1b5adf00-82ce-4dda-a95a-988670a9b702" />

Ce qui tourne de la fin de session par le superviseur utilise encore le terme `supervisor`.

## 🛷 Proposition

Renommer l'URL `end-assessment-by-supervisor` et les éléments autour pour utiliser le terme `invigilator` 

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Ouvrir une session en tant que superviseur (dans pixcertif) ;
- Démarrer sur la session ouverte en tant que candidat (mon-pix) ;
- Terminer la session en tant que superviseur (dans pixcertif) ;

<img width="1591" height="604" alt="image" src="https://github.com/user-attachments/assets/bdf5ce04-7227-45ae-b507-6ae5e79352ae" />

<img width="1591" height="344" alt="image" src="https://github.com/user-attachments/assets/31aeba52-c573-4e99-b4a3-917689b882a3" />

