### PR TITLE
[TECH] Créer la table module_issue_reports (PIX-20490)

### DIFF
--- a/api/db/migrations/20251203134935_create-module-issue-reports-table.js
+++ b/api/db/migrations/20251203134935_create-module-issue-reports-table.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'module_issue_reports';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.uuid('moduleId').notNullable().comment('Id of module');
+    table.uuid('elementId').notNullable().comment('Element id in the module');
+    table.integer('passageId').references('id').inTable('passages').notNullable();
+    table.text('answer').nullable().comment('Answer of the user');
+    table.text('userAgent').nullable().comment('User agent of the users browser');
+    table.string('categoryKey').notNullable().comment('Reason for the report');
+    table.text('comment').notNullable().comment('Comment of the user');
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

On veut stocker les signalements des modules dans une table.

## 🛷 Proposition

Le faire.

## ☃️ Remarques

- Le champ `answer` a été mis `nullable` dans le cas où on voudrait faire du signalement en dehors du feedback.
- Pour le champ `userAgent`, c'est dans le cas où on ne pourrait pas le récupérer.

## 🧑‍🎄 Pour tester
### En local
- Lancer un npm run db:migrate
- Vérifier que la table`module_issue_reports` a bien été crée avec les champs précisés dans la migration.
- Lancer 2 fois la commande `npm run db:rollback:latest` 
- Vérifier que la table n'existe plus 👻 
