### PR TITLE
[BUGFIX] Les bordures des cartes de formation ne sont pas très clean sur Pix App (PIX-20618)

### DIFF
--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -4,6 +4,7 @@
   position: relative;
   min-width: 240px;
   padding: 0;
+  overflow: hidden;
 }
 
 .training-card__content {

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -74,6 +74,7 @@
 .user-trainings-content-list {
   &__item {
     &:hover {
+      border-radius: var(--pix-spacing-2x);
       box-shadow:
         0 7px 14px 0 var(--pix-neutral-100),
         0 3px 6px 0 var(--pix-neutral-500);


### PR DESCRIPTION
## ❄️ Problème

Le rendu des formations proposées est moche actuellement : en hover, on voit un cadre derrière la carte de la formation.

## 🛷 Proposition

Corriger le border-radius du block encadrant chaque carte de formation.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

- Se connecter avec Dave Comp sur [PixApp](https://app-pr14359.review.pix.fr/connexion)
- Si besoin, finir un ou plusieurs parcours
- Aller dans "Mes Formations"
- Survoler avec la souris les carte affichant les formations
- Vérifier que la bordure est arrondie pour la carte
