### PR TITLE
[FEATURE] BACK Filtrer les organisations sur l'équipe en charge (PIX-20691)

### DIFF
--- a/api/src/organizational-entities/application/organization/organization.admin.route.js
+++ b/api/src/organizational-entities/application/organization/organization.admin.route.js
@@ -117,6 +117,7 @@ const register = async function (server) {
               id: identifiersType.organizationId.empty('').allow(null).optional(),
               name: Joi.string().empty('').allow(null).optional(),
               hideArchived: Joi.boolean().optional(),
+              administrationTeamId: identifiersType.administrationTeamId.empty('').allow(null).optional(),
             }).default({}),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),
@@ -132,7 +133,7 @@ const register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle permettant un accès à l'admin de Pix**\n" +
             '- Elle permet de récupérer & chercher une liste d’organisations\n' +
-            '- Cette liste est paginée et filtrée selon un **name** et/ou un **type** et/ou un **identifiant externe** donnés',
+            '- Cette liste est paginée et filtrée selon un **name** et/ou un **type** et/ou un **identifiant externe** et/ou une **équipe en charge** donnés',
         ],
       },
     },

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -378,7 +378,7 @@ async function _enableFeatures(knexConn, featuresToEnable, organizationId) {
 }
 
 function _setSearchFiltersForQueryBuilder(qb, filter) {
-  const { id, name, type, externalId, hideArchived } = filter;
+  const { id, name, type, externalId, hideArchived, administrationTeamId } = filter;
   if (id) {
     qb.where('organizations.id', id);
   }
@@ -393,6 +393,10 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
   }
   if (hideArchived) {
     qb.whereNull('archivedAt');
+  }
+
+  if (administrationTeamId) {
+    qb.where('administrationTeamId', administrationTeamId);
   }
 }
 

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -43,6 +43,7 @@ const queriesType = {
 
 const typesPositiveInteger32bits = [
   'adminMemberId',
+  'administrationTeamId',
   'assessmentId',
   'authenticationMethodId',
   'autonomousCourseId',

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -217,15 +217,22 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
     beforeEach(async function () {
       const userSuperAdmin = databaseBuilder.factory.buildUser.withRole();
 
+      const administrationTeamId1 = databaseBuilder.factory.buildAdministrationTeam({ id: 56789 }).id;
+      const administrationTeamId2 = databaseBuilder.factory.buildAdministrationTeam({ id: 1234 }).id;
+
       databaseBuilder.factory.buildOrganization({
+        id: 1,
         name: 'The name of the organization',
         type: 'SUP',
         externalId: '1234567A',
+        administrationTeamId: administrationTeamId1,
       });
       databaseBuilder.factory.buildOrganization({
+        id: 2,
         name: 'Organization of the night',
         type: 'PRO',
         externalId: '1234568A',
+        administrationTeamId: administrationTeamId2,
       });
 
       options = {
@@ -298,6 +305,23 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(1);
         expect(response.result.data[0].type).to.equal('organizations');
+      });
+
+      it('should return a 200 status code with filtered data', async function () {
+        // given
+        options.url =
+          '/api/admin/organizations?filter[name]=Organization of the night&filter[externalId]=1234568A&filter[administrationTeamId]=1234&page[number]=1&page[size]=2';
+        const expectedMetaData = { page: 1, pageSize: 2, rowCount: 1, pageCount: 1 };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.meta).to.deep.equal(expectedMetaData);
+        expect(response.result.data).to.have.lengthOf(1);
+        expect(response.result.data[0].type).to.equal('organizations');
+        expect(response.result.data[0].id).to.equal('2');
       });
 
       it('should return a 200 status code with empty result', async function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -316,6 +316,36 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });
+
+    context('when there are organizations matching the "administrationTeamId" filter', function () {
+      let teamA, teamB;
+
+      beforeEach(function () {
+        teamA = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team A' });
+        teamB = databaseBuilder.factory.buildAdministrationTeam({ name: 'Team B' });
+        databaseBuilder.factory.buildOrganization({ name: 'Org A1', administrationTeamId: teamA.id });
+        databaseBuilder.factory.buildOrganization({ name: 'Org A2', administrationTeamId: teamA.id });
+        databaseBuilder.factory.buildOrganization({ name: 'Org B1', administrationTeamId: teamB.id });
+        return databaseBuilder.commit();
+      });
+
+      it('return only Organizations matching "administrationTeamId" if given in filters', async function () {
+        // given
+        const filter = { administrationTeamId: teamA.id };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
+        // when
+        const { models: matchingOrganizations, pagination } =
+          await repositories.organizationForAdminRepository.findPaginatedFiltered({
+            filter,
+            page,
+          });
+
+        // then
+        expect(_.map(matchingOrganizations, 'name')).to.have.members(['Org A1', 'Org A2']);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+    });
   });
 
   describe('#archive', function () {


### PR DESCRIPTION
## ❄️ Problème

On a recemment ajouté la colonne “équipe” dans la liste des organisations, mai son ne peut pas filtrer dessus

## 🛷 Proposition

ajouter un filtre “Equipe”

## ☃️ Remarques

Cette PR se concentre uniquement sur la partie BACK

## 🧑‍🎄 Pour tester
- Récuperer un Token valide depuis pix-admin
- Faire une requête GET sur `https://admin-pr14351.review.pix.fr/api/admin/organizations?filter%5BadministrationTeamId%5D=1002&page%5Bnumber%5D=1&page%5Bsize%5D=10`
- Constater qu'on récupère bien une liste d'organisations filtrée par équipe en charge

<img width="1485" height="688" alt="image" src="https://github.com/user-attachments/assets/1487a514-f682-431b-9697-3f62d43d377f" />
