### PR TITLE
[FEATURE] Assigner le status STARTED aux participations de collectes de profiles à leurs créations (PIX-20706)

### DIFF
--- a/api/src/prescription/campaign-participation/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign-participation/application/http-error-mapper-configuration.js
@@ -1,9 +1,9 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
-import { CampaignParticiationInvalidStatus } from '../domain/errors.js';
+import { CampaignParticipationInvalidStatus } from '../domain/errors.js';
 
 const campaignParticipationDomainErrorMappingConfiguration = [
   {
-    name: CampaignParticiationInvalidStatus.name,
+    name: CampaignParticipationInvalidStatus.name,
     httpErrorFn: (error) => {
       return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
     },

--- a/api/src/prescription/campaign-participation/domain/errors.js
+++ b/api/src/prescription/campaign-participation/domain/errors.js
@@ -12,7 +12,7 @@ class CantCalculateCampaignParticipationResultError extends DomainError {
   }
 }
 
-class CampaignParticiationInvalidStatus extends DomainError {
+class CampaignParticipationInvalidStatus extends DomainError {
   constructor(campaignParticipationId, acceptedStatus) {
     super(
       `Campaign participation: ${campaignParticipationId} status do not fulfill requirement. Accepted Status : ${acceptedStatus}`,
@@ -21,7 +21,7 @@ class CampaignParticiationInvalidStatus extends DomainError {
 }
 
 export {
-  CampaignParticiationInvalidStatus,
   CampaignParticipationDeletedError,
+  CampaignParticipationInvalidStatus,
   CantCalculateCampaignParticipationResultError,
 };

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -7,7 +7,7 @@ import {
 } from '../../../../../src/shared/domain/errors.js';
 import { ArchivedCampaignError } from '../../../campaign/domain/errors.js';
 import { CampaignParticipationLoggerContext, CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
-import { CampaignParticiationInvalidStatus, CampaignParticipationDeletedError } from '../errors.js';
+import { CampaignParticipationDeletedError, CampaignParticipationInvalidStatus } from '../errors.js';
 
 class CampaignParticipation {
   #loggerContext;
@@ -123,7 +123,7 @@ class CampaignParticipation {
 
   _canBeImproved() {
     if (this.status !== CampaignParticipationStatuses.TO_SHARE) {
-      throw new CampaignParticiationInvalidStatus(this.id, CampaignParticipationStatuses.TO_SHARE);
+      throw new CampaignParticipationInvalidStatus(this.id, CampaignParticipationStatuses.TO_SHARE);
     }
 
     if (this.campaign.isProfilesCollection) {
@@ -133,7 +133,7 @@ class CampaignParticipation {
 
   _canBeShared() {
     if (this.status === CampaignParticipationStatuses.STARTED) {
-      throw new CampaignParticiationInvalidStatus(this.id, CampaignParticipationStatuses.STARTED);
+      throw new CampaignParticipationInvalidStatus(this.id, CampaignParticipationStatuses.STARTED);
     }
 
     if (this.isShared) {

--- a/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/models/CampaignParticipation.js
@@ -44,9 +44,8 @@ class CampaignParticipation {
   }
 
   static start({ campaign, userId, organizationLearnerId = null, participantExternalId }) {
-    const { isAssessment, isExam } = campaign;
-    const { STARTED, TO_SHARE } = CampaignParticipationStatuses;
-    const status = [isAssessment, isExam].includes(true) ? STARTED : TO_SHARE;
+    const { STARTED } = CampaignParticipationStatuses;
+    const status = STARTED;
 
     return new CampaignParticipation({
       campaign,
@@ -132,10 +131,9 @@ class CampaignParticipation {
   }
 
   _canBeShared() {
-    if (this.status === CampaignParticipationStatuses.STARTED) {
+    if (this.status === CampaignParticipationStatuses.STARTED && this.campaign.isProfilesCollection === false) {
       throw new CampaignParticipationInvalidStatus(this.id, CampaignParticipationStatuses.STARTED);
     }
-
     if (this.isShared) {
       throw new AlreadySharedCampaignParticipationError();
     }

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -17,7 +17,7 @@ import { KnowledgeElementCollection } from '../../../shared/domain/models/Knowle
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { AvailableCampaignParticipation } from '../../domain/read-models/AvailableCampaignParticipation.js';
 
-const { TO_SHARE, SHARED } = CampaignParticipationStatuses;
+const { STARTED, TO_SHARE, SHARED } = CampaignParticipationStatuses;
 
 const { pick } = lodash;
 
@@ -271,7 +271,7 @@ const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async func
     .where({ userId })
     .whereNull('campaign-participations.deletedAt')
     .whereNull('archivedAt')
-    .andWhere({ status: TO_SHARE })
+    .whereIn('status', [TO_SHARE, STARTED])
     .andWhere({ 'campaigns.type': CampaignTypes.PROFILES_COLLECTION })
     .orderBy('campaign-participations.createdAt', 'desc')
     .first();

--- a/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/prescription/campaign-participation/integration/domain/usecases/start-campaign-participation_test.js
@@ -19,6 +19,6 @@ describe('Integration | UseCases | startCampaignParticipation', function () {
       });
     });
 
-    expect(startedParticipation).to.deep.include({ userId, campaignId, status: 'TO_SHARE' });
+    expect(startedParticipation).to.deep.include({ userId, campaignId, status: 'STARTED' });
   });
 });

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1657,16 +1657,23 @@ describe('Integration | Repository | Campaign Participation', function () {
     it('should return code of the last participation to a campaign of type PROFILES_COLLECTION for the user', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', code: expectedCode });
-      const otherCampaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', code: 'BAD' });
+      const secondCampaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', code: 'BAD' });
+      const thirdCampaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', code: 'BADTOO' });
       databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: otherCampaign.id,
+        campaignId: secondCampaign.id,
         status: TO_SHARE,
-        createdAt: new Date(Date.parse('11/11/2011')),
+        createdAt: new Date(Date.parse('10/11/2011')),
         userId,
       });
       databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
+        campaignId: thirdCampaign.id,
         status: TO_SHARE,
+        userId,
+        createdAt: new Date(Date.parse('11/11/2011')),
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        status: STARTED,
         userId,
         createdAt: new Date(Date.parse('12/11/2011')),
       });

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
@@ -175,7 +175,7 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
 
         expect(campaignParticipant.campaignParticipation).to.deep.include({
           campaignId: campaignToStartParticipation.id,
-          status: 'TO_SHARE',
+          status: 'STARTED',
           userId: userIdentity.id,
           organizationLearnerId,
         });

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -1,7 +1,7 @@
 import { ArchivedCampaignError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import {
-  CampaignParticiationInvalidStatus,
   CampaignParticipationDeletedError,
+  CampaignParticipationInvalidStatus,
 } from '../../../../../../src/prescription/campaign-participation/domain/errors.js';
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import {
@@ -121,13 +121,13 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
     });
 
     context('when the campaign participation status is STARTED', function () {
-      it('throws an CampaignParticiationInvalidStatus', async function () {
+      it('throws an CampaignParticipationInvalidStatus', async function () {
         const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.ASSESSMENT });
         const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
 
         const error = catchErrSync(campaignParticipation.improve, campaignParticipation)();
 
-        expect(error).to.be.an.instanceOf(CampaignParticiationInvalidStatus);
+        expect(error).to.be.an.instanceOf(CampaignParticipationInvalidStatus);
       });
     });
 
@@ -157,13 +157,13 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       });
 
       context('when the campaign is started', function () {
-        it('throws an CampaignParticiationInvalidStatus error', function () {
+        it('throws an CampaignParticipationInvalidStatus error', function () {
           const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
           const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
 
           const error = catchErrSync(campaignParticipation.share, campaignParticipation)();
 
-          expect(error).to.be.an.instanceOf(CampaignParticiationInvalidStatus);
+          expect(error).to.be.an.instanceOf(CampaignParticipationInvalidStatus);
         });
       });
 

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipation_test.js
@@ -157,8 +157,19 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
       });
 
       context('when the campaign is started', function () {
-        it('throws an CampaignParticipationInvalidStatus error', function () {
+        it('share profile collection campaignParticipation', function () {
           const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
+          const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
+
+          campaignParticipation.share();
+
+          expect(campaignParticipation.isShared).to.be.true;
+          expect(campaignParticipation.sharedAt).to.deep.equals(now);
+          expect(campaignParticipation.status).to.equals(CampaignParticipationStatuses.SHARED);
+        });
+
+        it('do not share assessment campaignParticipation', function () {
+          const campaign = domainBuilder.buildCampaign({ type: CampaignTypes.ASSESSMENT });
           const campaignParticipation = new CampaignParticipation({ campaign, status: STARTED });
 
           const error = catchErrSync(campaignParticipation.share, campaignParticipation)();
@@ -306,7 +317,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
 
     context('status', function () {
       context('when the campaign has the type PROFILES_COLLECTION', function () {
-        it('should set status to TO_SHARE', function () {
+        it('should set status to STARTED', function () {
           const campaign = domainBuilder.buildCampaignToStartParticipation({ type: CampaignTypes.PROFILES_COLLECTION });
           const campaignParticipation = CampaignParticipation.start({
             campaign,
@@ -315,7 +326,7 @@ describe('Unit | Domain | Models | CampaignParticipation', function () {
             participantExternalId,
           });
 
-          expect(campaignParticipation.status).to.be.equal(CampaignParticipationStatuses.TO_SHARE);
+          expect(campaignParticipation.status).to.be.equal(CampaignParticipationStatuses.STARTED);
         });
       });
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/statistics/get-campaign-participations-counts-by-stage_test.js
@@ -139,6 +139,12 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
         status: CampaignParticipationStatuses.TO_SHARE,
       });
 
+      // this participation should not be taken into account
+      const startedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        status: CampaignParticipationStatuses.STARTED,
+      });
+
       // shared participations
       const [sharedParticipation1, sharedParticipation2, sharedParticipation3] = Array.from({ length: 3 }, () =>
         databaseBuilder.factory.buildCampaignParticipation({
@@ -160,6 +166,10 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
       // stage 2
       databaseBuilder.factory.buildStageAcquisition({
         campaignParticipationId: toShareParticipation.id,
+        stageId: stage2.id,
+      }); // this participation should not be taken into account
+      databaseBuilder.factory.buildStageAcquisition({
+        campaignParticipationId: startedParticipation.id,
         stageId: stage2.id,
       }); // this participation should not be taken into account
       databaseBuilder.factory.buildStageAcquisition({


### PR DESCRIPTION
## ❄️ Problème

Actuellement les campagnes de type collecte de profil ont deux statuts possibles: `TO_SHARE` et `SHARED` 
Dans le but d’éliminer progressivement le statut `TO_SHARE` de notre base de données il va falloir remplacer le statut `TO_SHARE` de ce type de campagne en statut `STARTED`.

## 🛷 Proposition

Pour le faire graduellement nous allons déjà commencer par créer les nouvelles campagnes de profil avec le statut `STARTED` par défaut. 
Nous aurons donc pendant un temps les statuts `TO_SHARE` et `STARTED` qui coexisteront et que nous devons considérer comme un seul et même statut.

## ☃️ Remarques

J'ai corrigé une faute de frappe 🥊 

## 🧑‍🎄 Pour tester
Vérifiez que partout où on traite des collectes de profil, on ait un comportement identique pour les deux statuts. 

### Status `TO_SHARE`
- [x] Ajouter une collecte de profile en BDD avec le status `TO_SHARE`
- [x] Vérifier qu'elle est visible depuis `pix-orga`
- [x] Vérifier qu'elle est partageable depuis `mon-pix` 
### Status `STARTED`
- [x] Participer à une collecte de profile avec un nouveau compte
- [x] Vérifier qu'elle a bien le status `STARTED`
- [x] Vérifier qu'elle s'affiche bien côté `pix-orga` et `mon-pix`
- [x] Vérifier qu'elle est partageable depuis `mon-pix` 

🎉 
