### PR TITLE
[FEATURE] Suivi utilisation de l'oralisation en certification Pix (PIX-20378).

### DIFF
--- a/certif/app/components/sessions/session-details/enrolled-candidates/candidate-edition-modal.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/candidate-edition-modal.gjs
@@ -5,13 +5,26 @@ import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 export default class CandidateEditionModal extends Component {
+  @service pixMetrics;
+
   closeModal = () => {
     this.args.candidate.rollbackAttributes();
     this.args.closeModal();
+  };
+
+  handleFormSubmit = (event) => {
+    event.preventDefault();
+
+    this.args.updateCandidate();
+
+    if (this.args.candidate.accessibilityAdjustmentNeeded) {
+      this.pixMetrics.trackEvent('certifCandidateAccessibilityAdjustmentNeeded');
+    }
   };
 
   <template>
@@ -22,7 +35,7 @@ export default class CandidateEditionModal extends Component {
       @onCloseButtonClick={{this.closeModal}}
     >
       <:content>
-        <form id='edit-candidate-form' class='edit-candidate-modal__form' {{on 'submit' @updateCandidate}}>
+        <form id='edit-candidate-form' class='edit-candidate-modal__form' {{on 'submit' this.handleFormSubmit}}>
           <div class='edit-candidate-modal-form__disabled-fields'>
             <PixInput @id='last-name' autocomplete='off' disabled='true' value={{@candidate.lastName}}>
               <:label>{{t 'common.labels.candidate.birth-name'}}</:label>

--- a/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
+++ b/certif/app/components/sessions/session-details/enrolled-candidates/index.gjs
@@ -122,8 +122,7 @@ export default class EnrolledCandidates extends Component {
   }
 
   @action
-  async updateCandidate(event) {
-    event.preventDefault();
+  async updateCandidate() {
     try {
       const adapter = this.store.adapterFor('certification-candidate');
       await adapter.updateRecord({ candidate: this.certificationCandidateInEditModal, sessionId: this.args.sessionId });

--- a/certif/app/metrics-adapters/plausible-adapter.js
+++ b/certif/app/metrics-adapters/plausible-adapter.js
@@ -1,0 +1,52 @@
+import BaseAdapter from 'ember-metrics/metrics-adapters/base';
+
+export default class PlausibleAdapter extends BaseAdapter {
+  toStringExtension() {
+    return PlausibleAdapter.name;
+  }
+
+  install() {
+    const { siteId, scriptUrl } = this.config;
+
+    window.plausible =
+      window.plausible ||
+      function (...args) {
+        (window.plausible.q = window.plausible.q || []).push(args);
+      };
+
+    const scriptElement = document.createElement('script');
+    const firstScriptElement = document.getElementsByTagName('script')[0];
+    scriptElement.type = 'text/javascript';
+    scriptElement.defer = true;
+    scriptElement.async = true;
+    scriptElement.src = scriptUrl;
+    scriptElement.setAttribute('data-domain', siteId);
+    firstScriptElement.parentNode.insertBefore(scriptElement, firstScriptElement);
+  }
+
+  identify() {}
+
+  /**
+   * Custom events allow you to measure button clicks, form completions...
+   *
+   * @param {Object} params
+   * @param {string} params.eventName - must not contain spaces, examples: verify-this or That+Completion
+   * @param {Objects} params.props - event metadatas, must not contain any personally identifiable information
+   */
+  trackEvent({ eventName, plausibleAttributes = {}, ...props }) {
+    window.plausible(eventName, { ...plausibleAttributes, props });
+  }
+
+  trackPage({ plausibleAttributes = {}, ...props }) {
+    window.plausible('pageview', { ...plausibleAttributes, props });
+  }
+
+  alias() {}
+
+  uninstall() {
+    document.querySelectorAll('script[src*="plausible"]').forEach((el) => {
+      el.parentElement?.removeChild(el);
+    });
+    delete window.plausible;
+  }
+}

--- a/certif/app/services/pix-metrics.js
+++ b/certif/app/services/pix-metrics.js
@@ -1,0 +1,40 @@
+import Service, { service } from '@ember/service';
+
+export default class PixMetricsService extends Service {
+  @service metrics;
+  @service router;
+
+  trackEvent(eventName, { disabled, ...props } = {}) {
+    if (disabled) return;
+    const url = this.getRedactedPageUrl();
+    this.metrics.trackEvent({ eventName, plausibleAttributes: { u: url }, ...props });
+  }
+
+  trackPage(props) {
+    const url = this.getRedactedPageUrl();
+    this.metrics.trackPage({ plausibleAttributes: { u: url }, ...props });
+  }
+
+  getRedactedPageUrl() {
+    const params = extractParamsFromRouteInfo(this.router.currentRoute);
+    const currentUrl = this.router.currentURL;
+    if (!currentUrl) return null;
+
+    const [base, queryParams] = currentUrl.split('?');
+    if (!base) return null;
+
+    const redactedUrl = base
+      .split('/')
+      .map((token) => {
+        return params.includes(token) ? '_ID_' : token;
+      })
+      .join('/');
+    const baseUrl = new URL(window.location).origin;
+    return queryParams ? `${baseUrl}${redactedUrl}?${queryParams}` : `${baseUrl}${redactedUrl}`;
+  }
+}
+
+const extractParamsFromRouteInfo = (routeInfo = {}, params = []) =>
+  routeInfo?.parent
+    ? extractParamsFromRouteInfo(routeInfo.parent, params.concat(Object.values(routeInfo.params)))
+    : params;

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -12,6 +12,10 @@ function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue
   );
 }
 
+function _isFeatureEnabled(environmentVariable) {
+  return environmentVariable === 'true';
+}
+
 const ACTIVE_FEATURE_TOGGLES = [];
 
 module.exports = function (environment) {
@@ -109,6 +113,17 @@ module.exports = function (environment) {
     'ember-inputmask5': {
       defaults: { showMaskOnHover: false },
     },
+
+    metricsAdapters: [
+      {
+        name: 'PlausibleAdapter',
+        environments: _isFeatureEnabled(process.env.ANALYTICS_ENABLED) ? ['all'] : [],
+        config: {
+          siteId: process.env.ANALYTICS_SITE_ID,
+          scriptUrl: process.env.ANALYTICS_SCRIPT_URL,
+        },
+      },
+    ],
   };
 
   if (environment === 'test') {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -54,6 +54,7 @@
         "ember-keyboard": "^9.0.1",
         "ember-lifeline": "^7.0.0",
         "ember-load-initializers": "^3.0.1",
+        "ember-metrics": "^2.0.0",
         "ember-modifier": "^4.2.0",
         "ember-page-title": "^9.0.0",
         "ember-qunit": "^9.0.0",
@@ -23891,6 +23892,906 @@
       },
       "peerDependencies": {
         "ember-source": ">= 5"
+      }
+    },
+    "node_modules/ember-metrics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-metrics/-/ember-metrics-2.0.0.tgz",
+      "integrity": "sha512-r62LSNiivGKdhV7UOC9H9lmmApO/zaCnVo9BStVDkHTgcdzoq6iENft/ZDsCihQt3loevCi/BXb+DLffOBjKxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-funnel": "^3.0.2",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.1.1"
+      },
+      "engines": {
+        "node": "18.* || 20.* || >= 22"
+      },
+      "peerDependencies": {
+        "@ember/string": ">= 3.0.0",
+        "ember-source": ">= 3.28.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-babel-transpiler/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-babel/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.3.0.tgz",
+      "integrity": "sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-typescript/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/find-babel-config": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
+      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^1.0.2",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fixturify/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ember-metrics/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
       }
     },
     "node_modules/ember-modifier": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -93,6 +93,7 @@
     "ember-keyboard": "^9.0.1",
     "ember-lifeline": "^7.0.0",
     "ember-load-initializers": "^3.0.1",
+    "ember-metrics": "^2.0.0",
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^9.0.0",
     "ember-qunit": "^9.0.0",

--- a/certif/tests/unit/metrics-adapters/plausible-adapter-test.js
+++ b/certif/tests/unit/metrics-adapters/plausible-adapter-test.js
@@ -1,0 +1,103 @@
+import { setupTest } from 'ember-qunit';
+import PlausibleAdapter from 'pix-certif/metrics-adapters/plausible-adapter';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | MetricsAdapter | plausible-adapter', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    const config = {
+      scriptUrl: 'https://plausible.io/js/script.manual.js',
+      siteId: 'review.pix.fr',
+    };
+
+    this.adapter = new PlausibleAdapter(config);
+    this.adapter.install();
+  });
+
+  hooks.afterEach(function () {
+    this.adapter.uninstall();
+  });
+
+  test('#install installs container correctly', function (assert) {
+    const script = document.querySelector('script[src*="plausible"]');
+    assert.strictEqual(script.getAttribute('src'), 'https://plausible.io/js/script.manual.js');
+    assert.strictEqual(script.getAttribute('data-domain'), 'review.pix.fr');
+  });
+
+  test('#trackEvent calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackEvent({
+      'pix-event-category': 'button',
+      'pix-event-action': 'click',
+      eventName: 'nav buttons',
+      'pix-event-value': 4,
+    });
+    assert.ok(
+      stub.calledWith('nav buttons', {
+        props: {
+          'pix-event-category': 'button',
+          'pix-event-action': 'click',
+          'pix-event-value': 4,
+        },
+      }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackEvent calls Plausible with the overriden plausible props', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackEvent({
+      'pix-event-category': 'button',
+      'pix-event-action': 'click',
+      eventName: 'nav buttons',
+      'pix-event-value': 4,
+      plausibleAttributes: { u: 'hello' },
+    });
+    assert.ok(
+      stub.calledWith('nav buttons', {
+        u: 'hello',
+        props: {
+          'pix-event-category': 'button',
+          'pix-event-action': 'click',
+          'pix-event-value': 4,
+        },
+      }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackPage calls Plausible with the right arguments', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({
+      page: '/my-overridden-page?id=1',
+    });
+    sinon.assert.calledOnceWithExactly(stub, 'pageview', { props: { page: '/my-overridden-page?id=1' } });
+    assert.ok(
+      stub.calledWith('pageview', { props: { page: '/my-overridden-page?id=1' } }),
+      'it sends the correct arguments',
+    );
+  });
+
+  test('#trackPage calls Plausible with the overriden plausible props', function (assert) {
+    const stub = sinon.stub(window, 'plausible').callsFake(() => {
+      return true;
+    });
+
+    this.adapter.trackPage({ plausibleAttributes: { u: '/page/_ID_/test?id=1' }, page: 'page' });
+    assert.ok(
+      stub.calledWith('pageview', { u: '/page/_ID_/test?id=1', props: { page: 'page' } }),
+      'it sends the correct arguments',
+    );
+  });
+});

--- a/certif/tests/unit/services/pix-metrics-test.js
+++ b/certif/tests/unit/services/pix-metrics-test.js
@@ -1,0 +1,163 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | PixMetrics', function (hooks) {
+  setupTest(hooks);
+
+  let pixMetricsService;
+  let metricsService;
+  let routerService;
+
+  hooks.beforeEach(function () {
+    pixMetricsService = this.owner.lookup('service:pix-metrics');
+    metricsService = this.owner.lookup('service:metrics');
+    routerService = this.owner.lookup('service:router');
+    sinon.stub(metricsService, 'trackPage');
+    sinon.stub(metricsService, 'trackEvent');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('trackPage', function () {
+    test('it should redact id from url', function (assert) {
+      // given
+      const currentURL = '/campagnes/SCOASSMUL/presentation';
+      const currentRoute = {
+        name: 'campaigns.campaign-landing-page',
+        params: {},
+        parent: {
+          name: 'campaigns',
+          params: {
+            id: 'SCOASSMUL',
+          },
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackPage({ params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+
+    test('it should forward query parameters', function (assert) {
+      // given
+      const currentURL = '/assessments/1234/checkpoint?finalCheckpoint=true';
+      const currentRoute = {
+        name: 'assessments.checkpoint',
+        params: {},
+        parent: {
+          name: 'assessments',
+          params: {
+            id: '1234',
+          },
+
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackPage({ params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackPage, {
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('trackEvent', function () {
+    test('it should redact id from url', function (assert) {
+      // given
+      const currentURL = '/campagnes/SCOASSMUL/presentation';
+      const currentRoute = {
+        name: 'campaigns.campaign-landing-page',
+        params: {},
+        parent: {
+          name: 'campaigns',
+          params: {
+            id: 'SCOASSMUL',
+          },
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
+        eventName: 'mon-event',
+        plausibleAttributes: { u: `${new URL(window.location).origin}/campagnes/_ID_/presentation` },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+
+    test('it should forward query parameters', function (assert) {
+      // given
+      const currentURL = '/assessments/1234/checkpoint?finalCheckpoint=true';
+      const currentRoute = {
+        name: 'assessments.checkpoint',
+        params: {},
+        parent: {
+          name: 'assessments',
+          params: {
+            id: '1234',
+          },
+
+          parent: {
+            name: 'application',
+            params: {},
+            parent: null,
+          },
+        },
+      };
+      sinon.stub(routerService, 'currentRoute').value(currentRoute);
+      sinon.stub(routerService, 'currentURL').value(currentURL);
+
+      // when
+      pixMetricsService.trackEvent('mon-event', { params: 1 });
+
+      // then
+      sinon.assert.calledOnceWithExactly(metricsService.trackEvent, {
+        eventName: 'mon-event',
+        plausibleAttributes: {
+          u: `${new URL(window.location).origin}/assessments/_ID_/checkpoint?finalCheckpoint=true`,
+        },
+        params: 1,
+      });
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/app/components/challenge-statement.gjs
+++ b/mon-pix/app/components/challenge-statement.gjs
@@ -16,6 +16,9 @@ import MarkdownToHtml from 'mon-pix/components/markdown-to-html';
 import MarkdownToHtmlUnsafe from 'mon-pix/components/markdown-to-html-unsafe';
 import ENV from 'mon-pix/config/environment';
 import extractExtension from 'mon-pix/helpers/extract-extension';
+import { SessionStorageEntry } from 'mon-pix/utils/session-storage-entry';
+
+const certifCandidateStorage = new SessionStorageEntry('certifCandidateStorage');
 
 const PREFERRED_ATTACHMENT_FORMATS = ['docx', 'xlsx', 'pptx'];
 
@@ -199,12 +202,12 @@ export default class ChallengeStatement extends Component {
   }
 
   get showTextToSpeechButton() {
-    const certificationCourse = this.args.assessment.belongsTo('certificationCourse').value();
-
     const isTextToSpeechFeatureActivated =
       window.speechSynthesis &&
       this.featureToggles.featureToggles?.isTextToSpeechButtonEnabled &&
       this.args.isTextToSpeechActivated;
+
+    const certificationCourse = this.args.assessment.belongsTo('certificationCourse').value();
 
     const shouldShowInAssessment =
       !this.args.assessment.isCertification || certificationCourse?.isAdjustedForAccessibility;
@@ -262,6 +265,13 @@ export default class ChallengeStatement extends Component {
       category: 'Vocalisation',
       action: "Lecture d'une épreuve",
     });
+
+    if (this.args.assessment.isCertification) {
+      if (!certifCandidateStorage.get()) {
+        this.pixMetrics.trackEvent('certifChallengeTextToSpeech');
+        certifCandidateStorage.set('certifChallengeTextToSpeech');
+      }
+    }
   }
 
   stopTextToSpeechOnLeaveOrRefresh() {


### PR DESCRIPTION
> [!NOTE]
> Y a beaucoup de lignes, mais c'est juste à cause du package-lock.json 

## ❄️ Problème

Nous venons de lancer une nouvelle fonctionnalité : le MVP de l’oralisation de la certification Pix coeur.

Nous ne savons pas à quel point ce MVP sera utilisé ni quelle proportion des demandes de tests aménagés seront concernés par ce besoin.

## 🛷 Proposition

On souhaite suivre via Plausible du nombre de cases de demandes de tests aménagées cochées et le comparer au nombre d'activations de l'option d'oralisation (traduite par au moins un clic sur le bouton lecture mis à disposition des candidats inscrits en test aménagé).

## ☃️ Remarques

- Plausible n'était pas encore ajouté sur PixCertif, un commit de cette PR est dédiée à cela.

- Le session storage a été utilisé pour garder en mémoire la première activation de vocalisation d'un utilisateur.

- Les deux événements ont été créés sur Plausible : 

<img width="587" height="186" alt="image" src="https://github.com/user-attachments/assets/38132076-7d03-472f-b171-bf52bd557eeb" />


## 🧑‍🎄 Pour tester

- Sur Firefox, il faut désactiver toutes les protections de base du navigateur

<img width="1008" height="840" alt="image" src="https://github.com/user-attachments/assets/6790adf8-54f7-420d-939e-415d0e7401ed" />


- Reproduire les 2 événements ciblés
- Sur Plausible, les events devraient remonter
 
<img width="1088" height="233" alt="image" src="https://github.com/user-attachments/assets/67b194c9-bb6d-48c3-9327-213886ee9e70" />

