### PR TITLE
[FEATURE] Enregistrer les signalements en base (PIX-2049)

### DIFF
--- a/api/src/devcomp/application/module-issue-report/module-issue-report-controller.js
+++ b/api/src/devcomp/application/module-issue-report/module-issue-report-controller.js
@@ -1,0 +1,23 @@
+import { usecases } from '../../domain/usecases/index.js';
+
+const createModuleIssueReport = async function (request, h) {
+  const userAgent = request.headers['user-agent'].slice(0, 255);
+
+  const {
+    'module-id': moduleId,
+    'passage-id': passageId,
+    'element-id': elementId,
+    answer,
+    comment,
+    'category-key': categoryKey,
+  } = request.payload.data.attributes;
+
+  const moduleIssueReport = { moduleId, passageId, elementId, answer, comment, categoryKey, userAgent };
+  await usecases.createModuleIssueReport({ moduleIssueReport });
+
+  return h.response().created();
+};
+
+const moduleIssueReportController = { createModuleIssueReport };
+
+export { moduleIssueReportController };

--- a/api/src/devcomp/application/module-issue-report/module-issue-report-route.js
+++ b/api/src/devcomp/application/module-issue-report/module-issue-report-route.js
@@ -1,0 +1,38 @@
+import Joi from 'joi';
+
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
+import { moduleIssueReportController } from './module-issue-report-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/module-issue-reports',
+      config: {
+        auth: false,
+        handler: handlerWithDependencies(moduleIssueReportController.createModuleIssueReport),
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              type: Joi.string().valid('module-issue-reports').required(),
+              attributes: Joi.object({
+                'module-id': identifiersType.moduleId,
+                'element-id': identifiersType.elementId,
+                'passage-id': identifiersType.passageId,
+                answer: Joi.string().allow('').optional(),
+                'category-key': Joi.string().required(),
+                comment: Joi.string().required(),
+              }).required(),
+            }).required(),
+          }).required(),
+        },
+        notes: ["- Permet à l'utilisateur d'envoyer un signalement pour un module donné"],
+        tags: ['api', 'modules', 'module-issue-reports'],
+      },
+    },
+  ]);
+};
+
+const name = 'module-issue-report-api';
+export { name, register };

--- a/api/src/devcomp/domain/models/module/ModuleIssueReport.js
+++ b/api/src/devcomp/domain/models/module/ModuleIssueReport.js
@@ -1,0 +1,24 @@
+import { DomainError } from '../../../../shared/domain/errors.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+export class ModuleIssueReport {
+  constructor({ moduleId, elementId, passageId, answer, userAgent, categoryKey, comment }) {
+    assertNotNullOrUndefined(moduleId, 'The moduleId is required for a ModuleIssueReport');
+    assertNotNullOrUndefined(elementId, 'The elementId is required for a ModuleIssueReport');
+    assertNotNullOrUndefined(passageId, 'The passageId is required for a ModuleIssueReport');
+    assertNotNullOrUndefined(categoryKey, 'The categoryKey is required for a ModuleIssueReport');
+    assertNotNullOrUndefined(comment, 'The comment is required for a ModuleIssueReport');
+
+    if (comment.trim().length === 0) {
+      throw new DomainError('The comment should not be empty');
+    }
+
+    this.moduleId = moduleId;
+    this.elementId = elementId;
+    this.passageId = passageId;
+    this.answer = answer;
+    this.userAgent = userAgent;
+    this.categoryKey = categoryKey;
+    this.comment = comment;
+  }
+}

--- a/api/src/devcomp/domain/usecases/create-module-issue-report.js
+++ b/api/src/devcomp/domain/usecases/create-module-issue-report.js
@@ -1,0 +1,8 @@
+import { ModuleIssueReport } from '../models/module/ModuleIssueReport.js';
+
+const createModuleIssueReport = async function ({ moduleIssueReport, moduleIssueReportRepository } = {}) {
+  const moduleIssueReportToSave = new ModuleIssueReport({ ...moduleIssueReport });
+  return moduleIssueReportRepository.save(moduleIssueReportToSave);
+};
+
+export { createModuleIssueReport };

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -10,6 +10,7 @@ import * as skillRepository from '../../../shared/infrastructure/repositories/sk
 import * as tubeRepository from '../../../shared/infrastructure/repositories/tube-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
+import * as moduleIssueReportRepository from '../../infrastructure/repositories/module-issue-report-repository.js';
 import * as targetProfileTrainingRepository from '../../infrastructure/repositories/target-profile-training-repository.js';
 
 const dependencies = {
@@ -17,6 +18,7 @@ const dependencies = {
   campaignRepository,
   campaignParticipationRepository,
   knowledgeElementRepository,
+  moduleIssueReportRepository,
   targetProfileRepository,
   targetProfileSummaryForAdminRepository,
   tubeRepository,
@@ -32,6 +34,7 @@ import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { addTutorialEvaluation } from './add-tutorial-evaluation.js';
 import { addTutorialToUser } from './add-tutorial-to-user.js';
 import { attachTargetProfilesToTraining } from './attach-target-profiles-to-training.js';
+import { createModuleIssueReport } from './create-module-issue-report.js';
 import { createOrUpdateTrainingTrigger } from './create-or-update-training-trigger.js';
 import { createPassage } from './create-passage.js';
 import { createTraining } from './create-training.js';
@@ -65,6 +68,7 @@ const usecasesWithoutInjectedDependencies = {
   addTutorialToUser,
   attachTargetProfilesToTraining,
   createOrUpdateTrainingTrigger,
+  createModuleIssueReport,
   createPassage,
   deleteTrainingTrigger,
   createTraining,

--- a/api/src/devcomp/infrastructure/repositories/module-issue-report-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-issue-report-repository.js
@@ -1,0 +1,8 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+export async function save(moduleIssueReport) {
+  const knexConn = DomainTransaction.getConnection();
+  const [result] = await knexConn('module_issue_reports').insert(moduleIssueReport).returning('id');
+
+  return result.id;
+}

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -1,4 +1,5 @@
 import * as campaignParticipationRoute from './application/campaign-participations/campaign-participation-route.js';
+import * as moduleIssueReport from './application/module-issue-report/module-issue-report-route.js';
 import * as modulesRoutes from './application/modules/module-route.js';
 import * as passageEvents from './application/passage-events/passage-event-route.js';
 import * as passages from './application/passages/passage-route.js';
@@ -9,6 +10,7 @@ import * as userTutorials from './application/user-tutorials/user-tutorials-rout
 
 const devcompRoutes = [
   campaignParticipationRoute,
+  moduleIssueReport,
   modulesRoutes,
   passages,
   passageEvents,

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -90,7 +90,7 @@ const typesPositiveInteger32bits = [
 
 const typesPositiveInteger64bits = ['answerId'];
 
-const typesUuid = ['chatId'];
+const typesUuid = ['chatId', 'moduleId', 'elementId'];
 
 const typesAlphanumeric = ['courseId', 'tutorialId'];
 const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'code', 'skillId'];

--- a/api/tests/devcomp/acceptance/application/module-issue-report/module-issue-report-route_test.js
+++ b/api/tests/devcomp/acceptance/application/module-issue-report/module-issue-report-route_test.js
@@ -1,0 +1,49 @@
+import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Acceptance | Route | module-issue-report', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/module-issue-reports', function () {
+    let options;
+
+    beforeEach(async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'POST',
+        url: '/api/module-issue-reports',
+        payload: {
+          data: {
+            type: 'module-issue-reports',
+            attributes: {
+              'module-id': '7d2a96d8-b7e3-4b97-acbf-5e51aa892279',
+              'element-id': '0aed9f0d-e735-48f8-900b-32cc4251dd0e',
+              'passage-id': passage.id,
+              answer: 'ma super réponse',
+              'category-key': 'C’est tout cassé',
+              comment: 'C’est tout cassé',
+            },
+          },
+        },
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Linux; Android 10; MGA-AL00 Build/HUAWEIMGA-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.99 XWEB/4343 MMWEBSDK/20221011 Mobile Safari/537.36 MMWEBID/7309 MicroMessenger/8.0.30.2260(0x28001E3B) WeChat/arm64 Weixin NetType/WIFI Language/zh_CN ABI/arm64',
+        },
+      };
+    });
+
+    it('should return 201 HTTP status code', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+});

--- a/api/tests/devcomp/integration/application/module-issue-report/module-issue-report-route_test.js
+++ b/api/tests/devcomp/integration/application/module-issue-report/module-issue-report-route_test.js
@@ -1,0 +1,41 @@
+import * as moduleUnderTest from '../../../../../src/devcomp/application/module-issue-report/module-issue-report-route.js';
+import { expect, HttpTestServer } from '../../../../test-helper.js';
+
+describe('Integration | Devcomp | Application | Module | Router | module-issue-report-router', function () {
+  describe('POST /api/module-issue-reports', function () {
+    describe('when provided payload is empty', function () {
+      it('should return an HTTP 400 error', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {};
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/module-issue-reports', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    describe('when some attributes are missing in payload', function () {
+      it('should return an HTTP 400 error', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const payloadWithoutCategoryKey = {
+          'module-id': '6282925d-4775-4bca-b513-4c3009ec5886',
+          'element-id': '96e29215-3610-4bc6-b4a6-026bf13276b8',
+          'passage-id': '12',
+          comment: "Pix c'est génial.",
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/module-issue-reports', payloadWithoutCategoryKey);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/repositories/module-issue-report-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-issue-report-repository_test.js
@@ -1,0 +1,48 @@
+import { ModuleIssueReport } from '../../../../src/devcomp/domain/models/module/ModuleIssueReport.js';
+import * as moduleIssueReportRepository from '../../../../src/devcomp/infrastructure/repositories/module-issue-report-repository.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+
+describe('Integration | DevComp | Repositories | ModuleIssueReportRepository', function () {
+  describe('#save', function () {
+    it('should save a module issue report', async function () {
+      // given
+      const passage = databaseBuilder.factory.buildPassage();
+      await databaseBuilder.commit();
+
+      const moduleId = '7d2a96d8-b7e3-4b97-acbf-5e51aa892279';
+      const elementId = '0aed9f0d-e735-48f8-900b-32cc4251dd0e';
+      const passageId = passage.id;
+      const answer = 'ma super réponse';
+      const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:145.0) Gecko/20100101 Firefox/145.0';
+      const categoryKey = "C'est tout cassé";
+      const comment = "C'est tout cassé";
+
+      // when
+      const issueReport = new ModuleIssueReport({
+        moduleId,
+        elementId,
+        passageId,
+        answer,
+        userAgent,
+        categoryKey,
+        comment,
+      });
+
+      // when
+      const id = await moduleIssueReportRepository.save(issueReport);
+
+      // then
+      const moduleIssueReportDb = await knex.select('*').from('module_issue_reports').first();
+
+      expect(moduleIssueReportDb.id).to.equal(id);
+      expect(moduleIssueReportDb.moduleId).to.equal(moduleId);
+      expect(moduleIssueReportDb.elementId).to.equal(elementId);
+      expect(moduleIssueReportDb.passageId).to.equal(passage.id);
+      expect(moduleIssueReportDb.answer).to.equal(answer);
+      expect(moduleIssueReportDb.userAgent).to.equal(userAgent);
+      expect(moduleIssueReportDb.categoryKey).to.equal(categoryKey);
+      expect(moduleIssueReportDb.comment).to.equal(comment);
+      expect(moduleIssueReportDb.createdAt).to.exist;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/ModuleIssueReport_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/ModuleIssueReport_test.js
@@ -1,0 +1,146 @@
+import { ModuleIssueReport } from '../../../../../../src/devcomp/domain/models/module/ModuleIssueReport.js';
+import { DomainError } from '../../../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Module | ModuleIssueReport', function () {
+  describe('#constructor', function () {
+    it('should create an issue report corresponding to attributes', function () {
+      // given
+      const moduleId = '7d2a96d8-b7e3-4b97-acbf-5e51aa892279';
+      const elementId = '0aed9f0d-e735-48f8-900b-32cc4251dd0e';
+      const passageId = 2571;
+      const answer = 'ma super réponse';
+      const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:145.0) Gecko/20100101 Firefox/145.0';
+      const categoryKey = "C'est tout cassé";
+      const comment = "C'est tout cassé";
+
+      // when
+      const issueReport = moduleIssueReportBuilder({ comment });
+
+      // then
+      expect(issueReport.moduleId).to.equal(moduleId);
+      expect(issueReport.elementId).to.equal(elementId);
+      expect(issueReport.passageId).to.equal(passageId);
+      expect(issueReport.answer).to.equal(answer);
+      expect(issueReport.userAgent).to.equal(userAgent);
+      expect(issueReport.categoryKey).to.equal(categoryKey);
+      expect(issueReport.comment).to.equal(comment);
+    });
+
+    describe('if a comment contains only a space', function () {
+      it('should throw an error', function () {
+        // given
+        const commentWithOneSpaceOnly = ' ';
+
+        // when
+        const error = catchErrSync(() => moduleIssueReportBuilder({ comment: commentWithOneSpaceOnly }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The comment should not be empty');
+      });
+    });
+
+    describe('if a comment is empty', function () {
+      it('should throw an error', function () {
+        // given
+        const emptyComment = '';
+
+        // when
+        const error = catchErrSync(() => moduleIssueReportBuilder({ comment: emptyComment }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The comment should not be empty');
+      });
+    });
+
+    describe('if an issueReport does not have a moduleId', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new ModuleIssueReport({}))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The moduleId is required for a ModuleIssueReport');
+      });
+    });
+
+    describe('if an issueReport does not have an elementId', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(() => new ModuleIssueReport({ moduleId: '7d2a96d8-b7e3-4b97-acbf-5e51aa892279' }))();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The elementId is required for a ModuleIssueReport');
+      });
+    });
+
+    describe('if an issueReport does not have a passageId', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new ModuleIssueReport({
+              moduleId: '7d2a96d8-b7e3-4b97-acbf-5e51aa892279',
+              elementId: '0aed9f0d-e735-48f8-900b-32cc4251dd0e',
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The passageId is required for a ModuleIssueReport');
+      });
+    });
+
+    describe('if an issueReport does not have a categoryKey', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new ModuleIssueReport({
+              moduleId: '7d2a96d8-b7e3-4b97-acbf-5e51aa892279',
+              elementId: '0aed9f0d-e735-48f8-900b-32cc4251dd0e',
+              passageId: '25375',
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The categoryKey is required for a ModuleIssueReport');
+      });
+    });
+
+    describe('if an issueReport does not have a comment', function () {
+      it('should throw an error', function () {
+        // when
+        const error = catchErrSync(
+          () =>
+            new ModuleIssueReport({
+              moduleId: '7d2a96d8-b7e3-4b97-acbf-5e51aa892279',
+              elementId: '0aed9f0d-e735-48f8-900b-32cc4251dd0e',
+              passageId: '25375',
+              categoryKey: 'categoryKey',
+            }),
+        )();
+
+        // then
+        expect(error).to.be.instanceOf(DomainError);
+        expect(error.message).to.equal('The comment is required for a ModuleIssueReport');
+      });
+    });
+  });
+});
+
+const moduleIssueReportBuilder = ({ moduleId, elementId, passageId, answer, userAgent, categoryKey, comment } = {}) => {
+  return new ModuleIssueReport({
+    moduleId: moduleId || '7d2a96d8-b7e3-4b97-acbf-5e51aa892279',
+    elementId: elementId || '0aed9f0d-e735-48f8-900b-32cc4251dd0e',
+    passageId: passageId || 2571,
+    answer: answer || 'ma super réponse',
+    userAgent: userAgent || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:145.0) Gecko/20100101 Firefox/145.0',
+    categoryKey: categoryKey || "C'est tout cassé",
+    comment,
+  });
+};

--- a/api/tests/devcomp/unit/domain/usecases/create-module-issue-report_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-module-issue-report_test.js
@@ -1,0 +1,32 @@
+import { ModuleIssueReport } from '../../../../../src/devcomp/domain/models/module/ModuleIssueReport.js';
+import { createModuleIssueReport } from '../../../../../src/devcomp/domain/usecases/create-module-issue-report.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | UseCase | create-module-issue-report', function () {
+  it('should call the repository with the right arguments', async function () {
+    // given
+    const moduleIssueReport = {
+      moduleId: 1,
+      passageId: 1,
+      elementId: 1,
+      comment: "C'est cassé chef",
+      answer: 'La réponse D',
+      userAgent: 'Mozilla/5.0',
+      categoryKey: 'Bug',
+    };
+    const moduleIssueReportRepository = {
+      save: sinon.stub(),
+    };
+
+    // when
+    await createModuleIssueReport({
+      moduleIssueReport,
+      moduleIssueReportRepository,
+    });
+
+    // then
+    expect(moduleIssueReportRepository.save).to.have.been.calledWithExactly(
+      new ModuleIssueReport({ ...moduleIssueReport }),
+    );
+  });
+});


### PR DESCRIPTION
## 🛷 Proposition

La table module-issue-report a été déjà créée. Il faut maintenant créer la route API pour enregistrer les signalement, par requête POST.

## ☃️ Remarques

- Les tests de la route, côté intégration, permettent de vérifier les cas limites (mais on ne cherche pas à tester tout Joi non plus)

## 🧑‍🎄 Pour tester

- La CI doit passer
- Appeler l'[endpoint](https://api-pr14390.review.pix.fr/api/module-issue-reports) POST /api/module-issue-reports avec un payload complet
- Vérifier en base, dans la table `module_issue_reports`, qu'une entrée est bien créée avec les bonnes informations
