### PR TITLE
[TECH] :recycle: Met à jour le candidat dans une transaction (pix-20719)

### DIFF
--- a/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
+++ b/api/src/certification/enrolment/domain/usecases/update-enrolled-candidate.js
@@ -2,6 +2,7 @@
  * @typedef {import('./index.js').CandidateRepository} CandidateRepository
  */
 
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import {
   CandidateAlreadyLinkedToUserError,
   CertificationCandidateNotFoundError,
@@ -12,7 +13,7 @@ import {
  * @param {EditedCandidate} params.editedCandidate
  * @param {CandidateRepository} params.candidateRepository
  */
-const updateEnrolledCandidate = async function ({ editedCandidate, candidateRepository }) {
+export const updateEnrolledCandidate = withTransaction(async function ({ editedCandidate, candidateRepository }) {
   const foundCandidate = await candidateRepository.get({ certificationCandidateId: editedCandidate.id });
 
   if (!foundCandidate) {
@@ -26,6 +27,4 @@ const updateEnrolledCandidate = async function ({ editedCandidate, candidateRepo
   foundCandidate.updateAccessibilityAdjustmentNeededStatus(editedCandidate.accessibilityAdjustmentNeeded);
 
   return candidateRepository.update(foundCandidate);
-};
-
-export { updateEnrolledCandidate };
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/update-enrolled-candidate_test.js
@@ -1,4 +1,5 @@
 import { updateEnrolledCandidate } from '../../../../../../src/certification/enrolment/domain/usecases/update-enrolled-candidate.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import {
   CandidateAlreadyLinkedToUserError,
   CertificationCandidateNotFoundError,
@@ -19,6 +20,10 @@ describe('Unit | UseCase | update-enrolled-candidate', function () {
     editedCandidate = domainBuilder.certification.enrolment.buildEditedCandidate({
       id: 123,
       accessibilityAdjustmentNeeded: true,
+    });
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((fn) => {
+      return fn({});
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

Nous avons découvert que certains candidats ont deux souscriptions du même type (CORE, etc.) en même temps, pour la même certification.

```sql
SELECT 
    "certificationCandidateId",
    COUNT(*) as nombre_complementary
FROM "certification-subscriptions"
WHERE type = 'COMPLEMENTARY'
GROUP BY "certificationCandidateId"
HAVING COUNT(*) > 1;
```

## 🛷 Proposition

Placer la mise à jour du candidat dans une transaction.

## ☃️ Remarques

Cette PR est une extraction de la PR #14350 . Ici, nous ne traitons que de la transaction. Nous gardons l'autre PR pour explorer un remaniement du code autour de la mise à jour d'un candidat.

## 🧑‍🎄 Pour tester

- Créer une session de certification (dans pix Certif) ;
- Créer un candidat ;
- Modifier le candidat depuis deux navigateurs dans un délai très court (difficile tester la concurrence d'accès « à la main »);
- S'assurer que tout ce passe bien

L'opération peu être répété avec un import de candidats via un fichier ODS.
