### PR TITLE
[FEATURE] Ajouter la locale es-419 dans le locale switcher (pix-20627)

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -41,7 +41,7 @@ module.exports = function (environment) {
       SUPPORTED_LOCALES: [
         { value: 'en', nativeName: 'English', displayedInSwitcher: true },
         { value: 'es', nativeName: 'Español', displayedInSwitcher: false },
-        { value: 'es-419', nativeName: 'Español (Latinoamérica)', displayedInSwitcher: false },
+        { value: 'es-419', nativeName: 'Español (Latinoamérica y el Caribe)', displayedInSwitcher: true },
         { value: 'fr', nativeName: 'Français', displayedInSwitcher: true },
         { value: 'fr-FR', nativeName: 'Français (France)', displayedInSwitcher: false },
         { value: 'fr-BE', nativeName: 'Français (Belgique)', displayedInSwitcher: true },

--- a/mon-pix/tests/unit/services/locale-test.js
+++ b/mon-pix/tests/unit/services/locale-test.js
@@ -330,6 +330,10 @@ module('Unit | Services | locale', function (hooks) {
           value: 'en',
         },
         {
+          label: 'Español (Latinoamérica y el Caribe)',
+          value: 'es-419',
+        },
+        {
           label: 'Français',
           value: 'fr',
         },


### PR DESCRIPTION
## ❄️ Problème

Il faut ajouter la locale es-419 dans le locale switcher

## 🛷 Proposition

La valeur à afficher dans le locale switcher : 
Si ça passe complétement → Español (Latinoamérica y el Caribe) :heavy_check_mark: 
Sinon on réduit et on affiche → Español (Latinoamérica)

## ☃️ Remarques



## 🧑‍🎄 Pour tester

Aller sur [pix app (domaine .org)](https://app-pr14319.review.pix.org/), vérifier la présence de Español (Latinoamérica y el Caribe) dans le locale switcher, changer la locale (vers es-419 et retour) pour vérifier que tout fonctionne.
