### PR TITLE
[FEATURE] Améliorer le rendu des images transparentes dans des grains avec un fond (PIX-20640)

### DIFF
--- a/mon-pix/app/components/module/_normalize.scss
+++ b/mon-pix/app/components/module/_normalize.scss
@@ -92,7 +92,7 @@
     object-fit: contain;
     font-style: italic;
     vertical-align: middle;
-    background-color: var(--pix-neutral-0);
+    background-color: transparent;
     background-repeat: no-repeat;
     background-size: contain;
     shape-margin: 1rem;


### PR DESCRIPTION
## ❄️ Problème

Actuellement, on affiche par défaut un fond blanc (token pix-neutral-0) sur les images des modules. Cela cause des problèmes lorsque l'image est utilisée sur un fond colorée comme les grains de type recap.

## 🛷 Proposition

Changer la couleur du fond par défaut des images des modules en transparent.

## ☃️ Remarques

On utilise la couleur transparente par défaut pour éviter qu'elle soit surchargée par d'autres fichiers (design system...)

## 🧑‍🎄 Pour tester

- Aller sur le module [Phishing Novice](https://app-pr14392.review.pix.fr/modules/975d25d1/cyber-message-arnaque)
- Passer le module jusqu'au grain recap 
- Vérifier que le couleur de fond de l'image affiché a changé 😄 
