### PR TITLE
[TECH] En 'test', s'assurer que les variables d'env sont définies et écrasent celles définies localement (PIX-20566)

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -198,8 +198,11 @@ module.exports = function (environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
-
     ENV.APP.DEFAULT_LOCALE = 'fr';
+
+    ENV.APP.BANNER_CONTENT = '';
+    ENV.APP.BANNER_TYPE = '';
+    ENV.APP.INFORMATION_BANNER_POLLING_TIME = 1000 * 60;
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
@@ -213,6 +216,9 @@ module.exports = function (environment) {
     ENV.APP.LOAD_EXTERNAL_SCRIPT = false;
     ENV.APP.FT_FOCUS_CHALLENGE_ENABLED = true;
     ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID = 999;
+    ENV.APP.AUTO_SHARE_AFTER_DATE = '2025-07-18';
+    ENV.APP.COMBINIX_SURVEY_LINK =
+      'https://app-eu.123formbuilder.com/index.php?p=login&pactionafter=edit_fields%26id%3D86361%26startup_panel%3Deditor%26click_from%3Dyour_forms';
 
     ENV.companion.disabled = true;
 


### PR DESCRIPTION
## ❄️ Problème

Lors du développement de la barre de navigation, on avait modifié des variables dans nos fichiers `.env` respectifs, côté PixApp, en local, pour faire apparaître une bannière des cap'tains.
Mais en lançant les tests localement, beaucoup échouèrent car les variables définies dans le `.env` local, qui faisaient apparaître la bannière, ont "primé". Ainsi, une bannière est apparue dans des tests où on ne voulait pas qu'elle soit là.

## 🛷 Proposition

Dans le fichier `mon-pix/config/environment.js`, dans le context `if (environment === 'test')`, définir les valeurs des variables d'environnement qui peuvent impacter des tests lancés en local. (ex. `BANNER_CONTENT`)

## ☃️ Remarques

- J'en ai profité pour définir d'autres variables, en cherchant lorsqu'elles étaient utilisées dans des tests.
- Faut-il une relecture cross-team?

## 🧑‍🎄 Pour tester

- La CI doit être super-green.
