### PR TITLE
[TECH] Ajouter dans les seeds l'initialisation des valeurs de la table certification_sco_blocked_access_dates

### DIFF
--- a/api/db/seeds/data/team-certification/shared/setup-configuration.js
+++ b/api/db/seeds/data/team-certification/shared/setup-configuration.js
@@ -1,9 +1,11 @@
+import { buildDefaultScoBlockedAccessDates } from '../../../../database-builder/factory/build-sco-blocked-access-dates.js';
 import { createCertificationConfiguration } from '../tools/algorithm-configuration/create-certification-configuration.js';
 import { createIssueReportCategories } from '../tools/algorithm-configuration/create-issue-report-categories.js';
 
 export async function setupConfigurations({ databaseBuilder }) {
   await createCertificationConfiguration({ databaseBuilder });
   await createIssueReportCategories({ databaseBuilder });
+  buildDefaultScoBlockedAccessDates();
 
   await databaseBuilder.commit();
 }

--- a/api/db/seeds/data/team-certification/shared/setup-configuration.js
+++ b/api/db/seeds/data/team-certification/shared/setup-configuration.js
@@ -1,11 +1,9 @@
-import { buildDefaultScoBlockedAccessDates } from '../../../../database-builder/factory/build-sco-blocked-access-dates.js';
 import { createCertificationConfiguration } from '../tools/algorithm-configuration/create-certification-configuration.js';
 import { createIssueReportCategories } from '../tools/algorithm-configuration/create-issue-report-categories.js';
 
 export async function setupConfigurations({ databaseBuilder }) {
   await createCertificationConfiguration({ databaseBuilder });
   await createIssueReportCategories({ databaseBuilder });
-  buildDefaultScoBlockedAccessDates();
 
   await databaseBuilder.commit();
 }


### PR DESCRIPTION
## ❄️ Problème

La PR #14226 a créé la table ` certification_sco_blocked_access_dates`. L'API ne permet que l'édition et non la création de valeurs dans cette table, il est donc nécessaire que les seeds initialise les valeurs de cette table.

## 🛷 Proposition

Appeler dans les seed le database builder associé à cette table

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Vérifier qu'en lançant les seeds on retrouve dans la table des valeurs par défauts pour les tags COLLEGE et LYCEE
