### PR TITLE
[FEATURE] Ajout de la lecture du postMessage des embed coté junior(PIX-19497)

### DIFF
--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -63,7 +63,7 @@ export default class ChallengeContent extends Component {
     return this.isRebootable && !this.args.isDisabled;
   }
 
-  get computedEmbedHeight() {
+  get embedHeight() {
     const height = this.args.challenge.embedHeight || this.heightFromPostMessage;
     return height + 'px';
   }
@@ -80,7 +80,7 @@ export default class ChallengeContent extends Component {
           <EmbeddedSimulator
             @url={{@challenge.embedUrl}}
             @title={{@challenge.embedTitle}}
-            @computedEmbedHeight={{this.computedEmbedHeight}}
+            @embedHeight={{this.embedHeight}}
             @isGDevelop={{@challenge.isEmbedGDevelop}}
             @hideSimulator={{@isDisabled}}
             @isMediaWithForm={{this.isMediaWithForm}}

--- a/junior/app/components/challenge/challenge-content.gjs
+++ b/junior/app/components/challenge/challenge-content.gjs
@@ -14,12 +14,17 @@ import Qrocm from './content/qrocm';
 
 export default class ChallengeContent extends Component {
   @tracked isRebootable = false;
+  @tracked heightFromPostMessage = 0;
 
   constructor() {
     super(...arguments);
     window.addEventListener('message', ({ data }) => {
       if (data?.from === 'pix' && data?.type === 'init') {
         this.isRebootable = !!data.rebootable;
+      }
+
+      if (data?.from === 'pix' && data?.type === 'height') {
+        this.heightFromPostMessage = data.height;
       }
     });
   }
@@ -58,6 +63,11 @@ export default class ChallengeContent extends Component {
     return this.isRebootable && !this.args.isDisabled;
   }
 
+  get computedEmbedHeight() {
+    const height = this.args.challenge.embedHeight || this.heightFromPostMessage;
+    return height + 'px';
+  }
+
   <template>
     <div class="challenge-content {{this.challengeContentClassname}}">
       {{#if @challenge.illustrationUrl}}
@@ -70,7 +80,7 @@ export default class ChallengeContent extends Component {
           <EmbeddedSimulator
             @url={{@challenge.embedUrl}}
             @title={{@challenge.embedTitle}}
-            @height={{@challenge.embedHeight}}
+            @computedEmbedHeight={{this.computedEmbedHeight}}
             @isGDevelop={{@challenge.isEmbedGDevelop}}
             @hideSimulator={{@isDisabled}}
             @isMediaWithForm={{this.isMediaWithForm}}

--- a/junior/app/components/challenge/content/embedded-simulator.gjs
+++ b/junior/app/components/challenge/content/embedded-simulator.gjs
@@ -1,22 +1,20 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
-import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 
 import didRender from '../../../modifiers/did-render';
 
 export default class EmbeddedSimulator extends Component {
-  get embedDocumentHeightStyle() {
-    const { isGDevelop, height: configuredHeight } = this.args;
-    const height = configuredHeight ?? '600';
-    const cssProperties = isGDevelop ? `max-height: ${height}px; aspect-ratio: 860/680` : `height: ${height}px`;
-    return htmlSafe(cssProperties);
-  }
-
   @action
   setIframeHtmlElement(htmlElement) {
     this.iframe = htmlElement;
+
+    this.iframe.style.height = this.args.computedEmbedHeight;
+
+    if (this.args.isGDevelop) {
+      this.iframe.style.aspectRatio = '860/680';
+    }
   }
 
   @action
@@ -46,13 +44,14 @@ export default class EmbeddedSimulator extends Component {
       {{#if @hideSimulator}}
         <div class="challenge-embed-simulator__overlay"></div>
       {{/if}}
-
       <iframe
         tabindex={{if @hideSimulator "-1"}}
         class="challenge-embed-simulator__iframe"
         src="{{@url}}"
         title="{{@title}}"
-        style="{{this.embedDocumentHeightStyle}}"
+        allowfullscreen="true"
+        webkitallowfullscreen="true"
+        mozallowfullscreen="true"
         {{didRender this.setIframeHtmlElement}}
       >
       </iframe>

--- a/junior/app/components/challenge/content/embedded-simulator.gjs
+++ b/junior/app/components/challenge/content/embedded-simulator.gjs
@@ -10,7 +10,7 @@ export default class EmbeddedSimulator extends Component {
   setIframeHtmlElement(htmlElement) {
     this.iframe = htmlElement;
 
-    this.iframe.style.height = this.args.computedEmbedHeight;
+    this.iframe.style.height = this.args.embedHeight;
 
     if (this.args.isGDevelop) {
       this.iframe.style.aspectRatio = '860/680';

--- a/junior/app/styles/components/challenge/challenge-content.scss
+++ b/junior/app/styles/components/challenge/challenge-content.scss
@@ -14,17 +14,17 @@
 
   &__grid-multiple-element {
     grid-template-areas:
-    "left right"
-    "left actions";
+      'left right'
+      'left actions';
     grid-template-rows: min-content min-content;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(200px, 1fr) minmax(200px, 1fr);
 
     &--40-60 {
-      grid-template-columns: 2fr 3fr;
+      grid-template-columns: minmax(200px, 2fr) minmax(300px, 3fr);
     }
 
     &--60-40 {
-      grid-template-columns: 3fr 2fr;
+      grid-template-columns: minmax(300px, 3fr) minmax(200px, 2fr);
     }
 
     div:nth-child(1) {
@@ -50,4 +50,3 @@
     display: none;
   }
 }
-

--- a/junior/app/styles/components/challenge/challenge-layout.scss
+++ b/junior/app/styles/components/challenge/challenge-layout.scss
@@ -11,12 +11,12 @@
 
   &--error {
     background-color: rgb(var(--pix-error-500-inline), 10%);
-    border: 2px solid var(--pix-error-500);
+    outline: 2px solid var(--pix-error-500);
   }
 
   &--success {
     background-color: rgb(var(--pix-success-500-inline), 10%);
-    border: 2px solid var(--pix-success-500);
+    outline: 2px solid var(--pix-success-500);
   }
 
   &--feedback {
@@ -25,7 +25,7 @@
 
   &--feedback--success {
     background-color: rgb(var(--pix-secondary-500-inline), 10%);
-    background-image: url("/images/background-stars-success.svg");
+    background-image: url('/images/background-stars-success.svg');
   }
 
   &--result {
@@ -34,6 +34,6 @@
 
   &--result--success {
     background-color: rgb(var(--pix-secondary-500-inline), 10%);
-    background-image: url("/images/background-success-result-page.svg");
+    background-image: url('/images/background-success-result-page.svg');
   }
 }

--- a/junior/app/styles/globals/_buttons.scss
+++ b/junior/app/styles/globals/_buttons.scss
@@ -1,5 +1,4 @@
 .pix1d-button {
-  padding: 12px 32px;
   font-weight: 700;
   font-size: 1rem;
   border: 1px solid var(--pix-primary-500);
@@ -14,7 +13,10 @@
     color: var(--pix-primary-500);
     background-color: var(--pix-neutral-0);
 
-    &:hover, &:focus, &:active, &:focus-visible {
+    &:hover,
+    &:focus,
+    &:active,
+    &:focus-visible {
       color: var(--pix-neutral-0);
     }
 

--- a/junior/app/styles/pages/identified/missions/introduction.scss
+++ b/junior/app/styles/pages/identified/missions/introduction.scss
@@ -19,7 +19,7 @@
   &__media {
     display: flex;
     justify-content: center;
-    min-height: 400px;
+    min-width: 400px;
     margin: var(--pix-spacing-4x) 140px;
     padding: var(--pix-spacing-4x);
     background-color: var(--pix-neutral-0);


### PR DESCRIPTION
## 🔆 Problème

La plupart des challenges possèdent une hauteur au niveau du challange sous le nom `embedHeight`.
Coté junior, même si les emebd possèdent une haiteur dynamique elle n'est pas lue, mais c'est bien cette `embedHeight` qui permettaient de gérer les hauteurs par l'équipe métier. Le problème est que l'on voi très rapidement que sur des petite configuration les elements ne se resize pas correctement, laissant du vide en dessous.

Conclusion
1. Les emebed on du mal a se resize.
2. La fonctionnalité plein écran des vidéo ne marche pas

## ⛱️ Proposition

- Lire les postMessage des embed de pix pour récupéré leur hauteur! Mais pour éviter des regression les infos de embedHeight sont toujours prioritaire aux postmessage de hauteur.

- Ajouter les autorisation pour que l'iframe puissent faire du plein écran

## 🌊 Remarques

Pas simple pour tester

## 🏄 Pour tester
A tester en local pour plus de simplicité !
Il suffit de check avant de modifier la db.
modifier la DB avec 
```
UPDATE learningcontent.challenges
	SET "embedHeight" = null
	WHERE id = <id_challenge>;
```
relancer le back et normalement le changement devrait  être visible


[un carousel](http://localhost:4205/challenges/challenge1oAytYdPosm0O9/preview) id: challenge1oAytYdPosm0O9
Ecran à 1000px de largeur 
- avant
<img width="862" height="747" alt="image" src="https://github.com/user-attachments/assets/3c388983-ccc5-49d3-a8a2-8552b517c8b3" />

- après suppression de `embedHeight` coté db
<img width="862" height="747" alt="image" src="https://github.com/user-attachments/assets/431f40c6-6114-462e-800b-7828ecd2a4f1" />

[video](http://localhost:4205/challenges/challenge28dsJ2VvfgSyRC/preview) id: challenge28dsJ2VvfgSyRC
- avant 
<img width="862" height="902" alt="image" src="https://github.com/user-attachments/assets/9ed46c40-9a2d-4c1f-b08e-6508d84583ef" />

- après suppression de `embedHeight` coté db
<img width="862" height="902" alt="image" src="https://github.com/user-attachments/assets/afa2b9a1-add4-45af-9a38-1a1c25ae61da" />


> [!CAUTION]
> Ne pas sipprimer les embedHeight pour les gdevelop  sinon voici ce qui se passe !
[gdevelop](http://localhost:4205/challenges/challenge2oq5WOxdlyzu2u/preview) id : challenge2oq5WOxdlyzu2u
- avant
<img width="838" height="880" alt="image" src="https://github.com/user-attachments/assets/0b56a6f2-b8d8-4629-a8b0-f72d475abd11" />

- après suppression de `embedHeight` coté db
<img width="838" height="353" alt="image" src="https://github.com/user-attachments/assets/ac24609b-8597-4ce5-b29f-9b1fe687b04e" />

