### PR TITLE
[FEATURE] Enlever "tmp" dans les slug des modules (PIX-20663)

### DIFF
--- a/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
+++ b/api/db/seeds/data/team-prescription/fixtures/pro-complete-combined-course.js
@@ -139,7 +139,7 @@ export const MAXI_COMBINED_COURSE = {
     trainings: [
       {
         title: 'Mon premier prompt !',
-        link: '/modules/4920d56c/tmp-ia-premier-prompt/details',
+        link: '/modules/4920d56c/ia-premier-prompt/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -150,7 +150,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "J'améliore mon prompt !",
-        link: '/modules/4eacd0c3/tmp-prompt-intermediaire',
+        link: '/modules/4eacd0c3/prompt-intermediaire',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -161,7 +161,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Elles hallucinent, ces IA génératives !',
-        link: '/modules/9be9cfae/tmp-ia-hallu/details',
+        link: '/modules/9be9cfae/ia-hallu/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -172,7 +172,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les deepfakes (hypertrucages) : c’est quoi ?',
-        link: '/modules/05b24fee/tmp-ia-deepfakes/passage',
+        link: '/modules/05b24fee/ia-deepfakes/passage',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -183,7 +183,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: "J'améliore mon prompt !",
-        link: '/modules/4eacd0c3/tmp-prompt-intermediaire',
+        link: '/modules/4eacd0c3/prompt-intermediaire',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -194,7 +194,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Elles hallucinent, ces IA génératives !',
-        link: '/modules/9be9cfae/tmp-ia-hallu/details',
+        link: '/modules/9be9cfae/ia-hallu/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -205,7 +205,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les deepfakes : c’est quoi ?',
-        link: '/modules/05b24fee/tmp-ia-deepfakes/passage',
+        link: '/modules/05b24fee/ia-deepfakes/passage',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -216,7 +216,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment font les IA génératives pour répondre à nos demandes ?',
-        link: '/modules/797ea8fb/tmp-ia-fonctionnement-debut/details',
+        link: '/modules/797ea8fb/ia-fonctionnement-debut/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -227,7 +227,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment font les IA génératives pour répondre à nos demandes ?',
-        link: '/modules/797ea8fb/tmp-ia-fonctionnement-debut/details',
+        link: '/modules/797ea8fb/ia-fonctionnement-debut/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -239,7 +239,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment une IA générative a-t-elle appris à discuter ?',
-        link: '/modules/76961c86/tmp-ia-fonctionnement-ind/details',
+        link: '/modules/76961c86/ia-fonctionnement-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -250,7 +250,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Comment une IA générative a-t-elle appris à discuter ?',
-        link: '/modules/76961c86/tmp-ia-fonctionnement-ind/details',
+        link: '/modules/76961c86/ia-fonctionnement-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -262,7 +262,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les biais des IA',
-        link: '/modules/163b520e/tmp-ia-bias-ind/details',
+        link: '/modules/163b520e/ia-bias-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -273,7 +273,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Les biais des IA',
-        link: '/modules/163b520e/tmp-ia-bias-ind/details',
+        link: '/modules/163b520e/ia-bias-ind/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -306,7 +306,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'IA, vous avez dit IA ?',
-        link: '/modules/cc0cbab7/tmp-ia-dit-ia/details',
+        link: '/modules/cc0cbab7/ia-dit-ia/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr-fr',
@@ -317,7 +317,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'IA, vous avez dit IA ?',
-        link: '/modules/cc0cbab7/tmp-ia-dit-ia/details',
+        link: '/modules/cc0cbab7/ia-dit-ia/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',
@@ -328,7 +328,7 @@ export const MAXI_COMBINED_COURSE = {
       },
       {
         title: 'Mon premier prompt !',
-        link: '/modules/4920d56c/tmp-ia-premier-prompt/details',
+        link: '/modules/4920d56c/ia-premier-prompt/details',
         type: 'modulix',
         duration: '0 years 0 mons 0 days 0 hours 10 mins 0.0 secs',
         locale: 'fr',

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "0aed9f0d-e735-48f8-900b-32cc4251dd0e",
   "shortId": "8ee73f2b",
-  "slug": "tmp-cyber-gestionnaire",
+  "slug": "cyber-gestionnaire",
   "title": "Un coffre-fort pour vos mots de passe",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYGestionMDP_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "93c4a755-7576-47b7-b2f0-9001ca9c2e57",
   "shortId": "09afbfa2",
-  "slug": "tmp-cyber-proteger-mdp",
+  "slug": "cyber-proteger-mdp",
   "title": "Protéger ses mots de passe",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMDP_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "fbde0db0-344a-4b98-a9b4-68f74f358629",
   "shortId": "0389ba82",
-  "slug": "tmp-cyber-mdp-fort",
+  "slug": "cyber-mdp-fort",
   "title": "Un mot de passe fort, c’est quoi ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_AVA.json
@@ -1,7 +1,7 @@
 {
   "id": "f924b0e8-0b2b-4b8e-b7fe-f1b14e9b8094",
   "shortId": "4fb0e2cd",
-  "slug": "tmp-cyber-ingenierie-sociale",
+  "slug": "cyber-ingenierie-sociale",
   "title": "Cyberattaques : quand l’ingénierie sociale s’en mêle !",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYPhishing_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "70813abe-7423-426d-80c8-b1f0271ae0b4",
   "shortId": "82920553",
-  "slug": "tmp-anatomie-message-arnaque",
+  "slug": "anatomie-message-arnaque",
   "title": "Anatomie d’un message d’arnaque",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYVirus_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "f8fdc1be-1a2c-4708-9f2e-b388e82d2f8a",
   "shortId": "448b2c93",
-  "slug": "tmp-cyber-virus-nov",
+  "slug": "cyber-virus-nov",
   "title": "Mon ordinateur a attrapé un virus : comment est-ce possible ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "bc6d164f-26bd-4f58-9925-8cf5365e2ca6",
   "shortId": "43e420e6",
-  "slug": "tmp-ia-def-ind",
+  "slug": "ia-def-ind",
   "title": "Une IA apprentie botaniste : un cas d’apprentissage supervisé.",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IADefinition_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "40ab5711-4025-4052-a269-00fd0448d60a",
   "shortId": "cc0cbab7",
-  "slug": "tmp-ia-dit-ia",
+  "slug": "ia-dit-ia",
   "title": "IA, vous avez dit IA ? ",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_AVA.json
@@ -1,7 +1,7 @@
 {
   "id": "ccad60a8-6c48-4d91-84cb-d717a1ea4918",
   "shortId": "5bb2f995",
-  "slug": "tmp-iagenbiais-avance",
+  "slug": "iagenbiais-avance",
   "title": "IA génératives : Qui programme la morale ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "a1eea948-2125-488f-8006-9f85e646830d",
   "shortId": "163b520e",
-  "slug": "tmp-ia-bias-ind",
+  "slug": "ia-bias-ind",
   "title": "Les biais des IA génératives",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "c8607621-09ab-4601-be7d-68ed9c914c30",
   "shortId": "9be9cfae",
-  "slug": "tmp-ia-hallu",
+  "slug": "ia-hallu",
   "title": "Elles hallucinent, ces IA génératives ! ",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -1,7 +1,7 @@
 {
   "id": "178e7bb5-9d0a-43e6-b0a1-c7039bd7e2a8",
   "shortId": "e5019e0e",
-  "slug": "tmp-ia-biais-ind-alt",
+  "slug": "ia-biais-ind-alt",
   "title": "Les biais des lA",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenEthique_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "8266f923-4255-46ba-97c5-61cbdbe18986",
   "shortId": "e71a9bdd",
-  "slug": "tmp-iagenethique",
+  "slug": "iagenethique",
   "title": "Ce qu’il faut éviter de dire à une IA générative",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "d03cef94-74af-463d-8901-c886b48d6e0b",
   "shortId": "76961c86",
-  "slug": "tmp-ia-fonctionnement-ind",
+  "slug": "ia-fonctionnement-ind",
   "title": "Comment l’IA générative apprend-elle à discuter avec vous ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "71618929-fcc9-415e-a3f3-9582545d7a78",
   "shortId": "797ea8fb",
-  "slug": "tmp-ia-fonctionnement-debut",
+  "slug": "ia-fonctionnement-debut",
   "title": "Comment font les IA génératives pour répondre à nos demandes ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -1,7 +1,7 @@
 {
   "id": "7a38c90d-9937-4497-bee3-fe58541af420",
   "shortId": "4eacd0c3",
-  "slug": "tmp-prompt-intermediaire",
+  "slug": "prompt-intermediaire",
   "title": "J’améliore mes prompts !",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "cf183961-e85a-421d-a316-05870191ff82",
   "shortId": "4920d56c",
-  "slug": "tmp-ia-premier-prompt",
+  "slug": "ia-premier-prompt",
   "title": "Mon premier prompt !",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAInfox_NOV.json
@@ -1,7 +1,7 @@
 {
   "id": "8aa17e6d-3470-479d-838d-ff6923de6686",
   "shortId": "05b24fee",
-  "slug": "tmp-ia-deepfakes",
+  "slug": "ia-deepfakes",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Durabilite-AVA.json
@@ -1,7 +1,7 @@
 {
   "id": "2b01b6af-1b32-44ac-9f64-9fb064fa2971",
   "shortId": "dd3ddf6c",
-  "slug": "tmp-nr-obsolescence-programmee",
+  "slug": "nr-obsolescence-programmee",
   "title": "En finir avec l’obsolescence programmée ? ",
   "isBeta": true,
   "details": {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ia-deepfakes-alt.json
@@ -1,7 +1,7 @@
 {
   "id": "c7fe268a-9371-4eec-8a8a-df79c7479a46",
   "shortId": "a23e9d63",
-  "slug": "tmp-ia-deepfakes-alt",
+  "slug": "ia-deepfakes-alt",
   "title": "Les deepfakes (hypertrucages) : c’est quoi ?",
   "isBeta": true,
   "details": {

--- a/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
+++ b/api/tests/modulix/integration/scripts/update-modulix-trainings-link.script_test.js
@@ -24,7 +24,7 @@ describe('integration | modulix | scripts | UpdateModulixTrainingsLink', functio
       // given
       databaseBuilder.factory.buildTraining({
         id: 1,
-        link: `https://app.pix.fr/modules/tmp-prompt-intermediaire`,
+        link: `https://app.pix.fr/modules/prompt-intermediaire`,
         updatedAt: new Date('2020-09-10'),
         type: 'modulix',
       });
@@ -45,15 +45,15 @@ describe('integration | modulix | scripts | UpdateModulixTrainingsLink', functio
 
       const trainings = await knex('trainings').orderBy('id');
 
-      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/tmp-prompt-intermediaire');
       expect(trainings[0].updatedAt).to.deep.equal(new Date('2020-09-10'));
+      expect(trainings[0].link).to.equal('https://app.pix.fr/modules/prompt-intermediaire');
     });
 
     it('update modulix trainings link', async function () {
       // given
       databaseBuilder.factory.buildTraining({
         id: 1,
-        link: `https://app.pix.fr/modules/tmp-prompt-intermediaire`,
+        link: `https://app.pix.fr/modules/prompt-intermediaire`,
         updatedAt: new Date('2020-09-10'),
         type: 'modulix',
       });

--- a/mon-pix/app/routes/old-module.js
+++ b/mon-pix/app/routes/old-module.js
@@ -7,7 +7,8 @@ export default class ModuleRoute extends Route {
   @service router;
 
   model(params) {
-    return this.store.queryRecord('module', { slug: params.slug, encryptedRedirectionUrl: params.redirection });
+    const slug = params.slug.replace(/tmp-/, '');
+    return this.store.queryRecord('module', { slug, encryptedRedirectionUrl: params.redirection });
   }
 
   activate() {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-details_test.js
@@ -32,9 +32,32 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleDetails', function (
 
       // when
       const screen = await visit('/modules/m4tth7a5/bien-ecrire-son-adresse-mail/details');
-
       // then
       assert.dom(screen.getByRole('button', { name: t('pages.modulix.details.startModule') })).exists({ count: 1 });
+    });
+
+    test('should ignore tmp string from slug if present in url', async function (assert) {
+      // given
+      server.create('module', {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'm4tth7a5',
+        slug: 'ia-def-ind',
+        title: 'Bien écrire son adresse mail',
+        sections: [],
+        details: {
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          description: '<p>Description</p>',
+          duration: 'duration',
+          level: 'level',
+          objectives: ['Objectif #1'],
+        },
+      });
+
+      // when
+      await visit('/modules/tmp-ia-def-ind');
+
+      // then
+      assert.strictEqual(currentURL(), '/modules/m4tth7a5/ia-def-ind/details');
     });
 
     test('should navigate to passage page by clicking on start module button', async function (assert) {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -9,7 +9,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('when user arrive on the module passage page', function () {
+  module('when user arrives on the module passage page', function () {
     test('should ignore tmp string from slug if present in url', async function (assert) {
       // given
       server.create('module', {
@@ -62,7 +62,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
     });
   });
 
-  module('when user click on continue button', function () {
+  module('when user clicks on continue button', function () {
     module('when the grain displayed is not the last', function () {
       test('should display the continue button', async function (assert) {
         // given

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -10,6 +10,33 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
   setupMirage(hooks);
 
   module('when user arrive on the module passage page', function () {
+    test('should ignore tmp string from slug if present in url', async function (assert) {
+      // given
+      server.create('module', {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        shortId: 'm4tth7a5',
+        slug: 'ia-def-ind',
+        title: 'Bien écrire son adresse mail',
+        sections: [],
+        details: {
+          image: 'https://assets.pix.org/modules/bien-ecrire-son-adresse-mail-details.svg',
+          description: '<p>Description</p>',
+          duration: 'duration',
+          level: 'level',
+          objectives: ['Objectif #1'],
+        },
+      });
+
+      server.create('passage', {
+        moduleId: '6282925d-4775-4bca-b513-4c3009ec5886',
+      });
+
+      // when
+      await visit('/modules/tmp-ia-def-ind/passage');
+
+      // then
+      assert.strictEqual(currentURL(), '/modules/m4tth7a5/ia-def-ind/passage');
+    });
     test('should display only the first lesson grain', async function (assert) {
       // given
       const sections = _createSections(server);


### PR DESCRIPTION
## ❄️ Problème
Actuellement il y a tmp qui est inscrit dans les slug des modules. Mais on souhaite le retirer.

## 🛷 Proposition
Renommer les slugs.

## ☃️ Remarques

> ⚠️ Il faut attendre que les redirections soient mises en place avant de merger cette PR  ⚠️
=> **Finalement, pas besoin : la redirection est gérée dans cette PR !**


## 🧑‍🎄 Pour tester

Vérifier qu'on peut toujours accéder au modules suivants:
- https://app-pr14330.review.pix.fr/modules/cyber-gestionnaire
- https://app-pr14330.review.pix.fr/modules/anatomie-message-arnaque
- https://app-pr14330.review.pix.fr/modules/ia-def-ind
- https://app-pr14330.review.pix.fr/modules/iagenbiais-avance
- https://app-pr14330.review.pix.fr/modules/ia-hallu
- https://app-pr14330.review.pix.fr/modules/prompt-intermediaire
- https://app-pr14330.review.pix.fr/modules/ia-deepfakes

### anciennes url
- https://app-pr14330.review.pix.fr/modules/tmp-cyber-gestionnaire
- https://app-pr14330.review.pix.fr/modules/tmp-anatomie-message-arnaque
- https://app-pr14330.review.pix.fr/modules/tmp-ia-def-ind
- https://app-pr14330.review.pix.fr/modules/tmp-iagenbiais-avance
- https://app-pr14330.review.pix.fr/modules/tmp-ia-hallu
- https://app-pr14330.review.pix.fr/modules/tmp-prompt-intermediaire
- https://app-pr14330.review.pix.fr/modules/tmp-ia-deepfakes


