### PR TITLE
[FEATURE] Rendre insensible aux accents le filtre d'une organisation par le nom (PIX-20165)

### DIFF
--- a/api/db/migrations/20251205145127_add-unaccent-sql-extension.js
+++ b/api/db/migrations/20251205145127_add-unaccent-sql-extension.js
@@ -1,0 +1,9 @@
+const up = async function (knex) {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS unaccent;');
+};
+
+const down = async function (knex) {
+  await knex.raw('DROP EXTENSION IF EXISTS unaccent;');
+};
+
+export { down, up };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -383,7 +383,7 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
     qb.where('organizations.id', id);
   }
   if (name) {
-    qb.whereILike('organizations.name', `%${name}%`);
+    qb.where(knex.raw('unaccent(organizations.name) ILIKE unaccent(?)', [`%${name}%`]));
   }
   if (type) {
     qb.where('type', type);


### PR DESCRIPTION
## ❄️ Problème

Actuellement sur Pix Admin, lorsqu'on recherche une organisation par son nom, le filtre est sensible aux accents. Par exemple une orga nommée **"Collège"** ne sortira pas si on recherche **"college"**. La recherche n'est pas assez tolérante et implique de savoir à l'avance si l'organisation a été créée avec ou sans accents pour la retrouver facilement.

## 🛷 Proposition

Permettre de comparer le texte recherché sans les accents, avec les noms d'organisation sans les accents,  lors de l'opération de filtrage. Vu que le filtre est géré par une requête SQL, on propose d'utiliser l'extension `unaccent` de PostgreSQL.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester
Sur Pix Admin:
- aller sur la page de la liste des organisations
- rechercher avec le mot-clé **"college"** ou **"lycee"** (sans les accents)
- constater que la recherche a bien ignoré les accents, et qu'on affiche bien les orgas correspondant

<img width="779" height="607" alt="image" src="https://github.com/user-attachments/assets/ada0af9b-e97d-4f81-af2c-95741b0b9bda" />

