### PR TITLE
[FEATURE] Ajouter un feature toggle isModulixIssueReportDisplayed (PIX-20489) 

### DIFF
--- a/api/config/feature-toggles-config.js
+++ b/api/config/feature-toggles-config.js
@@ -36,6 +36,13 @@ export default {
     devDefaultValues: { test: false, reviewApp: true },
     tags: ['frontend', 'team-devcomp', 'pix-admin'],
   },
+  isModulixIssueReportDisplayed: {
+    type: 'boolean',
+    description: 'Enable issue report in modules',
+    defaultValue: false,
+    devDefaultValues: { test: false, reviewApp: true },
+    tags: ['frontend', 'team-devcomp', 'modulix', 'pix-app'],
+  },
   isSelfAccountDeletionEnabled: {
     description: 'Toggle self account deletion feature',
     type: 'boolean',

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Shared | Application | Controller | feature-toggle', func
             'is-async-quest-rewarding-calculation-enabled': false,
             'is-auto-share-enabled': false,
             'is-filtering-recommended-training-by-organizations-enabled': false,
+            'is-modulix-issue-report-displayed': false,
             'is-survey-enabled-for-combined-courses': true,
             'is-quest-enabled': true,
             'is-self-account-deletion-enabled': true,

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -6,4 +6,5 @@ export default class FeatureToggle extends Model {
   @attr('boolean') isAutoShareEnabled;
   @attr('boolean') isSurveyEnabledForCombinedCourses;
   @attr('boolean') areModuleShortIdUrlsEnabled;
+  @attr('boolean') isModulixIssueReportDisplayed;
 }


### PR DESCRIPTION
## ❄️ Contexte

 On veut faire un feature-toggle pour activer / désactiver la fonctionnalité permettant de signaler dans les modules.

## 🛷 Proposition

Le faire.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

- Ouvrir le module [bac-a-sable](https://app-pr14329.review.pix.fr/modules/6a68bf32/bac-a-sable) 
- Vérifier, grâce à la console dev, que la requête vers l'API feature-toggles renvoie bien `isModulixIssueReportDisplayed` à `true`
