### PR TITLE
[TECH]: Ajouter des tests sur la route de création d'orga pour inclure l'externalId et le provinceCode (PIX-20694)

### DIFF
--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -391,6 +391,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
                   'data-protection-officer-email': 'justin.ptipeu@example.net',
                   'administration-team-id': 1234,
                   'country-code': 99100,
+                  'external-id': 'My external Id',
+                  'province-code': '078',
                 },
               },
             },
@@ -407,6 +409,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           expect(createdOrganization['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
           expect(createdOrganization['created-by']).to.equal(superAdminUserId);
           expect(createdOrganization['country-code']).to.equal(99100);
+          expect(createdOrganization['external-id']).to.equal('My external Id');
+          expect(createdOrganization['province-code']).to.equal('078');
         });
       });
 

--- a/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/create-organization_test.js
@@ -40,6 +40,8 @@ describe('Integration | UseCases | create-organization', function () {
       createdBy: superAdminUserId,
       administrationTeamId: 1234,
       countryCode: 99100,
+      externalId: 'My external Id',
+      provinceCode: '078',
     });
 
     // when
@@ -55,6 +57,8 @@ describe('Integration | UseCases | create-organization', function () {
     expect(createdOrganization.dataProtectionOfficer.lastName).to.equal('');
     expect(createdOrganization.dataProtectionOfficer.email).to.equal('');
     expect(createdOrganization.countryCode).to.equal(99100);
+    expect(createdOrganization.externalId).to.equal('My external Id');
+    expect(createdOrganization.provinceCode).to.equal('078');
   });
 
   describe('error cases', function () {
@@ -175,6 +179,8 @@ describe('Integration | UseCases | create-organization', function () {
         const organization = new OrganizationForAdmin({
           name: 'ACME',
           type: 'PRO',
+          administrationTeamId: undefined,
+          countryCode: undefined,
         });
 
         // when


### PR DESCRIPTION
## ❄️ Problème

Dans le cadre de l'amélioration du processus de création d'organisation, on veut maintenant donner à l'utilisateur la possibilité de fournir l'identifiant externe (**externalId)** et le département (**provinceCode**). Tout est déjà prévu côté API pour enregistrer ces champs à la création, mais les tests ne le reflètent pas.

## 🛷 Proposition

Dans les tests de création d'orga (test d'acceptance de la route et test d'intégration du usecase), ajouter ces deux champs.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

- Tests au vert
