### PR TITLE
[BUGFIX] Afficher clairement le référentiel d'un candidat d'une session (PIX-20741).

### DIFF
--- a/admin/app/components/sessions/session/session-candidates.gjs
+++ b/admin/app/components/sessions/session/session-candidates.gjs
@@ -10,16 +10,14 @@ export default class SessionCandidates extends Component {
   @service intl;
 
   computeSubscriptionsText = (candidate) => {
-    if (candidate.subscriptions.length === 2) {
-      return this.intl.t('pages.sessions.candidates.subscriptions.dual-core-clea');
-    }
     const subscription = candidate.subscriptions[0];
+
     if (subscription.isCore) {
       return this.intl.t('pages.sessions.candidates.subscriptions.core');
     }
 
     return this.intl.t('pages.sessions.candidates.subscriptions.complementary', {
-      complementaryCertificationId: subscription.complementaryCertificationId,
+      complementaryCertificationKey: subscription.complementaryCertificationKey,
     });
   };
 

--- a/admin/app/models/subscription.js
+++ b/admin/app/models/subscription.js
@@ -6,7 +6,7 @@ export const SUBSCRIPTION_TYPES = Object.freeze({
 });
 
 export default class SubscriptionModel extends Model {
-  @attr('number') complementaryCertificationId;
+  @attr('string') complementaryCertificationKey;
   @attr('string') type;
 
   get isCore() {

--- a/admin/tests/integration/components/sessions/session/session-candidates-test.gjs
+++ b/admin/tests/integration/components/sessions/session/session-candidates-test.gjs
@@ -1,32 +1,84 @@
 import { render } from '@1024pix/ember-testing-library';
+import { setupRenderingTest } from 'ember-qunit';
 import SessionCandidates from 'pix-admin/components/sessions/session/session-candidates';
 import { SUBSCRIPTION_TYPES } from 'pix-admin/models/subscription';
 import { module, test } from 'qunit';
 
-import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import setupIntl from '../../../../helpers/setup-intl';
 
 module('Integration | Component | Sessions | Session | SessionCandidates', function (hooks) {
-  setupIntlRenderingTest(hooks);
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   let store;
 
   hooks.beforeEach(async function () {
+    this.intl = this.owner.lookup('service:intl');
     store = this.owner.lookup('service:store');
   });
 
-  test('it should display candidate information', async function (assert) {
+  test('it should display candidate with only a core subscription', async function (assert) {
     // given
-    const complementaryCertificationId = 2;
     const coreSubscription = store.createRecord('subscription', {
       type: SUBSCRIPTION_TYPES.CORE,
-      complementaryCertificationId: null,
-    });
-    const complementarySubscription = store.createRecord('subscription', {
-      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
-      complementaryCertificationId,
     });
     const candidate = _buildCertificationCandidate({
-      subscriptions: [coreSubscription, complementarySubscription],
+      subscriptions: [coreSubscription],
+    });
+    const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
+
+    // when
+    const screen = await render(
+      <template><SessionCandidates @certificationCandidates={{certificationCandidates}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(screen.getByRole('cell', { name: this.intl.t('pages.sessions.candidates.subscriptions.core') }))
+      .exists();
+  });
+
+  test('it should display candidate with only a complementary subscription', async function (assert) {
+    // given
+    const complementaryCertificationKey = 'pix-certif-1';
+    const complementarySubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+      complementaryCertificationKey,
+    });
+    const candidate = _buildCertificationCandidate({
+      subscriptions: [complementarySubscription],
+    });
+    const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
+
+    // when
+    const screen = await render(
+      <template><SessionCandidates @certificationCandidates={{certificationCandidates}} /></template>,
+    );
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('cell', {
+          name: this.intl.t('pages.sessions.candidates.subscriptions.complementary', {
+            complementaryCertificationKey,
+          }),
+        }),
+      )
+      .exists();
+  });
+
+  test('it should display candidate with a double subscription', async function (assert) {
+    // given
+    const complementaryCertificationKey = 'pix-certif-1';
+    const complementarySubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.COMPLEMENTARY,
+      complementaryCertificationKey,
+    });
+    const coreSubscription = store.createRecord('subscription', {
+      type: SUBSCRIPTION_TYPES.CORE,
+    });
+    const candidate = _buildCertificationCandidate({
+      subscriptions: [complementarySubscription, coreSubscription],
     });
 
     const certificationCandidates = [store.createRecord('certification-candidate', candidate)];
@@ -37,8 +89,15 @@ module('Integration | Component | Sessions | Session | SessionCandidates', funct
     );
 
     // then
-    assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].lastName })).exists();
-    assert.dom(screen.getByRole('cell', { name: certificationCandidates[0].firstName })).exists();
+    assert
+      .dom(
+        screen.getByRole('cell', {
+          name: this.intl.t('pages.sessions.candidates.subscriptions.complementary', {
+            complementaryCertificationKey,
+          }),
+        }),
+      )
+      .exists();
   });
 });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1226,7 +1226,7 @@
         "caption": "Candidats",
         "empty-result": "No result",
         "subscriptions": {
-          "complementary": "{complementaryCertificationId} complementary",
+          "complementary": "Complementary ({complementaryCertificationKey})",
           "core": "Pix Certification",
           "dual-core-clea": "Double Certification CléA Numérique"
         }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1227,7 +1227,7 @@
         "caption": "Candidats",
         "empty-result": "Aucun résultat",
         "subscriptions": {
-          "complementary": "Complémentaire {complementaryCertificationId}",
+          "complementary": "Complémentaire ({complementaryCertificationKey})",
           "core": "Certification Pix",
           "dual-core-clea": "Double Certification CléA Numérique"
         }


### PR DESCRIPTION
## ❄️ Problème

Dans la liste des candidats d’une session, on s’est rendu compte que si son nombre de souscription est > 1, alors on affiche “Cléa”.
Sauf qu’en V2, on avait plus de 1 souscription pour toutes les complémentaires !

## 🛷 Proposition

Afficher le nom de la complémentaire (si elle existe) dans les souscriptions d’un candidat.

<img width="212" height="125" alt="image" src="https://github.com/user-attachments/assets/0f070739-8087-4b89-bf27-84851068e227" />

## 🧑‍🎄 Pour tester

- Aller sur Pix Admin en RA
- Visualiser l'onglet "Candidats" de sessions avec des référentiels différents (Cléa : **7404**, DROIT : **7406** et SCO : **7400**)
- Si le candidat a une souscription de type complémentaire, alors elle devrait s'afficher directement dans le tableau
