### PR TITLE
[FEATURE] Ajouter les boutons de signalement dans les feedbacks et POI des modules (PIX-20492).

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -21,6 +21,10 @@
     font-weight: var(--pix-font-bold);
   }
 
+  &__report-button {
+    color: var(--modulix-feedback-state-color);
+  }
+
   @media (not (prefers-reduced-motion: reduce)) {
     animation: 0.75s zoom-in-zoom-out ease;
 

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -16,3 +16,12 @@
     justify-content: space-between;
   }
 }
+
+.element-custom-draft-buttons {
+  &__retry {
+    padding: 0 var(--pix-spacing-4x);
+    background-color: var(--pix-primary-100);
+    border: none;
+    border-radius: 0 0 8px 8px;
+  }
+}

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -11,8 +11,8 @@
     border: none;
   }
 
-  &__reset {
+  &__buttons {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -55,3 +55,9 @@
     }
   }
 }
+
+.element-qcu-declarative-feedback {
+  &__report-button {
+    color: var(--pix-neutral-0);
+  }
+}

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -43,3 +43,9 @@
     }
   }
 }
+
+.element-qcu-discovery-feedback {
+  &__report-button {
+    color: var(--pix-info-700);
+  }
+}

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { t } from 'ember-intl';
 
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
@@ -8,6 +9,8 @@ import didInsert from '../../../modifiers/modifier-did-insert';
 import ModuleElement from './module-element';
 
 export default class ModulixCustomDraft extends ModuleElement {
+  @service featureToggles;
+
   get heightStyle() {
     return htmlUnsafe(`height: ${this.args.customDraft.height}px`);
   }
@@ -46,7 +49,13 @@ export default class ModulixCustomDraft extends ModuleElement {
         ></iframe>
       </fieldset>
 
-      <div class="element-custom-draft__reset">
+      <div class="element-custom-draft__buttons">
+        {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+          <PixButton @variant="tertiary" @iconBefore="flag" aria-label={{t "pages.modulix.issue-report.aria-label"}}>{{t
+              "pages.modulix.issue-report.button"
+            }}</PixButton>
+        {{/if}}
+
         <PixButton
           @iconBefore="refresh"
           @variant="tertiary"

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -57,6 +57,7 @@ export default class ModulixCustomDraft extends ModuleElement {
         {{/if}}
 
         <PixButton
+          class="element-custom-draft-buttons__retry"
           @iconBefore="refresh"
           @variant="tertiary"
           @triggerAction={{this.resetEmbed}}

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -1,3 +1,4 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -13,6 +14,7 @@ export default class ModuleQcuDeclarative extends ModuleElement {
   @tracked shouldDisplayFeedback = false;
   @service passageEvents;
   @service modulixPreviewMode;
+  @service featureToggles;
 
   get selectedProposalFeedback() {
     return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
@@ -84,6 +86,15 @@ export default class ModuleQcuDeclarative extends ModuleElement {
     {{#if this.shouldDisplayFeedback}}
       <div class="element-qcu-declarative__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.selectedProposalFeedback}}
+
+        {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+          <PixButton
+            @variant="tertiary"
+            @iconBefore="flag"
+            class="element-qcu-declarative-feedback__report-button"
+            aria-label={{t "pages.modulix.issue-report.aria-label"}}
+          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+        {{/if}}
       </div>
     {{/if}}
   </template>

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -1,3 +1,4 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -13,6 +14,7 @@ export default class ModuleQcuDiscovery extends ModuleElement {
   @tracked shouldDisplayFeedback = false;
   @service passageEvents;
   @service modulixPreviewMode;
+  @service featureToggles;
 
   get selectedProposalFeedback() {
     return this.element.proposals.find((proposal) => proposal.id === this.selectedProposalId).feedback.diagnosis;
@@ -86,6 +88,15 @@ export default class ModuleQcuDiscovery extends ModuleElement {
     {{#if this.shouldDisplayFeedback}}
       <div class="feedback element-qcu-discovery__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.selectedProposalFeedback}}
+
+        {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+          <PixButton
+            @variant="tertiary"
+            @iconBefore="flag"
+            class="element-qcu-discovery-feedback__report-button"
+            aria-label={{t "pages.modulix.issue-report.aria-label"}}
+          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+        {{/if}}
       </div>
     {{/if}}
   </template>

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -1,8 +1,13 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 import { htmlUnsafe } from '../../helpers/html-unsafe';
 
 export default class ModulixFeedback extends Component {
+  @service featureToggles;
+
   get type() {
     return this.args.answerIsValid ? 'success' : 'error';
   }
@@ -13,6 +18,15 @@ export default class ModulixFeedback extends Component {
         <div class="feedback__state">{{htmlUnsafe @feedback.state}}</div>
       {{/if}}
       {{htmlUnsafe @feedback.diagnosis}}
+
+      {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+        <PixButton
+          class="feedback__report-button"
+          @variant="tertiary"
+          @iconBefore="flag"
+          aria-label={{t "pages.modulix.issue-report.aria-label"}}
+        >{{t "pages.modulix.issue-report.button"}}</PixButton>
+      {{/if}}
     </div>
   </template>
 }

--- a/mon-pix/tests/integration/components/module/custom-draft_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-draft_test.gjs
@@ -4,6 +4,7 @@ import { find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixCustomDraft from 'mon-pix/components/module/element/custom-draft';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -69,6 +70,48 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
       // then
       const iframe = screen.getByTitle(customDraft.title);
       assert.strictEqual(document.activeElement, iframe);
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is enabled', function () {
+    test('should display report button', async function (assert) {
+      // given
+      const customDraft = {
+        id: 'id',
+        title: 'title',
+        url: 'https://example.org',
+        instruction: '<p>Instruction du POIC</p>',
+        height: 400,
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+
+      // when
+      const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is disabled', function () {
+    test('should not display report button', async function (assert) {
+      // given
+      const customDraft = {
+        id: 'id',
+        title: 'title',
+        url: 'https://example.org',
+        instruction: '<p>Instruction du POIC</p>',
+        height: 400,
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+
+      // when
+      const screen = await render(<template><ModulixCustomDraft @customDraft={{customDraft}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/feedback_test.gjs
+++ b/mon-pix/tests/integration/components/module/feedback_test.gjs
@@ -1,10 +1,13 @@
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
+import { t } from 'ember-intl/test-support';
 import ModulixFeedback from 'mon-pix/components/module/feedback';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Feedback', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   test('should display feedback information', async function (assert) {
     // given
     const feedback = {
@@ -35,5 +38,45 @@ module('Integration | Component | Module | Feedback', function (hooks) {
 
     // then
     assert.dom(screen.getByText("C'est la bonne réponse !")).exists();
+  });
+
+  module('when isModulixIssueReportDisplayed FT is enabled', function () {
+    test('should display report button', async function (assert) {
+      // given
+      const feedback = {
+        state: 'Correct !',
+        diagnosis: "<p>C'est la bonne réponse !</p>",
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+
+      // when
+      const screen = await render(
+        <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is disabled', function () {
+    test('should not display report button', async function (assert) {
+      // given
+      const feedback = {
+        state: 'Correct !',
+        diagnosis: "<p>C'est la bonne réponse !</p>",
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+
+      // when
+      const screen = await render(
+        <template><ModulixFeedback @answerIsValid={{true}} @feedback={{feedback}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-declarative_test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { VERIFY_RESPONSE_DELAY } from 'mon-pix/components/module/component/element';
 import ModuleQcuDeclarative from 'mon-pix/components/module/element/qcu-declarative';
 import { module, test } from 'qunit';
@@ -114,6 +115,54 @@ module('Integration | Component | Module | QCUDeclarative', function (hooks) {
       assert.dom(screen.getByText("C'est l'approche de la plupart des gens.")).exists();
       assert.dom(screen.getByText('Possible, mais attention à ne pas faire une rafarinade !')).exists();
       assert.dom(screen.getByText('Digne des plus grands acrobates !')).exists();
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is enabled', function () {
+    test('should display report button', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+      const qcuDeclarativeElement = _getQcuDeclarativeElement();
+      const onAnswerStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
+      await click(firstButton);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is disabled', function () {
+    test('should not display report button', async function (assert) {
+      // given
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+      const qcuDeclarativeElement = _getQcuDeclarativeElement();
+      const onAnswerStub = sinon.stub();
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDeclarative @element={{qcuDeclarativeElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const firstButton = screen.getByRole('button', { name: qcuDeclarativeElement.proposals[0].content });
+      await click(firstButton);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
+++ b/mon-pix/tests/integration/components/module/qcu-discovery_test.gjs
@@ -134,6 +134,58 @@ module('Integration | Component | Module | QCUDiscovery', function (hooks) {
         .exists();
     });
   });
+
+  module('when isModulixIssueReportDisplayed FT is enabled', function () {
+    test('should display report button', async function (assert) {
+      // given
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcuDiscoveryElement = _getQcuDiscoveryElement();
+      const { proposals } = qcuDiscoveryElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const button1 = screen.getByRole('button', { name: proposals[0].content });
+      await click(button1);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is disabled', function () {
+    test('should not display report button', async function (assert) {
+      // given
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+      const passageEventService = this.owner.lookup('service:passageEvents');
+      sinon.stub(passageEventService, 'record');
+      const onAnswerStub = sinon.stub();
+
+      const qcuDiscoveryElement = _getQcuDiscoveryElement();
+      const { proposals } = qcuDiscoveryElement;
+
+      // when
+      const screen = await render(
+        <template><ModuleQcuDiscovery @element={{qcuDiscoveryElement}} @onAnswer={{onAnswerStub}} /></template>,
+      );
+      const button1 = screen.getByRole('button', { name: proposals[0].content });
+      await click(button1);
+
+      await clock.tickAsync(VERIFY_RESPONSE_DELAY + 10);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+    });
+  });
 });
 
 function _getQcuDiscoveryElement() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1671,6 +1671,10 @@
       "interactiveElement": {
         "label": "Interactive element"
       },
+      "issue-report": {
+        "aria-label": "Send a problem or suggestion",
+        "button": "Report"
+      },
       "modals": {
         "alternativeText": {
           "title": "Alternative text"

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1667,6 +1667,10 @@
       "interactiveElement": {
         "label": "Elemento interactivo"
       },
+      "issue-report": {
+        "aria-label": "Enviar un problema o una sugerencia",
+        "button": "Señalar"
+      },
       "modals": {
         "alternativeText": {
           "title": "Texto alternativo"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1667,6 +1667,10 @@
       "interactiveElement": {
         "label": "Elemento interactivo"
       },
+      "issue-report": {
+        "aria-label": "Enviar un problema o una sugerencia",
+        "button": "Señalar"
+      },
       "modals": {
         "alternativeText": {
           "title": "Texto alternativo"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1679,6 +1679,10 @@
       "interactiveElement": {
         "label": "Élément interactif"
       },
+      "issue-report": {
+        "aria-label": "Envoyer un problème ou une suggestion",
+        "button": "Signaler"
+      },
       "modals": {
         "alternativeText": {
           "title": "Alternative textuelle"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1671,6 +1671,10 @@
       "interactiveElement": {
         "label": "Interactief element"
       },
+      "issue-report": {
+        "aria-label": "Een probleem of suggestie doorgeven",
+        "button": "Melden"
+      },
       "modals": {
         "alternativeText": {
           "title": "Tekst alternatief"


### PR DESCRIPTION
## ❄️ Problème

Nous souhaitons que les utilisateurs puissent nous contacter en cas de module contenant des bugs/fautes/etc.. 

## 🛷 Proposition

Ajouter les boutons de signalement dans les feedbacks de tous les éléments (compris, déclaratif et découverte) ainsi que sous les POI

## ☃️ Remarques

J'ai également mis un fond de couleur sous le bouton réessayer du POI, comme Figma l'indiquait. (vu avec Clément)

## 🧑‍🎄 Pour tester

Aller sur le module [bac-a-sable](https://app-pr14377.review.pix.fr/modules/6a68bf32/bac-a-sable/details)

<img width="635" height="480" alt="Capture d’écran 2025-12-10 à 16 54 47" src="https://github.com/user-attachments/assets/5c0552a7-9b80-4673-8693-338d966bac91" />
<img width="639" height="460" alt="Capture d’écran 2025-12-10 à 16 54 54" src="https://github.com/user-attachments/assets/4d267fdf-d6dd-470f-b04d-0e35cfde118c" />
<img width="652" height="427" alt="Capture d’écran 2025-12-10 à 16 55 00" src="https://github.com/user-attachments/assets/c0a981e0-c513-4861-b7ae-ce59f2036371" />
<img width="661" height="499" alt="Capture d’écran 2025-12-10 à 16 55 07" src="https://github.com/user-attachments/assets/f2b4f4fd-6a8d-4eb2-8185-2903d9edc0b1" />
<img width="797" height="559" alt="Capture d’écran 2025-12-10 à 16 55 30" src="https://github.com/user-attachments/assets/b0243e52-72fd-4e89-82af-58aa52483a0b" />
