### PR TITLE
[FEATURE] Ajouter une table pour les schémas de parcours combinés (PIX-20727)

### DIFF
--- a/api/db/migrations/20251208150013_add-combined-course-blueprint-table.js
+++ b/api/db/migrations/20251208150013_add-combined-course-blueprint-table.js
@@ -1,0 +1,36 @@
+const TABLE_NAME = 'combined_course_blueprints';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.comment('This table contains data specific to combined courses blueprints.');
+    table.increments('id').primary().notNullable();
+    table.string('name').notNullable().comment('The public name of the combined course once created');
+    table.string('internalName').notNullable().comment('The internal name of the combined course used in pixAdmin');
+    table.text('description').comment('This description of the combined course once created');
+    table
+      .json('successRequirements')
+      .notNullable()
+      .comment(
+        'list of combined courses requirements to fulfill - a JSON in the form of `[{ type: "campaignParticipations" or "passages", value: id of profile cible (for campaignParticipations) or module id (for passages))}]`',
+      );
+    table
+      .text('illustration')
+      .comment('This illustration of the combined course once created visible on the combined course home page');
+    table.dateTime('createdAt').defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME);
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

On souhaite faciliter le suivi des déploiements des différents parcours combinés. Or pour l'instant rien n'existe ce qui rend la chose compliqué.

## 🛷 Proposition

Ajouter une table pour suivre les différent schéma de parcours disponibles

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Se connecter sur la RA 

```bash
scalingo -a pix-api-review-pr14373 pgsql-console
\d combined_course_blueprints;
```

