### PR TITLE
[FEATURE] Permettre à un utilisateur invité de se connecter par un SSO (pix-20665)

### DIFF
--- a/orga/app/components/authentication/oidc-association-confirmation.gjs
+++ b/orga/app/components/authentication/oidc-association-confirmation.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
+import get from 'lodash/get';
 
 export default class OidcAssociationConfirmation extends Component {
   <template>
@@ -54,7 +55,7 @@ export default class OidcAssociationConfirmation extends Component {
       {{/if}}
 
       <div class="oidc-association__action-buttons">
-        <PixButton @triggerAction={{this.reconcile}} @isLoading={{this.isLoading}}>
+        <PixButton @triggerAction={{this.confirm}} @isLoading={{this.isLoading}}>
           {{t "components.authentication.oidc-association-confirmation.confirm"}}
         </PixButton>
         <PixButton @triggerAction={{this.backToLoginForm}} @variant="secondary">
@@ -69,6 +70,7 @@ export default class OidcAssociationConfirmation extends Component {
   @service session;
   @service authErrorMessages;
   @service router;
+  @service store;
 
   @tracked reconcileErrorMessage = null;
   @tracked isLoading = false;
@@ -86,11 +88,21 @@ export default class OidcAssociationConfirmation extends Component {
     this.router.transitionTo('authentication.oidc.login', this.args.identityProviderSlug);
   }
 
-  // TODO : gérer la réconciliation et le reconcileErrorMessage dans une prochaine PR
   @action
-  async reconcile() {
+  async confirm() {
     this.isLoading = true;
-
+    if (this.args.invitationId) {
+      try {
+        await this._acceptOrganizationInvitation(this.args.invitationId, this.args.invitationCode, this.args.email);
+      } catch (responseError) {
+        // EmberAdapter and EmberSimpleAuth use different error formats, so we manage both cases below
+        const error = get(responseError, responseError?.isAdapterError ? 'errors[0]' : 'responseJSON.errors[0]');
+        const isUserAlreadyOrganizationMember = error?.status === '412';
+        if (!isUserAlreadyOrganizationMember) {
+          throw responseError;
+        }
+      }
+    }
     try {
       await this.session.authenticate('authenticator:oidc', {
         authenticationKey: this.args.authenticationKey,
@@ -101,6 +113,22 @@ export default class OidcAssociationConfirmation extends Component {
       this.reconcileErrorMessage = this.authErrorMessages.getAuthenticationErrorMessage(responseError);
     } finally {
       this.isLoading = false;
+    }
+  }
+
+  async _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, email) {
+    const type = 'organization-invitation-response';
+    const id = `${organizationInvitationId}_${organizationInvitationCode}`;
+    const organizationInvitationRecord = this.store.peekRecord(type, id);
+    if (!organizationInvitationRecord) {
+      let record;
+      try {
+        record = this.store.createRecord(type, { id, code: organizationInvitationCode, email });
+        await record.save({ adapterOptions: { organizationInvitationId } });
+      } catch (error) {
+        record.deleteRecord();
+        throw error;
+      }
     }
   }
 }

--- a/orga/app/controllers/authentication/oidc/login.js
+++ b/orga/app/controllers/authentication/oidc/login.js
@@ -48,6 +48,7 @@ export default class OidcLoginController extends Controller {
     const attributes = responseJson.data.attributes;
     const oidcAssociationConfirmationData = {
       email,
+      authenticationKey: this.authenticationKey,
       fullNameFromPix: attributes['full-name-from-pix'],
       fullNameFromExternalIdentityProvider: attributes['full-name-from-external-identity-provider'],
       authenticationMethods: attributes['authentication-methods'],

--- a/orga/app/controllers/authentication/oidc/login.js
+++ b/orga/app/controllers/authentication/oidc/login.js
@@ -18,6 +18,10 @@ export default class OidcLoginController extends Controller {
     return invitationStorage.get();
   }
 
+  get isWithInvitation() {
+    return Boolean(this.currentInvitation);
+  }
+
   get authenticationKey() {
     return oidcUserAuthenticationStorage.get()?.authenticationKey;
   }

--- a/orga/app/routes/authentication/oidc/confirm.js
+++ b/orga/app/routes/authentication/oidc/confirm.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { SessionStorageEntry } from '../../../utils/session-storage-entry';
 
 const oidcAssociationConfirmationStorage = new SessionStorageEntry('oidcAssociationConfirmation');
+const invitationStorage = new SessionStorageEntry('joinInvitationData');
 
 export default class ConfirmRoute extends Route {
   @service oidcIdentityProviders;
@@ -15,9 +16,17 @@ export default class ConfirmRoute extends Route {
       this.oidcIdentityProviders.findBySlug(identityProviderSlug).organizationName;
 
     const storedInformations = oidcAssociationConfirmationStorage.get();
+
+    const storedInvitation = invitationStorage.get() ?? {};
+    const invitationId = storedInvitation.invitationId;
+    const invitationCode = storedInvitation.code;
+
     return {
       identityProviderOrganizationName,
       identityProviderSlug,
+      invitationId,
+      invitationCode,
+      authenticationKey: storedInformations.authenticationKey,
       authenticationMethods: storedInformations.authenticationMethods,
       fullNameFromPix: storedInformations.fullNameFromPix,
       fullNameFromExternalIdentityProvider: storedInformations.fullNameFromExternalIdentityProvider,

--- a/orga/app/templates/authentication/oidc/confirm.gjs
+++ b/orga/app/templates/authentication/oidc/confirm.gjs
@@ -19,6 +19,9 @@ import OidcAssociationConfirmation from '../../../components/authentication/oidc
         @fullNameFromPix={{@model.fullNameFromPix}}
         @fullNameFromExternalIdentityProvider={{@model.fullNameFromExternalIdentityProvider}}
         @email={{@model.email}}
+        @invitationId={{@model.invitationId}}
+        @invitationCode={{@model.invitationCode}}
+        @authenticationKey={{@model.authenticationKey}}
       />
     </:content>
   </AuthenticationLayout>

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -24,7 +24,7 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </div>
 
       <LoginForm
-        @isWithInvitation={{false}}
+        @isWithInvitation={{@controller.isWithInvitation}}
         @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.redirectToAssociationConfirmation}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -794,4 +794,19 @@ function routes() {
     },
     200,
   );
+  this.post('/oidc/user/reconcile', (schema, request) => {
+    const params = parseQueryString(request.requestBody);
+    const identityProvider = params.identityProvider;
+    const foundUser = schema.prescribers.first();
+
+    return {
+      access_token:
+        'aaa.' +
+        btoa(
+          `{"user_id":${foundUser.id},"source":"oidc-externe","identity_provider":"${identityProvider}","iat":1545321469,"exp":4702193958}`,
+        ) +
+        '.bbb',
+      logout_url_uuid: null,
+    };
+  });
 }

--- a/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-flow-test.js
@@ -3,11 +3,18 @@ import { click, currentURL, fillIn, settled } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { currentSession } from 'ember-simple-auth/test-support';
 import Location from 'pix-orga/utils/location';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntl from '../../helpers/setup-intl';
+import {
+  createPrescriberByUser,
+  createUserWithMembership,
+  createUserWithMembershipAndTermsOfServiceAccepted,
+} from '../../helpers/test-init';
 import { unabortedVisit } from '../../helpers/unaborted-visit';
 
 module('Acceptance | OIDC | authentication flow', function (hooks) {
@@ -57,136 +64,228 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
     });
 
     module('when the wanted OIDC Provider is enabled and ready', function () {
-      test('it redirects the user to the SSO login page', async function (assert) {
+      test('the user is redirected to the Pix login form', async function (assert) {
         // when
-        await unabortedVisit('/connexion/oidc-partner?code=code&state=state');
+        await visit('/connexion/oidc-partner?code=code&state=state');
 
         // then
         assert.strictEqual(currentURL(), '/connexion/oidc-partner/login');
       });
 
-      module('when the Pix account exists and the password is correct', function () {
-        test('the login form redirects to the OIDC association confirmation page', async function (assert) {
-          // given
-          server.create('user', {
-            email: 'lloyd.ce@example.net',
-            password: 'pix123',
-            cgu: true,
-            mustValidateTermsOfService: false,
-            lastTermsOfServiceValidatedAt: new Date(),
+      module('when the user submits Pix login form', function () {
+        module('when the Pix account exists and the password is correct', function () {
+          test('the user is redirected to the confirmation page', async function (assert) {
+            // given
+            const user = server.create('user', {
+              email: 'lloyd.ce@example.net',
+            });
+
+            const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+            // when
+            await fillIn(await screen.getByRole('textbox', { name: t('pages.login-form.email.label') }), user.email);
+            await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
+
+            await click(await screen.getByRole('button', { name: 'Je me connecte' }));
+
+            // then
+            assert.ok(
+              await screen.findByRole('heading', {
+                name: `${t('components.authentication.oidc-association-confirmation.title')}`,
+              }),
+            );
+            assert.ok(await screen.findByText(t('components.authentication.oidc-association-confirmation.email')));
+            assert.ok(await screen.findByText('lloyd.ce@example.net'));
+            assert.ok(
+              await screen.findByText(
+                t('components.authentication.oidc-association-confirmation.authentication-method-to-add'),
+              ),
+            );
+            assert.ok(
+              await screen.findByText(
+                `${t('components.authentication.oidc-association-confirmation.external-connection-via')} Partenaire OIDC`,
+              ),
+            );
+            assert.ok(await screen.findByText('LLoyd Idp'));
+            assert.strictEqual(currentURL(), '/connexion/oidc-partner/confirm');
           });
-          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+        });
 
-          // when
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
-            'lloyd.ce@example.net',
-          );
-          await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'pix123');
+        module('when the Pix account does not exist or the password is incorrect', function () {
+          test('the login form displays a missing or invalid credentials error message', async function (assert) {
+            // given
+            this.server.post(
+              '/oidc/user/check-reconciliation',
+              {
+                errors: [
+                  {
+                    status: '401',
+                    code: 'MISSING_OR_INVALID_CREDENTIALS',
+                    title: 'Unauthorized',
+                    detail: 'Missing or invalid credentials',
+                    meta: { isLoginFailureWithUsername: false },
+                  },
+                ],
+              },
+              401,
+            );
+            const screen = await visit('/connexion/oidc-partner?code=code&state=state');
 
-          await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
-          // eslint-disable-next-line ember/no-settled-after-test-helper
-          await settled();
+            // when
+            await fillIn(
+              screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
+              'no-account-with-this-email@example.net',
+            );
+            await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
 
-          // then
-          assert.ok(
-            screen.getByRole('heading', {
-              name: `${t('components.authentication.oidc-association-confirmation.title')}`,
-            }),
-          );
-          assert.ok(screen.getByText(t('components.authentication.oidc-association-confirmation.email')));
-          assert.ok(screen.getByText('lloyd.ce@example.net'));
-          assert.ok(
-            screen.getByText(t('components.authentication.oidc-association-confirmation.authentication-method-to-add')),
-          );
-          assert.ok(
-            screen.getByText(
-              `${t('components.authentication.oidc-association-confirmation.external-connection-via')} Partenaire OIDC`,
-            ),
-          );
-          assert.ok(screen.getByText('LLoyd Idp'));
+            await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
+            // eslint-disable-next-line ember/no-settled-after-test-helper
+            await settled();
+
+            // then
+            assert.ok(screen.getByText(t('common.api-error-messages.login-unauthorized-error')));
+          });
+        });
+
+        module('when there is an unexpected error', function () {
+          test('the login form displays a generic error message', async function (assert) {
+            // given
+            this.server.post('/oidc/user/check-reconciliation', undefined, 500);
+
+            const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+            // when
+            await fillIn(
+              screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
+              'no-account-with-this-email@example.net',
+            );
+            await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
+
+            await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
+            // eslint-disable-next-line ember/no-settled-after-test-helper
+            await settled();
+
+            // Translation common.api-error-messages.login-unexpected-error contains HTML
+            // assert.ok(screen.getByText(t('common.api-error-messages.login-unexpected-error')));
+            assert.ok(screen.getByText(new RegExp('Impossible de se connecter.')));
+          });
         });
       });
 
-      module('when the Pix account does not exist or the password is incorrect', function () {
-        test('the login form displays a missing or invalid credentials error message', async function (assert) {
-          // given
-          this.server.post(
-            '/oidc/user/check-reconciliation',
-            {
-              errors: [
-                {
-                  status: '401',
-                  code: 'MISSING_OR_INVALID_CREDENTIALS',
-                  title: 'Unauthorized',
-                  detail: 'Missing or invalid credentials',
-                  meta: { isLoginFailureWithUsername: false },
-                },
-              ],
-            },
-            401,
-          );
-          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+      module('when the user confirms the addition of a new authentication method', function () {
+        module('when the user is invited', function (hooks) {
+          const invitationStorage = new SessionStorageEntry('joinInvitationData');
+          let invitation;
 
-          // when
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
-            'no-account-with-this-email@example.net',
-          );
-          await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
+          hooks.beforeEach(() => {
+            invitation = server.create('organizationInvitation', {
+              status: 'pending',
+              code: 'ABCD',
+              organizationName: 'College BRO & Evil Associates',
+            });
 
-          await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
-          // eslint-disable-next-line ember/no-settled-after-test-helper
-          await settled();
+            invitationStorage.set({
+              invitationId: String(invitation.id),
+              code: invitation.code,
+              organizationName: invitation.organizationName,
+            });
+          });
 
-          // then
-          assert.ok(screen.getByText(t('common.api-error-messages.login-unauthorized-error')));
-        });
-      });
+          hooks.afterEach(function () {
+            invitationStorage.remove();
+          });
 
-      module('when there is an unexpected error', function () {
-        test('the login form displays a generic error message', async function (assert) {
-          // given
-          this.server.post('/oidc/user/check-reconciliation', undefined, 500);
+          async function fillInAndSubmitLoginForm(screen) {
+            await fillIn(
+              await screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
+              'harry@cover.com',
+            );
+            await fillIn(await screen.getByLabelText(t('pages.login-form.password')), 'pix123');
+            await click(await screen.getByRole('button', { name: 'Je me connecte' }));
+          }
 
-          const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+          module('when the user has already accepted Pix Orga terms of service', function () {
+            test('he is redirected to his homepage', async function (assert) {
+              // given
+              const user = createUserWithMembershipAndTermsOfServiceAccepted();
+              createPrescriberByUser({ user });
 
-          // when
-          await fillIn(
-            screen.getByRole('textbox', { name: t('pages.login-form.email.label') }),
-            'no-account-with-this-email@example.net',
-          );
-          await fillIn(screen.getByLabelText(t('pages.login-form.password')), 'incorrect-password');
+              const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+              await fillInAndSubmitLoginForm(screen);
+              await settled();
 
-          await click(screen.getByRole('button', { name: t('pages.login-form.login') }));
-          // eslint-disable-next-line ember/no-settled-after-test-helper
-          await settled();
+              // when
+              await click(
+                await screen.findByText(t('components.authentication.oidc-association-confirmation.confirm')),
+              );
 
-          // Translation common.api-error-messages.login-unexpected-error contains HTML
-          // assert.ok(screen.getByText(t('common.api-error-messages.login-unexpected-error')));
-          assert.ok(screen.getByText(new RegExp('Impossible de se connecter.')));
+              // then
+              await screen.findByText('Harry Cover');
+
+              assert.strictEqual(currentURL(), '/');
+              assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
+            });
+          });
+
+          module('when the user has not accepted Pix Orga terms of service', function (hooks) {
+            let screen;
+            hooks.beforeEach(async function () {
+              const user = createUserWithMembership();
+              createPrescriberByUser({ user });
+              screen = await visit('/connexion/oidc-partner?code=code&state=state');
+              await fillInAndSubmitLoginForm(screen);
+            });
+
+            test('he is redirected to the cgu page', async function (assert) {
+              // given
+              await click(
+                await screen.findByText(t('components.authentication.oidc-association-confirmation.confirm')),
+              );
+
+              // then
+              await screen.findByRole('heading', { name: t('components.terms-of-service.title.requested') });
+              assert.strictEqual(currentURL(), '/cgu');
+            });
+
+            module('when the user accepts Pix Orga terms of service', function () {
+              test('he is redirected to his homepage', async function (assert) {
+                // given
+                await click(
+                  await screen.findByText(t('components.authentication.oidc-association-confirmation.confirm')),
+                );
+
+                // when
+                await click(await screen.findByText(t('components.terms-of-service.actions.accept')));
+
+                // then
+                await screen.findByText('Harry Cover');
+                assert.strictEqual(currentURL(), '/');
+                assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
+              });
+            });
+          });
         });
       });
     });
-  });
 
-  // TODO: Uncomment and make those tests work when the signup template is done
-  //   module('when the user logs out', function () {
-  //     toRenameToTest('it redirects the user to the logout URL', async function (assert) {
-  //       // given
-  //       const screen = await visit('/connexion/oidc-partner?code=code&state=state');
-  //       await click(screen.getByLabelText(t('common.cgu.label')));
-  //       await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
-  //       // eslint-disable-next-line ember/no-settled-after-test-helper
-  //       await settled();
-  //
-  //       await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
-  //
-  //       // when
-  //       await click(screen.getByRole('link', { name: 'Se déconnecter' }));
-  //
-  //       // then
-  //       assert.strictEqual(currentURL(), '/deconnexion');
-  //     });
-  //   });
+    // TODO: Uncomment and make those tests work when the signup template is done
+    //   module('when the user logs out', function () {
+    //     toRenameToTest('it redirects the user to the logout URL', async function (assert) {
+    //       // given
+    //       const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+    //       await click(screen.getByLabelText(t('common.cgu.label')));
+    //       await click(screen.getByRole('button', { name: 'Je crée mon compte' }));
+    //       // eslint-disable-next-line ember/no-settled-after-test-helper
+    //       await settled();
+    //
+    //       await click(screen.getByRole('button', { name: 'Lloyd Consulter mes informations' }));
+    //
+    //       // when
+    //       await click(screen.getByRole('link', { name: 'Se déconnecter' }));
+    //
+    //       // then
+    //       assert.strictEqual(currentURL(), '/deconnexion');
+    //     });
+    //   });
+  });
 });


### PR DESCRIPTION
## ❄️ Problème

Un utilisateur invité dans une organisation doit pouvoir accepter l'invitation en étant identifié par SSO

## 🛷 Proposition

Permettre à un utilisateur invité de se connecter par SSO

## ☃️ Remarques

Comment tester en acceptance le scénario passant d'invitation, sachant que rien ne s'affiche différemment au moment de la dernière étape de la connexion gérée ici ? (la différence visible se trouve plus haut, dans le formulaire de login)
 `orga/tests/acceptance/join-and-signup-test.js`. 

Les tests d'acceptance `orga/tests/acceptance/oidc/oidc-authentication-flow-test.js` seront peut-être à remanier/compléter, en différenciant les cas d'authentification par SSO pour un utilisateur déjà membre d'une organisation, qui rajoute une méthode d'authentification (non traités dans cette PR) et les cas d'authentification SSO associés à une invitation (donc destinés à un utilisateur pas encore membre de cette organisation).


## 🧑‍🎄 Pour tester

- Se connecter sur Pix Orga en tant qu'admin (par exemple allorga@example.net ou admin-orga@example.net)
- Envoyer un mail d'invitation à l'orga (peu importe le destinataire)
- Récupérer le lien figurant dans le mail
- Sur la page de connexion de ce lien, se connecter via SSO
- De retour sur la page de login, entrer les identifiants d'un utilisateur ayant déjà un compte Pix mais n'ayant pas accepté les CGU de Pix Orga et se connecter
- Sur la page de confirmation, cliquer sur "Confirmer"
- Constater que la page suivante demande l'acceptation des CGU
- Accepter l'acceptation des CGU
- Constater que l'utilisateur arrive sur sa homepage
- Vérifier qu'en base : 
   - l’invitation est marquée comme utilisée 
   - le membership est créé
   - l’authentication method est créée

Refaire le même parcours avec un utilisateur ayant déjà accepté les CGU de Pix Orga, vérifier que tout se passe de la même manière (sauf la demande d'acceptation des CGU bien sûr).

Tester le même parcours avec une invitation déjà acceptée : cela ne doit pas bloquer la connexion.

