### PR TITLE
[TECH] Simplifier la déclaration de Parcours dans les tests (PIX-20725).

### DIFF
--- a/api/db/database-builder/factory/build-combined-course.js
+++ b/api/db/database-builder/factory/build-combined-course.js
@@ -1,13 +1,13 @@
 import isUndefined from 'lodash/isUndefined.js';
 
+import { CombinedCourseTemplate } from '../../../src/quest/domain/models/CombinedCourseTemplate.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildOrganization } from './build-organization.js';
 import { buildQuestForCombinedCourse } from './build-quest.js';
 
 const buildCombinedCourse = function ({
   id = databaseBuffer.getNextId(),
-  eligibilityRequirements = [],
-  successRequirements = [],
+  combinedCourseContents = [],
   code = 'COMBINIX1',
   name = 'Mon parcours combiné',
   organizationId,
@@ -18,10 +18,13 @@ const buildCombinedCourse = function ({
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
 
+  const successRequirementsFromContents = combinedCourseContents.map((content) =>
+    CombinedCourseTemplate.buildRequirementForCombinedCourse(content).toDTO(),
+  );
+
   const questId = buildQuestForCombinedCourse({
     illustration,
-    eligibilityRequirements,
-    successRequirements,
+    successRequirements: successRequirementsFromContents,
     organizationId,
     code,
     name,

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-route_test.js
@@ -1,11 +1,5 @@
 import times from 'lodash/times.js';
 
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { constants } from '../../../../../src/shared/domain/constants.js';
 import { SCOPES } from '../../../../../src/shared/domain/models/BadgeDetails.js';
 import { Membership } from '../../../../../src/shared/domain/models/Membership.js';
@@ -875,64 +869,11 @@ describe('Acceptance | API | Campaign Participations', function () {
         rewardId: null,
         code: 'COMBINIX1',
         organizationId: campaignInCombinedCourse.organizationId,
-        eligibilityRequirements: [],
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignInCombinedCourse.id,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'f32a2238-4f65-4698-b486-15d51935d335',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'ab82925d-4775-4bca-b513-4c3009ec5886',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaignInCombinedCourse.id },
+          { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
+          { moduleId: 'f32a2238-4f65-4698-b486-15d51935d335' },
+          { moduleId: 'ab82925d-4775-4bca-b513-4c3009ec5886' },
         ],
       });
       databaseBuilder.factory.campaignParticipationOverviewFactory.build({

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -9,11 +9,6 @@ import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { constants } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import {
@@ -927,36 +922,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           rewardId: null,
           code: 'COMBINIX1',
           organizationId: campaignInCombinedCourse.organizationId,
-          eligibilityRequirements: [],
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                campaignId: {
-                  data: campaignInCombinedCourse.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-                status: {
-                  data: 'SHARED',
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                moduleId: {
-                  data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-                isTerminated: {
-                  data: true,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
+          combinedCourseContents: [
+            { campaignId: campaignInCombinedCourse.id },
+            { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
           ],
         });
         databaseBuilder.factory.campaignParticipationOverviewFactory.build({

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -14,11 +14,6 @@ import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { constants } from '../../../../../../src/shared/domain/constants.js';
 import { DomainTransaction, withTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
@@ -1486,36 +1481,9 @@ describe('Integration | Repository | Campaign Participation', function () {
         rewardId: null,
         code: 'COMBINIX1',
         organizationId: campaignInCombinedCourse.organizationId,
-        eligibilityRequirements: [],
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignInCombinedCourse.id,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaignInCombinedCourse.id },
+          { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' },
         ],
       });
       databaseBuilder.factory.buildOrganizationLearnerParticipation({
@@ -1550,22 +1518,7 @@ describe('Integration | Repository | Campaign Participation', function () {
         userId,
       });
       databaseBuilder.factory.buildCombinedCourse({
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignInCombinedCourse.id,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: campaignInCombinedCourse.id }],
       });
 
       databaseBuilder.factory.buildAssessment({

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-user-management-repository_test.js
@@ -6,11 +6,6 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { databaseBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -91,22 +86,7 @@ describe('Integration | Repository | Participations-For-User-Management', functi
           code: 'ABCDE1234',
           name: 'Mon parcours Combiné',
           organizationId: combinedCourseCampaign.organizationId,
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                campaignId: {
-                  data: combinedCourseCampaign.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-                status: {
-                  data: CampaignParticipationStatuses.SHARED,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
+          combinedCourseContents: [{ campaignId: combinedCourseCampaign.id }],
         });
 
         const combinedCourseCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({

--- a/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
+++ b/api/tests/prescription/campaign/integration/application/usecases/checkCampaignBelongsToCombinedCourse_test.js
@@ -1,11 +1,5 @@
 import * as checkAuthorizationToAccessCombinedCourse from '../../../../../../src/prescription/campaign/application/usecases/checkCampaignBelongsToCombinedCourse.js';
 import { CampaignBelongsToCombinedCourseError } from '../../../../../../src/prescription/campaign/domain/errors.js';
-import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Campaign | Application | Usecases | checkCampaignBelongsToCombinedCourse', function () {
@@ -24,22 +18,7 @@ describe('Integration | Campaign | Application | Usecases | checkCampaignBelongs
       code: 'ABCDE1234',
       name: 'Mon parcours Combiné',
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId }],
     });
     await databaseBuilder.commit();
 
@@ -57,22 +36,7 @@ describe('Integration | Campaign | Application | Usecases | checkCampaignBelongs
       code: 'ABCDE1234',
       name: 'Mon parcours Combiné',
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: anotherCampaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: anotherCampaignId }],
     });
     await databaseBuilder.commit();
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/delete-campaigns_test.js
@@ -3,15 +3,7 @@ import { PIX_ADMIN } from '../../../../../../src/authorization/domain/constants.
 import { CampaignBelongsToCombinedCourseError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
-import {
-  CampaignParticipationLoggerContext,
-  CampaignParticipationStatuses,
-} from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
+import { CampaignParticipationLoggerContext } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { EventLoggingJob } from '../../../../../../src/shared/domain/models/jobs/EventLoggingJob.js';
@@ -660,22 +652,7 @@ describe('Integration | UseCases | delete-campaign', function () {
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId }],
       });
 
       buildCampaignParticipation({ campaignId });

--- a/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-managements_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/find-paginated-campaign-managements_test.js
@@ -14,18 +14,7 @@ describe('Integration | UseCase | find-paginated-campaign-managements', function
       code: 'ABCDE1234',
       name: 'Mon parcours Combiné',
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: 'campaignParticipations',
-          comparison: 'all',
-          data: {
-            campaignId: {
-              data: campaignIdInCombinedCourse,
-              comparison: 'equal',
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: campaignIdInCombinedCourse }],
     });
     await databaseBuilder.commit();
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/get-campaign_test.js
@@ -3,11 +3,6 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | UseCase | get-campaign', function () {
@@ -33,22 +28,7 @@ describe('Integration | UseCase | get-campaign', function () {
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: campaign.id }],
       }).id;
       await databaseBuilder.commit();
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-management-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-management-repository_test.js
@@ -184,18 +184,7 @@ describe('Integration | Repository | Campaign-Management', function () {
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId: organization.id,
-        successRequirements: [
-          {
-            requirement_type: 'campaignParticipations',
-            comparison: 'all',
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: 'equal',
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: campaign.id }],
       });
 
       await databaseBuilder.commit();

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -8,11 +8,6 @@ import {
   CampaignParticipationStatuses,
   CampaignTypes,
 } from '../../../../../../src/prescription/shared/domain/constants.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { CAMPAIGN_FEATURES } from '../../../../../../src/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
@@ -1081,22 +1076,7 @@ describe('Integration | Repository | Campaign-Report', function () {
           code: 'ABCDE1234',
           name: 'Mon parcours Combiné',
           organizationId,
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                campaignId: {
-                  data: campaignInQuest.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-                status: {
-                  data: CampaignParticipationStatuses.SHARED,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
+          combinedCourseContents: [{ campaignId: campaignInQuest.id }],
         });
         await databaseBuilder.commit();
 
@@ -1118,22 +1098,7 @@ describe('Integration | Repository | Campaign-Report', function () {
           code: 'ABCDE1234',
           name: 'Mon parcours Combiné',
           organizationId,
-          successRequirements: [
-            {
-              requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-              comparison: REQUIREMENT_COMPARISONS.ALL,
-              data: {
-                campaignId: {
-                  data: campaignInQuest.id,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-                status: {
-                  data: CampaignParticipationStatuses.SHARED,
-                  comparison: CRITERION_COMPARISONS.EQUAL,
-                },
-              },
-            },
-          ],
+          combinedCourseContents: [{ campaignId: campaignInQuest.id }],
         });
         await databaseBuilder.commit();
 

--- a/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
+++ b/api/tests/prescription/target-profile/integration/infrastructure/repositories/target-profile-summary-for-admin-repository_test.js
@@ -1,10 +1,4 @@
-import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import * as targetProfileSummaryForAdminRepository from '../../../../../../src/prescription/target-profile/infrastructure/repositories/target-profile-summary-for-admin-repository.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../../src/quest/domain/models/Quest.js';
 import { TargetProfile } from '../../../../../../src/shared/domain/models/TargetProfile.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -382,20 +376,9 @@ describe('Integration | Repository | Target-profile-summary-for-admin', function
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId: organization.id,
-        successRequirements: [
+        combinedCourseContents: [
           {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignIdInCombinedCourse,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
+            campaignId: campaignIdInCombinedCourse,
           },
         ],
       });

--- a/api/tests/quest/acceptance/application/api/combined-course-api_test.js
+++ b/api/tests/quest/acceptance/application/api/combined-course-api_test.js
@@ -1,12 +1,6 @@
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import * as combinedCourseApi from '../../../../../src/quest/application/api/combined-course-api.js';
 import { CombinedCourse } from '../../../../../src/quest/application/api/CombinedCourse.model.js';
 import { MultipleQuestFoundError } from '../../../../../src/quest/application/api/errors.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Quest | Application | combined-course-api', function () {
@@ -20,22 +14,7 @@ describe('Acceptance | Quest | Application | combined-course-api', function () {
       code: 'ABCDE1234',
       name: combinedCourseName,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId }],
     }).id;
     await databaseBuilder.commit();
   });
@@ -70,24 +49,7 @@ describe('Acceptance | Quest | Application | combined-course-api', function () {
       code: 'QWERTY123',
       name: combinedCourseName,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
-      rewardId: null,
-      rewardType: null,
+      combinedCourseContents: [{ campaignId }],
     });
 
     await databaseBuilder.commit();

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -203,7 +203,6 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code: 'COMBINIX1',
         organizationId,
-        successRequirements: [],
       });
       databaseBuilder.factory.buildOrganizationLearnerParticipation({
         type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,
@@ -239,7 +238,6 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,
-          successRequirements: [],
         });
         databaseBuilder.factory.buildMembership({ userId, organizationId });
         await databaseBuilder.commit();
@@ -268,7 +266,6 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,
-          successRequirements: [],
         });
         const learner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
         databaseBuilder.factory.buildMembership({ userId, organizationId });
@@ -306,7 +303,6 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,
-          successRequirements: [],
         });
         const learnerId = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
         databaseBuilder.factory.buildMembership({ userId, organizationId });
@@ -344,7 +340,6 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
           name: 'Mon parcours combiné',
           code: 'PARCOURS123',
           organizationId,
-          successRequirements: [],
         });
         const learner = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,

--- a/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
+++ b/api/tests/quest/integration/domain/services/combined-course-details-service_test.js
@@ -5,10 +5,7 @@ import {
   COMBINED_COURSE_ITEM_TYPES,
   CombinedCourseItem,
 } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
-import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/domain/models/CriterionProperty.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import { REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/Quest.js';
-import { COMPARISONS as COMPARISONS_REQUIREMENT } from '../../../../../src/quest/domain/models/Requirement.js';
 import combinedCourseDetailsService from '../../../../../src/quest/domain/services/combined-course-details-service.js';
 import { repositories } from '../../../../../src/quest/infrastructure/repositories/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -77,50 +74,7 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: campaign.id }, { moduleId: moduleId1 }, { moduleId: moduleId2 }],
       });
 
       await databaseBuilder.commit();
@@ -192,63 +146,11 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId3,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaign.id },
+          { moduleId: moduleId1 },
+          { moduleId: moduleId2 },
+          { moduleId: moduleId3 },
         ],
       });
 
@@ -391,63 +293,11 @@ describe('Integration | Quest | Domain | Services | CombinedCourseDetailsService
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId3,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaign.id },
+          { moduleId: moduleId1 },
+          { moduleId: moduleId2 },
+          { moduleId: moduleId3 },
         ],
       });
 

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-campaign-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-campaign-id_test.js
@@ -1,10 +1,4 @@
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -21,22 +15,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-campa
       code,
       name,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId }],
     }).id;
     await databaseBuilder.commit();
   });

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-by-module-id-and-user-id_test.js
@@ -1,9 +1,4 @@
 import { CombinedCourse } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -22,24 +17,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
       code: 'QWERTY123',
       name: 'name1',
       organizationId: organizationLearner.organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            moduleId: {
-              data: moduleId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
-      rewardId: null,
-      rewardType: null,
+      combinedCourseContents: [{ moduleId }],
     });
 
     //CombinedCourse2 with same module but organization linked to organizationLearner2
@@ -47,24 +25,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
       code: 'AZERTY123',
       name: 'name2',
       organizationId: otherOrganizationLearner.organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            moduleId: {
-              data: moduleId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
-      rewardId: null,
-      rewardType: null,
+      combinedCourseContents: [{ moduleId }],
     });
 
     //CombinedCourse3 with same module but with an organization not linked to user
@@ -72,24 +33,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
       code: 'AZERTYABC',
       name: 'name2',
       organizationId: thirdOrganization.id,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            moduleId: {
-              data: moduleId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
-      rewardId: null,
-      rewardType: null,
+      combinedCourseContents: [{ moduleId }],
     });
 
     //CombinedCourse4 with other module but organization linked to user
@@ -97,24 +41,7 @@ describe('Integration | Quest | Domain | UseCases | find-combined-course-by-modu
       code: 'QWERTYDBE',
       name: 'name1',
       organizationId: organizationLearner.organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            moduleId: {
-              data: 'module-cde',
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
-      rewardId: null,
-      rewardType: null,
+      combinedCourseContents: [{ moduleId: 'module-cde' }],
     });
 
     await databaseBuilder.commit();

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-participations_test.js
@@ -1,14 +1,6 @@
-import {
-  CampaignParticipationStatuses,
-  CombinedCourseParticipationStatuses,
-} from '../../../../../src/prescription/shared/domain/constants.js';
+import { CombinedCourseParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseParticipationDetails } from '../../../../../src/quest/domain/models/CombinedCourseParticipationDetails.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -20,36 +12,7 @@ describe('Quest | Integration | Domain | Usecases | findCombinedCourseParticipat
     const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
       code: 'COMBI1',
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: campaignId,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            moduleId: {
-              data: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId }, { moduleId: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' }],
     });
     combinedCourseId = combinedCourse.id;
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-code_test.js
@@ -4,10 +4,7 @@ import {
   COMBINED_COURSE_ITEM_TYPES,
   CombinedCourseItem,
 } from '../../../../../src/quest/domain/models/CombinedCourseItem.js';
-import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/domain/models/CriterionProperty.js';
 import { OrganizationLearnerParticipationStatuses } from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import { REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/Quest.js';
-import { COMPARISONS as COMPARISONS_REQUIREMENT } from '../../../../../src/quest/domain/models/Requirement.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
@@ -52,50 +49,7 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: campaign.id }, { moduleId: moduleId1 }, { moduleId: moduleId2 }],
       });
 
       databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
@@ -211,63 +165,11 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId3,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaign.id },
+          { moduleId: moduleId1 },
+          { moduleId: moduleId2 },
+          { moduleId: moduleId3 },
         ],
       });
 
@@ -366,63 +268,11 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-by-code'
       const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
         code,
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              campaignId: {
-                data: campaign.id,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId1,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId2,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: COMPARISONS_REQUIREMENT.ALL,
-            data: {
-              moduleId: {
-                data: moduleId3,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
+        combinedCourseContents: [
+          { campaignId: campaign.id },
+          { moduleId: moduleId1 },
+          { moduleId: moduleId2 },
+          { moduleId: moduleId3 },
         ],
       });
 

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-by-id_test.js
@@ -1,10 +1,4 @@
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
@@ -20,51 +14,7 @@ describe('Quest | Integration | Domain | Usecases | getCombinedCourseById', func
       illustration: 'https://example.com/image.png',
       code: 'TEST_COURSE_123',
       organizationId,
-      eligibilityRequirements: [],
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: 100,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: 200,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: REQUIREMENT_COMPARISONS.ALL,
-          data: {
-            campaignId: {
-              data: 300,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: CRITERION_COMPARISONS.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: 100 }, { campaignId: 200 }, { campaignId: 300 }],
     }).id;
 
     await databaseBuilder.commit();

--- a/api/tests/quest/integration/domain/usecases/get-verified-code_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-verified-code_test.js
@@ -21,8 +21,6 @@ describe('Quest | Integration | Domain | Usecases | getVerifiedCode', function (
       name: 'Combinix',
       code: 'COMBINIX1',
       organizationId,
-      eligibilityRequirements: [],
-      successRequirements: [],
     });
     await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
+++ b/api/tests/quest/integration/domain/usecases/update-combined-course_test.js
@@ -1,11 +1,8 @@
 import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
-import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/domain/models/CriterionProperty.js';
 import {
   OrganizationLearnerParticipationStatuses,
   OrganizationLearnerParticipationTypes,
 } from '../../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
-import { REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/Quest.js';
-import { COMPARISONS as COMPARISONS_REQUIREMENTS } from '../../../../../src/quest/domain/models/Requirement.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { databaseBuilder, expect, knex, nock, sinon } from '../../../../test-helper.js';
 
@@ -35,36 +32,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            moduleId: {
-              data: moduleId,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: campaign.id }, { moduleId }],
     });
 
     const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
@@ -142,55 +110,11 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            moduleId: {
-              data: moduleId,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            isTerminated: {
-              data: true,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            moduleId: {
-              data: module2Id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            moduleId: {
-              data: module3Id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
+      combinedCourseContents: [
+        { campaignId: campaign.id },
+        { moduleId },
+        { moduleId: module2Id },
+        { moduleId: module3Id },
       ],
     });
     databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
@@ -223,22 +147,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: campaign.id }],
     });
     const combinedCourseParticipation =
       databaseBuilder.factory.buildOrganizationLearnerParticipation.ofTypeCombinedCourse({
@@ -269,22 +178,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: campaign.id }],
     });
     await databaseBuilder.commit();
 
@@ -304,22 +198,7 @@ describe('Integration | Quest | Domain | UseCases | update-combined-course', fun
     const { id: combinedCourseId } = databaseBuilder.factory.buildCombinedCourse({
       code,
       organizationId,
-      successRequirements: [
-        {
-          requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-          comparison: COMPARISONS_REQUIREMENTS.ALL,
-          data: {
-            campaignId: {
-              data: campaign.id,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-            status: {
-              data: CampaignParticipationStatuses.SHARED,
-              comparison: COMPARISONS_CRITERION.EQUAL,
-            },
-          },
-        },
-      ],
+      combinedCourseContents: [{ campaignId: campaign.id }],
     });
     const combinedCourseParticipation = databaseBuilder.factory.buildOrganizationLearnerParticipation({
       type: OrganizationLearnerParticipationTypes.COMBINED_COURSE,

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-details-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-details-repository_test.js
@@ -1,11 +1,4 @@
-import { CampaignParticipationStatuses } from '../../../../../src/prescription/shared/domain/constants.js';
 import { CombinedCourseDetails } from '../../../../../src/quest/domain/models/CombinedCourse.js';
-import { COMPARISONS as COMPARISONS_CRITERION } from '../../../../../src/quest/domain/models/CriterionProperty.js';
-import {
-  CRITERION_COMPARISONS,
-  REQUIREMENT_COMPARISONS,
-  REQUIREMENT_TYPES,
-} from '../../../../../src/quest/domain/models/Quest.js';
 import * as combinedCourseDetailsRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-details-repository.js';
 import { databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -20,43 +13,13 @@ describe('Quest | Integration | Repository | combined-course-details', function 
         code: 'COURSE1',
         name: 'Parcours 1',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignId,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId }],
       });
       const combinedCourse2 = databaseBuilder.factory.buildCombinedCourse({
         code: 'COURSE2',
         name: 'Parcours 2',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ moduleId: moduleId }],
       });
       await databaseBuilder.commit();
 
@@ -81,22 +44,7 @@ describe('Quest | Integration | Repository | combined-course-details', function 
         code: 'COURSE1',
         name: 'Parcours 1',
         organizationId: anotherOrganizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: 123,
-                comparison: COMPARISONS_CRITERION.ALL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: COMPARISONS_CRITERION.ALL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId: 123 }],
       });
       await databaseBuilder.commit();
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -167,22 +167,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
         organizationId,
         description,
         illustration,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.CAMPAIGN_PARTICIPATIONS,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              campaignId: {
-                data: campaignId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              status: {
-                data: CampaignParticipationStatuses.SHARED,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
+        combinedCourseContents: [{ campaignId }],
       });
       await databaseBuilder.commit();
     });
@@ -356,96 +341,28 @@ describe('Quest | Integration | Repository | combined-course', function () {
         code: 'QWERTY123',
         name: 'name1',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId }],
       });
 
       const otherCombinedCourseWithModule = databaseBuilder.factory.buildCombinedCourse({
         code: 'AZERTY123',
         name: 'name2',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId }],
       });
 
       databaseBuilder.factory.buildCombinedCourse({
         code: 'AZERTY456',
         name: 'name3',
         organizationId: organizationId2,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId }],
       });
 
       databaseBuilder.factory.buildCombinedCourse({
         code: 'QWERTY456',
         name: 'name3',
         organizationId: organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'module-cde',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId: 'module-cde' }],
       });
 
       await databaseBuilder.commit();
@@ -494,72 +411,21 @@ describe('Quest | Integration | Repository | combined-course', function () {
         code: 'QWERTY123',
         name: 'name1',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId }],
       });
 
       const combinedCourseWithModuleAndOtherOrga = databaseBuilder.factory.buildCombinedCourse({
         code: 'AZERTY123',
         name: 'name2',
         organizationId: organizationId2,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: moduleId,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId }],
       });
 
       databaseBuilder.factory.buildCombinedCourse({
         code: 'AZERTY456',
         name: 'name3',
         organizationId,
-        successRequirements: [
-          {
-            requirement_type: REQUIREMENT_TYPES.OBJECT.PASSAGES,
-            comparison: REQUIREMENT_COMPARISONS.ALL,
-            data: {
-              moduleId: {
-                data: 'module-cde',
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-              isTerminated: {
-                data: true,
-                comparison: CRITERION_COMPARISONS.EQUAL,
-              },
-            },
-          },
-        ],
-        rewardId: null,
-        rewardType: null,
+        combinedCourseContents: [{ moduleId: 'module-cde' }],
       });
 
       await databaseBuilder.commit();

--- a/api/tests/shared/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/shared/acceptance/application/security-pre-handlers_test.js
@@ -52,16 +52,9 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
         code: 'ABCDE1234',
         name: 'Mon parcours Combiné',
         organizationId,
-        successRequirements: [
+        combinedCourseContents: [
           {
-            requirement_type: 'campaignParticipations',
-            comparison: 'all',
-            data: {
-              campaignId: {
-                data: campaignId,
-                comparison: 'equal',
-              },
-            },
+            campaignId,
           },
         ],
       });


### PR DESCRIPTION
## ❄️ Problème

On lie trop la création de parcours avec la définition d'une quête dans l'écriture des tests. 
- si cela est amené à changer la réécriture des tests sera compliqué.
- l'oublie des conditions qui permet de créer un parcours combiné est facilement oubliable. 

## 🛷 Proposition

Faire en sorte que le databaseBuilder fasse le travail à notre place nous garantissant la création d'un parcours combiné ISO à ce que nous avons en production

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert.