### PR TITLE
[BUGFIX]  Gérer les erreurs non-prévues (c’est à dire non-JSON:API) dans le parcours d'authentification OIDC (PIX-20710)

### DIFF
--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -118,6 +118,10 @@ export default class LoginOidcRoute extends Route {
       return { identityProviderSlug, shouldCreateUserAccount: false };
     } catch (response) {
       const apiError = get(response, 'errors[0]');
+      if (!apiError) {
+        throw response;
+      }
+
       const error = new JSONApiError(apiError.detail, apiError);
 
       if (error.code == 'MISSING_OIDC_STATE') {

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -95,27 +95,25 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
           );
         });
       });
+    });
+  });
 
-      module('when the user creates an account', function () {
-        module('when the user logs out', function () {
-          test('it redirects the user to the logout URL', async function (assert) {
-            // given
-            const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-            await click(screen.getByLabelText(t('common.cgu.label')));
-            await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
-            // eslint-disable-next-line ember/no-settled-after-test-helper
-            await settled();
+  module('when the user logs out', function () {
+    test('it redirects the user to the logout URL', async function (assert) {
+      // given
+      const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+      await click(screen.getByLabelText(t('common.cgu.label')));
+      await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+      // eslint-disable-next-line ember/no-settled-after-test-helper
+      await settled();
 
-            await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+      await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
 
-            // when
-            await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+      // when
+      await click(screen.getByRole('link', { name: 'Se déconnecter' }));
 
-            // then
-            assert.strictEqual(currentURL(), '/deconnexion');
-          });
-        });
-      });
+      // then
+      assert.strictEqual(currentURL(), '/deconnexion');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -5,6 +5,7 @@ import Location from 'mon-pix/utils/location';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { stubOidcIdentityProvidersService } from '../../../helpers/service-stubs';
 import setupIntl from '../../../helpers/setup-intl';
 
 module('Unit | Route | login-oidc', function (hooks) {
@@ -42,18 +43,17 @@ module('Unit | Route | login-oidc', function (hooks) {
         sinon.stub(window, 'fetch').resolves({
           json: sinon.stub().resolves({ redirectTarget: 'https://oidc/connexion' }),
         });
-        const oidcPartner = {
-          id: 'oidc-partner',
-          slug: 'oidc-partner',
-          code: 'OIDC_PARTNER',
-        };
 
-        class OidcIdentityProvidersStub extends Service {
-          'oidc-partner' = oidcPartner;
-          list = [oidcPartner];
-        }
-
-        this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+        stubOidcIdentityProvidersService(this.owner, {
+          oidcIdentityProviders: [
+            {
+              id: 'oidc-partner',
+              slug: 'oidc-partner',
+              code: 'OIDC_PARTNER',
+              organizationName: 'OIDC Partner',
+            },
+          ],
+        });
       });
 
       module('when identity provider is not supported', function () {

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -249,10 +249,10 @@ module('Unit | Route | login-oidc', function (hooks) {
       });
     });
 
-    module('when CGU are already validated and authenticate fails', function () {
+    module('when CGU are already validated but authenticate fails', function () {
       test('it throws an error', async function (assert) {
         // given
-        const authenticateStub = sinon.stub().rejects({ errors: [{ detail: 'there was an error' }] });
+        const authenticateStub = sinon.stub().rejects({ errors: [{ detail: 'Some error' }] });
         const sessionStub = Service.create({
           authenticate: authenticateStub,
           data: {},
@@ -267,46 +267,8 @@ module('Unit | Route | login-oidc', function (hooks) {
         } catch (error) {
           // then
           sinon.assert.calledOnce(authenticateStub);
-          assert.strictEqual(error.message, 'there was an error');
+          assert.strictEqual(error.message, 'Some error');
           assert.ok(true);
-        }
-      });
-    });
-
-    module('when the identity provider does not provide all the user required information', function () {
-      test('it throws an error', async function (assert) {
-        // given
-        const authenticateStub = sinon.stub().rejects({
-          errors: [
-            {
-              status: '422',
-              code: 'USER_INFO_MANDATORY_MISSING_FIELDS',
-              title: 'Unprocessable entity',
-              detail:
-                "Un ou des champs obligatoires (Champs manquants : given_name}) n'ont pas été renvoyés par votre fournisseur d'identité OIDC partner.",
-              meta: {
-                shortCode: 'OIDC01',
-              },
-            },
-          ],
-        });
-        const sessionStub = Service.create({
-          authenticate: authenticateStub,
-          data: {},
-        });
-        const route = this.owner.lookup('route:authentication/login-oidc');
-        route.set('session', sessionStub);
-        route.router = { transitionTo: sinon.stub() };
-
-        try {
-          // when
-          await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
-        } catch (error) {
-          // then
-          assert.strictEqual(
-            error.message,
-            "Un ou des champs obligatoires (Champs manquants : given_name}) n'ont pas été renvoyés par votre fournisseur d'identité OIDC partner.",
-          );
         }
       });
     });

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -17,7 +17,7 @@ module('Unit | Route | login-oidc', function (hooks) {
 
   module('#beforeModel', function () {
     module('when receives error from identity provider', function () {
-      test('throws an error', function (assert) {
+      test('it throws an error', function (assert) {
         // given
         const route = this.owner.lookup('route:authentication/login-oidc');
 
@@ -57,7 +57,7 @@ module('Unit | Route | login-oidc', function (hooks) {
       });
 
       module('when identity provider is not supported', function () {
-        test('should redirect the user to main login page', async function (assert) {
+        test('it redirects the user to main login page', async function (assert) {
           // given
           const route = this.owner.lookup('route:authentication/login-oidc');
           route.router = { transitionTo: sinon.stub() };
@@ -73,7 +73,7 @@ module('Unit | Route | login-oidc', function (hooks) {
 
       module('when attempting transition', function () {
         module('when TransitionIntent is a URLTransitionIntent', function () {
-          test('stores the intent url in session data nextUrl', async function (assert) {
+          test('it stores the intent url in session data nextUrl', async function (assert) {
             // given
             const sessionStub = Service.create({
               attemptedTransition: { intent: { url: '/organisations/PIXOIDC01/acces' } },
@@ -99,7 +99,7 @@ module('Unit | Route | login-oidc', function (hooks) {
 
         module('when TransitionIntent is a NamedTransitionIntent (no URL)', function () {
           module('when there is at least one context', function () {
-            test('builds a url from the intent name and contexts and stores it in session data nextUrl', async function (assert) {
+            test('it builds a url from the intent name and contexts and stores it in session data nextUrl', async function (assert) {
               // given
               const authenticateStub = sinon.stub().resolves();
               const sessionStub = Service.create({
@@ -127,7 +127,7 @@ module('Unit | Route | login-oidc', function (hooks) {
           });
 
           module('when there is no context', function () {
-            test('builds a url from the intent name and stores it in session data nextUrl', async function (assert) {
+            test('it builds a url from the intent name and stores it in session data nextUrl', async function (assert) {
               // given
               const authenticateStub = sinon.stub().resolves();
               const sessionStub = Service.create({
@@ -198,7 +198,7 @@ module('Unit | Route | login-oidc', function (hooks) {
       this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
     });
 
-    test('authenticates the user with identity provider', async function (assert) {
+    test('it authenticates the user with identity provider', async function (assert) {
       // given
       const authenticateStub = sinon.stub().resolves();
       const sessionStub = Service.create({
@@ -219,7 +219,7 @@ module('Unit | Route | login-oidc', function (hooks) {
       assert.deepEqual(sessionStub.data, {});
     });
 
-    test('returns values to be received by afterModel to validate CGU', async function (assert) {
+    test('it returns values to be received by afterModel to validate CGU', async function (assert) {
       // given
       const authenticateStub = sinon.stub().rejects({
         errors: [
@@ -253,7 +253,7 @@ module('Unit | Route | login-oidc', function (hooks) {
     });
 
     module('when there is an unexpected error (not a JSON:API error)', function () {
-      test('throws back the error', async function (assert) {
+      test('it throws back the error', async function (assert) {
         // given
         const authenticateStub = sinon.stub().rejects(new Error('Internal Server Error, this is not a JSON:API error'));
         const sessionStub = Service.create({
@@ -304,7 +304,7 @@ module('Unit | Route | login-oidc', function (hooks) {
     });
 
     module('when CGU are already validated and authenticate fails', function () {
-      test('throws an error', async function (assert) {
+      test('it throws an error', async function (assert) {
         // given
         const authenticateStub = sinon.stub().rejects({ errors: [{ detail: 'there was an error' }] });
         const sessionStub = Service.create({
@@ -328,7 +328,7 @@ module('Unit | Route | login-oidc', function (hooks) {
     });
 
     module('when the identity provider does not provide all the user required information', function () {
-      test('throws an error', async function (assert) {
+      test('it throws an error', async function (assert) {
         // given
         const authenticateStub = sinon.stub().rejects({
           errors: [

--- a/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc-test.js
@@ -11,6 +11,10 @@ module('Unit | Route | login-oidc', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('#beforeModel', function () {
     module('when receives error from identity provider', function () {
       test('throws an error', function (assert) {
@@ -50,10 +54,6 @@ module('Unit | Route | login-oidc', function (hooks) {
         }
 
         this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
-      });
-
-      hooks.afterEach(function () {
-        sinon.restore();
       });
 
       module('when identity provider is not supported', function () {

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -106,6 +106,9 @@ export default class LoginOidcRoute extends Route {
       return { identityProviderSlug, shouldCreateUserAccount: false };
     } catch (response) {
       const apiError = get(response, 'errors[0]');
+      if (!apiError) {
+        throw response;
+      }
 
       if (apiError.code == 'MISSING_OIDC_STATE') {
         this.router.transitionTo('authentication.login');

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -92,28 +92,26 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
           assert.ok(screen.getByRole('button', { name: t('pages.login-form.login') }));
         });
       });
-
-      // TODO: Uncomment and make those tests work when the signup template is done
-      // module('when the user creates an account', function () {
-      //   module('when the user logs out', function () {
-      //     toRenameToTest('it redirects the user to the logout URL', async function (assert) {
-      //       // given
-      //       const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-      //       await click(screen.getByLabelText(t('common.cgu.label')));
-      //       await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
-      //       // eslint-disable-next-line ember/no-settled-after-test-helper
-      //       await settled();
-
-      //       await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
-
-      //       // when
-      //       await click(screen.getByRole('link', { name: 'Se déconnecter' }));
-
-      //       // then
-      //       assert.strictEqual(currentURL(), '/deconnexion');
-      //     });
-      //   });
-      // });
     });
   });
+
+  // TODO: Uncomment and make those tests work when the signup template is done
+  //   module('when the user logs out', function () {
+  //     toRenameToTest('it redirects the user to the logout URL', async function (assert) {
+  //       // given
+  //       const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+  //       await click(screen.getByLabelText(t('common.cgu.label')));
+  //       await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+  //       // eslint-disable-next-line ember/no-settled-after-test-helper
+  //       await settled();
+  //
+  //       await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+  //
+  //       // when
+  //       await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+  //
+  //       // then
+  //       assert.strictEqual(currentURL(), '/deconnexion');
+  //     });
+  //   });
 });

--- a/orga/tests/helpers/service-stubs.js
+++ b/orga/tests/helpers/service-stubs.js
@@ -1,0 +1,49 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import sinon from 'sinon';
+
+/**
+ * Stubs the oidcIdentityProviders service.
+ *
+ * @param {Object} owner - The owner object.
+ * @returns {Service} The stubbed oidcIdentityProviders service.
+ */
+export function stubOidcIdentityProvidersService(owner, { oidcIdentityProviders, featuredIdentityProviderCode } = {}) {
+  class OidcProvidersServiceStub extends Service {
+    @tracked isOidcProviderAuthenticationInProgress = false;
+
+    constructor() {
+      super();
+      this.oidcIdentityProviders = oidcIdentityProviders || [];
+
+      this.oidcIdentityProviders.forEach((oidcIdentityProvider) => {
+        this[oidcIdentityProvider.id] = oidcIdentityProvider;
+      });
+
+      this.featuredIdentityProviderCode = featuredIdentityProviderCode;
+
+      this.shouldDisplayAccountRecoveryBanner = sinon.stub();
+    }
+
+    load() {
+      return Promise.resolve();
+    }
+
+    get list() {
+      return this.oidcIdentityProviders;
+    }
+
+    get hasIdentityProviders() {
+      return this.list.length > 0;
+    }
+
+    findBySlug(providerSlug) {
+      if (!this.hasIdentityProviders) return;
+      return this.list.find((oidcProvider) => oidcProvider.slug === providerSlug);
+    }
+  }
+
+  owner.unregister('service:oidcIdentityProviders');
+  owner.register('service:oidcIdentityProviders', OidcProvidersServiceStub);
+  return owner.lookup('service:oidcIdentityProviders');
+}

--- a/orga/tests/unit/routes/authentication/oidc/flow-test.js
+++ b/orga/tests/unit/routes/authentication/oidc/flow-test.js
@@ -1,0 +1,104 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { stubOidcIdentityProvidersService } from '../../../../helpers/service-stubs';
+import setupIntl from '../../../../helpers/setup-intl';
+
+module('Unit | Route | Authentication | OIDC | flow', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#model', function (hooks) {
+    hooks.beforeEach(function () {
+      stubOidcIdentityProvidersService(this.owner, {
+        oidcIdentityProviders: [
+          {
+            id: 'oidc-partner',
+            slug: 'oidc-partner',
+            code: 'OIDC_PARTNER',
+            organizationName: 'OIDC Partner',
+          },
+        ],
+      });
+    });
+
+    module('when there is an unexpected error (not a JSON:API error)', function () {
+      test('it throws back the error', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects(new Error('Internal Server Error, this is not a JSON:API error'));
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/oidc.flow');
+        route.set('session', sessionStub);
+        route.router = { transitionTo: sinon.stub() };
+
+        // when & then
+        await assert.rejects(
+          route.model(
+            { identity_provider_slug: 'oidc-partner' },
+            { to: { queryParams: { code: 'test' } } },
+            /Internal Server Error, this is not a JSON:API error/,
+          ),
+        );
+      });
+    });
+
+    module('when there is a MISSING_OIDC_STATE error', function () {
+      test('it redirects to authentication.login page', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects({
+          errors: [
+            {
+              code: 'MISSING_OIDC_STATE',
+            },
+          ],
+        });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/oidc.flow');
+        route.set('session', sessionStub);
+        route.router = { transitionTo: sinon.stub() };
+
+        // when
+        await route.model({ identity_provider_slug: 'oidc-partner' }, { to: { queryParams: { code: 'test' } } });
+
+        // then
+        sinon.assert.calledOnce(authenticateStub);
+        sinon.assert.calledWith(route.router.transitionTo, 'authentication.login');
+        assert.ok(true);
+      });
+    });
+
+    module('when CGU are already validated but authenticate fails', function () {
+      test('it throws an error', async function (assert) {
+        // given
+        const authenticateStub = sinon.stub().rejects({ errors: [{ detail: 'Some error' }] });
+        const sessionStub = Service.create({
+          authenticate: authenticateStub,
+          data: {},
+        });
+        const route = this.owner.lookup('route:authentication/oidc.flow');
+        route.set('session', sessionStub);
+        route.router = { transitionTo: sinon.stub() };
+
+        await assert.rejects(
+          route.model(
+            { identity_provider_slug: 'oidc-partner' },
+            { to: { queryParams: { code: 'test' } } },
+            /Some error/,
+          ),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Dans le parcours d'authentification OIDC, quand une erreur non-prévue (c’est à dire non-JSON:API) survient, alors le message de cette erreur n’est pas affiché sur Pix App et un message d’erreur inutile s’affiche à la place :
```
TypeError: Cannot read properties of undefined (reading 'detail')
``` 

<img width="1783" height="806" alt="oidc-error" src="https://github.com/user-attachments/assets/d2005649-3d03-48a7-b022-2e9b2f4ee3ad" />

## 🛷 Proposition

Dans les frontaux (Pix App, Pix Orga), lorsqu’une erreur intervient dans le parcours d'authentification OIDC, ne chercher à utiliser des propriétés particulières (`detail`, `code`, `meta.authenticationKey`) que si l’erreur est une erreur JSON:API.

Une erreur non-JSON:API pourra ainsi « s’afficher sans erreur sur le frontal » : 

<img width="1280" height="841" alt="oidc-error-handled" src="https://github.com/user-attachments/assets/06bbacc9-adf3-4c04-9ade-54f46d3cbb43" />

## ☃️ Remarques

Les tests unitaires et d’acceptance pour le workflow OIDC sur Pix App et Pix Orga ont aussi été retravaillés pour être plus clairs et supprimer les tests redondants.

Idéalement, dans les frontaux, il faudrait une gestion extensible complète de toutes les erreurs qui sache gérer tous types d’erreur : les erreurs JSON:API et les erreurs non-prévues.

## 🧑‍🎄 Pour tester

À tester en local.

* Tester qu’une connexion par OIDC fonctionne toujours bien
* Modifier le fichier `mon-pix/app/routes/authentication/login-oidc.js` comme ci-dessous et vérifier que l’erreur affichée sur le frontal est `Error: Internal Server Error`

```javascript
  async _handleOidcCallbackRequest({ identityProvider, code, state, iss }) {
    const identityProviderSlug = identityProvider.slug;
    try {
      throw new Error('Internal Server Error')
      await this.session.authenticate('authenticator:oidc', {
        code,
        state,
        iss,
        identityProviderSlug,
        hostSlug: 'token',
      });

      return { identityProviderSlug, shouldCreateUserAccount: false };
    } catch (response) {
      const apiError = get(response, 'errors[0]');
      if (!apiError) {
        throw response;
      }

      const error = new JSONApiError(apiError.detail, apiError);

      if (error.code == 'MISSING_OIDC_STATE') {
        this.router.transitionTo('authentication.login');
        return;
      }

      const shouldValidateCgu = error.code === 'SHOULD_VALIDATE_CGU';
      if (shouldValidateCgu && error.meta.authenticationKey) {
        oidcUserAuthenticationStorage.set(error.meta);

        return { identityProviderSlug, shouldCreateUserAccount: true };
      }

      throw error;
    }
  }
```
