### PR TITLE
[FEATURE] Revoir la page de design de configuration d'association de compte (PIX-20755)

### DIFF
--- a/orga/app/components/authentication/oidc-association-confirmation.gjs
+++ b/orga/app/components/authentication/oidc-association-confirmation.gjs
@@ -1,4 +1,3 @@
-import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
@@ -12,55 +11,40 @@ export default class OidcAssociationConfirmation extends Component {
   <template>
     <h1 class="oidc-association__title">
       {{t "components.authentication.oidc-association-confirmation.title"}}
-      <span class="oidc-association__subtitle">{{t
-          "components.authentication.oidc-association-confirmation.sub-title"
-        }}</span>
     </h1>
-    <p class="oidc-association__information">{{t
-        "components.authentication.oidc-association-confirmation.information"
-      }}</p>
+
     <div class="oidc-association__container">
+
       <div class="oidc-association__user-information">
-        <PixIcon @name="userCircle" @plainIcon={{true}} @ariaHidden={{true}} />
-        <p>{{@fullNameFromPix}}</p>
+        <div class="oidc-association__avatar">
+          <PixIcon @name="userCircle" @plainIcon={{true}} @ariaHidden={{true}} />
+          <p>{{@fullNameFromPix}}</p>
+        </div>
+
         <div class="oidc-association__user-authentication-methods">
           <p>{{t "components.authentication.oidc-association-confirmation.current-authentication-methods"}}</p>
-          <dl
-            class="oidc-association__user-authentication-methods-list"
-            title={{t "components.authentication.oidc-association-confirmation.current-authentication-methods"}}
-          >
+          <dl class="oidc-association__user-authentication-methods-list">
             {{#if this.shouldShowEmail}}
-              <div>
-                <dt>{{t "components.authentication.oidc-association-confirmation.email"}}</dt>
-                <dd>{{@email}}</dd>
-              </div>
+              <dt>{{t "components.authentication.oidc-association-confirmation.email"}}</dt>
+              <dd>{{@email}}</dd>
             {{/if}}
             {{#each this.oidcAuthenticationMethodOrganizationNames as |organizationName|}}
-              <div>
-                <dt>{{t "components.authentication.oidc-association-confirmation.external-connection"}}</dt>
-                <dd>{{organizationName}}</dd>
-              </div>
+              <dt>{{t "components.authentication.oidc-association-confirmation.external-connection"}}</dt>
+              <dd>{{organizationName}}</dd>
             {{/each}}
           </dl>
-        </div>
-      </div>
 
-      <div class="oidc-association__switch-account-button">
-        <PixButton @triggerAction={{this.backToLoginForm}} @variant="secondary">{{t
-            "components.authentication.oidc-association-confirmation.switch-account"
-          }}</PixButton>
-      </div>
+          <PixIcon @name="add" @ariaHidden={{true}} class="oidc-association__arrow" />
 
-      <PixIcon @name="arrowTop" @ariaHidden={{true}} class="oidc-association__arrow" />
-      <div class="oidc-association__new-authentication-method">
-        <p>{{t "components.authentication.oidc-association-confirmation.authentication-method-to-add"}}</p>
-        <PixBlock class="oidc-association__authentication-method-to-add">
-          <dl title={{t "components.authentication.oidc-association-confirmation.authentication-method-to-add"}}>
-            <dt>{{t "components.authentication.oidc-association-confirmation.external-connection-via"}}
-              {{@identityProviderOrganizationName}}</dt>
+          <p>{{t "components.authentication.oidc-association-confirmation.authentication-method-to-add"}}</p>
+          <dl class="oidc-association__user-authentication-methods-list">
+            <dt>
+              {{t "components.authentication.oidc-association-confirmation.external-connection-via"}}
+              {{@identityProviderOrganizationName}}
+            </dt>
             <dd>{{@fullNameFromExternalIdentityProvider}}</dd>
           </dl>
-        </PixBlock>
+        </div>
       </div>
 
       {{#if this.reconcileErrorMessage}}
@@ -70,11 +54,11 @@ export default class OidcAssociationConfirmation extends Component {
       {{/if}}
 
       <div class="oidc-association__action-buttons">
-        <PixButton @triggerAction={{this.backToLoginForm}} @variant="secondary">{{t
-            "components.authentication.oidc-association-confirmation.return"
-          }}</PixButton>
         <PixButton @triggerAction={{this.reconcile}} @isLoading={{this.isLoading}}>
           {{t "components.authentication.oidc-association-confirmation.confirm"}}
+        </PixButton>
+        <PixButton @triggerAction={{this.backToLoginForm}} @variant="secondary">
+          {{t "components.authentication.oidc-association-confirmation.return"}}
         </PixButton>
       </div>
     </div>

--- a/orga/app/components/authentication/oidc-association-confirmation.scss
+++ b/orga/app/components/authentication/oidc-association-confirmation.scss
@@ -1,148 +1,88 @@
 @use 'pix-design-tokens/typography';
 
 .oidc-association {
-  &__title,
-  &__subtitle,
-  &__information {
-    color: var(--pix-neutral-900);
-    text-align: center;
-  }
-
   &__title {
-    @extend %pix-title-m;
-
-    padding-top: var(--pix-spacing-8x);
-    text-align: center;
-  }
-
-  &__subtitle {
-    @extend %pix-title-xs;
-
-    display: block;
-    margin: 0;
-    padding: var(--pix-spacing-4x) 0 var(--pix-spacing-1x) 0;
-  }
-
-  &__information {
-    @extend %pix-title-xs;
-
-    margin-bottom: var(--pix-spacing-12x);
-    font-weight: 400;
+    @extend %pix-title-s;
   }
 
   &__container {
     display: flex;
     flex-direction: column;
     align-items: center;
-    min-height: 500px;
   }
 
   &__user-information {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    width: 570px;
-    padding-top: var(--pix-spacing-8x);
-    background-color: var(--pix-neutral-20);
+    gap: var(--pix-spacing-8x);
+    width: 100%;
+    margin-top: var(--pix-spacing-4x);
+    padding: var(--pix-spacing-4x);
+    background-color: var(--pix-orga-50);
     border-radius: var(--pix-spacing-2x);
+  }
+
+  &__avatar {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-items: center;
+    padding: var(--pix-spacing-4x);
 
     svg {
-      min-width: 120px;
-      height: 120px;
+      min-width: 48px;
+      height: 48px;
       color: var(--pix-neutral-100);
     }
 
     p {
       @extend %pix-title-xs;
-
-      margin: 0;
-      padding-top: var(--pix-spacing-2x);
-      color: var(--pix-neutral-900);
     }
   }
 
   &__user-authentication-methods {
-    width: 100%;
-    padding: var(--pix-spacing-8x);
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
 
     p {
-      @extend %pix-title-xs;
-
-      font-weight: 400;
+      @extend %pix-body-m;
     }
   }
 
   &__new-authentication-method {
-    width: 506px;
-    padding-top: var(--pix-spacing-4x);
-
-    p {
-      @extend %pix-title-xs;
-
-      color: var(--pix-neutral-900);
-      font-weight: 400;
-    }
+    width: 100%;
   }
 
   &__user-authentication-methods-list {
-    padding: var(--pix-spacing-8x) var(--pix-spacing-10x);
+    display: flex;
+    flex-direction: column;
+    padding: var(--pix-spacing-6x);
     background-color: var(--pix-neutral-0);
     border-radius: var(--pix-spacing-2x);
 
     dd,
     dt {
-      display: inline;
-      color: var(--pix-neutral-900);
-
       @extend %pix-body-l;
     }
 
     dt {
-      display: inline-block;
-      width: 38%;
       padding: var(--pix-spacing-1x) 0;
       font-weight: 500;
     }
   }
 
-  &__switch-account-button {
-    display: flex;
-    justify-content: right;
-    width: 570px;
-    margin-top: var(--pix-spacing-2x);
-  }
-
   &__arrow {
-    min-width: 50px;
-    height: 70px;
-    color: var(--pix-neutral-20);
-  }
-
-  &__authentication-method-to-add {
-    margin-bottom: 32px;
-    border-radius: 8px;
-
-    dl {
-      margin: 0;
-      padding: var(--pix-spacing-8x) var(--pix-spacing-10x);
-
-      @extend %pix-body-l;
-
-      color: var(--pix-neutral-900);
-    }
-
-    dd,
-    dt {
-      display: inline;
-    }
-
-    dt {
-      font-weight: 500;
-    }
+    align-self: center;
+    width: 32px;
+    height: 32px;
+    margin-top: var(--pix-spacing-4x);
+    color: var(--pix-neutral-300);
   }
 
   &__action-buttons {
     display: flex;
+    flex-direction: column;
     gap: var(--pix-spacing-6x);
     justify-content: center;
     width: 100%;

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -19,8 +19,8 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       {{/if}}
 
       <div>
-        <h1 class="pix-title-m">{{t "pages.login.title"}}</h1>
-        <h3 class="pix-body-l">{{t "pages.login.with-pix-account"}}</h3>
+        <h1 class="pix-title-m">{{t "pages.oidc.login.title"}}</h1>
+        <h3 class="pix-body-l">{{t "pages.oidc.login.sub-title"}}</h3>
       </div>
 
       <LoginForm

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -91,7 +91,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
           // then
           assert.ok(
             screen.getByRole('heading', {
-              name: `${t('components.authentication.oidc-association-confirmation.title')} ${t('components.authentication.oidc-association-confirmation.sub-title')}`,
+              name: `${t('components.authentication.oidc-association-confirmation.title')}`,
             }),
           );
           assert.ok(screen.getByText(t('components.authentication.oidc-association-confirmation.email')));

--- a/orga/tests/integration/components/authentication/oidc-association-confirmation-test.gjs
+++ b/orga/tests/integration/components/authentication/oidc-association-confirmation-test.gjs
@@ -45,10 +45,9 @@ module('Integration | Component | Oidc-association-confirmation', function (hook
     // then
     assert.ok(
       screen.getByRole('heading', {
-        name: `${t('components.authentication.oidc-association-confirmation.title')} ${t('components.authentication.oidc-association-confirmation.sub-title')}`,
+        name: `${t('components.authentication.oidc-association-confirmation.title')}`,
       }),
     );
-    assert.ok(screen.getByText(t('components.authentication.oidc-association-confirmation.information')));
     assert.ok(screen.getByText('Lloyd Cé'));
     assert.ok(screen.getByText('Lloyd Pix'));
     assert.ok(
@@ -68,9 +67,6 @@ module('Integration | Component | Oidc-association-confirmation', function (hook
       ),
     );
 
-    assert.ok(
-      screen.getByRole('button', { name: t('components.authentication.oidc-association-confirmation.switch-account') }),
-    );
     assert.ok(
       screen.getByRole('button', { name: t('components.authentication.oidc-association-confirmation.return') }),
     );

--- a/orga/tests/integration/templates/authentication/oidc/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/oidc/login-test.gjs
@@ -1,0 +1,52 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import Login from 'pix-orga/templates/authentication/oidc/login';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | Authentication | OIDC | login', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays the login template with invitation banner and form component', async function (assert) {
+    // given
+    const controller = {
+      currentInvitation: {
+        invitationId: 1,
+        code: 'ABC123',
+        organizationName: 'Organisation OIDC',
+      },
+    };
+
+    // when
+    const screen = await render(<template><Login @controller={{controller}} /></template>);
+
+    // then
+    assert
+      .dom(
+        screen.getByText(
+          t('pages.login.join-invitation', {
+            organizationName: controller.currentInvitation.organizationName,
+          }),
+        ),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: `${t('pages.oidc.login.title')}`,
+        }),
+      )
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: `${t('pages.oidc.login.sub-title')}`,
+        }),
+      )
+      .exists();
+    assert.dom(screen.getByRole('textbox', { name: t('pages.login-form.email.label') })).exists();
+    assert.dom(screen.getByLabelText(t('pages.login-form.password'))).exists();
+    assert.dom(screen.getByRole('button', { name: t('pages.login-form.login') })).exists();
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1402,6 +1402,12 @@
       },
       "title": "Missions"
     },
+    "oidc": {
+      "login": {
+        "sub-title": "to link it to your new access method",
+        "title": "Use your Pix account"
+      }
+    },
     "organization-learner": {
       "activity": {
         "assessment-summary": "Customised tests participations summary",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -347,17 +347,14 @@
         }
       },
       "oidc-association-confirmation": {
-        "authentication-method-to-add": "Login method added:",
+        "authentication-method-to-add": "Login method added",
         "confirm": "Continue",
-        "current-authentication-methods": "My current login methods:",
+        "current-authentication-methods": "My current login methods",
         "email": "Email address",
         "external-connection": "External login",
         "external-connection-via": "Login via",
-        "information": "As the assessment of your digital skills is personalized, your account must remain strictly personal",
         "return": "Back",
-        "sub-title": "A new login method is about to be added to your Pix account",
-        "switch-account": "Change account",
-        "title": "Warning",
+        "title": "A new login method is about to be added to your Pix account",
         "username": "Username"
       },
       "oidc-provider-selector": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1390,6 +1390,12 @@
       },
       "title": "Missions"
     },
+    "oidc": {
+      "login": {
+        "sub-title": "pour le lier à votre nouvelle méthode de connexion",
+        "title": "Utilisez votre compte Pix"
+      }
+    },
     "organization-learner": {
       "activity": {
         "assessment-summary": "Récapitulatif des participations aux campagnes d'évaluation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -347,17 +347,14 @@
         }
       },
       "oidc-association-confirmation": {
-        "authentication-method-to-add": "Connexion ajoutée :",
+        "authentication-method-to-add": "Connexion ajoutée",
         "confirm": "Continuer",
-        "current-authentication-methods": "Mes méthodes de connexion actuelles :",
+        "current-authentication-methods": "Mes méthodes de connexion actuelles",
         "email": "Adresse e-mail",
         "external-connection": "Connexion externe",
         "external-connection-via": "Connexion via",
-        "information": "L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel",
         "return": "Retour",
-        "sub-title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
-        "switch-account": "Changer de compte",
-        "title": "Attention !",
+        "title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
         "username": "Identifiant"
       },
       "oidc-provider-selector": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -346,17 +346,14 @@
         }
       },
       "oidc-association-confirmation": {
-        "authentication-method-to-add": "Verbinding toegevoegd :",
+        "authentication-method-to-add": "Verbinding toegevoegd",
         "confirm": "Ga verder met",
-        "current-authentication-methods": "Mijn huidige verbindingsmethoden:",
+        "current-authentication-methods": "Mijn huidige verbindingsmethoden",
         "email": "E-mailadres",
         "external-connection": "Externe aansluiting",
         "external-connection-via": "Verbinding via",
-        "information": "Aangezien de vaardigheidstoetsing persoonlijk is, moet je account strikt persoonlijk blijven.",
         "return": "Terug",
-        "sub-title": "Er wordt binnenkort een nieuwe verbindingsmethode toegevoegd aan je Pix-account",
-        "switch-account": "Account wijzigen",
-        "title": "Let op!",
+        "title": "Er wordt binnenkort een nieuwe verbindingsmethode toegevoegd aan je Pix-account",
         "username": "Inloggen"
       },
       "oidc-provider-selector": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1384,6 +1384,12 @@
       },
       "title": "Opdrachten"
     },
+    "oidc": {
+      "login": {
+        "sub-title": "om te koppelen aan uw nieuwe aanmeldingsmethode",
+        "title": "Gebruik uw Pix-account"
+      }
+    },
     "organization-learner": {
       "activity": {
         "assessment-summary": "Samenvatting van deelname aan beoordelingscampagnes",


### PR DESCRIPTION
## ❄️ Problème

Revoir le design de la page d'association de compte SSO sur Pix ORGA

Modifier également les titres affichés sur la page de connexion suite au passage par un SSO

## 🛷 Proposition

<img width="1896" height="956" alt="image" src="https://github.com/user-attachments/assets/f0d312ac-b35a-43cc-b65d-c90b700db216" />

<img width="1597" height="922" alt="image" src="https://github.com/user-attachments/assets/14e9eab1-b9a8-456c-8de1-6b916d115da8" />



## 🧑‍🎄 Pour tester

Associer un compte PIX à un compte SSO sur Pix Orga.
