### PR TITLE
[FEATURE] Modifier les urls des modules dans la table trainings (PIX-20389)

### DIFF
--- a/api/scripts/modulix/update-modulix-trainings-link.js
+++ b/api/scripts/modulix/update-modulix-trainings-link.js
@@ -7,7 +7,7 @@ import { ScriptRunner } from '../../src/shared/application/scripts/script-runner
 export class UpdateModulixTrainingsLink extends Script {
   constructor() {
     super({
-      description: 'Update Modulix training link',
+      description: 'Update Modulix training link and remove tmp from slug',
       permanent: false,
       options: {
         dryRun: {
@@ -33,7 +33,8 @@ export class UpdateModulixTrainingsLink extends Script {
           link: training.link,
           moduleRepository: repositories.moduleRepository,
         });
-        const newLink = `${splittedLink[0]}modules/${module.shortId}${splittedLink[1]}`;
+        const tmpSlug = splittedLink[1].split('tmp-');
+        const newLink = `${splittedLink[0]}modules/${module.shortId}${tmpSlug.join('')}`;
         await trx('trainings').update({ link: newLink, updatedAt: new Date() }).where({ id: training.id });
       }
 
@@ -49,7 +50,6 @@ export class UpdateModulixTrainingsLink extends Script {
 
       await trx.commit();
       logger.info(`${trainingsToBeUpdated.length} trainings have been successfully updated`);
-      return;
     } catch (error) {
       await trx.rollback();
       throw error;

--- a/api/scripts/modulix/update-modulix-trainings-link.js
+++ b/api/scripts/modulix/update-modulix-trainings-link.js
@@ -1,0 +1,60 @@
+import { knex } from '../../db/knex-database-connection.js';
+import moduleService from '../../src/devcomp/domain/services/module-service.js';
+import { repositories } from '../../src/devcomp/infrastructure/repositories/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+
+export class UpdateModulixTrainingsLink extends Script {
+  constructor() {
+    super({
+      description: 'Update Modulix training link',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: false,
+        },
+      },
+    });
+  }
+
+  async handle({ logger, options }) {
+    const { dryRun } = options;
+    logger.info('Script execution started');
+
+    const trx = await knex.transaction();
+    try {
+      const trainingsToBeUpdated = await trx('trainings').whereLike('link', `%/modules/%`).andWhere('type', 'modulix');
+
+      for (const training of trainingsToBeUpdated) {
+        const splittedLink = training.link.split('modules');
+        const module = await moduleService.getModuleByLink({
+          link: training.link,
+          moduleRepository: repositories.moduleRepository,
+        });
+        const newLink = `${splittedLink[0]}modules/${module.shortId}${splittedLink[1]}`;
+        await trx('trainings').update({ link: newLink, updatedAt: new Date() }).where({ id: training.id });
+      }
+
+      if (dryRun) {
+        const training = await trx('trainings').whereLike('link', `%/modules/%`).andWhere('type', 'modulix').first();
+
+        logger.info(`Training link after update : ${training.link}`);
+        await trx.rollback();
+
+        logger.info(`${trainingsToBeUpdated.length} training(s) should have been updated`);
+        return;
+      }
+
+      await trx.commit();
+      logger.info(`${trainingsToBeUpdated.length} trainings have been successfully updated`);
+      return;
+    } catch (error) {
+      await trx.rollback();
+      throw error;
+    }
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, UpdateModulixTrainingsLink);

--- a/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
+++ b/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
@@ -40,7 +40,7 @@ describe('integration | modulix | scripts | UpdateModulixTrainingsLink', functio
       expect(logger.info).to.have.been.calledWith('1 training(s) should have been updated');
 
       expect(logger.info).to.have.been.calledWith(
-        'Training link after update : https://app.pix.fr/modules/4eacd0c3/tmp-prompt-intermediaire',
+        'Training link after update : https://app.pix.fr/modules/4eacd0c3/prompt-intermediaire',
       );
 
       const trainings = await knex('trainings').orderBy('id');
@@ -86,7 +86,7 @@ describe('integration | modulix | scripts | UpdateModulixTrainingsLink', functio
       // then
       const trainings = await knex('trainings').orderBy('id');
 
-      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/4eacd0c3/tmp-prompt-intermediaire');
+      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/4eacd0c3/prompt-intermediaire');
       expect(trainings[0].updatedAt).to.deep.equal(now);
 
       expect(trainings[1].link).to.equal('https://app.pix.fr/modules/6a68bf32/bac-a-sable/details');

--- a/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
+++ b/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
@@ -1,0 +1,102 @@
+import { UpdateModulixTrainingsLink } from '../../../../scripts/modulix/update-modulix-trainings-link.js';
+import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+
+describe('integration | modulix | scripts | UpdateModulixTrainingsLink', function () {
+  describe('#handle', function () {
+    let file;
+    let script;
+    let logger;
+    let clock;
+    let now;
+
+    beforeEach(function () {
+      now = new Date('2025-10-10');
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+      script = new UpdateModulixTrainingsLink();
+      logger = { info: sinon.spy() };
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('runs the script with dryRun', async function () {
+      // given
+      databaseBuilder.factory.buildTraining({
+        id: 1,
+        link: `https://app.pix.fr/modules/tmp-prompt-intermediaire`,
+        updatedAt: new Date('2020-09-10'),
+        type: 'modulix',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file, dryRun: true },
+        logger,
+      });
+
+      // then
+      expect(logger.info).to.have.been.calledWith('1 training(s) should have been updated');
+
+      expect(logger.info).to.have.been.calledWith(
+        'Training link after update : https://app.pix.fr/modules/4eacd0c3/tmp-prompt-intermediaire',
+      );
+
+      const trainings = await knex('trainings').orderBy('id');
+
+      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/tmp-prompt-intermediaire');
+      expect(trainings[0].updatedAt).to.deep.equal(new Date('2020-09-10'));
+    });
+
+    it('update modulix trainings link', async function () {
+      // given
+      databaseBuilder.factory.buildTraining({
+        id: 1,
+        link: `https://app.pix.fr/modules/tmp-prompt-intermediaire`,
+        updatedAt: new Date('2020-09-10'),
+        type: 'modulix',
+      });
+      databaseBuilder.factory.buildTraining({
+        id: 2,
+        link: `https://app.pix.fr/modules/bac-a-sable/details`,
+        updatedAt: new Date('2021-10-10'),
+        type: 'modulix',
+      });
+      databaseBuilder.factory.buildTraining({
+        id: 3,
+        link: 'https://app.pix.fr/campagnes/SJKQSDHQD',
+        updatedAt: new Date('2022-10-10'),
+        type: 'modulix',
+      });
+      databaseBuilder.factory.buildTraining({
+        id: 4,
+        link: 'https://app.pix.fr/modules/galerie',
+        updatedAt: new Date('2023-10-10'),
+        type: 'webinaire',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({
+        options: { file },
+        logger,
+      });
+
+      // then
+      const trainings = await knex('trainings').orderBy('id');
+
+      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/4eacd0c3/tmp-prompt-intermediaire');
+      expect(trainings[0].updatedAt).to.deep.equal(now);
+
+      expect(trainings[1].link).to.equal('https://app.pix.fr/modules/6a68bf32/bac-a-sable/details');
+      expect(trainings[1].updatedAt).to.deep.equal(now);
+
+      expect(trainings[2].link).to.equal('https://app.pix.fr/campagnes/SJKQSDHQD');
+      expect(trainings[2].updatedAt).to.deep.equal(new Date('2022-10-10'));
+
+      expect(trainings[3].link).to.equal('https://app.pix.fr/modules/galerie');
+      expect(trainings[3].updatedAt).to.deep.equal(new Date('2023-10-10'));
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème
Dans le cadre de l'ajout des shortId dans les url des modules, il faut mettre à jour les `link` de la table training. 

## 🛷 Proposition
Faire un script de reprise de données.

## ☃️ Remarques
On en a profité pour retirer le "tmp" des slugs en vue de la généralisation en 2026.

## 🧑‍🎄 Pour tester
Lancer le script 

```shell
LOG_LEVEL=info LOG_ENABLED=true  node api/scripts/modulix/update-modulix-trainings-link.js
``` 

et constater que les urls de la colonne `link` sont bien mises à jour dans la table trainings sous la forme : 

```javascript
 // avant le script
const link =  'http://app.pix.fr/modules/tmp-mon-super-module';
 
// après le script
const link =  'http://app.pix.fr/modules/<shortId>/mon-super-module';
```