### PR TITLE
[FEATURE] FRONT Filtrer les organisations sur l'équipe en charge (PIX-20692)

### DIFF
--- a/admin/app/components/organizations/list-items.gjs
+++ b/admin/app/components/organizations/list-items.gjs
@@ -50,13 +50,33 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
   }
 
   @action
+  filterAdministrationTeam(value) {
+    const event = { target: { value } };
+    this.args.triggerFiltering('administrationTeamId', event);
+  }
+
+  @action
   filterHideArchived(value) {
     const event = { target: { value } };
     this.args.triggerFiltering('hideArchived', event);
   }
 
+  get optionAdministrationTeam() {
+    return this.args.administrationTeams.map((team) => ({
+      value: team.id,
+      label: team.name,
+    }));
+  }
+
   get isClearFiltersButtonDisabled() {
-    return !this.args.id && !this.args.name && !this.args.type && !this.args.externalId && !this.args.hideArchived;
+    return (
+      !this.args.id &&
+      !this.args.name &&
+      !this.args.type &&
+      !this.args.externalId &&
+      !this.args.hideArchived &&
+      !this.args.administrationTeamId
+    );
   }
 
   <template>
@@ -80,6 +100,15 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
         @value={{@type}}
       >
         <:label>Type</:label>
+      </PixSelect>
+      <PixSelect
+        @id="administrationTeam"
+        @hideDefaultOption={{true}}
+        @options={{this.optionAdministrationTeam}}
+        @onChange={{this.filterAdministrationTeam}}
+        @value={{@administrationTeamId}}
+      >
+        <:label>{{t "components.organizations.list-items.table.header.administration-team-name"}}</:label>
       </PixSelect>
       <PixInput value={{@externalId}} oninput={{fn @triggerFiltering "externalId"}}>
         <:label>Identifiant externe</:label>

--- a/admin/app/components/target-profiles/organizations.gjs
+++ b/admin/app/components/target-profiles/organizations.gjs
@@ -183,6 +183,7 @@ export default class Organizations extends Component {
 
       <ListItems
         @organizations={{@organizations}}
+        @administrationTeams={{@administrationTeams}}
         @id={{@id}}
         @name={{@name}}
         @type={{@type}}
@@ -193,6 +194,7 @@ export default class Organizations extends Component {
         @targetProfileName={{@targetProfile.internalName}}
         @hideArchived={{@hideArchived}}
         @showDetachColumn={{this.isSuperAdminOrMetier}}
+        @administrationTeamId={{@administrationTeamId}}
         @onResetFilter={{@onResetFilter}}
       />
     </section>

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -10,7 +10,7 @@ const DEFAULT_PAGE_NUMBER = 1;
 export default class ListController extends Controller {
   @service accessControl;
 
-  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'hideArchived'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId', 'hideArchived', 'administrationTeamId'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
@@ -20,6 +20,7 @@ export default class ListController extends Controller {
   @tracked type = null;
   @tracked externalId = null;
   @tracked hideArchived = false;
+  @tracked administrationTeamId = null;
 
   updateFilters(filters) {
     for (const filterKey of Object.keys(filters)) {
@@ -40,5 +41,6 @@ export default class ListController extends Controller {
     this.type = null;
     this.externalId = null;
     this.hideArchived = false;
+    this.administrationTeamId = null;
   }
 }

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -21,6 +21,7 @@ export default class TargetProfileOrganizationsController extends Controller {
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;
+  @tracked administrationTeamId = null;
 
   updateFilters(filters) {
     for (const filterKey of Object.keys(filters)) {
@@ -64,5 +65,6 @@ export default class TargetProfileOrganizationsController extends Controller {
     this.type = null;
     this.externalId = null;
     this.hideArchived = false;
+    this.administrationTeamId = null;
   }
 }

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default class ListRoute extends Route {
   @service store;
@@ -15,9 +16,10 @@ export default class ListRoute extends Route {
   };
 
   async model(params) {
-    let model;
+    let organizations, administrationTeams;
     try {
-      model = await this.store.query('organization', {
+      administrationTeams = await this.store.findAll('administration-team');
+      organizations = await this.store.query('organization', {
         filter: {
           id: params.id ? params.id.trim() : '',
           name: params.name ? params.name.trim() : '',
@@ -31,9 +33,13 @@ export default class ListRoute extends Route {
         },
       });
     } catch {
-      model = [];
+      organizations = [];
+      administrationTeams = [];
     }
-    return model;
+    return RSVP.hash({
+      organizations,
+      administrationTeams,
+    });
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -13,6 +13,7 @@ export default class ListRoute extends Route {
     type: { refreshModel: true },
     externalId: { refreshModel: true },
     hideArchived: { refreshModel: true },
+    administrationTeamId: { refreshModel: true },
   };
 
   async model(params) {
@@ -26,6 +27,7 @@ export default class ListRoute extends Route {
           type: params.type ? params.type.trim() : '',
           externalId: params.externalId ? params.externalId.trim() : '',
           hideArchived: params.hideArchived,
+          administrationTeamId: params.administrationTeamId ? params.administrationTeamId.trim() : '',
         },
         page: {
           number: params.pageNumber,
@@ -51,6 +53,7 @@ export default class ListRoute extends Route {
       controller.type = null;
       controller.externalId = null;
       controller.hideArchived = false;
+      controller.administrationTeamId = null;
     }
   }
 }

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -13,6 +13,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
     type: { refreshModel: true },
     externalId: { refreshModel: true },
     hideArchived: { refreshModel: true },
+    administrationTeamId: { refreshModel: true },
   };
 
   beforeModel() {
@@ -20,7 +21,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
   }
 
   async model(params) {
-    let organizations;
+    let organizations, administrationTeams;
     const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
     const queryParams = {
       targetProfileId: targetProfile.id,
@@ -34,17 +35,21 @@ export default class TargetProfileOrganizationsRoute extends Route {
         type: params.type,
         externalId: params.externalId,
         hideArchived: params.hideArchived,
+        administrationTeamId: params.administrationTeamId,
       },
     };
     try {
+      administrationTeams = await this.store.findAll('administration-team');
       organizations = await this.store.query('organization', queryParams);
     } catch {
       organizations = [];
+      administrationTeams = [];
     }
 
     return {
       organizations,
       targetProfile,
+      administrationTeams,
     };
   }
 
@@ -57,6 +62,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
       controller.type = null;
       controller.externalId = null;
       controller.hideArchived = false;
+      controller.administrationTeamId = null;
     }
   }
 }

--- a/admin/app/templates/authenticated/organizations/list.gjs
+++ b/admin/app/templates/authenticated/organizations/list.gjs
@@ -18,7 +18,8 @@ import ListItems from 'pix-admin/components/organizations/list-items';
   <main class="page-body">
     <section class="page-section organizations-list">
       <ListItems
-        @organizations={{@model}}
+        @organizations={{@model.organizations}}
+        @administrationTeams={{@model.administrationTeams}}
         @id={{@controller.id}}
         @name={{@controller.name}}
         @type={{@controller.type}}
@@ -27,6 +28,7 @@ import ListItems from 'pix-admin/components/organizations/list-items';
         @hideArchived={{@controller.hideArchived}}
         @toggleArchived={{fn (mut @controller.hideArchived)}}
         @showDetachColumn={{false}}
+        @administrationTeamId={{@controller.administrationTeamId}}
         @onResetFilter={{@controller.onResetFilter}}
       />
     </section>

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.gjs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.gjs
@@ -5,6 +5,7 @@ import Organizations from 'pix-admin/components/target-profiles/organizations';
 
   <Organizations
     @organizations={{@model.organizations}}
+    @administrationTeams={{@model.administrationTeams}}
     @targetProfile={{@model.targetProfile}}
     @id={{@controller.id}}
     @name={{@controller.name}}
@@ -14,6 +15,7 @@ import Organizations from 'pix-admin/components/target-profiles/organizations';
     @triggerFiltering={{@controller.triggerFiltering}}
     @goToOrganizationPage={{@controller.goToOrganizationPage}}
     @detachOrganizations={{@controller.detachOrganizations}}
+    @administrationTeamId={{@controller.administrationTeamId}}
     @onResetFilter={{@controller.onResetFilter}}
   />
 </template>

--- a/admin/tests/integration/components/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/organizations/list-items-test.gjs
@@ -19,6 +19,9 @@ module('Integration | Component | ListItems', function (hooks) {
   const organization1 = { id: 123, name: 'Orga1', externalId: 'O1' };
   const organization2 = { id: 456, name: 'Orga2', externalId: 'O2' };
   const organizations = [organization1, organization2];
+  const administrationTeam = { id: 1, name: 'Admin Team 1' };
+  const administrationTeam2 = { id: 2, name: 'Admin Team 2' };
+  const administrationTeams = [administrationTeam, administrationTeam2];
   organizations.meta = { page: 1, pageSize: 1 };
 
   const triggerFiltering = sinon.stub();
@@ -32,6 +35,7 @@ module('Integration | Component | ListItems', function (hooks) {
       <template>
         <ListItems
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @externalId={{null}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
@@ -54,6 +58,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @externalId={{null}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -78,6 +83,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @externalId={{null}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -104,6 +110,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @externalId={{null}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -134,6 +141,7 @@ module('Integration | Component | ListItems', function (hooks) {
           <template>
             <ListItems
               @organizations={{organizations}}
+              @administrationTeams={{administrationTeams}}
               @externalId="123"
               @goToOrganizationPage={{goToOrganizationPage}}
               @triggerFiltering={{triggerFiltering}}
@@ -154,6 +162,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @externalId="123"
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -176,6 +185,7 @@ module('Integration | Component | ListItems', function (hooks) {
         <template>
           <ListItems
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
             @onResetFilter={{resetFilter}}

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.gjs
@@ -7,6 +7,11 @@ import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering'
 
 module('Integration | Component | routes/authenticated/organizations | list-items', function (hooks) {
   setupIntlRenderingTest(hooks);
+  const administrationTeams = [
+    { id: 1, name: 'Team A' },
+    { id: 2, name: 'Team B' },
+    { id: 3, name: 'Team C' },
+  ];
 
   hooks.beforeEach(async function () {
     const currentUser = this.owner.lookup('service:currentUser');
@@ -24,6 +29,9 @@ module('Integration | Component | routes/authenticated/organizations | list-item
       { id: 2, name: 'Université BROS', type: 'SUP', externalId },
       { id: 3, name: 'Entreprise KSSOS', type: 'PRO', externalId },
     ];
+
+    organizations.administrationTeams = administrationTeams;
+
     organizations.meta = {
       rowCount: 3,
     };
@@ -33,6 +41,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
       <template>
         <ListItems
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @triggerFiltering={{triggerFiltering}}
           @onResetFilter={{resetFilter}}
         />
@@ -55,9 +64,17 @@ module('Integration | Component | routes/authenticated/organizations | list-item
   });
 
   test('if should display search inputs', async function (assert) {
+    // given
+
     // when
     const screen = await render(
-      <template><ListItems @triggerFiltering={{triggerFiltering}} @onResetFilter={{resetFilter}} /></template>,
+      <template>
+        <ListItems
+          @administrationTeams={{administrationTeams}}
+          @triggerFiltering={{triggerFiltering}}
+          @onResetFilter={{resetFilter}}
+        />
+      </template>,
     );
 
     // then
@@ -75,6 +92,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
       { id: 2, name: 'Université BROS', type: 'SUP', externalId: '1234567B', administrationTeamName: 'Team B' },
       { id: 3, name: 'Entreprise KSSOS', type: 'PRO', externalId: '1234567C', administrationTeamName: 'Team C' },
     ];
+
     organizations.meta = {
       rowCount: 3,
     };
@@ -84,6 +102,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
       <template>
         <ListItems
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @triggerFiltering={{triggerFiltering}}
           @onResetFilter={{resetFilter}}
         />

--- a/admin/tests/integration/components/target-profiles/organizations-test.gjs
+++ b/admin/tests/integration/components/target-profiles/organizations-test.gjs
@@ -14,6 +14,9 @@ module('Integration | Component | target-profiles | Organizations', function (ho
   const detachOrganizations = () => {};
   const resetFilters = () => {};
   const queryParams = { hideArchived: false };
+  const administrationTeam = EmberObject.create({ id: 1, name: 'Admin Team 1' });
+  const administrationTeam2 = EmberObject.create({ id: 2, name: 'Admin Team 2' });
+  const administrationTeams = [administrationTeam, administrationTeam2];
 
   hooks.beforeEach(function () {
     const currentUser = this.owner.lookup('service:currentUser');
@@ -25,6 +28,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
     const organization2 = EmberObject.create({ id: 456, name: 'Orga2', externalId: 'O2' });
     const organizations = [organization1, organization2];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -32,6 +36,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -50,6 +55,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     // given
     const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
     const organizations = [organization1];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -57,6 +63,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -75,6 +82,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
   test('it displays a message when there is no organizations', async function (assert) {
     // given
     const organizations = [];
+
     organizations.meta = { page: 1, pageSize: 1 };
     this.organizations = [];
 
@@ -83,6 +91,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -104,6 +113,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -127,6 +137,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -145,6 +156,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     // given
     const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
     const organizations = [organization1];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -152,6 +164,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -172,6 +185,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
 
     const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
     const organizations = [organization1];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -179,6 +193,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -199,6 +214,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
 
     const organization1 = EmberObject.create({ id: 123, name: 'Orga1', externalId: 'O1' });
     const organizations = [organization1];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -206,6 +222,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -222,6 +239,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
   test('it should disable buttons when the inputs are empty', async function (assert) {
     // given
     const organizations = [];
+
     organizations.meta = { page: 1, pageSize: 1 };
 
     // when
@@ -229,6 +247,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
       <template>
         <Organizations
           @organizations={{organizations}}
+          @administrationTeams={{administrationTeams}}
           @goToOrganizationPage={{goToOrganizationPage}}
           @triggerFiltering={{triggerFiltering}}
           @hideArchived={{queryParams.hideArchived}}
@@ -255,6 +274,10 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     test('it should enable button when input has content', async function (assert) {
       // given
       const organizations = [];
+      const administrationTeam = EmberObject.create({ id: 1, name: 'Admin Team 1' });
+      const administrationTeam2 = EmberObject.create({ id: 2, name: 'Admin Team 2' });
+      const administrationTeams = [administrationTeam, administrationTeam2];
+      const queryParams = { hideArchived: false };
       const targetProfile = { id: 56 };
 
       // when
@@ -262,6 +285,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
         <template>
           <Organizations
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -280,6 +304,9 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     test('it should call adapter when form is submitted', async function (assert) {
       // given
       const organizations = [];
+      const administrationTeam = EmberObject.create({ id: 1, name: 'Admin Team 1' });
+      const administrationTeam2 = EmberObject.create({ id: 2, name: 'Admin Team 2' });
+      const administrationTeams = [administrationTeam, administrationTeam2];
       const targetProfile = { id: 56 };
       const adapter = store.adapterFor('target-profile');
       const attachOrganizationsStub = sinon.stub(adapter, 'attachOrganizations').resolves({
@@ -291,6 +318,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
         <template>
           <Organizations
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}
@@ -310,6 +338,9 @@ module('Integration | Component | target-profiles | Organizations', function (ho
     test('it should enable button for existing target profile attachment', async function (assert) {
       // given
       const organizations = [];
+      const administrationTeam = EmberObject.create({ id: 1, name: 'Admin Team 1' });
+      const administrationTeam2 = EmberObject.create({ id: 2, name: 'Admin Team 2' });
+      const administrationTeams = [administrationTeam, administrationTeam2];
       const targetProfile = { id: 56 };
 
       // when
@@ -317,6 +348,7 @@ module('Integration | Component | target-profiles | Organizations', function (ho
         <template>
           <Organizations
             @organizations={{organizations}}
+            @administrationTeams={{administrationTeams}}
             @targetProfile={{targetProfile}}
             @goToOrganizationPage={{goToOrganizationPage}}
             @triggerFiltering={{triggerFiltering}}

--- a/admin/tests/unit/routes/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list-test.js
@@ -35,6 +35,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
           type: '',
           externalId: '',
           hideArchived: undefined,
+          administrationTeamId: '',
         };
 
         // then
@@ -52,12 +53,14 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         params.type = 'someType ';
         params.externalId = 'someExternalId';
         params.hideArchived = true;
+        params.administrationTeamId = ' someAdministrationTeamId ';
         expectedQueryArgs.filter = {
           id: 'someId',
           name: 'someName',
           type: 'someType',
           externalId: 'someExternalId',
           hideArchived: true,
+          administrationTeamId: 'someAdministrationTeamId',
         };
 
         // when
@@ -98,6 +101,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         type: 'someType',
         externalId: 'someExternalId',
         hideArchived: false,
+        administrationTeamId: 'someAdministrationTeamId',
       };
     });
 
@@ -114,6 +118,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         assert.strictEqual(controller.type, null);
         assert.strictEqual(controller.externalId, null);
         assert.false(controller.hideArchived);
+        assert.strictEqual(controller.administrationTeamId, null);
       });
     });
 
@@ -130,6 +135,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         assert.strictEqual(controller.type, 'someType');
         assert.strictEqual(controller.externalId, 'someExternalId');
         assert.false(controller.hideArchived);
+        assert.strictEqual(controller.administrationTeamId, 'someAdministrationTeamId');
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list-test.js
@@ -16,6 +16,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
 
     hooks.beforeEach(function () {
       route.store.query = sinon.stub().resolves();
+      route.store.findAll = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
       expectedQueryArgs.page = {
@@ -25,7 +26,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
     });
 
     module('when queryParams filters are falsy', function () {
-      test('it should call store.query with no filters on id, name, type and externalId', async function (assert) {
+      test('it should call store with no filters on id, name, type and externalId', async function (assert) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
@@ -38,12 +39,13 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
 
         // then
         sinon.assert.calledWith(route.store.query, 'organization', expectedQueryArgs);
+        sinon.assert.calledWith(route.store.findAll, 'administration-team');
         assert.ok(true);
       });
     });
 
     module('when queryParams filters are  truthy', function () {
-      test('it should call store.query with filters containing trimmed values', async function (assert) {
+      test('it should call store with filters containing trimmed values', async function (assert) {
         // given
         params.id = ' someId';
         params.name = ' someName';
@@ -63,6 +65,7 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
 
         // then
         sinon.assert.calledWith(route.store.query, 'organization', expectedQueryArgs);
+        sinon.assert.calledWith(route.store.findAll, 'administration-team');
         assert.ok(true);
       });
     });
@@ -75,10 +78,10 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         route.store.query = sinon.stub().rejects();
 
         // when
-        const organizations = await route.model(params);
+        const model = await route.model(params);
 
         // then
-        assert.deepEqual(organizations, []);
+        assert.deepEqual(model, { organizations: [], administrationTeams: [] });
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations-test.js
@@ -20,6 +20,7 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         name: 'someName',
         type: 'someType',
         externalId: 'someExternalId',
+        administrationTeamId: 'someAdministrationTeamId',
       };
     });
 
@@ -34,6 +35,7 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         assert.deepEqual(controller.name, null);
         assert.deepEqual(controller.type, null);
         assert.deepEqual(controller.externalId, null);
+        assert.deepEqual(controller.administrationTeamId, null);
       });
     });
 
@@ -48,23 +50,26 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
         assert.deepEqual(controller.name, 'someName');
         assert.deepEqual(controller.type, 'someType');
         assert.deepEqual(controller.externalId, 'someExternalId');
+        assert.deepEqual(controller.administrationTeamId, 'someAdministrationTeamId');
       });
     });
   });
 
   module('#model', function () {
     module('when an error occurs', function () {
-      test('returns an empty array', async function (assert) {
+      test('returns empty arrays', async function (assert) {
         // given
         const params = {};
         route.modelFor = sinon.stub().returns({ id: '123' });
         route.store.query = sinon.stub().rejects();
+        route.store.findAll = sinon.stub().rejects();
 
         // when
         const model = await route.model(params);
 
         // then
         assert.deepEqual(model.organizations, []);
+        assert.deepEqual(model.administrationTeams, []);
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

On a recemment ajouté la colonne “équipe” dans la liste des organisations, mai son ne peut pas filtrer dessus

## 🛷 Proposition

ajouter un filtre “Equipe en charge”

## ☃️ Remarques

Suite de #14351 

## 🧑‍🎄 Pour tester

- Se connecter à Pix-admin
- Aller sur la page de listing des organsations
- Constater qu'il est possible de filtrer par équipe en charge

<img width="1485" height="688" alt="image" src="https://github.com/user-attachments/assets/245b3fbd-ddf2-4172-85ff-1a325a0b2c60" />
