### PR TITLE
[FEATURE] Améliorer le créateur de parcours combiné sur Admin (PIX-20654).

### DIFF
--- a/admin/app/components/combined-courses/form.gjs
+++ b/admin/app/components/combined-courses/form.gjs
@@ -19,7 +19,7 @@ export default class CombineCourseForm extends Component {
 
   @tracked combinedCourseItems = [];
   @tracked itemId = null;
-  @tracked itemType = 'campaign';
+  @tracked itemType = 'targetProfile';
   @tracked name = '';
   @tracked illustration = '';
   @tracked description = '';
@@ -29,8 +29,8 @@ export default class CombineCourseForm extends Component {
   @action
   addItem(event) {
     event.preventDefault();
-    if (this.itemType === 'campaign') {
-      this.addCampaign();
+    if (this.itemType === 'targetProfile') {
+      this.addTargetProfile();
     } else {
       this.addModule();
     }
@@ -38,7 +38,7 @@ export default class CombineCourseForm extends Component {
     document.getElementsByName('itemType')[0].focus();
   }
 
-  addCampaign() {
+  addTargetProfile() {
     this.combinedCourseItems = [
       ...this.combinedCourseItems,
       {
@@ -83,14 +83,18 @@ export default class CombineCourseForm extends Component {
       exportLink.setAttribute('download', `${this.name}.csv`);
       exportLink.click();
 
-      console.log(csvContent);
-    } catch (e) {
-      console.error(e);
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t('components.combined-courses.create-form.notifications.success'),
+      });
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t('components.combined-courses.create-form.notifications.error'),
+      });
     }
   }
 
   getItemType(item) {
-    return item.type === 'campaignParticipations' ? 'campaign' : 'module';
+    return item.type === 'campaignParticipations' ? 'targetProfile' : 'module';
   }
 
   getItemValue(item) {
@@ -116,36 +120,55 @@ export default class CombineCourseForm extends Component {
 
   <template>
     <PixBlock @variant="admin" class="combined-course-page">
-      <h1 class="combined-course-page__title"> {{t "common.components.combined-courses.create-form.title"}}</h1>
 
       <form class="combined-course-page__form">
-        <PixInput
-          @id="organizationIds"
-          @value={{this.organizationIds}}
-          @requiredLabel="Champ obligatoire"
-          {{on "change" (fn this.setData "organizationIds")}}
-          class="combined-course-page__input"
-        >
-          <:label>
-            {{t "common.components.combined-courses.create-form.labels.organizationsList"}}
-          </:label>
-          <:subLabel>
-            {{t "common.components.combined-courses.create-form.labels.organizationsListSubLabel"}}
-          </:subLabel>
-        </PixInput>
+        <h1 class="combined-course-page__title"> {{t "components.combined-courses.create-form.title"}}</h1>
 
-        <PixInput
-          @id="creatorId"
-          @value={{this.creatorId}}
-          @requiredLabel="Champ obligatoire"
-          {{on "change" (fn this.setData "creatorId")}}
-          class="combined-course-page__input"
-        >
-          <:label>
-            {{t "common.components.combined-courses.create-form.labels.creatorId"}}
-          </:label>
-        </PixInput>
+        <PixFieldset>
+          <:title>
+            {{t "components.combined-courses.create-form.fieldsetElement"}}
+          </:title>
+          <:content>
+            <div class="combined-course-page__fieldset">
+              <PixRadioButton
+                name="itemType"
+                @value="targetProfile"
+                checked={{if (eq this.itemType "targetProfile") "checked"}}
+                {{on "change" (fn this.setData "itemType")}}
+              >
+                <:label>{{t "components.combined-courses.create-form.labels.target-profile"}}</:label>
+              </PixRadioButton>
+              <PixRadioButton
+                name="itemType"
+                checked={{if (eq this.itemType "module") "checked"}}
+                @value="module"
+                {{on "change" (fn this.setData "itemType")}}
+              >
+                <:label>{{t "components.combined-courses.create-form.labels.module"}}</:label>
+              </PixRadioButton>
+            </div>
+          </:content>
+        </PixFieldset>
 
+        <div class="combined-course-page__form-addItem">
+          <PixInput
+            @id="itemId"
+            @value={{this.itemId}}
+            @requiredLabel="Champ obligatoire"
+            {{on "change" (fn this.setData "itemId")}}
+            {{on "keyup" this.handleKeyPress}}
+            class="combined-course-page__input"
+          >
+            <:label>
+              {{t "components.combined-courses.create-form.labels.itemId"}}
+            </:label>
+          </PixInput>
+
+          <PixButton @triggerAction={{this.addItem}} class="combined-course-page__button">{{t
+              "components.combined-courses.create-form.addItemButton"
+            }}</PixButton>
+        </div>
+        <hr class="combined-course-page__separator" />
         <PixInput
           @id="name"
           @value={{this.name}}
@@ -154,7 +177,7 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            {{t "common.components.combined-courses.create-form.labels.name"}}
+            {{t "components.combined-courses.create-form.labels.name"}}
           </:label>
         </PixInput>
 
@@ -166,7 +189,7 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            {{t "common.components.combined-courses.create-form.labels.illustration"}}
+            {{t "components.combined-courses.create-form.labels.illustration"}}
 
           </:label>
         </PixInput>
@@ -177,78 +200,68 @@ export default class CombineCourseForm extends Component {
           @requiredLabel="Champ obligatoire"
           {{on "change" (fn this.setData "description")}}
           class="combined-course-page__input"
+          rows="10"
         >
           <:label>
-            {{t "common.components.combined-courses.create-form.labels.description"}}
+            {{t "components.combined-courses.create-form.labels.description"}}
 
           </:label>
         </PixTextarea>
 
-        <PixFieldset>
-          <:title>
-            {{t "common.components.combined-courses.create-form.fieldsetElement"}}
-          </:title>
-          <:content>
-            <PixRadioButton
-              name="itemType"
-              @value="campaign"
-              checked={{if (eq this.itemType "campaign") "checked"}}
-              {{on "change" (fn this.setData "itemType")}}
-            >
-              <:label>{{t "common.components.combined-courses.create-form.label.campaign"}}</:label>
-            </PixRadioButton>
-            <PixRadioButton
-              name="itemType"
-              checked={{if (eq this.itemType "module") "checked"}}
-              @value="module"
-              {{on "change" (fn this.setData "itemType")}}
-            >
-              <:label> {{t "common.components.combined-courses.create-form.label.module"}}</:label>
-            </PixRadioButton>
-          </:content>
-        </PixFieldset>
+        <hr class="combined-course-page__separator" />
 
         <PixInput
-          @id="itemId"
-          @value={{this.itemId}}
+          @id="organizationIds"
+          @value={{this.organizationIds}}
           @requiredLabel="Champ obligatoire"
-          {{on "change" (fn this.setData "itemId")}}
-          {{on "keyup" this.handleKeyPress}}
+          {{on "change" (fn this.setData "organizationIds")}}
           class="combined-course-page__input"
         >
           <:label>
-            {{t "common.components.combined-courses.create-form.label.itemId"}}
+            {{t "components.combined-courses.create-form.labels.organizationsList"}}
+          </:label>
+          <:subLabel>
+            {{t "components.combined-courses.create-form.labels.organizationsListSubLabel"}}
+          </:subLabel>
+        </PixInput>
+
+        <PixInput
+          @id="creatorId"
+          @value={{this.creatorId}}
+          @requiredLabel="Champ obligatoire"
+          {{on "change" (fn this.setData "creatorId")}}
+          class="combined-course-page__input"
+        >
+          <:label>
+            {{t "components.combined-courses.create-form.labels.creatorId"}}
           </:label>
         </PixInput>
 
-        <PixButton @triggerAction={{this.addItem}} class="combined-course-page__button">{{t
-            "common.components.combined-courses.create-form.addItemButton"
-          }}</PixButton>
       </form>
 
-      <hr class="combined-course-page__separator" />
+      <div class="combined-course-page__items">
+        <h2 class="combined-course-page__title">
+          {{t "components.combined-courses.create-form.courseContent"}}</h2>
 
-      <h2 class="combined-course-page__title">
-        {{t "common.components.combined-courses.create-form.label.courseContent"}}</h2>
+        {{#if (gt this.combinedCourseItems.length 0)}}
+          <ul class="combined-course-page__list">
+            {{#each this.combinedCourseItems as |item|}}
+              <li class="combined-course-page__list-item"><PixTag @color={{this.getItemColor item}}>
+                  {{this.getItemType item}}
+                  -
+                  {{this.getItemValue item}}
+                </PixTag>
+              </li>
+            {{/each}}
+          </ul>
+        {{else}}
+          <p> {{t "components.combined-courses.create-form.contentFeedback"}}</p>
+        {{/if}}
 
-      {{#if (gt this.combinedCourseItems.length 0)}}
-        <ul class="combined-course-page__list">
-          {{#each this.combinedCourseItems as |item|}}
-            <li class="combined-course-page__list-item"><PixTag @color={{this.getItemColor item}}>
-                {{this.getItemType item}}
-                -
-                {{this.getItemValue item}}
-              </PixTag>
-            </li>
-          {{/each}}
-        </ul>
-      {{else}}
-        <p> {{t "common.components.combined-courses.create-form.contentFeedback"}}</p>
-      {{/if}}
-
-      <PixButton class="combined-course-page__button" @triggerAction={{this.downloadCSV}} @variant="success">{{t
-          "common.components.combined-courses.create-form.downloadButton"
-        }}</PixButton>
+        <PixButton class="combined-course-page__button" @triggerAction={{this.downloadCSV}} @variant="success">{{t
+            "components.combined-courses.create-form.downloadButton"
+          }}</PixButton>
+      </div>
     </PixBlock>
   </template>
 }

--- a/admin/app/components/combined-courses/form.gjs
+++ b/admin/app/components/combined-courses/form.gjs
@@ -10,6 +10,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import { eq, gt } from 'ember-truth-helpers';
 import PixFieldset from 'pix-admin/components/ui/pix-fieldset';
 
@@ -115,7 +116,7 @@ export default class CombineCourseForm extends Component {
 
   <template>
     <PixBlock @variant="admin" class="combined-course-page">
-      <h1 class="combined-course-page__title">Créateur de parcours</h1>
+      <h1 class="combined-course-page__title"> {{t "common.components.combined-courses.create-form.title"}}</h1>
 
       <form class="combined-course-page__form">
         <PixInput
@@ -126,10 +127,10 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            liste des organisations
+            {{t "common.components.combined-courses.create-form.labels.organizationsList"}}
           </:label>
           <:subLabel>
-            (ids séparés par des virgules)
+            {{t "common.components.combined-courses.create-form.labels.organizationsListSubLabel"}}
           </:subLabel>
         </PixInput>
 
@@ -141,7 +142,7 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            Identifiant du créateur
+            {{t "common.components.combined-courses.create-form.labels.creatorId"}}
           </:label>
         </PixInput>
 
@@ -153,7 +154,7 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            Nom
+            {{t "common.components.combined-courses.create-form.labels.name"}}
           </:label>
         </PixInput>
 
@@ -165,7 +166,8 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            Illustration
+            {{t "common.components.combined-courses.create-form.labels.illustration"}}
+
           </:label>
         </PixInput>
 
@@ -177,12 +179,15 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            Description
+            {{t "common.components.combined-courses.create-form.labels.description"}}
+
           </:label>
         </PixTextarea>
 
         <PixFieldset>
-          <:title>Choisissez le type d'élément à ajouter :</:title>
+          <:title>
+            {{t "common.components.combined-courses.create-form.fieldsetElement"}}
+          </:title>
           <:content>
             <PixRadioButton
               name="itemType"
@@ -190,7 +195,7 @@ export default class CombineCourseForm extends Component {
               checked={{if (eq this.itemType "campaign") "checked"}}
               {{on "change" (fn this.setData "itemType")}}
             >
-              <:label>Campagne</:label>
+              <:label>{{t "common.components.combined-courses.create-form.label.campaign"}}</:label>
             </PixRadioButton>
             <PixRadioButton
               name="itemType"
@@ -198,7 +203,7 @@ export default class CombineCourseForm extends Component {
               @value="module"
               {{on "change" (fn this.setData "itemType")}}
             >
-              <:label>Module</:label>
+              <:label> {{t "common.components.combined-courses.create-form.label.module"}}</:label>
             </PixRadioButton>
           </:content>
         </PixFieldset>
@@ -212,16 +217,19 @@ export default class CombineCourseForm extends Component {
           class="combined-course-page__input"
         >
           <:label>
-            Identifiant
+            {{t "common.components.combined-courses.create-form.label.itemId"}}
           </:label>
         </PixInput>
 
-        <PixButton @triggerAction={{this.addItem}} class="combined-course-page__button">Ajouter un item</PixButton>
+        <PixButton @triggerAction={{this.addItem}} class="combined-course-page__button">{{t
+            "common.components.combined-courses.create-form.addItemButton"
+          }}</PixButton>
       </form>
 
       <hr class="combined-course-page__separator" />
 
-      <h2 class="combined-course-page__title">Contenu du parcours tout court</h2>
+      <h2 class="combined-course-page__title">
+        {{t "common.components.combined-courses.create-form.label.courseContent"}}</h2>
 
       {{#if (gt this.combinedCourseItems.length 0)}}
         <ul class="combined-course-page__list">
@@ -235,11 +243,12 @@ export default class CombineCourseForm extends Component {
           {{/each}}
         </ul>
       {{else}}
-        <p>Votre parcours n'a aucun élément ajouté.</p>
+        <p> {{t "common.components.combined-courses.create-form.contentFeedback"}}</p>
       {{/if}}
 
-      <PixButton class="combined-course-page__button" @triggerAction={{this.downloadCSV}} @variant="success">Télécharger
-        le CSV</PixButton>
+      <PixButton class="combined-course-page__button" @triggerAction={{this.downloadCSV}} @variant="success">{{t
+          "common.components.combined-courses.create-form.downloadButton"
+        }}</PixButton>
     </PixBlock>
   </template>
 }

--- a/admin/app/styles/components/combined-course/form.scss
+++ b/admin/app/styles/components/combined-course/form.scss
@@ -2,8 +2,11 @@
 
 .combined-course-page {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: var(--pix-spacing-6x);
+  justify-content: space-around;
+  padding-top: var(--pix-spacing-8x);
+  padding-bottom: var(--pix-spacing-8x);
 
   &__title {
     @extend %pix-title-m;
@@ -11,8 +14,15 @@
 
   &__form {
     display: inline-flex;
+    flex: 0 1 30rem;
     flex-direction: column;
     gap: var(--pix-spacing-6x);
+  }
+
+  &__form-addItem {
+    display: inline-flex;
+    gap: var(--pix-spacing-4x);
+    align-items: end;
   }
 
   &__input {
@@ -33,4 +43,24 @@
     flex-direction: column;
     gap: var(--pix-spacing-3x);
   }
+
+  &__fieldset {
+    display: inline-flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+
+    .pix-radio-button {
+      margin-top: 0;
+    }
+  }
+
+  &__items {
+    display: inline-flex;
+    flex: 0 0 50%;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+  }
+
+
+
 }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -437,6 +437,31 @@
         "placeholder": "Certification ID"
       }
     },
+    "combined-courses": {
+      "create-form": {
+        "addItemButton": "Add",
+        "contentFeedback": "Your course does not have any items yet.",
+        "courseContent": "Course content",
+        "downloadButton": "Download CSV",
+        "fieldsetElement": "Choose the element type you want to add :",
+        "labels": {
+          "creatorId": "Creator id",
+          "description": " Description",
+          "illustration": "Illustration",
+          "itemId": "Id",
+          "module": "Module",
+          "name": "Name",
+          "organizationsList": "Organisations list",
+          "organizationsListSubLabel": "(ids separated by commas)",
+          "target-profile": "Target profile"
+        },
+        "notifications": {
+          "error": "Oups. Something went wrong. Please try again.",
+          "success": "CSV downloaded ! Go to create your combined course"
+        },
+        "title": "Course creator"
+      }
+    },
     "complementary-certifications": {
       "item": {
         "certification-framework": "Complementary certification",
@@ -498,27 +523,6 @@
         }
       },
       "title": "All certification frameworks"
-    },
-     "combined-courses": {
-      "create-form": {
-        "title": "Course creator",
-      "labels": {
-        "organizationsList": "Organisations list",
-        "organizationsListSubLabel": "(ids separated by commas)",
-        "creatorId": "Creator id",
-        "name":  "Name",
-        "illustration": "Illustration",
-        "description": " Description",
-        "campaign": "Campaign",
-        "module": "Module",
-        "itemId": "Id"
-      },
-      "fieldsetElement": "Choose the element type you want to add :",
-      "addItemButton": "Add",
-      "downloadButton": "Download CSV",
-      "courseContent": "Course content",
-      "contentFeedback": "Your course does not have any items yet."
-      }
     },
     "layout": {
       "menu-bar": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -499,6 +499,27 @@
       },
       "title": "All certification frameworks"
     },
+     "combined-courses": {
+      "create-form": {
+        "title": "Course creator",
+      "labels": {
+        "organizationsList": "Organisations list",
+        "organizationsListSubLabel": "(ids separated by commas)",
+        "creatorId": "Creator id",
+        "name":  "Name",
+        "illustration": "Illustration",
+        "description": " Description",
+        "campaign": "Campaign",
+        "module": "Module",
+        "itemId": "Id"
+      },
+      "fieldsetElement": "Choose the element type you want to add :",
+      "addItemButton": "Add",
+      "downloadButton": "Download CSV",
+      "courseContent": "Course content",
+      "contentFeedback": "Your course does not have any items yet."
+      }
+    },
     "layout": {
       "menu-bar": {
         "entries": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -500,6 +500,27 @@
       },
       "title": "Tous les référentiels de certification"
     },
+    "combined-courses": {
+      "create-form": {
+        "title": "Créateur de parcours",
+      "labels": {
+        "organizationsList": "liste des organisations",
+        "organizationsListSubLabel": "(ids séparés par des virgules)",
+        "creatorId": "Identifiant du créateur",
+        "name":  "Nom",
+        "illustration": "Illustration",
+        "description": " Description",
+        "campaign": "Campagne",
+        "module": "Module",
+        "itemId": "Identifiant"
+      },
+      "fieldsetElement": "Choisissez le type d'élément à ajouter :",
+      "addItemButton": "Ajouter",
+      "downloadButton": "Télécharger le CSV",
+      "courseContent": "Contenu du parcours",
+      "contentFeedback": "Votre parcours n'a aucun élément ajouté."
+      }
+    },
     "layout": {
       "menu-bar": {
         "entries": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -437,6 +437,31 @@
         "placeholder": "ID de la certification"
       }
     },
+    "combined-courses": {
+      "create-form": {
+        "addItemButton": "Ajouter",
+        "contentFeedback": "Votre parcours n'a aucun élément ajouté.",
+        "courseContent": "Contenu du parcours",
+        "downloadButton": "Télécharger le CSV",
+        "fieldsetElement": "Choisissez le type d'élément à ajouter :",
+        "labels": {
+          "creatorId": "Identifiant du créateur",
+          "description": " Description",
+          "illustration": "Illustration",
+          "itemId": "Identifiant",
+          "module": "Module",
+          "name": "Nom",
+          "organizationsList": "liste des organisations",
+          "organizationsListSubLabel": "(ids séparés par des virgules)",
+          "target-profile": "Profil cible"
+        },
+        "notifications": {
+          "error": "Oups. Une erreur est survenue lors du téléchargement du CSV.",
+          "success": "Téléchargement du CSV réussi ! En route pour la création des parcours."
+        },
+        "title": "Créateur de parcours"
+      }
+    },
     "complementary-certifications": {
       "item": {
         "certification-framework": "Référentiel de certification",
@@ -499,27 +524,6 @@
         }
       },
       "title": "Tous les référentiels de certification"
-    },
-    "combined-courses": {
-      "create-form": {
-        "title": "Créateur de parcours",
-      "labels": {
-        "organizationsList": "liste des organisations",
-        "organizationsListSubLabel": "(ids séparés par des virgules)",
-        "creatorId": "Identifiant du créateur",
-        "name":  "Nom",
-        "illustration": "Illustration",
-        "description": " Description",
-        "campaign": "Campagne",
-        "module": "Module",
-        "itemId": "Identifiant"
-      },
-      "fieldsetElement": "Choisissez le type d'élément à ajouter :",
-      "addItemButton": "Ajouter",
-      "downloadButton": "Télécharger le CSV",
-      "courseContent": "Contenu du parcours",
-      "contentFeedback": "Votre parcours n'a aucun élément ajouté."
-      }
     },
     "layout": {
       "menu-bar": {

--- a/api/src/quest/domain/models/CombinedCourseTemplate.js
+++ b/api/src/quest/domain/models/CombinedCourseTemplate.js
@@ -46,27 +46,39 @@ export class CombinedCourseTemplate {
     );
   }
 
+  static buildRequirementForCombinedCourse({ campaignId, moduleId }) {
+    if (campaignId) {
+      return buildRequirement({
+        requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+        comparison: COMPARISONS.ALL,
+        data: {
+          campaignId: { data: campaignId, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
+          status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
+        },
+      });
+    } else if (moduleId) {
+      return buildRequirement({
+        requirement_type: TYPES.OBJECT.PASSAGES,
+        comparison: COMPARISONS.ALL,
+        data: {
+          moduleId: { data: moduleId, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
+          isTerminated: { data: true, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
+        },
+      });
+    }
+  }
+
   toCombinedCourseQuestFormat(campaigns) {
     const successRequirements = this.#content.map((requirement) => {
       if (requirement.type === TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS) {
         const requirementTargetProfileId = requirement.value;
         const campaignId = campaigns.find(({ targetProfileId }) => targetProfileId === requirementTargetProfileId).id;
-        return buildRequirement({
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS.ALL,
-          data: {
-            campaignId: { data: campaignId, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
-            status: { data: CampaignParticipationStatuses.SHARED, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
-          },
+        return CombinedCourseTemplate.buildRequirementForCombinedCourse({
+          campaignId,
         });
       } else if (requirement.type === TYPES.OBJECT.PASSAGES) {
-        return buildRequirement({
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS.ALL,
-          data: {
-            moduleId: { data: requirement.value, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
-            isTerminated: { data: true, comparison: CRITERION_PROPERTY_COMPARISONS.EQUAL },
-          },
+        return CombinedCourseTemplate.buildRequirementForCombinedCourse({
+          moduleId: requirement.value,
         });
       } else {
         return requirement;

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -38,7 +38,7 @@ describe('Quest | Acceptance | Application | Combined course Route ', function (
         await databaseBuilder.commit();
 
         const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}`;
+${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}`;
 
         const options = {
           method: 'POST',
@@ -70,7 +70,7 @@ ${organizationId};"{""name"":""Combinix"",""successRequirements"":[],""descripti
 
         // when
         const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-100;"{""name"":""Combinix"",""successRequirements"":[]}";${notAdminUserId}`;
+100;"{""name"":""Combinix"",""combinedCourseContent"":[]}";${notAdminUserId}`;
 
         const options = {
           method: 'POST',

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -36,8 +36,8 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     await databaseBuilder.commit();
 
     const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfile.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
-${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""campaignParticipations"",""comparison"":""all"",""data"":{""targetProfileId"":{""data"":${targetProfileWithTraining.id},""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a"",""comparison"":""equal""}}},{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""combinedCourseContent"":[{""type"":""campaignParticipations"",""value"":${targetProfile.id}},{""type"":""passages"",""value"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a""},{""type"":""passages"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
+${firstOrganizationId};"{""name"":""Combinix"",""combinedCourseContent"":[{""type"":""campaignParticipations"",""value"":${targetProfileWithTraining.id}},{""type"":""passages"",""value"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a""},{""type"":""passages"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}]}";${userId}
 `;
 
     const payload = iconv.encode(input, 'UTF-8');
@@ -229,8 +229,8 @@ ${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requi
     await databaseBuilder.commit();
 
     const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
-${firstOrganizationId};"{""name"":""Combinix"",""successRequirements"":[{""requirement_type"":""passages"",""comparison"":""all"",""data"":{""moduleId"":{""data"":""f32a2238-4f65-4698-b486-15d51935d335"",""comparison"":""equal""}}}]}";${userId}
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""combinedCourseContent"":[{""type"":""passages"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}]}";${userId}
+${firstOrganizationId};"{""name"":""Combinix"",""combinedCourseContent"":[{""type"":""passages"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}]}";${userId}
 `;
 
     const payload = iconv.encode(input, 'UTF-8');

--- a/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseTemplate_test.js
@@ -4,41 +4,25 @@ import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/d
 import { Quest } from '../../../../../src/quest/domain/models/Quest.js';
 import { COMPARISONS as COMPARISONS_REQUIREMENT, TYPES } from '../../../../../src/quest/domain/models/Requirement.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
-import { expect } from '../../../../test-helper.js';
+import { catchErrSync, expect } from '../../../../test-helper.js';
 
 describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () {
   describe('#validate', function () {
-    let successRequirements;
-    beforeEach(function () {
-      successRequirements = [
+    it('should throw if name is not provided', function () {
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: 123,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 'abcfdf-156465',
         },
         {
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: 1,
         },
       ];
-    });
-
-    it('should throw if name is not provided', function () {
       // when
       const createCombineCourse = () =>
         new CombinedCourseTemplate({
-          successRequirements,
+          combinedCourseContent,
           description: 'bla bla bla',
           illustration: 'illu.svg',
         });
@@ -47,121 +31,83 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
       expect(createCombineCourse).to.throw(EntityValidationError);
     });
 
-    it('should throw if successRequirement is not provided', function () {
+    it('should throw if combinedCourseContent does not pass validation', function () {
       // when
-      const createCombineCourse = () =>
-        new CombinedCourseTemplate({
-          name: 'combinix',
-          description: 'description',
-          illustration: 'illu.svg',
-        });
-
-      // then
-      expect(createCombineCourse).to.throw(EntityValidationError);
-    });
-
-    it('should throw if successRequirement does not pass validation', function () {
-      // when
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 1,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 1,
         },
       ];
 
       // then
-      expect(
+      const error = catchErrSync(
         () =>
           new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements,
+            combinedCourseContent,
             description: 'description',
             illustration: 'illu.svg',
           }),
-      ).to.throw(EntityValidationError);
+      )();
+
+      expect(error).instanceOf(EntityValidationError);
     });
 
-    it('should throw when a target profile id in success requirement is a string', async function () {
+    it('should throw when a target profile id in combinedCourseContent is a string', async function () {
       //given
 
       const targetProfileId = 12;
 
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: targetProfileId.toString(),
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: targetProfileId.toString(),
         },
       ];
       // then
-      expect(
+      const error = catchErrSync(
         () =>
           new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements,
+            combinedCourseContent,
             description: 'description',
             illustration: 'illu.svg',
           }),
-      ).to.throw(EntityValidationError);
+      )();
+
+      expect(error).instanceOf(EntityValidationError);
     });
   });
+
   describe('#getTargetProfileIds', function () {
     it('should return target profile ids from campaignParticipations success requirements', async function () {
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: 1,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: 1,
         },
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: 8,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: 8,
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name: 'combinix',
-        successRequirements,
+        combinedCourseContent,
       });
       expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([1, 8]);
     });
     it('should return empty list of ids if template has not any campaignParticipations success requirements', async function () {
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name: 'combinix',
-        successRequirements,
+        combinedCourseContent,
       });
       expect(combinedCourseTemplate.targetProfileIds).to.deep.equal([]);
     });
@@ -169,61 +115,37 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
 
   describe('#moduleIds', function () {
     it('should return module ids from passages success requirements', async function () {
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 'abcdef-555',
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 'abcdef-555',
         },
         {
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 'abcdef-777',
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 'abcdef-777',
         },
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: 8,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: 8,
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name: 'combinix',
-        successRequirements,
+        combinedCourseContent,
       });
       expect(combinedCourseTemplate.moduleIds).to.deep.equal(['abcdef-555', 'abcdef-777']);
     });
 
     it('should return empty list of ids if template has not any campaignParticipations success requirements', async function () {
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: 12,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: 12,
         },
       ];
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name: 'combinix',
-        successRequirements,
+        combinedCourseContent,
       });
       expect(combinedCourseTemplate.moduleIds).to.deep.equal([]);
     });
@@ -249,36 +171,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
           targetProfileId: secondTargetProfileId,
         },
       ];
-      const successRequirements = [
+      const combinedCourseContent = [
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: firstTargetProfileId,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: firstTargetProfileId,
         },
         {
-          requirement_type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            targetProfileId: {
-              data: secondTargetProfileId,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+          value: secondTargetProfileId,
         },
         {
-          requirement_type: TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENT.ALL,
-          data: {
-            moduleId: {
-              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
+          type: TYPES.OBJECT.PASSAGES,
+          value: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
         },
       ];
       const description = 'bla bla bla';
@@ -287,7 +191,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseTemplate', function () 
       // when
       const combinedCourseTemplate = new CombinedCourseTemplate({
         name,
-        successRequirements,
+        combinedCourseContent,
         description,
         illustration,
       });

--- a/api/tests/quest/unit/domain/models/CombinedCourse_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourse_test.js
@@ -908,16 +908,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'Combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                value: campaign.targetProfileId,
               },
             ],
           });
@@ -956,16 +950,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const campaign = new Campaign({ id: 2, code: 'ABCDIAG1', title: 'diagnostique', targetProfileId: 7 });
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+
+                value: campaign.targetProfileId,
               },
             ],
           });
@@ -1004,16 +993,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+
+                value: campaign.targetProfileId,
               },
             ],
           });
@@ -1051,16 +1035,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const encryptedCombinedCourseUrl = 'encryptedCombinedCourseUrl';
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  moduleId: {
-                    data: 'abcdefgh1',
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                value: 'abcdefgh1',
               },
             ],
           });
@@ -1111,26 +1089,15 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const recommendedModuleIdsForUser = [];
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                value: campaign.targetProfileId,
               },
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  moduleId: {
-                    data: module.id,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+
+                value: module.id,
               },
             ],
           });
@@ -1185,26 +1152,16 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
           const recommendedModuleIdsForUser = [{ moduleId: module.id }];
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+
+                value: campaign.targetProfileId,
               },
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  moduleId: {
-                    data: module.id,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+
+                value: module.id,
               },
             ],
           });
@@ -1276,36 +1233,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
               name: 'combinix',
-              successRequirements: [
+              combinedCourseContent: [
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: firstModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: firstModule.id,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: secondModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: secondModule.id,
                 },
               ],
             });
@@ -1375,46 +1314,22 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
               name: 'combinix',
-              successRequirements: [
+              combinedCourseContent: [
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: firstModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: firstModule.id,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: secondCampaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: secondCampaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: secondModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: secondModule.id,
                 },
               ],
             });
@@ -1503,36 +1418,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
               name: 'combinix',
-              successRequirements: [
+              combinedCourseContent: [
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: firstModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: firstModule.id,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: secondModule.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: secondModule.id,
                 },
               ],
             });
@@ -1587,46 +1484,22 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
               name: 'combinix',
-              successRequirements: [
+              combinedCourseContent: [
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: module.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: module.id,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign2.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign2.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: module2.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: module2.id,
                 },
               ],
             });
@@ -1714,36 +1587,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
             const recommendedModuleIdsForUser = [];
             const combinedCourseTemplate = new CombinedCourseTemplate({
               name: 'combinix',
-              successRequirements: [
+              combinedCourseContent: [
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    targetProfileId: {
-                      data: campaign.targetProfileId,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+                  value: campaign.targetProfileId,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: moduleFromTargetProfile.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: moduleFromTargetProfile.id,
                 },
                 {
-                  requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-                  comparison: REQUIREMENT_COMPARISONS.ALL,
-                  data: {
-                    moduleId: {
-                      data: moduleFromQuest.id,
-                      comparison: CRITERION_COMPARISONS.EQUAL,
-                    },
-                  },
+                  type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+                  value: moduleFromQuest.id,
                 },
               ],
             });
@@ -1816,16 +1671,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
           name: 'combinix',
-          successRequirements: [
+          combinedCourseContent: [
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                targetProfileId: {
-                  data: campaign1.targetProfileId,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign1.targetProfileId,
             },
           ],
         });
@@ -1867,36 +1716,18 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
           name: 'combinix',
-          successRequirements: [
+          combinedCourseContent: [
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                targetProfileId: {
-                  data: campaign2.targetProfileId,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign2.targetProfileId,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                targetProfileId: {
-                  data: campaign1.targetProfileId,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign1.targetProfileId,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module.id,
             },
           ],
         });
@@ -1964,16 +1795,10 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
           name: 'combinix',
-          successRequirements: [
+          combinedCourseContent: [
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module.id,
             },
           ],
         });
@@ -2007,16 +1832,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+
+                value: campaign.targetProfileId,
               },
             ],
           });
@@ -2052,16 +1872,11 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
           const combinedCourseTemplate = new CombinedCourseTemplate({
             name: 'combinix',
-            successRequirements: [
+            combinedCourseContent: [
               {
-                requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-                comparison: REQUIREMENT_COMPARISONS.ALL,
-                data: {
-                  targetProfileId: {
-                    data: campaign.targetProfileId,
-                    comparison: CRITERION_COMPARISONS.EQUAL,
-                  },
-                },
+                type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+
+                value: campaign.targetProfileId,
               },
             ],
           });
@@ -2103,66 +1918,30 @@ describe('Quest | Unit | Domain | Models | CombinedCourse', function () {
 
         const combinedCourseTemplate = new CombinedCourseTemplate({
           name: 'combinix',
-          successRequirements: [
+          combinedCourseContent: [
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                targetProfileId: {
-                  data: campaign2.targetProfileId,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign2.targetProfileId,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module2.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module2.id,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module22.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module22.id,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                targetProfileId: {
-                  data: campaign1.targetProfileId,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
+              value: campaign1.targetProfileId,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module1.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module1.id,
             },
             {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: module11.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
+              type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
+              value: module11.id,
             },
           ],
         });


### PR DESCRIPTION
## ❄️ Problème

On veut pouvoir télécharger un CSV directement dans le créateur de parcours combiné et ne plus avoir à copier le JSON à la main dans un fichier.

## 🛷 Proposition

Simplifier la déclaration du parcours combiné dans le JSON pour ne plus dépendre d'un format de quête.

## ☃️ Remarques
On en a profité pour faire un peu de design sur la page de création des parcours combinés.

## 🧑‍🎄 Pour tester
Créer un parcours combiné sur Admin.
Aller sur /combined-course-creator pour vérifier le design et le fonctionnenement.