### PR TITLE
[TECH] Configurer typescript-eslint sur l'audit-logger

### DIFF
--- a/audit-logger/eslint.config.mjs
+++ b/audit-logger/eslint.config.mjs
@@ -12,6 +12,7 @@ import mocha from 'eslint-plugin-mocha';
 import nRecommendedConfig from 'eslint-plugin-n';
 import prettierRecommendedConfig from 'eslint-plugin-prettier/recommended';
 import unicorn from 'eslint-plugin-unicorn';
+import tseslint from 'typescript-eslint';
 
 const nonPhraseGeneratedFiles = ['translations/en.json', 'translations/fr.json'];
 
@@ -20,6 +21,7 @@ const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url));
 export default [
   includeIgnoreFile(gitignorePath),
   ...pixRecommendedConfig,
+  ...tseslint.configs.recommended,
   prettierRecommendedConfig,
   nRecommendedConfig.configs['flat/recommended'],
   { plugins: { 'chai-expect': fixupPluginRules(chai) } },

--- a/audit-logger/src/db/migrations/20250507131419_drop-non-generic-constraints.ts
+++ b/audit-logger/src/db/migrations/20250507131419_drop-non-generic-constraints.ts
@@ -9,24 +9,18 @@ const ROLE_COLUMN_NAME = 'role';
 const ROLE_COLUMN_CONSTRAINT_NAME = 'audit-log_role_check';
 
 const up = async function (knex: Knex): Promise<void> {
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${ACTION_COLUMN_CONSTRAINT_NAME}"`);
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CLIENT_COLUMN_CONSTRAINT_NAME}"`);
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${ROLE_COLUMN_CONSTRAINT_NAME}"`);
 };
 
 const down = async function (knex: Knex): Promise<void> {
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(
     `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${ACTION_COLUMN_CONSTRAINT_NAME}" CHECK ( "${ACTION_COLUMN_NAME}" IN ('ANONYMIZATION', 'ANONYMIZATION_GAR', 'EMAIL_CHANGED') )`,
   );
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(
     `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CLIENT_COLUMN_CONSTRAINT_NAME}" CHECK ( "${CLIENT_COLUMN_NAME}" IN ('PIX_ADMIN', 'PIX_APP') )`,
   );
-  // eslint-disable-next-line knex/avoid-injections -- Safe operation - the string is interpolated with a constant.
   await knex.raw(
     `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${ROLE_COLUMN_CONSTRAINT_NAME}" CHECK ( "${ROLE_COLUMN_NAME}" IN ('SUPER_ADMIN', 'SUPPORT', 'USER') )`,
   );

--- a/audit-logger/src/lib/domain/models/audit-log.ts
+++ b/audit-logger/src/lib/domain/models/audit-log.ts
@@ -1,4 +1,3 @@
-
 export class AuditLog {
   id?: string;
   occurredAt: Date;


### PR DESCRIPTION
## ❄️ Problème

ESlint ne passe pas sur les fichier typescripts.

## 🛷 Proposition

Ajouter la configuration de `typescript-eslint` dans `esling.config.mjs`

## 🧑‍🎄 Pour tester

Le linter doit passer.