### PR TITLE
[FEATURE] Mettre à jour le bandeau sco avec l'url de la nouvelle doc (PIX-20650)

### DIFF
--- a/orga/tests/integration/components/banner/sco-communication-test.gjs
+++ b/orga/tests/integration/components/banner/sco-communication-test.gjs
@@ -48,8 +48,8 @@ module('Integration | Component | Banner::Sco-communication', function (hooks) {
             const createCampaignLink = screen.queryByRole('link', { name: 'Créer les campagnes' });
             assert.strictEqual(createCampaignLink.href, 'https://cloud.pix.fr/s/RaPpKjFHNX2kSR4');
 
-            const certifLink = screen.queryByRole('link', { name: 'En savoir plus sur la nouvelle certification' });
-            assert.strictEqual(certifLink.href, 'https://cloud.pix.fr/s/2q4c4QT9jGbGbEq');
+            const certifLink = screen.queryByRole('link', { name: 'En savoir plus sur la certification' });
+            assert.strictEqual(certifLink.href, 'https://cloud.pix.fr/s/GqwW6dFDDrHezfS');
           });
         });
       });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -72,7 +72,7 @@
       "step1b": "importing",
       "step1c": "the student database (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='Back-to-school how-to' class='link link--banner link--bold link--underlined' '>'Create campaigns'</a>' (back-to-school, 6th grade, thematic, subject-based, targeted courses, etc.).",
-      "step3": "Certify learners. '<'a href='https://cloud.pix.fr/s/2q4c4QT9jGbGbEq' title='Preparing and organising student certification how-to' class='link link--banner link--bold link--underlined' '>'Find out more about the new certification'</a>'."
+      "step3": "Certify learners. '<'a href='https://cloud.pix.fr/s/GqwW6dFDDrHezfS' title='Preparing and organising student certification how-to' class='link link--banner link--bold link--underlined' '>'Find out more about the certification'</a>'."
     },
     "last-places-lot-available": {
       "message": "Please note that your seats will expire in {days, number} days."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -72,7 +72,7 @@
       "step1b": "importer",
       "step1c": "la base élèves (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='Guide Lancer les parcours de rentrée' class='link link--banner link--bold link--underlined' '>'Créer les campagnes'</a>' (parcours rentrée, 6e, thématiques, disciplinaires, ciblés…).",
-      "step3": "Certifier les apprenants. '<'a href='https://cloud.pix.fr/s/2q4c4QT9jGbGbEq' title='Guide Préparer et organiser la certification des élèves' class='link link--banner link--bold link--underlined' '>'En savoir plus sur la nouvelle certification'</a>'."
+      "step3": "Certifier les apprenants. '<'a href='https://cloud.pix.fr/s/GqwW6dFDDrHezfS' title='Guide Préparer et organiser la certification des élèves' class='link link--banner link--bold link--underlined' '>'En savoir plus sur la certification'</a>'."
     },
     "last-places-lot-available": {
       "message": "Attention, vos places arrivent à échéance dans {days, number} jours."

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -72,7 +72,7 @@
       "step1b": "Importeren",
       "step1c": "studentendatabase (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='Gids voor het lanceren van back-to-school cursussen' class='link- banner link-old link--underlined' '>'Campagnes maken'</a>' (cursussen rentrée, 6e, thematisch, disciplinair, gericht...).",
-      "step3": "Certificering van lerenden. '<'a href='https://cloud.pix.fr/s/2q4c4QT9jGbGbEq' title='Gids Certificering van lerenden voorbereiden en organiseren' class='link link--banner link--bold link--underlined' '>'Lees meer over de nieuwe certificering'</a>'."
+      "step3": "Certificering van lerenden. '<'a href='https://cloud.pix.fr/s/GqwW6dFDDrHezfS' title='Gids Certificering van lerenden voorbereiden en organiseren' class='link link--banner link--bold link--underlined' '>'Lees meer over de certificering'</a>'."
     },
     "last-places-lot-available": {
       "message": "{days, number} Houd er rekening mee dat je tickets over enkele dagen verlopen."


### PR DESCRIPTION
## ❄️ Problème

La documentation a changé dans le bandeau SCO a changé 
<img width="712" height="154" alt="image" src="https://github.com/user-attachments/assets/f19328cd-e34a-4ae3-bdce-a817b95fe5f3" />


## 🛷 Proposition

Mettre à jour avec la nouvelle URL https://cloud.pix.fr/s/GqwW6dFDDrHezfS


## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
