### PR TITLE
[TECH] Completer les acquisitions de paliers et les snapshots dans les seeds des parcours combines (PIX-20711) 

### DIFF
--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -15,9 +15,11 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
     buildCampaignParticipation,
     buildCampaignSkill,
     buildCombinedCourse,
+    buildKnowledgeElementSnapshot,
     buildOrganizationLearner,
     buildOrganizationLearnerParticipation,
     buildStage,
+    buildStageAcquisition,
     buildTargetProfile,
     buildTargetProfileTraining,
     buildTargetProfileTube,
@@ -153,6 +155,23 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
         type: Assessment.types.CAMPAIGN,
         campaignParticipationId,
       });
+
+      // If the campaign participation is shared, build knowledge elements and stage acquisitions
+      if (participation.campaignStatus === CampaignParticipationStatuses.SHARED) {
+        // Build knowledge element snapshot for this user
+        buildKnowledgeElementSnapshot({
+          campaignParticipationId,
+          userId,
+        });
+
+        // Build stage 0 acquisition if there are stages
+        if (combinedCourseData.targetProfile.stages) {
+          buildStageAcquisition({
+            stageId: combinedCourseData.targetProfile.stages[0].id,
+            campaignParticipationId,
+          });
+        }
+      }
     }
   });
 };


### PR DESCRIPTION
## ❄️ Problème

La page d'analyse ne fonctionne pas pour les participations aux campagnes créées dans les seeds des parcours combinés.

Il nous manque en effet un knowledge element snapshot et l'acquisition du palier 0 pour mimer le comportement de l'application. 

## 🛷 Proposition

Ajouter le snapshot et l'acquisition dans les seeds des parcours combines pour les campagnes partagées.

## 🧑‍🎄 Pour tester

Sur PixOrga, accéder à la page d'analyse d'une participation d'un learner à une campagne issue d'un parcours combine, ca ne 💥 pas.