### PR TITLE
[FEATURE] Supprimer le champ Crédits dans le formulaire de création d'orga (PIX-29696)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -170,9 +170,6 @@ export default class OrganizationCreationForm extends Component {
           <PixInput @id="documentationUrl" onchange={{this.handleDocumentationUrlChange}}>
             <:label>Lien vers la documentation</:label>
           </PixInput>
-          <PixInput @id="credits" onchange={{this.handleCreditsChange}} type="number">
-            <:label>Crédits</:label>
-          </PixInput>
         </Card>
 
         <Card class="admin-form__card" @title="Data Privacy Officer">

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -130,8 +130,6 @@ module('Acceptance | Organizations | Create', function (hooks) {
       await screen.findByRole('listbox');
       await click(screen.getByText('France (99100)'));
 
-      await fillByLabel('Crédits', 120);
-
       await fillByLabel('Prénom du DPO', 'Justin');
       await fillByLabel('Nom du DPO', 'Ptipeu');
       await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -137,8 +137,6 @@ module('Integration | Component | organizations/creation-form', function (hooks)
 
       await fillByLabel('Lien vers la documentation', 'www.documentation.fr');
 
-      await fillByLabel('Crédits', 120);
-
       await fillByLabel('Prénom du DPO', 'Justin');
       await fillByLabel('Nom du DPO', 'Ptipeu');
       await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
@@ -151,7 +149,6 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       assert.strictEqual(organization.provinceCode, '78');
       assert.strictEqual(organization.countryCode, '99100');
       assert.strictEqual(organization.documentationUrl, 'www.documentation.fr');
-      assert.strictEqual(organization.credit, 120);
       assert.strictEqual(organization.dataProtectionOfficerFirstName, 'Justin');
       assert.strictEqual(organization.dataProtectionOfficerLastName, 'Ptipeu');
       assert.strictEqual(organization.dataProtectionOfficerEmail, 'justin.ptipeu@example.net');


### PR DESCRIPTION
## ❄️ Problème

La notion de Crédits est progressivement en train de disparaître. On veut dans un premier temps empêcher le fait de créer une organisation avec des crédits.

## 🛷 Proposition

Supprimer le champs "Crédits" du formulaire de création d'organisation.

## ☃️ Remarques

Cette PR concerne uniquement le front, un nettoyage est prévu pour plus tard côté back pour supprimer la notion de crédit sur la route POST.

## 🧑‍🎄 Pour tester

Sur Pix Admin
- aller sur la page de création d'orga
- constater qu'il n'y a plus le champs "Crédits"
