### PR TITLE
[TECH] Retirer l'usage d'une table qui n'est plus alimenté (PIX-20738).

### DIFF
--- a/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
+++ b/api/src/quest/infrastructure/repositories/organization-learner-participation-repository.js
@@ -9,11 +9,6 @@ export const findByOrganizationLearnerIdAndModuleIds = async ({ organizationLear
 
   const organizationLearnerParticipations = await knexConn('organization_learner_participations')
     .select('organization_learner_participations.*')
-    .leftJoin(
-      'organization_learner_passage_participations',
-      'organization_learner_participations.id',
-      'organization_learner_passage_participations.organizationLearnerParticipationId',
-    )
     .where({ organizationLearnerId, type: OrganizationLearnerParticipationTypes.PASSAGE })
     .whereIn('referenceId', moduleIds)
     .whereNull('deletedAt');


### PR DESCRIPTION
## ❄️ Problème

Avec la centralisation des participations dans la table organization learner participations. la table organization learner passage participation n'est plus alimenté. 

## 🛷 Proposition

Supprimer cette jointure pour supprimer cette table plus tard. Comme c'était un left join, il n'y avait pas d'incidence à que cette table ne soit plus almenté. autant supprimer cette jointure. 

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI au vert