### PR TITLE
[FEATURE] Ajouter les détails des étapes et statuts de participations aux parcours combinés (PIX-20527)

### DIFF
--- a/orga/app/components/activity-type.gjs
+++ b/orga/app/components/activity-type.gjs
@@ -2,30 +2,47 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+const types = {
+  ASSESSMENT: {
+    icon: 'speed',
+    class: 'assessment',
+  },
+  CAMPAIGN: {
+    icon: 'speed',
+    class: 'assessment',
+  },
+  PROFILES_COLLECTION: {
+    icon: 'profileShare',
+    class: 'profiles-collection',
+  },
+  EXAM: {
+    icon: 'school',
+    class: 'exam',
+  },
+  COMBINED_COURSE: {
+    icon: 'studyLesson',
+    class: 'combined-course',
+  },
+  MODULE: {
+    icon: 'book',
+    class: 'module',
+  },
+  FORMATION: {
+    icon: 'lock',
+    class: 'formation',
+  },
+};
+
 export default class ActivityType extends Component {
   @service intl;
 
-  get iconConfig() {
-    const { type } = this.args;
-    switch (type) {
-      case 'ASSESSMENT':
-        return { icon: 'speed', class: 'activity-type__icon--assessment' };
-      case 'PROFILES_COLLECTION':
-        return { icon: 'profileShare', class: 'activity-type__icon--profile-collection' };
-      case 'EXAM':
-        return { icon: 'school', class: 'activity-type__icon--exam' };
-      case 'COMBINED_COURSE':
-        return { icon: 'studyLesson', class: 'activity-type__icon--combined-course' };
-      default:
-        return { icon: 'close', class: '' };
-    }
+  get icon() {
+    return types[this.args.type].icon;
   }
 
   get pictoCssClass() {
     const classes = ['activity-type__icon'];
-
-    classes.push(this.iconConfig.class);
-
+    classes.push('activity-type__icon--' + types[this.args.type].class);
     if (this.args.big) {
       classes.push(classes[0] + '--big');
     }
@@ -41,30 +58,16 @@ export default class ActivityType extends Component {
   }
 
   get label() {
-    const informationLabels = {
-      ASSESSMENT: 'components.activity-type.information.ASSESSMENT',
-      PROFILES_COLLECTION: 'components.activity-type.information.PROFILES_COLLECTION',
-      EXAM: 'components.activity-type.information.EXAM',
-      COMBINED_COURSE: 'components.activity-type.information.COMBINED_COURSE',
-    };
-
-    const explanationLabels = {
-      ASSESSMENT: 'components.activity-type.explanation.ASSESSMENT',
-      PROFILES_COLLECTION: 'components.activity-type.explanation.PROFILES_COLLECTION',
-      EXAM: 'components.activity-type.explanation.EXAM',
-      COMBINED_COURSE: 'components.activity-type.explanation.COMBINED_COURSE',
-    };
-
     const { type, displayInformationLabel } = this.args;
-
-    return this.intl.t(displayInformationLabel ? informationLabels[type] : explanationLabels[type]);
+    const i18nKey = displayInformationLabel ? 'information' : 'explanation';
+    return this.intl.t(`components.activity-type.${i18nKey}.${type}`);
   }
 
   <template>
     <span class="activity-type">
       <PixIcon
         class={{this.pictoCssClass}}
-        @name={{this.iconConfig.icon}}
+        @name={{this.icon}}
         @ariaHidden={{this.pictoAriaHidden}}
         @title={{this.pictoTitle}}
         ...attributes

--- a/orga/app/components/combined-course/participation-detail.gjs
+++ b/orga/app/components/combined-course/participation-detail.gjs
@@ -1,10 +1,50 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import ActivityType from 'pix-orga/components/activity-type';
 import Breadcrumb from 'pix-orga/components/ui/breadcrumb';
 import PageTitle from 'pix-orga/components/ui/page-title';
+import ParticipationStatus from 'pix-orga/components/ui/participation-status';
+
+const ITEM_TYPES = {
+  CAMPAIGN: 'CAMPAIGN',
+  FORMATION: 'FORMATION',
+  MODULE: 'MODULE',
+};
 
 export default class ParticipationDetail extends Component {
   @service intl;
+
+  getStepLabel = (index, hasMultipleSteps) => {
+    if (!hasMultipleSteps) return '';
+    return this.intl.t('pages.combined-course.participation-detail.step-label', { number: index + 1 });
+  };
+
+  getColumnLabel = (items) => {
+    if (!items || items.length === 0) return '';
+    const firstItemType = items[0].type;
+    const key = firstItemType === ITEM_TYPES.CAMPAIGN ? 'campaign' : 'module';
+    return this.intl.t(`pages.combined-course.participation-detail.column.${key}`);
+  };
+
+  getParticipationStatus = (item) => {
+    switch (true) {
+      case item.isLocked:
+        return 'LOCKED';
+      case item.isCompleted:
+        return 'COMPLETED';
+      case item.participationStatus === 'NOT_STARTED':
+        return 'NOT_STARTED';
+      default:
+        return 'STARTED';
+    }
+  };
+
+  isFormation = (type) => {
+    return type === ITEM_TYPES.FORMATION;
+  };
 
   get breadcrumbLinks() {
     return [
@@ -22,9 +62,16 @@ export default class ParticipationDetail extends Component {
         model: this.args.combinedCourse.id,
       },
       {
-        label: `Participation de ${this.args.participation.firstName} ${this.args.participation.lastName}`,
+        label: this.intl.t('pages.combined-course.participation-detail.breadcrumb', {
+          firstName: this.args.participation.firstName,
+          lastName: this.args.participation.lastName,
+        }),
       },
     ];
+  }
+
+  get hasMultipleSteps() {
+    return this.args.itemsBySteps?.length > 1;
   }
 
   <template>
@@ -37,5 +84,51 @@ export default class ParticipationDetail extends Component {
         {{@participation.lastName}}
       </:title>
     </PageTitle>
+
+    {{#each @itemsBySteps as |items index|}}
+      {{#if this.hasMultipleSteps}}
+        <h2 class="participation-detail__step-title">{{this.getStepLabel index this.hasMultipleSteps}}</h2>
+      {{/if}}
+
+      <PixTable
+        @variant="orga"
+        @caption={{this.getStepLabel index this.hasMultipleSteps}}
+        @data={{items}}
+        class="table"
+      >
+        <:columns as |item context|>
+
+          <PixTableColumn @context={{context}}>
+            <:header>
+              {{this.getColumnLabel items}}
+            </:header>
+
+            <:cell>
+              <span class="participation-detail__item-title">
+                <ActivityType @type={{item.type}} @hideLabel={{true}} />
+                {{#if (this.isFormation item.type)}}
+                  {{t "pages.combined-course.participation-detail.formation-locked"}}
+                {{else}}
+                  {{item.title}}
+                {{/if}}
+              </span>
+            </:cell>
+          </PixTableColumn>
+
+          <PixTableColumn @context={{context}} class="participation-detail__status-column">
+            <:header>
+              {{t "pages.combined-course.participation-detail.column.status"}}
+            </:header>
+            <:cell>
+              {{#if (this.isFormation item.type)}}
+                <span aria-label={{t "pages.combined-course.participation-detail.formation-locked"}}>-</span>
+              {{else}}
+                <ParticipationStatus @status={{this.getParticipationStatus item}} />
+              {{/if}}
+            </:cell>
+          </PixTableColumn>
+        </:columns>
+      </PixTable>
+    {{/each}}
   </template>
 }

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -8,6 +8,7 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
@@ -21,6 +22,7 @@ const debounceTime = ENV.pagination.debounce;
 export default class CombinedCourse extends Component {
   @service intl;
   @service locale;
+  @service router;
   @service currentUser;
 
   get statusesOptions() {
@@ -57,6 +59,10 @@ export default class CombinedCourse extends Component {
           empty: 'common.filters.groups.empty',
         };
   }
+
+  onClickParticipation = (participation) => {
+    this.router.transitionTo('authenticated.combined-course.participation-detail', participation.id);
+  };
 
   get divisionColumnName() {
     return this.intl.t(`components.group.${this.isScoOrganization ? 'SCO' : 'SUP'}`);
@@ -128,6 +134,7 @@ export default class CombinedCourse extends Component {
         @caption={{t "pages.combined-course.table.description"}}
         @data={{@participations}}
         class="table"
+        @onRowClick={{this.onClickParticipation}}
       >
         <:columns as |participation context|>
           <PixTableColumn @context={{context}}>
@@ -135,7 +142,9 @@ export default class CombinedCourse extends Component {
               {{t "pages.combined-course.table.column.last-name"}}
             </:header>
             <:cell>
-              {{participation.lastName}}
+              <LinkTo @route="authenticated.combined-course.participation-detail" @model={{participation.id}}>
+                {{participation.lastName}}
+              </LinkTo>
             </:cell>
           </PixTableColumn>
 

--- a/orga/app/components/ui/participation-status.gjs
+++ b/orga/app/components/ui/participation-status.gjs
@@ -23,6 +23,8 @@ export default class ParticipationStatus extends Component {
 }
 
 const COLORS = {
+  NOT_STARTED: 'blue',
+  LOCKED: 'grey-light',
   STARTED: 'yellow-light',
   SHARED: 'green-light',
   COMPLETED: 'green-light',

--- a/orga/app/styles/components/activity-type.scss
+++ b/orga/app/styles/components/activity-type.scss
@@ -16,7 +16,7 @@
       fill: var(--pix-tertiary-500);
     }
 
-    &--profile-collection {
+    &--profiles-collection {
       fill: var(--pix-primary-500);
     }
 
@@ -26,6 +26,14 @@
 
     &--combined-course {
       fill: var(--pix-certif-500);
+    }
+
+    &--module {
+      fill: var(--pix-certif-500);
+    }
+
+    &--formation {
+      fill: var(--pix-neutral-500);
     }
 
     &--big {

--- a/orga/app/styles/pages/authenticated/combined-course.scss
+++ b/orga/app/styles/pages/authenticated/combined-course.scss
@@ -7,6 +7,7 @@
     margin-bottom: var(--pix-spacing-8x);
   }
 
+
   &__header {
     display: flex;
     gap: var(--pix-spacing-4x);
@@ -23,3 +24,24 @@
     gap: var(--pix-spacing-2x);
   }
 }
+
+.participation-detail {
+  &__item-title{
+    display: flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
+  }
+
+  &__status-column {
+    width: 200px;
+  }
+
+  &__step-title{
+    @extend %pix-title-xs;
+
+    margin-top: var(--pix-spacing-8x);
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}
+
+

--- a/orga/app/templates/authenticated/combined-course/participation-detail.gjs
+++ b/orga/app/templates/authenticated/combined-course/participation-detail.gjs
@@ -1,5 +1,9 @@
 import ParticipationDetail from 'pix-orga/components/combined-course/participation-detail';
 
 <template>
-  <ParticipationDetail @combinedCourse={{@model.combinedCourse}} @participation={{@model.participation}} />
+  <ParticipationDetail
+    @combinedCourse={{@model.combinedCourse}}
+    @participation={{@model.participation}}
+    @itemsBySteps={{@model.itemsBySteps}}
+  />
 </template>

--- a/orga/tests/integration/components/activity-type-test.gjs
+++ b/orga/tests/integration/components/activity-type-test.gjs
@@ -1,0 +1,138 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'ember-qunit';
+import ActivityType from 'pix-orga/components/activity-type';
+import { module, test } from 'qunit';
+
+module('Integration | Component | ActivityType', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+
+  module('when rendering different activity types', function () {
+    test('it renders ASSESSMENT type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="ASSESSMENT" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--assessment').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.ASSESSMENT')));
+    });
+
+    test('it renders PROFILES_COLLECTION type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="PROFILES_COLLECTION" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--profiles-collection').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.PROFILES_COLLECTION')));
+    });
+
+    test('it renders EXAM type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="EXAM" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--exam').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.EXAM')));
+    });
+
+    test('it renders COMBINED_COURSE type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="COMBINED_COURSE" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--combined-course').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.COMBINED_COURSE')));
+    });
+
+    test('it renders MODULE type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="MODULE" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--module').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.MODULE')));
+    });
+
+    test('it renders FORMATION type with correct icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="FORMATION" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--formation').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.FORMATION')));
+    });
+
+    test('it renders CAMPAIGN type with assessment icon and label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="CAMPAIGN" /></template>);
+
+      // then
+      assert.dom('.activity-type').exists();
+      assert.dom('.activity-type__icon--assessment').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.CAMPAIGN')));
+    });
+  });
+
+  module('when displayInformationLabel is true', function () {
+    test('it displays information label instead of explanation label', async function (assert) {
+      // when
+      const screen = await render(
+        <template><ActivityType @type="ASSESSMENT" @displayInformationLabel={{true}} /></template>,
+      );
+
+      // then
+      assert.ok(screen.getByText(t('components.activity-type.information.ASSESSMENT')));
+      assert.notOk(screen.queryByText(t('components.activity-type.explanation.ASSESSMENT')));
+    });
+  });
+
+  module('when hideLabel is true', function () {
+    test('it hides the label', async function (assert) {
+      // when
+      await render(<template><ActivityType @type="ASSESSMENT" @hideLabel={{true}} /></template>);
+
+      // then
+      assert.dom('.activity-type__label').doesNotExist();
+      assert.dom('.activity-type__icon').exists();
+    });
+  });
+
+  module('when hideLabel is false', function () {
+    test('it shows the label', async function (assert) {
+      // when
+      const screen = await render(<template><ActivityType @type="ASSESSMENT" @hideLabel={{false}} /></template>);
+
+      // then
+      assert.dom('.activity-type__label').exists();
+      assert.ok(screen.getByText(t('components.activity-type.explanation.ASSESSMENT')));
+    });
+  });
+
+  module('when big is true', function () {
+    test('it adds big modifier class to icon', async function (assert) {
+      // when
+      await render(<template><ActivityType @type="ASSESSMENT" @big={{true}} /></template>);
+
+      // then
+      assert.dom('.activity-type__icon--big').exists();
+    });
+  });
+
+  module('when big is false', function () {
+    test('it does not add big modifier class to icon', async function (assert) {
+      // when
+      await render(<template><ActivityType @type="ASSESSMENT" @big={{false}} /></template>);
+
+      // then
+      assert.dom('.activity-type__icon--big').doesNotExist();
+    });
+  });
+});

--- a/orga/tests/integration/components/combined-course/participation-detail-test.gjs
+++ b/orga/tests/integration/components/combined-course/participation-detail-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ParticipationDetail from 'pix-orga/components/combined-course/participation-detail';
 import { module, test } from 'qunit';
 
@@ -40,9 +41,558 @@ module('Integration | Component | combined-course/participation-detail', functio
       <template><ParticipationDetail @participation={{participation}} @combinedCourse={{combinedCourse}} /></template>,
     );
 
-    assert.ok(screen.getByRole('link', { name: 'Campagnes' }));
-    assert.ok(screen.getByRole('link', { name: 'Parcours apprenants' }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.main.campaigns') }));
+    assert.ok(screen.getByRole('link', { name: t('navigation.main.combined-courses') }));
     assert.ok(screen.getByRole('link', { name: 'Combinix' }));
-    assert.ok(screen.getByText('Participation de Jean Bon'));
+    assert.ok(
+      screen.getByText(
+        t('pages.combined-course.participation-detail.breadcrumb', { firstName: 'Jean', lastName: 'Bon' }),
+      ),
+    );
+  });
+
+  module('when there are multiple steps', function () {
+    test('it displays step labels', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+        [
+          {
+            type: 'MODULE',
+            title: 'Module 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('heading', {
+          name: t('pages.combined-course.participation-detail.step-label', { number: 1 }),
+          level: 2,
+        }),
+      );
+      assert.ok(
+        screen.getByRole('heading', {
+          name: t('pages.combined-course.participation-detail.step-label', { number: 2 }),
+          level: 2,
+        }),
+      );
+    });
+  });
+
+  module('when there is a single step', function () {
+    test('it does not display step labels', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.notOk(screen.queryByText(t('pages.combined-course.participation-detail.step-label', { number: 1 })));
+    });
+  });
+
+  module('column labels', function () {
+    test('it displays "Campagne" column label when items are campaigns', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('columnheader', { name: t('pages.combined-course.participation-detail.column.campaign') }),
+      );
+    });
+
+    test('it displays "Module" column label when items are modules', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'MODULE',
+            title: 'Module 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('columnheader', { name: t('pages.combined-course.participation-detail.column.module') }),
+      );
+    });
+
+    test('it displays "Statut" column label', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(
+        screen.getByRole('columnheader', { name: t('pages.combined-course.participation-detail.column.status') }),
+      );
+    });
+  });
+
+  module('item rendering', function () {
+    test('it displays campaign items with their title', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText('Campaign 1'));
+    });
+
+    test('it displays module items with their title', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'MODULE',
+            title: 'Module 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText('Module 1'));
+    });
+
+    test('it displays formation items with formation text', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'FORMATION',
+            title: 'Formation 1',
+            isLocked: true,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText(t('pages.combined-course.participation-detail.formation-locked')));
+    });
+
+    test('it displays formation items with a dash for status', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'FORMATION',
+            title: 'Formation 1',
+            isLocked: true,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      const statusCell = screen.getByLabelText(t('pages.combined-course.participation-detail.formation-locked'));
+      assert.strictEqual(statusCell.textContent.trim(), '-');
+    });
+  });
+
+  module('participation status', function () {
+    test('it displays LOCKED status when item is locked', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: true,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText(t('components.participation-status.LOCKED')));
+    });
+
+    test('it displays COMPLETED status when item is completed', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: true,
+            participationStatus: 'SHARED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText(t('components.participation-status.COMPLETED')));
+    });
+
+    test('it displays NOT_STARTED status when item has not started', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText(t('components.participation-status.NOT_STARTED')));
+    });
+
+    test('it displays STARTED status when item is in progress', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText(t('components.participation-status.STARTED')));
+    });
+  });
+
+  module('with multiple items in a step', function () {
+    test('it displays all items in the table', async function (assert) {
+      const participation = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        combinedCourseId: 123,
+      };
+      const combinedCourse = {
+        id: 123,
+        name: 'Combinix',
+      };
+      const itemsBySteps = [
+        [
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 1',
+            isLocked: false,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 2',
+            isLocked: false,
+            isCompleted: true,
+            participationStatus: 'STARTED',
+          },
+          {
+            type: 'CAMPAIGN',
+            title: 'Campaign 3',
+            isLocked: true,
+            isCompleted: false,
+            participationStatus: 'NOT_STARTED',
+          },
+        ],
+      ];
+
+      const screen = await render(
+        <template>
+          <ParticipationDetail
+            @participation={{participation}}
+            @combinedCourse={{combinedCourse}}
+            @itemsBySteps={{itemsBySteps}}
+          />
+        </template>,
+      );
+
+      assert.ok(screen.getByText('Campaign 1'));
+      assert.ok(screen.getByText('Campaign 2'));
+      assert.ok(screen.getByText('Campaign 3'));
+    });
   });
 });

--- a/orga/tests/integration/components/combined-course/participations-test.gjs
+++ b/orga/tests/integration/components/combined-course/participations-test.gjs
@@ -47,7 +47,14 @@ module('Integration | Component | combined-course/participations', function (hoo
     };
   });
 
-  module('table', function () {
+  module('table', function (hooks) {
+    let router;
+
+    hooks.beforeEach(function () {
+      router = this.owner.lookup('service:router');
+      router.transitionTo = sinon.stub();
+    });
+
     test('it should have a caption to describe the table ', async function (assert) {
       // when
       const screen = await render(
@@ -202,6 +209,31 @@ module('Integration | Component | combined-course/participations', function (hoo
 
       // then
       assert.ok(within(campaignHeader).getByText(t('pages.combined-course.table.tooltip.modules-column')));
+    });
+
+    test('it should transition to participation detail when clicking on a row', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <CombinedCourseParticipations
+            @hasCampaigns={{true}}
+            @hasModules={{true}}
+            @participations={{participations}}
+            @onFilter={{onFilter}}
+          />
+        </template>,
+      );
+
+      const table = screen.getByRole('table');
+      const rows = within(table).getAllByRole('row');
+      // Skip header row, click on first data row
+      await click(rows[1]);
+
+      // then
+      assert.true(router.transitionTo.calledOnce);
+      assert.true(
+        router.transitionTo.calledWith('authenticated.combined-course.participation-detail', participations[0].id),
+      );
     });
   });
 

--- a/orga/tests/integration/components/ui/participation-status-test.gjs
+++ b/orga/tests/integration/components/ui/participation-status-test.gjs
@@ -1,6 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
-import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
+import ParticipationStatus from 'pix-orga/components/ui/participation-status';
 import { module, test } from 'qunit';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -10,12 +10,10 @@ module('Integration | Component | Ui | ParticipationStatus', function (hooks) {
 
   module('label', function () {
     test('it should display formatted label', async function (assert) {
-      this.set('status', 'SHARED');
+      const status = 'SHARED';
 
       // when
-      const screen = await render(
-        hbs`<Ui::ParticipationStatus @status={{this.status}} @campaignType={{this.campaignType}} />`,
-      );
+      const screen = await render(<template><ParticipationStatus @status={{status}} /></template>);
 
       // then
       assert.ok(screen.getByText(t('components.participation-status.SHARED')));

--- a/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
+++ b/orga/tests/unit/routes/authenticated/combined-course/participation-detail-test.js
@@ -27,8 +27,135 @@ module('Unit | Route | authenticated/combined-course', function (hooks) {
     });
   });
 
+  module('sortItemsByStep', function () {
+    test('should return an empty array when given an empty array', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.deepEqual(result, []);
+    });
+
+    test('should group consecutive CAMPAIGN items together in the same step', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [
+        { reference: 'CAMPAIGN-1', type: 'CAMPAIGN' },
+        { reference: 'CAMPAIGN-2', type: 'CAMPAIGN' },
+        { reference: 'CAMPAIGN-3', type: 'CAMPAIGN' },
+      ];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.strictEqual(result.length, 1);
+      assert.deepEqual(result, [
+        [
+          { reference: 'CAMPAIGN-1', type: 'CAMPAIGN' },
+          { reference: 'CAMPAIGN-2', type: 'CAMPAIGN' },
+          { reference: 'CAMPAIGN-3', type: 'CAMPAIGN' },
+        ],
+      ]);
+    });
+
+    test('should group consecutive MODULE items together in the same step', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [
+        { reference: 'MODULE-1', type: 'MODULE' },
+        { reference: 'MODULE-2', type: 'MODULE' },
+        { reference: 'MODULE-3', type: 'MODULE' },
+      ];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.strictEqual(result.length, 1);
+      assert.deepEqual(result, [
+        [
+          { reference: 'MODULE-1', type: 'MODULE' },
+          { reference: 'MODULE-2', type: 'MODULE' },
+          { reference: 'MODULE-3', type: 'MODULE' },
+        ],
+      ]);
+    });
+
+    test('should group FORMATION and MODULE items together in the same step', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [
+        { reference: 'FORMATION-1', type: 'FORMATION' },
+        { reference: 'MODULE-1', type: 'MODULE' },
+        { reference: 'MODULE-2', type: 'MODULE' },
+      ];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.strictEqual(result.length, 1);
+      assert.deepEqual(result, [
+        [
+          { reference: 'FORMATION-1', type: 'FORMATION' },
+          { reference: 'MODULE-1', type: 'MODULE' },
+          { reference: 'MODULE-2', type: 'MODULE' },
+        ],
+      ]);
+    });
+
+    test('should create a new step when a CAMPAIGN item appears after MODULE items', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [
+        { reference: 'MODULE-1', type: 'MODULE' },
+        { reference: 'MODULE-2', type: 'MODULE' },
+        { reference: 'CAMPAIGN-1', type: 'CAMPAIGN' },
+        { reference: 'MODULE-3', type: 'MODULE' },
+      ];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.strictEqual(result.length, 3);
+      assert.deepEqual(result, [
+        [
+          { reference: 'MODULE-1', type: 'MODULE' },
+          { reference: 'MODULE-2', type: 'MODULE' },
+        ],
+        [{ reference: 'CAMPAIGN-1', type: 'CAMPAIGN' }],
+        [{ reference: 'MODULE-3', type: 'MODULE' }],
+      ]);
+    });
+
+    test('should create a new step when FORMATION items are not consecutive with MODULE items', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
+      const itemsToSort = [
+        { reference: 'FORMATION-1', type: 'FORMATION' },
+        { reference: 'FORMATION-2', type: 'FORMATION' },
+      ];
+
+      // when
+      const result = route.sortItemsByStep(itemsToSort);
+
+      // then
+      assert.strictEqual(result.length, 2);
+      assert.deepEqual(result, [
+        [{ reference: 'FORMATION-1', type: 'FORMATION' }],
+        [{ reference: 'FORMATION-2', type: 'FORMATION' }],
+      ]);
+    });
+  });
+
   module('model', function () {
-    test('fetch a combined course participation detail', async function (assert) {
+    test('fetch a combined course participation det      g;ail', async function (assert) {
       // given
       const route = this.owner.lookup('route:authenticated/combined-course/participation-detail');
       const store = this.owner.lookup('service:store');
@@ -38,8 +165,7 @@ module('Unit | Route | authenticated/combined-course', function (hooks) {
       sinon.stub(route, 'modelFor').returns(combinedCourse);
 
       const participationId = Symbol('participationId');
-      const participationDetail = { participation: Symbol('participation'), items: Symbol('items') };
-
+      const participationDetail = { participation: Symbol('participation'), items: [Symbol('items')] };
       sinon
         .stub(store, 'queryRecord')
         .withArgs('combined-course-participation-detail', { combinedCourseId, participationId })
@@ -52,7 +178,7 @@ module('Unit | Route | authenticated/combined-course', function (hooks) {
       assert.deepEqual(result, {
         combinedCourse,
         participation: participationDetail.participation,
-        items: participationDetail.items,
+        itemsBySteps: [participationDetail.items],
       });
     });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -287,14 +287,20 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Campaign of type assessment",
+        "CAMPAIGN": "Campaign of type assessment",
         "COMBINED_COURSE": "Learning program",
         "EXAM": "Exam mode [beta]",
+        "FORMATION": "Training",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Campaign of type profiles collection"
       },
       "information": {
         "ASSESSMENT": "Assessment",
+        "CAMPAIGN": "Assessment",
         "COMBINED_COURSE": "Learning program",
         "EXAM": "Exam mode [beta]",
+        "FORMATION": "Training",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Profiles collection"
       }
     },
@@ -450,6 +456,8 @@
     },
     "participation-status": {
       "COMPLETED": "Completed",
+      "LOCKED": "To unlock",
+      "NOT_STARTED": "To do",
       "SHARED": "Completed",
       "STARTED": "In progress"
     },
@@ -1078,6 +1086,16 @@
         }
       },
       "introduction": "The learning courses combine assessments and personalised learning modules, enabling teaching to be tailored to each participant's level.",
+      "participation-detail": {
+        "breadcrumb": "Participation of {firstName} {lastName}",
+        "column": {
+          "campaign": "Campaign",
+          "module": "Module",
+          "status": "Status"
+        },
+        "formation-locked": "Unlocked once the campaign is completed",
+        "step-label": "Step {number}"
+      },
       "statistics": {
         "completed-participations": "Completed participations",
         "total-participations": "Total participations"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -287,14 +287,20 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Campagne d'évaluation",
+        "CAMPAIGN": "Campagne d'évaluation",
         "COMBINED_COURSE": "Parcours apprenant",
         "EXAM": "Mode interro [bêta]",
+        "FORMATION": "Formation",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Campagne de collecte de profil"
       },
       "information": {
         "ASSESSMENT": "Évaluation",
+        "CAMPAIGN": "Évaluation",
         "COMBINED_COURSE": "Parcours apprenant",
         "EXAM": "Mode interro [bêta]",
+        "FORMATION": "Formation",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Collecte de profil"
       }
     },
@@ -450,6 +456,8 @@
     },
     "participation-status": {
       "COMPLETED": "Terminé",
+      "LOCKED": "A déverrouiller",
+      "NOT_STARTED": "A faire",
       "SHARED": "Terminé",
       "STARTED": "En cours"
     },
@@ -1065,7 +1073,17 @@
           "placeholder": "Tous les statuts"
         }
       },
-      "introduction": "Les parcours apprenants articulent des évaluations et des modules d’apprentissage personnalisés, permettant une adaptation pédagogique fondée sur le niveau de chaque participant.",
+      "introduction": "Les parcours apprenants articulent des évaluations et des modules d'apprentissage personnalisés, permettant une adaptation pédagogique fondée sur le niveau de chaque participant.",
+      "participation-detail": {
+        "breadcrumb": "Participation de {firstName} {lastName}",
+        "column": {
+          "campaign": "Campagne",
+          "module": "Module",
+          "status": "Statut"
+        },
+        "formation-locked": "Débloquée une fois que la campagne sera terminée",
+        "step-label": "Étape {number}"
+      },
       "statistics": {
         "completed-participations": "Participations complétées",
         "total-participations": "Total des participations"
@@ -1083,7 +1101,7 @@
         "module-completion": "{nbItemsCompleted, plural, =0 {Aucun module complété sur {nbItems}} =1 {Un module complété sur {nbItems}} other {{nbItemsCompleted} modules complétés sur {nbItems}}}.",
         "no-module": "Aucun module recommandé.",
         "tooltip": {
-          "campaigns-column": "'x / y' indique la progression du participant : il a terminé x campagnes sur un total de y. Par exemple, 1/2 signifie qu’il a terminé 1 campagne sur 2.",
+          "campaigns-column": "'x / y' indique la progression du participant : il a terminé x campagnes sur un total de y. Par exemple, 1/2 signifie qu'il a terminé 1 campagne sur 2.",
           "modules-column": "'x / y' indique la progression du participant : il a terminé x modules sur un total de y. Le total de modules diffère pour chacun, en fonction des recommandations personnalisées."
         }
       }

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -290,12 +290,16 @@
         "ASSESSMENT": "Beoordelingscampagne",
         "COMBINED_COURSE": "Leerprogramma",
         "EXAM": "Vraagmodus [beta]",
+        "FORMATION": "Training",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Campagne profielverzameling"
       },
       "information": {
         "ASSESSMENT": "Beoordeling",
         "COMBINED_COURSE": "Leerprogramma",
         "EXAM": "Vraagmodus [beta]",
+        "FORMATION": "Training",
+        "MODULE": "Module",
         "PROFILES_COLLECTION": "Profielverzameling"
       }
     },
@@ -451,6 +455,8 @@
     },
     "participation-status": {
       "COMPLETED": "Voltooid",
+      "LOCKED": "Te ontgrendelen",
+      "NOT_STARTED": "Te doen",
       "SHARED": "Voltooid",
       "STARTED": "Bezig"
     },
@@ -1067,6 +1073,16 @@
         }
       },
       "introduction": "De leertrajecten bestaan uit beoordelingen en gepersonaliseerde leermodules, waardoor het onderwijs kan worden aangepast aan het niveau van elke deelnemer.",
+      "participation-detail": {
+        "breadcrumb": "Deelname van {firstName} {lastName}",
+        "column": {
+          "campaign": "Campagne",
+          "module": "Module",
+          "status": "Status"
+        },
+        "formation-locked": "Ontgrendeld zodra de campagne is voltooid",
+        "step-label": "Stap {number}"
+      },
       "statistics": {
         "completed-participations": "Voltooide deelnames",
         "total-participations": "Totaal van de deelnemingen"


### PR DESCRIPTION
## ❄️ Problème

Dans l'interface Orga, les parcours combinés ne permettaient pas de visualiser les détails des étapes et les statuts de participation de manière détaillée.

## 🛷 Proposition

Cette PR ajoute les fonctionnalités suivantes pour les parcours combinés :

- **Affichage des détails des étapes** : Ajout de l'affichage détaillé des étapes dans la vue de détail des participations
- **Statuts de participation** : Ajout de nouveaux statuts de participation avec leurs couleurs associées (en cours, terminé, non commencé, etc.)
- **Traductions** : Ajout des traductions pour les statuts et détails des étapes (FR, EN, NL)
- **Tri par étapes** : Implémentation de la fonctionnalité de tri des items par étape
- **Types d'activités** : Ajout des categories pour les types d'activités

### Modifications techniques :
- Mise à jour du composant `activity-type.gjs` avec les nouveaux types
- Refonte du composant `combined-course/participation-detail.gjs` pour afficher les étapes
- Ajout des styles pour les nouveaux statuts dans `ui/participation-status.gjs`
- Tests exhaustifs pour tous les composants modifiés

## 🧑‍🎄 Pour tester

1. Se connecter à l'interface Orga
2. Accéder à un parcours combiné avec des participations
3. Ouvrir le détail d'une participation
4. Vérifier que :
   - Les étapes sont affichées avec leurs détails
   - Les statuts de participation sont correctement colorés
   - Le tri par étape fonctionne correctement
   - Les traductions sont présentes dans les 3 langues (FR, EN, NL)