### PR TITLE
[FEATURE] Rediriger vers la page de l'orga mère lors de l'annulation de la création d'une orga fille sur Pix Admin (PIX-20560)

### DIFF
--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -15,7 +15,10 @@ export default class NewController extends Controller {
   @tracked parentOrganizationName = null;
 
   @action
-  goBackToOrganizationList() {
+  redirectOnCancel() {
+    if (this.parentOrganizationId) {
+      return this.router.transitionTo('authenticated.organizations.get.children', this.parentOrganizationId);
+    }
     this.router.transitionTo('authenticated.organizations');
   }
 

--- a/admin/app/templates/authenticated/organizations/new.hbs
+++ b/admin/app/templates/authenticated/organizations/new.hbs
@@ -13,7 +13,7 @@
     @administrationTeams={{@model.administrationTeams}}
     @countries={{@model.countries}}
     @onSubmit={{this.addOrganization}}
-    @onCancel={{this.goBackToOrganizationList}}
+    @onCancel={{this.redirectOnCancel}}
     @parentOrganizationName={{this.parentOrganizationName}}
   />
 </main>

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -38,13 +38,28 @@ module('Acceptance | Organizations | Create', function (hooks) {
       assert.dom(screen.getByText('Nouvelle organisation')).exists();
       assert.dom(screen.getByRole('button', { name: this.intl.t('common.actions.add') })).exists();
     });
+
+    test('it redirects the user to organizations list when cancelling', async function (assert) {
+      // given
+      const screen = await visit('/organizations/new');
+
+      // when
+      const cancelButton = await screen.getByRole('button', { name: this.intl.t('common.actions.cancel') });
+      await click(cancelButton);
+
+      // then
+      assert.strictEqual(currentURL(), '/organizations/list');
+    });
   });
 
-  module('when creating an organization with a parent organization', function () {
-    test('it shows the creation form with parent organization name', async function (assert) {
-      // given
-      const parentOrganization = server.create('organization', { name: 'Wayne Enterprises' });
+  module('when creating an organization with a parent organization', function (hooks) {
+    let parentOrganization;
 
+    hooks.beforeEach(function () {
+      parentOrganization = server.create('organization', { name: 'Wayne Enterprises' });
+    });
+
+    test('it shows the creation form with parent organization name', async function (assert) {
       // when
       const screen = await visit(
         `/organizations/new?parentOrganizationId=${parentOrganization.id}&parentOrganizationName=${encodeURIComponent(
@@ -71,6 +86,21 @@ module('Acceptance | Organizations | Create', function (hooks) {
           }),
         )
         .exists();
+    });
+
+    test('it redirects the user to parent organization page when cancelling', async function (assert) {
+      // given
+      const screen = await visit(
+        `/organizations/new?parentOrganizationId=${parentOrganization.id}&parentOrganizationName=${encodeURIComponent(
+          parentOrganization.name,
+        )}`,
+      );
+      // when
+      const cancelButton = await screen.getByRole('button', { name: this.intl.t('common.actions.cancel') });
+      await click(cancelButton);
+
+      // then
+      assert.strictEqual(currentURL(), `/organizations/${parentOrganization.id}/children`);
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

Actuellement sur Pix Admin, lorsqu'on est sur la page de création d'une organisation et qu'on clique sur "Annuler", on est redirigé vers la liste des organisations. Mais dans le cas de la création d'une orga fille, on est arrivé sur cette page via le bouton **"Créer une organisation fille"** de l'orga mère. Le fait d'être redirigé vers la page de toutes les orgas risque donc de créer une rupture dans le parcours utilisateur.

## 🛷 Proposition

Dans le cas de la création d'une orga fille, rediriger l'utilisateur vers la page de l'organisation mère lorsuq'on annule.

## ☃️ Remarques

Ajout d'un test de redirection à l'annulation dans les deux cas: création d'orga classique et création d'orga fille

## 🧑‍🎄 Pour tester

Sur Pix Admin, en tant que _SuperAdmin_:
- aller sur la page d'une orga, dans l'onglet **Organisations filles**
- cliquer sur **Créer une organisation fille**
- annuler la création
- constater qu'on est bien redirigé vers la page de l'orga mère

Pour vérifier la non-régression:
- aller sur la page des toutes les orgas
- cliquer sur **Nouvelle organisation**
- annuler la création
- constater qu'on est bien redirigé vers la liste des orgas
