### PR TITLE
[FEATURE] Ajouter les champs "Identifiant externe" et "Département" au formulaire de création d'orga (PIX-20695)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -87,6 +88,11 @@ export default class OrganizationCreationForm extends Component {
     this.args.organization.dataProtectionOfficerEmail = event.target.value;
   }
 
+  @action
+  handleInputChange(key, event) {
+    this.args.organization[key] = event.target.value;
+  }
+
   <template>
     <form class="admin-form" {{on "submit" @onSubmit}}>
       <section class="admin-form__content admin-form__content--with-counters">
@@ -123,6 +129,10 @@ export default class OrganizationCreationForm extends Component {
             <:default as |organizationType|>{{organizationType.label}}</:default>
           </PixSelect>
 
+          <PixInput @id="externalId" {{on "input" (fn this.handleInputChange "externalId")}}>
+            <:label>{{t "components.organizations.creation.external-id"}}</:label>
+          </PixInput>
+
           <PixSelect
             @onChange={{this.handleAdministrationTeamSelectionChange}}
             @options={{this.administrationTeamsOptions}}
@@ -135,6 +145,10 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>
+
+          <PixInput @id="provinceCode" {{on "input" (fn this.handleInputChange "provinceCode")}}>
+            <:label>{{t "components.organizations.creation.province-code"}}</:label>
+          </PixInput>
 
           <PixSelect
             @onChange={{this.handleCountrySelectionChange}}

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -27,40 +27,12 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     store = this.owner.lookup('service:store');
   });
 
-  test('it renders', async function (assert) {
-    //given
-    const organization = store.createRecord('organization', { type: '' });
-
-    // when
-    const screen = await render(
-      <template>
-        <CreationForm
-          @organization={{organization}}
-          @administrationTeams={{administrationTeams}}
-          @countries={{countries}}
-          @onSubmit={{onSubmit}}
-          @onCancel={{onCancel}}
-        />
-      </template>,
-    );
-
-    // then
-    assert.dom(screen.getByRole('textbox', { name: 'Nom *' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
-    assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
-    assert
-      .dom(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')))
-      .exists();
-    assert.ok(screen.getByLabelText(`${t('components.organizations.creation.country.selector.label')} *`));
-    assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
-  });
-
-  module('#selectOrganizationType', function () {
-    test('should update attribute organization.type', async function (assert) {
-      // given
+  module('Render', function () {
+    test('it renders', async function (assert) {
+      //given
       const organization = store.createRecord('organization', { type: '' });
 
+      // when
       const screen = await render(
         <template>
           <CreationForm
@@ -73,48 +45,20 @@ module('Integration | Component | organizations/creation-form', function (hooks)
         </template>,
       );
 
-      // when
-      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
-      await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
-
       // then
-      assert.strictEqual(organization.type, 'SCO');
+      assert.dom(screen.getByRole('textbox', { name: 'Nom *' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
+      assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
+      assert.ok(screen.getByRole('textbox', { name: 'Identifiant externe' }));
+      assert
+        .dom(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')))
+        .exists();
+      assert.ok(screen.getByRole('textbox', { name: 'Département (en 3 chiffres)' }));
+      assert.ok(screen.getByLabelText(`${t('components.organizations.creation.country.selector.label')} *`));
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
     });
-  });
 
-  module('#handleAdministrationTeamSelectionChange', function () {
-    test('should update attribute organization Administration team', async function (assert) {
-      // given
-      const organization = store.createRecord('organization', { type: '' });
-
-      const screen = await render(
-        <template>
-          <CreationForm
-            @organization={{organization}}
-            @administrationTeams={{administrationTeams}}
-            @countries={{countries}}
-            @onSubmit={{onSubmit}}
-            @onCancel={{onCancel}}
-          />
-        </template>,
-      );
-
-      // when
-      await click(
-        screen.getByRole('button', {
-          name: `${t('components.organizations.creation.administration-team.selector.label')} *`,
-        }),
-      );
-      await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Équipe 2' }));
-
-      // then
-      assert.strictEqual(organization.administrationTeamId, 'team-2');
-    });
-  });
-
-  module('Country information', function () {
     test('should render countries options in list', async function (assert) {
       // given
       const organization = store.createRecord('organization', { type: '' });
@@ -145,10 +89,12 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       assert.strictEqual(options[0].title, 'France (99100)');
       assert.strictEqual(options[1].title, 'Danemark (99101)');
     });
+  });
 
-    test('should update organization model with countryCode attribute when selecting a country', async function (assert) {
+  module('when filling form', function () {
+    test('should update organization model', async function (assert) {
       // given
-      const organization = store.createRecord('organization', { type: '' });
+      const organization = store.createRecord('organization');
 
       const screen = await render(
         <template>
@@ -163,66 +109,52 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
 
       // when
-      await click(
+      await fillByLabel('Nom *', 'Organisation de Test');
+
+      click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
+      await screen.findByRole('listbox');
+      click(screen.getByRole('option', { name: 'Établissement scolaire' }));
+
+      await fillByLabel(t('components.organizations.creation.external-id'), 'Mon identifiant externe');
+
+      click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.creation.administration-team.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      click(await screen.findByRole('option', { name: 'Équipe 2' }));
+
+      await fillByLabel(t('components.organizations.creation.province-code'), '78');
+
+      click(
         screen.getByRole('button', {
           name: `${t('components.organizations.creation.country.selector.label')} *`,
         }),
       );
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'France (99100)' }));
+      click(await screen.findByRole('option', { name: 'France (99100)' }));
+
+      await fillByLabel('Lien vers la documentation', 'www.documentation.fr');
+
+      await fillByLabel('Crédits', 120);
+
+      await fillByLabel('Prénom du DPO', 'Justin');
+      await fillByLabel('Nom du DPO', 'Ptipeu');
+      await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
 
       // then
+      assert.strictEqual(organization.name, 'Organisation de Test');
+      assert.strictEqual(organization.type, 'SCO');
+      assert.strictEqual(organization.externalId, 'Mon identifiant externe');
+      assert.strictEqual(organization.administrationTeamId, 'team-2');
+      assert.strictEqual(organization.provinceCode, '78');
       assert.strictEqual(organization.countryCode, '99100');
+      assert.strictEqual(organization.documentationUrl, 'www.documentation.fr');
+      assert.strictEqual(organization.credit, 120);
+      assert.strictEqual(organization.dataProtectionOfficerFirstName, 'Justin');
+      assert.strictEqual(organization.dataProtectionOfficerLastName, 'Ptipeu');
+      assert.strictEqual(organization.dataProtectionOfficerEmail, 'justin.ptipeu@example.net');
     });
-  });
-
-  test('Adds data protection officer information', async function (assert) {
-    // given
-    const organization = store.createRecord('organization', { type: '' });
-
-    await render(
-      <template>
-        <CreationForm
-          @organization={{organization}}
-          @administrationTeams={{administrationTeams}}
-          @countries={{countries}}
-          @onSubmit={{onSubmit}}
-          @onCancel={{onCancel}}
-        />
-      </template>,
-    );
-
-    // when
-    await fillByLabel('Prénom du DPO', 'Justin');
-    await fillByLabel('Nom du DPO', 'Ptipeu');
-    await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
-
-    // then
-    assert.strictEqual(organization.dataProtectionOfficerFirstName, 'Justin');
-    assert.strictEqual(organization.dataProtectionOfficerLastName, 'Ptipeu');
-    assert.strictEqual(organization.dataProtectionOfficerEmail, 'justin.ptipeu@example.net');
-  });
-
-  test('Credits can be added', async function (assert) {
-    // given
-    const organization = store.createRecord('organization', { type: '' });
-
-    await render(
-      <template>
-        <CreationForm
-          @organization={{organization}}
-          @administrationTeams={{administrationTeams}}
-          @countries={{countries}}
-          @onSubmit={{onSubmit}}
-          @onCancel={{onCancel}}
-        />
-      </template>,
-    );
-
-    // when
-    await fillByLabel('Crédits', 120);
-
-    // then
-    assert.strictEqual(organization.credit, 120);
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -651,7 +651,9 @@
             "placeholder": "Country (INSEE code)"
           }
         },
+        "external-id": "External Identifier",
         "parent-organization-name": "Parent organization: {parentOrganizationName}",
+        "province-code": "Province code (3 digits)",
         "required-fields-error": "Please fill in all required fields."
       },
       "editing": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -652,7 +652,9 @@
             "placeholder": "Pays (code INSEE)"
           }
         },
+        "external-id": "Identifiant externe",
         "parent-organization-name": "Organisation mère : {parentOrganizationName}",
+        "province-code": "Département (en 3 chiffres)",
         "required-fields-error": "Veuillez remplir tous les champs obligatoires."
       },
       "editing": {


### PR DESCRIPTION
## ❄️ Problème

Actuellement, certaines infos d'une orga ne peuvent pas être définies à la création, et il faut passer par la modification pour les renseigner, une fois l'orga créée. C'est le cas notamment de l'**identifiant externe** et du **département**. Dans le cadre de la refonte des formulaires de création et de modification d'orga, il faut intervenir pour unifier tout cela.

## 🛷 Proposition

Ajouter deux champs au formulaire de création d'orga: **Identifiant Externe** et **Département**

## ☃️ Remarques

- Refacto des tests d'intégration du composant de formulaire: pour vérifier le mécanisme de setter du modèle `organization` lorsqu'on remplit le formulaire, on teste maintenant tous les champs dans le même test, plutôt que de faire un test par champ.
- Ne pas s'attarder sur le style, car celui-ci changera complètement dans une future PR pour se conformer à la nouvelle maquette.

## 🧑‍🎄 Pour tester

Sur Pix Admin:
- aller sur la page de création d'orga
- constater la présence des champs **Identifiant Externe** et **Département**
- les remplir et créer l'orga
- constater que ces champs ont bien été enregistrés
