### PR TITLE
[FEATURE] Ajout d'une modal pour éviter le détachement accidentel d'un profil cible de ses contenus formatifs s'il est lié à un parcours combiné (PIX-20512)

### DIFF
--- a/admin/app/models/target-profile-summary.js
+++ b/admin/app/models/target-profile-summary.js
@@ -7,6 +7,7 @@ export default class TargetProfileSummary extends Model {
   @attr() category;
   @attr() createdAt;
   @attr() canDetach;
+  @attr() isPartOfCombinedCourse;
 
   get translationKeyCategory() {
     return categories[this.category];

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -98,25 +98,25 @@
 {{/if}}
 
 <PixModal
-  @title="Détacher le profil cible du contenu formatif"
+  @title={{t "pages.trainings.training.targetProfiles.detach-title"}}
   @onCloseButtonClick={{this.closeModal}}
   @showModal={{this.showModal}}
 >
   <:content>
     <p>
-      Etes-vous sûr de vouloir détacher le profil cible
-      <strong>{{this.targetProfileToDetach.internalName}}</strong>
-      ? Ce profil cible est lié à un parcours apprenant. La recommandation de ce modulix sera altérée si vous le
-      détachez.
+      {{t
+        "pages.trainings.training.targetProfiles.detach-modal"
+        htmlSafe=true
+        name=this.targetProfileToDetach.internalName
+      }}
     </p>
   </:content>
   <:footer>
     <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
       {{t "common.actions.cancel"}}
     </PixButton>
-    <PixButton
-      @variant="error"
-      @triggerAction={{fn this.detachTargetProfile this.targetProfileToDetach}}
-    >Confirmer</PixButton>
+    <PixButton @variant="error" @triggerAction={{fn this.detachTargetProfile this.targetProfileToDetach}}>{{t
+        "common.actions.confirm"
+      }}</PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -78,7 +78,11 @@
                     >Filtrer par organisations
                     </PixButtonLink>
                   {{/if}}
-                  <PixButton @variant="error" @iconBefore="delete" @triggerAction={{fn this.detachTargetProfile row}}>
+                  <PixButton
+                    @variant="error"
+                    @iconBefore="delete"
+                    @triggerAction={{fn this.onClickDetachTargetProfile row}}
+                  >
                     Détacher
                   </PixButton>
                 </div>
@@ -92,3 +96,27 @@
     </section>
   </div>
 {{/if}}
+
+<PixModal
+  @title="Détacher le profil cible du contenu formatif"
+  @onCloseButtonClick={{this.closeModal}}
+  @showModal={{this.showModal}}
+>
+  <:content>
+    <p>
+      Etes-vous sûr de vouloir détacher le profil cible
+      <strong>{{this.targetProfileToDetach.internalName}}</strong>
+      ? Ce profil cible est lié à un parcours apprenant. La recommandation de ce modulix sera altérée si vous le
+      détachez.
+    </p>
+  </:content>
+  <:footer>
+    <PixButton @variant="secondary" @triggerAction={{this.closeModal}}>
+      {{t "common.actions.cancel"}}
+    </PixButton>
+    <PixButton
+      @variant="error"
+      @triggerAction={{fn this.detachTargetProfile this.targetProfileToDetach}}
+    >Confirmer</PixButton>
+  </:footer>
+</PixModal>

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1476,6 +1476,8 @@
           "targetProfileCount": "Associated Targets Profiles"
         },
         "targetProfiles": {
+          "detach-modal": "Are you sure you want to detach the target profile <strong>{name}</strong>? This target profile is linked to a combined course. The recommendation for this modulix will be altered if you detach it.",
+          "detach-title": "Detach target profile from traning",
           "tabName": "Target Profiles",
           "title": "Attach one or more target profiles"
         },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1477,6 +1477,8 @@
           "targetProfileCount": "Profils cibles associés"
         },
         "targetProfiles": {
+          "detach-modal": "Etes-vous sûr de vouloir détacher le profil cible <strong>{name}</strong> ? Ce profil cible est lié à un parcours apprenant. La recommandation de ce modulix sera altérée si vous le détachez.",
+          "detach-title": "Détacher le profil cible du contenu formatif",
           "tabName": "Profils cibles associés",
           "title": "Rattacher un ou plusieurs profils cibles"
         },

--- a/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
+++ b/api/src/prescription/target-profile/domain/models/TargetProfileSummaryForAdmin.js
@@ -10,6 +10,9 @@ class TargetProfileSummaryForAdmin {
     this.createdAt = params.createdAt;
     this.#sharedOrganizationId = params.sharedOrganizationId;
     this.#ownerOrganizationId = params.ownerOrganizationId;
+    if ('isPartOfCombinedCourse' in params) {
+      this.isPartOfCombinedCourse = params.isPartOfCombinedCourse;
+    }
   }
   get canDetach() {
     return Boolean(this.#sharedOrganizationId) && this.#sharedOrganizationId !== this.#ownerOrganizationId;

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (targetProfileSummaries, meta) {
   return new Serializer('target-profile-summary', {
-    attributes: ['internalName', 'outdated', 'createdAt', 'category', 'canDetach'],
+    attributes: ['internalName', 'outdated', 'createdAt', 'category', 'canDetach', 'isPartOfCombinedCourse'],
     meta,
   }).serialize(targetProfileSummaries);
 };

--- a/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-route_test.js
@@ -519,6 +519,7 @@ describe('Acceptance | Controller | training-controller', function () {
           'created-at': undefined,
           'can-detach': false,
           category: undefined,
+          'is-part-of-combined-course': false,
         },
       };
 

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -319,11 +319,13 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
           ...targetProfile1,
           createdAt: undefined,
           category: undefined,
+          isPartOfCombinedCourse: false,
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           ...targetProfile2,
           createdAt: undefined,
           category: undefined,
+          isPartOfCombinedCourse: false,
         }),
       ];
       expect(targetProfileSummaries).to.deepEqualArray(expectedTargetProfileSummaries);

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer_test.js
@@ -12,6 +12,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
           outdated: false,
           category: 'OTHER',
           createdAt: new Date('2021-01-01'),
+          isPartOfCombinedCourse: true,
         }),
         domainBuilder.buildTargetProfileSummaryForAdmin({
           id: 2,
@@ -38,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
               category: 'OTHER',
               'created-at': new Date('2021-01-01'),
               'can-detach': false,
+              'is-part-of-combined-course': true,
             },
           },
           {

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-summary-for-admin.js
@@ -8,8 +8,9 @@ const buildTargetProfileSummaryForAdmin = function ({
   createdAt,
   ownerOrganizationId,
   sharedOrganizationId,
+  isPartOfCombinedCourse = undefined,
 } = {}) {
-  return new TargetProfileSummaryForAdmin({
+  const targetProfileSummaryForAdmin = new TargetProfileSummaryForAdmin({
     id,
     internalName,
     outdated,
@@ -18,6 +19,10 @@ const buildTargetProfileSummaryForAdmin = function ({
     ownerOrganizationId,
     sharedOrganizationId,
   });
+  if (isPartOfCombinedCourse !== undefined) {
+    targetProfileSummaryForAdmin.isPartOfCombinedCourse = isPartOfCombinedCourse;
+  }
+  return targetProfileSummaryForAdmin;
 };
 
 export { buildTargetProfileSummaryForAdmin };


### PR DESCRIPTION
## ❄️ Problème

Dans le cadre des travaux d'industrialisation de Combinix, on veut pouvoir empêcher le détachement intempestif d'un profil cible de ses contenus formatifs s'il est lié à un parcours combiné déjà déployé.

## 🛷 Proposition
On ajoute une modal pour être sûr.e que l'utilisateur sait ce qu'il fait.

## 🧑‍🎄 Pour tester
Pix Admin :

Cliquer sur le lien "Contenus formatifs"

- Trouver un contenu formatif avec un PC du style "Demo combinix 1"
Aller dans l'onglet "Profils cibles associés"
Cliquer sur Détacher
Voir la modal apparaître, cliquer sur "Confirmer"
-> Le profil cible associé disparaît de la page et la ligne correspondante dans target_profile_trainings disparaît

- Trouver un contenu formatif avec un PC autre
Aller dans l'onglet "Profils cibles associés"
Cliquer sur Détacher
La modal ne doit pas apparaître, juste le toast de succès
