### PR TITLE
[TECH] Permettre au métier d'entrer une URL complète d'image dans le formulaire de création de badge sur Pix Admin (PIX-20588)

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -32,8 +32,6 @@ export default class Badge extends Component {
     });
   }
 
-  IMAGE_BASE_URL = 'https://assets.pix.org/badges/';
-
   get isCertifiableText() {
     return this.args.badge.isCertifiable ? 'Certifiable' : 'Non certifiable';
   }
@@ -42,8 +40,8 @@ export default class Badge extends Component {
     return this.args.badge.isAlwaysVisible ? 'Lacunes' : null;
   }
 
-  get imageName() {
-    return this.args.badge.imageUrl.slice(this.IMAGE_BASE_URL.length);
+  get imageUrl() {
+    return this.args.badge.imageUrl;
   }
 
   get campaignScopeCriterion() {
@@ -66,7 +64,7 @@ export default class Badge extends Component {
         altMessage: this.form.altMessage,
         isCertifiable: this.form.isCertifiable,
         isAlwaysVisible: this.form.isAlwaysVisible,
-        imageUrl: this.IMAGE_BASE_URL + this.form.imageName,
+        imageUrl: this.form.imageUrl,
       };
       await this.args.onUpdateBadge(badgeDTO);
       this.pixToast.sendSuccessNotification({ message: 'Le badge a été mis à jour.' });
@@ -121,7 +119,7 @@ export default class Badge extends Component {
       altMessage: this.args.badge.altMessage,
       isCertifiable: this.args.badge.isCertifiable,
       isAlwaysVisible: this.args.badge.isAlwaysVisible,
-      imageName: this.imageName,
+      imageUrl: this.args.badge.imageUrl,
     };
   }
 
@@ -162,10 +160,10 @@ export default class Badge extends Component {
             <div class="badge-edit-form__field">
               <PixInput
                 class="form-control"
-                @value={{this.form.imageName}}
+                @value={{this.form.imageUrl}}
                 @requiredLabel={{t "common.forms.mandatory"}}
-                {{on "input" (this.onFormInputChange "imageName")}}
-              ><:label>Nom de l'image (svg)</:label></PixInput>
+                {{on "input" (this.onFormInputChange "imageUrl")}}
+              ><:label>Url de l'image (svg)</:label></PixInput>
             </div>
             <div class="badge-edit-form__field">
               <PixInput
@@ -224,8 +222,8 @@ export default class Badge extends Component {
                 <dd class="page-details__value">{{@badge.key}}</dd>
                 <dt class="page-details__label">Nom du badge&nbsp;:&nbsp;</dt>
                 <dd class="page-details__value">{{@badge.title}}</dd>
-                <dt class="page-details__label">Image&nbsp;:&nbsp;</dt>
-                <dd class="page-details__value">{{this.imageName}}</dd>
+                <dt class="page-details__label">Url de l'image&nbsp;:&nbsp;</dt>
+                <dd class="page-details__value">{{this.imageUrl}}</dd>
                 <dt class="page-details__label">Message&nbsp;:&nbsp;</dt>
                 <dd class="page-details__value">
                   <blockquote>

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights-test.js
@@ -482,7 +482,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           key: 'OLD_KEY',
           title: 'ancien titre',
           message: 'ancien message',
-          imageUrl: 'old_image.png',
+          imageUrl: 'https://assets.pix.org/badges/old_image.png',
           altMessage: 'ancien alt',
           isCertifiable: false,
           isAlwaysVisible: true,
@@ -498,7 +498,10 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         await fillIn(screen.getByLabelText('Titre *', { exact: false }), 'nouveau titre');
         await fillIn(screen.getByLabelText('Clé *', { exact: false }), 'NEW_KEY');
         await fillByLabel('Message', 'nouveau message');
-        await fillIn(screen.getByLabelText("Nom de l'image (svg) *", { exact: false }), 'new_image.svg');
+        await fillIn(
+          screen.getByLabelText("Url de l'image (svg) *", { exact: false }),
+          'https://assets.pix.org/badges/new_image.svg',
+        );
         await fillIn(screen.getByLabelText('Message Alternatif *', { exact: false }), 'nouveau alt');
         await clickByName('Certifiable');
         await clickByName('Lacunes');
@@ -508,7 +511,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/100');
         assert.dom(screen.getAllByText('100')[1]).exists();
         assert.dom(screen.getByText('nouveau titre')).exists();
-        assert.dom(screen.getByText('new_image.svg')).exists();
+        assert.dom(screen.getByText('https://assets.pix.org/badges/new_image.svg')).exists();
         assert.dom(screen.getByText('NEW_KEY')).exists();
         assert.dom(screen.getByText('nouveau message')).exists();
         assert.dom(screen.getByText('nouveau alt')).exists();
@@ -588,7 +591,10 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         await clickByName('Clés de lecture');
         await clickByName('Nouveau badge');
         await fillByLabel(/Nom du badge :/, 'Mon nouveau badge');
-        await fillIn(screen.getByLabelText("Nom de l'image (svg) *", { exact: false }), 'troll.png');
+        await fillIn(
+          screen.getByLabelText("Url de l'image (svg) *", { exact: false }),
+          'https://assets.pix.org/badges/troll.png',
+        );
         await fillByLabel(/Texte alternatif pour l'image :/, 'Je mets du png je fais ce que je veux');
         await fillByLabel('Message :', 'message de mon badge');
         await fillByLabel(/Clé/, 'MY_BADGE');
@@ -649,7 +655,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/1');
         assert.dom(screen.getAllByText('1')[1]).exists();
         assert.dom(screen.getByText('Mon nouveau badge')).exists();
-        assert.dom(screen.getByText('troll.png')).exists();
+        assert.dom(screen.getByText('https://assets.pix.org/badges/troll.png')).exists();
         assert.dom(screen.getByText('MY_BADGE')).exists();
         assert.dom(screen.getByText('message de mon badge')).exists();
         assert.dom(screen.getByText('Je mets du png je fais ce que je veux')).exists();

--- a/admin/tests/integration/components/badges/badge-test.gjs
+++ b/admin/tests/integration/components/badges/badge-test.gjs
@@ -42,6 +42,7 @@ module('Integration | Component | badges/badge', function (hooks) {
     assert.dom(screen.getByText(badge.message)).exists();
     assert.dom(screen.getByText(badge.key)).exists();
     assert.dom(screen.getByText(badge.altMessage)).exists();
+    assert.dom(screen.getByText(badge.imageUrl)).exists();
     assert.dom(screen.getByText('Certifiable')).exists();
     assert.dom(screen.getByText('Lacunes')).exists();
     assert.dom(screen.getByRole('presentation')).exists();
@@ -71,7 +72,7 @@ module('Integration | Component | badges/badge', function (hooks) {
       id: '42',
       title: 'mon titre',
       message: 'mon message',
-      imageUrl: 'data:,',
+      imageUrl: 'https://assets.pix.org/badges/new_badge.svg',
       key: 'ma clef',
       altMessage: 'mon message alternatif',
       isCertifiable: true,

--- a/admin/tests/mirage/factories/badge.js
+++ b/admin/tests/mirage/factories/badge.js
@@ -41,7 +41,7 @@ export default Factory.extend({
       });
       badge.update({
         criteria: [criteriaCampaign],
-        imageUrl: `https://assets.pix.org/badges/${badge.imageUrl}`,
+        imageUrl: `${badge.imageUrl}`,
       });
     }
   },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -349,6 +349,7 @@
     },
     "badges": {
       "api-error-messages": {
+        "incorrect-image-url-format": "The url format of the badge's image is incorrect.",
         "key-already-exists": "The badge key {badgeKey} already exists"
       },
       "tooltips": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -349,6 +349,7 @@
     },
     "badges": {
       "api-error-messages": {
+        "incorrect-image-url-format": "Le format de l'url de l'image du badge est incorrect.",
         "key-already-exists": "La clé de badge {badgeKey} est déjà utilisée"
       },
       "tooltips": {

--- a/api/src/evaluation/application/badges/index.js
+++ b/api/src/evaluation/application/badges/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
-import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { badgeImageUrlValidation, identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { badgesController } from './badges-controller.js';
 
 const register = async function (server) {
@@ -101,7 +101,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 key: Joi.string().required(),
                 'alt-message': Joi.string().required(),
-                'image-url': Joi.string().required(),
+                'image-url': Joi.string().regex(badgeImageUrlValidation).required(),
                 message: Joi.string().required().allow('').allow(null),
                 title: Joi.string().required().allow('').allow(null),
                 'is-certifiable': Joi.boolean().required(),

--- a/api/src/evaluation/application/badges/index.js
+++ b/api/src/evaluation/application/badges/index.js
@@ -30,7 +30,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 key: Joi.string().required(),
                 'alt-message': Joi.string().required(),
-                'image-url': Joi.string().required(),
+                'image-url': Joi.string().regex(badgeImageUrlValidation).required(),
                 message: Joi.string().required().allow(null, ''),
                 title: Joi.string().required().allow(null),
                 'is-certifiable': Joi.boolean().required(),

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -15,7 +15,7 @@ const implementationType = {
 
 const badgeImageUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/badges\/.*.svg$/);
 const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
-const editorLogoUrlValidation = new RegExp('^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$');
+const editorLogoUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/contenu-formatif\/editeur\/.*\.svg$/);
 
 const inePattern = new RegExp('^[0-9]{9}[a-zA-Z]{2}$');
 const inaPattern = new RegExp('^[0-9]{10}[a-zA-Z]{1}$');

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -13,6 +13,7 @@ const implementationType = {
   uuid: Joi.string().uuid(),
 };
 
+const badgeImageUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/badges\/.*.svg$/);
 const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
 const editorLogoUrlValidation = new RegExp('^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$');
 
@@ -106,6 +107,7 @@ paramsToExport.positiveInteger32bits = {
 };
 
 export {
+  badgeImageUrlValidation,
   certificationVerificationCodeType,
   editorLogoUrlValidation,
   paramsToExport as identifiersType,

--- a/api/tests/devcomp/integration/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/integration/application/trainings/training-route_test.js
@@ -253,7 +253,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
 
         // then
         expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-          '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
+          '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets.pix.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
         );
         expect(response.statusCode).to.equal(400);
       });
@@ -1036,7 +1036,7 @@ describe('Integration | Devcomp | Application | Trainings | Router | training-ro
 
           // then
           expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-            '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets\\.pix\\.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
+            '"data.attributes.editor-logo-url" with value "image.svg" fails to match the required pattern: /^https:\\/\\/assets.pix.org\\/contenu-formatif\\/editeur\\/.*\\.svg$/',
           );
           expect(response.statusCode).to.equal(400);
         });

--- a/api/tests/evaluation/acceptance/application/badges/index_test.js
+++ b/api/tests/evaluation/acceptance/application/badges/index_test.js
@@ -34,7 +34,7 @@ describe('Acceptance | Route | target-profiles', function () {
         const badgeCreation = {
           key: 'badge1',
           'alt-message': 'alt-message',
-          'image-url': 'https//images.example.net',
+          'image-url': 'https://assets.pix.org/badges/badge_url.svg',
           message: 'Bravo !',
           title: 'Le super badge',
           'is-certifiable': false,
@@ -79,7 +79,7 @@ describe('Acceptance | Route | target-profiles', function () {
           data: {
             attributes: {
               'alt-message': 'alt-message',
-              'image-url': 'https//images.example.net',
+              'image-url': 'https://assets.pix.org/badges/badge_url.svg',
               'is-certifiable': false,
               'is-always-visible': true,
               key: 'badge1',
@@ -118,7 +118,7 @@ describe('Acceptance | Route | target-profiles', function () {
         const badgeCreation = {
           key: 'badge1',
           'alt-message': 'alt-message',
-          'image-url': 'https//images.example.net',
+          'image-url': 'https://assets.pix.org/badges/badge_url.svg',
           message: 'Bravo !',
           title: 'Le super badge',
           'is-certifiable': false,
@@ -173,7 +173,7 @@ describe('Acceptance | Route | target-profiles', function () {
         const badgeCreation = {
           key: 'badge1',
           'alt-message': 'alt-message',
-          'image-url': 'https//images.example.net',
+          'image-url': 'https://assets.pix.org/badges/badge_url.svg',
           message: 'Bravo !',
           title: 'Le super badge',
           'is-certifiable': false,

--- a/api/tests/evaluation/unit/application/badges/index_test.js
+++ b/api/tests/evaluation/unit/application/badges/index_test.js
@@ -15,7 +15,7 @@ describe('Unit | Application | Badges | Routes', function () {
         attributes: {
           key: 'KEY',
           'alt-message': 'alt-message',
-          'image-url': 'https://example.net/image.svg',
+          'image-url': 'https://assets.pix.org/badges/badge_url.svg',
           message: 'message',
           title: 'title',
           'is-certifiable': false,

--- a/api/tests/evaluation/unit/application/badges/index_test.js
+++ b/api/tests/evaluation/unit/application/badges/index_test.js
@@ -184,7 +184,7 @@ describe('Unit | Application | Badges | Routes', function () {
           title: 'titre du badge modifié',
           message: 'Message modifié',
           'alt-message': 'Message alternatif modifié',
-          'image-url': 'url_image_modifiée',
+          'image-url': 'https://assets.pix.org/badges/new_badge_url.svg',
           'is-certifiable': true,
           'is-always-visible': true,
         },

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-creation-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-creation-serializer_test.js
@@ -11,7 +11,7 @@ describe('Unit | Serializer | JSONAPI | badge-creation-serializer', function () 
           attributes: {
             key: 'BADGE_KEY',
             'alt-message': 'alt-message',
-            'image-url': 'https://example.net/image.svg',
+            'image-url': 'https://assets.pix.org/badges/badge_url.svg',
             message: 'message',
             title: 'title',
             'is-certifiable': false,
@@ -28,7 +28,7 @@ describe('Unit | Serializer | JSONAPI | badge-creation-serializer', function () 
       const expectedBadgeCreation = {
         key: 'BADGE_KEY',
         altMessage: 'alt-message',
-        imageUrl: 'https://example.net/image.svg',
+        imageUrl: 'https://assets.pix.org/badges/badge_url.svg',
         message: 'message',
         title: 'title',
         isCertifiable: false,

--- a/api/tests/shared/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/shared/acceptance/application/badges/badge-controller_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | API | Badges', function () {
       badge = databaseBuilder.factory.buildBadge({
         id: 1,
         altMessage: 'Message alternatif',
-        imageUrl: 'url_image',
+        imageUrl: 'https://assets.pix.org/badges/badge_url.svg',
         message: 'Bravo',
         title: 'titre du badge',
         key: 'clef du badge',
@@ -37,7 +37,7 @@ describe('Acceptance | API | Badges', function () {
         title: 'titre du badge modifié',
         message: 'Message modifié',
         'alt-message': 'Message alternatif modifié',
-        'image-url': 'url_image_modifiée',
+        'image-url': 'https://assets.pix.org/badges/new_badge_url.svg',
         'is-certifiable': true,
         'is-always-visible': true,
       };


### PR DESCRIPTION
## ❄️ Problème

Aujourd’hui, lorsque le métier souhaite créer un badge sur Admin, il doit fournir le nom de l’image du badge.

Seulement, depuis le changement du lien de la liste, Pix Assets donne la possibilité de copier coller l’url complet à la différence de Pix Image qui proposait un copier-coller du nom de l’image uniquement.

Cette différence a provoqué des erreurs, car les personnes ont mis l’url complète et se sont retrouvé avec l'url + un prefix de domaine qui se faisait côté front, qu'on finit par enregistrer en BDD.

## 🛷 Proposition

- Remplacer le label du champ “nom de l'image” en “url de l'image” dans le formulaire de création de Badge
- Retirer le préfixe en dur dans le front pour permettre l'ajout de l'url complète
- Lors de la modification d’un badge, faire en sorte que ce soit l’url complète qui se retrouve dans le champ et pas juste le nom

## ☃️ Remarques

- Les derniers commits, avec la regex, permettent la vérification stricte de l'url. Les badges ont déjà été migrés vers `assets.pix.org` (action requise dans [cette PR](https://github.com/1024pix/pix/pull/14261)), donc le métier pourra mettre à jour les badges sans que cela crée de souci.
- Avec cette [question Metabase](https://metabase.pix.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImxpYi90eXBlIjoibWJxbC9xdWVyeSIsImRhdGFiYXNlIjoyLCJzdGFnZXMiOlt7ImxpYi90eXBlIjoibWJxbC5zdGFnZS9tYnFsIiwic291cmNlLXRhYmxlIjozMTAsImZpbHRlcnMiOltbImRvZXMtbm90LWNvbnRhaW4iLHsiY2FzZS1zZW5zaXRpdmUiOmZhbHNlLCJsaWIvdXVpZCI6IjJhYmY0MmI2LTQ4ZTEtNDc3ZC04Y2Y3LWM4NjJhN2UyMGZhYiJ9LFsiZmllbGQiLHsibGliL3V1aWQiOiI5MDE2MjkyYS1jOGUwLTQ5ZTItYWZjNC1kNDk2YTI0MGM2YzMiLCJlZmZlY3RpdmUtdHlwZSI6InR5cGUvVGV4dCIsImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9LDIzMzJdLCJhc3NldHMucGl4Lm9yZy9iYWRnZXMvIl1dfV19LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0), je constate qu'il y a des badges avec des urls étranges. Il faudrait investiguer pourquoi.

## 🧑‍🎄 Pour tester
*Ajouter un badge*
- Ouvrir [pixAdmin](https://admin-pr14348.review.pix.fr/login) et se connecter
- Dans PC, ouvrir un PC de son choix
- Dans l'onglet "Clés de lecture", cliquer sur "Nouveau badge"
- Vérifier qu'on voit bien le champ `Url de l'image (svg)` dans le formulaire
- Remplir tous les champs, en mettant `badge.png` dans le champ image
- Cliquer sur "Enregistrer le badge" 
- Une pop-up d'erreur doit apparaître indiquant que l'url de l'image n'est pas au bon format
- Corriger l'url en mettant `https://assets.pix.org/contenu-formatif/editeur/Logo-cour-des-comptes.svg`
- Cliquer sur "Enregistrer le badge" 
- Une pop-up d'erreur doit apparaître indiquant que l'url de l'image n'est pas au bon format
- Corriger l'url en mettant `https://assets.pix.org/badges/1-OFPPT-Premiere_Culture_num.svg`
- Cliquer sur "Enregistrer le badge" 
- Une pop-up de succès apparaîtra (enfin ! bravooo !)

*Afficher un badge*
- Revenir sur le badge créé. Ses informations s'affichent à l'écran
- Vérifier qu'on a bien le label "Url de l'image" dans la page