### PR TITLE
[FEATURE] Éviter d'avoir l'auto-complétion Google Pay sur le form de certif (PIX-20635).

### DIFF
--- a/mon-pix/app/components/certification-joiner.gjs
+++ b/mon-pix/app/components/certification-joiner.gjs
@@ -42,21 +42,25 @@ export default class CertificationJoiner extends Component {
     {{! template-lint-disable require-input-label no-bare-strings }}
     <section class="certification-joiner">
       <h1 class="certification-joiner__title">{{t "pages.certification-joiner.first-title"}}</h1>
-      <form autocomplete="off" {{on "submit" this.attemptNext}}>
+      <form {{on "submit" this.attemptNext}}>
         <p class="certification-joiner__mandatory">{{t "common.form.mandatory-all-fields"}}</p>
 
         <PixInput
           @id="certificationJoinerSessionId"
           @errorMessage={{this.sessionIdIsNotANumberMessage}}
           @validationStatus={{this.sessionIdStatus}}
-          pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
           title={{t "pages.certification-joiner.form.fields-validation.session-number-error"}}
           {{on "input" this.checkSessionIdIsValid}}
           {{on "change" this.setSessionId}}
-          inputmode="decimal"
+          type="number"
+          inputmode="numeric"
+          min="0"
+          step="1"
+          pattern={{this.SESSION_ID_VALIDATION_PATTERN}}
           required="true"
           @subLabel={{t "pages.certification-joiner.form.fields.session-number-information"}}
           placeholder={{t "pages.certification-joiner.form.placeholders.session-number"}}
+          autocomplete="organization"
         >
           <:label>{{t "pages.certification-joiner.form.fields.session-number"}}</:label>
         </PixInput>
@@ -65,6 +69,7 @@ export default class CertificationJoiner extends Component {
           required="true"
           {{on "change" this.setFirstName}}
           placeholder={{t "pages.certification-joiner.form.placeholders.first-name"}}
+          autocomplete="given-name"
         >
           <:label>{{t "pages.certification-joiner.form.fields.first-name"}}</:label>
         </PixInput>
@@ -73,6 +78,7 @@ export default class CertificationJoiner extends Component {
           required="true"
           {{on "change" this.setLastName}}
           placeholder={{t "pages.certification-joiner.form.placeholders.birth-name"}}
+          autocomplete="family-name"
         >
           <:label>{{t "pages.certification-joiner.form.fields.birth-name"}}</:label>
         </PixInput>
@@ -92,6 +98,7 @@ export default class CertificationJoiner extends Component {
               {{on "focus-in" this.handleInputFocus}}
               @screenReaderOnly="true"
               required="true"
+              autocomplete="bday-day"
             >
               <:label>{{t "pages.certification-joiner.form.fields.birth-day"}}</:label>
             </PixInput>
@@ -106,6 +113,7 @@ export default class CertificationJoiner extends Component {
               {{on "focus-in" this.handleInputFocus}}
               @screenReaderOnly="true"
               required="true"
+              autocomplete="bday-month"
             >
               <:label>{{t "pages.certification-joiner.form.fields.birth-month"}}</:label>
             </PixInput>
@@ -119,6 +127,7 @@ export default class CertificationJoiner extends Component {
               {{on "focus-in" this.handleInputFocus}}
               @screenReaderOnly="true"
               required="true"
+              autocomplete="bday-year"
             >
               <:label>{{t "pages.certification-joiner.form.fields.birth-year"}}</:label>
             </PixInput>
@@ -156,7 +165,6 @@ export default class CertificationJoiner extends Component {
   @service store;
   @service intl;
 
-  SESSION_ID_VALIDATION_PATTERN = '^[0-9]*$';
   V3_CERTIFICATION_SUPPORTED_LANGUAGES = ['en', 'fr'];
 
   @tracked errorMessage = null;

--- a/mon-pix/tests/helpers/certification.js
+++ b/mon-pix/tests/helpers/certification.js
@@ -15,7 +15,7 @@ export async function fillCertificationJoiner({
   const screen = await getScreen();
 
   await fillIn(
-    screen.getByRole('textbox', {
+    screen.getByRole('spinbutton', {
       name: `${t('pages.certification-joiner.form.fields.session-number')} ${t('pages.certification-joiner.form.fields.session-number-information')}`,
     }),
     sessionId,

--- a/mon-pix/tests/integration/components/certification-joiner-test.js
+++ b/mon-pix/tests/integration/components/certification-joiner-test.js
@@ -113,26 +113,6 @@ module('Integration | Component | certification-joiner', function (hooks) {
       );
     });
 
-    test('should display an error message if session id contains letters', async function (assert) {
-      // given
-      this.set('onStepChange', sinon.stub());
-      const screen = await render(hbs`<CertificationJoiner @onStepChange={{this.onStepChange}} />`);
-      const sessionIdWithLetters = '123AAA456AAA';
-
-      await _fillInputsToJoinSession({ sessionId: sessionIdWithLetters, screen, t });
-
-      const store = this.owner.lookup('service:store');
-      const createRecordMock = sinon.mock();
-      createRecordMock.returns({ save: function () {} });
-      store.createRecord = createRecordMock;
-
-      // when
-      await click(screen.getByRole('button', { name: t('pages.certification-joiner.form.actions.submit') }));
-
-      // then
-      assert.ok(screen.getByText('Le numéro de session est composé uniquement de chiffres.'));
-    });
-
     test('should display an error message on student mismatch error', async function (assert) {
       // given
       this.set('onStepChange', sinon.stub());
@@ -314,7 +294,7 @@ module('Integration | Component | certification-joiner', function (hooks) {
     // then
     assert
       .dom(
-        screen.getByRole('textbox', {
+        screen.getByRole('spinbutton', {
           name: 'Numéro de session Communiqué uniquement par le surveillant en début de session',
         }),
       )
@@ -403,7 +383,7 @@ module('Integration | Component | certification-joiner', function (hooks) {
 
   async function _fillInputsToJoinSession({ sessionId = '123456', screen, t }) {
     await fillIn(
-      screen.getByRole('textbox', {
+      screen.getByRole('spinbutton', {
         name: 'Numéro de session Communiqué uniquement par le surveillant en début de session',
       }),
       sessionId,


### PR DESCRIPTION
## ❄️ Problème

Suite [à une nouveauté de Chrome](https://blog.google/products/chrome/enhanced-autofill/), on voit Google Pay apparaitre côté Pix App sur le formulaire de certif. Le autocomplete ne s’applique pas dessus.

## 🛷 Proposition

Spécifier des règles d'autocomplete pour chaque champ, avec des [valeurs documentées](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#value).

## ☃️ Remarques

`organization` a été choisi pour le numéro de session, car il n'y a pas de vrai bon choix approprié.

## 🧑‍🎄 Pour tester

- Avoir une CB ajoutée sur Google Chrome ([voir comme faire](https://1024pix.atlassian.net/browse/PIX-20635?focusedCommentId=55737))
- Se connecter à PixApp en RA
- Visualiser le form d'entrée en certif
- Constater qu'il n'y a pas d'auto-complétion proposée
