### PR TITLE
[TECH] Enlever de config.js le v3Certification.numberOfChallengesPerCourse (PIX-20656)

### DIFF
--- a/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
+++ b/api/db/seeds/data/team-certification/tools/publish-session-with-validated-certification.js
@@ -58,7 +58,7 @@ export default async function publishSessionWithValidatedCertification({
     const simulatedCertification = await flashUseCases.simulateFlashAssessmentScenario({
       locale: FRENCH_SPOKEN,
       initialCapacity: version.challengesConfiguration.defaultCandidateCapacity,
-      stopAtChallenge: config.v3Certification.numberOfChallengesPerCourse - 1,
+      stopAtChallenge: version.challengesConfiguration.maximumAssessmentLength - 1,
       pickChallenge,
       pickAnswerStatus,
       versionId: version.id,

--- a/api/src/certification/configuration/domain/usecases/create-certification-version.js
+++ b/api/src/certification/configuration/domain/usecases/create-certification-version.js
@@ -47,6 +47,7 @@ const _buildNewVersion = async ({ scope, versionsRepository }) => {
       assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
       challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
         challengesBetweenSameCompetence: 0,
+        maximumAssessmentLength: 32,
         variationPercent: 1,
         defaultCandidateCapacity: 0,
       }),

--- a/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
@@ -1,11 +1,10 @@
 import Joi from 'joi';
 
-import { config } from '../../../../shared/config.js';
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 
 export class FlashAssessmentAlgorithmConfiguration {
   static #schema = Joi.object({
-    maximumAssessmentLength: Joi.number().integer().min(0),
+    maximumAssessmentLength: Joi.number().integer().min(0).required(),
     challengesBetweenSameCompetence: Joi.number().integer().min(0).required(),
     limitToOneQuestionPerTube: Joi.boolean(),
     enablePassageByAllCompetences: Joi.boolean(),
@@ -15,7 +14,7 @@ export class FlashAssessmentAlgorithmConfiguration {
 
   /**
    * @param {Object} props
-   * @param {number} [props.maximumAssessmentLength] - override the default limit for an assessment length
+   * @param {number} props.maximumAssessmentLength - limit for assessment length
    * @param {number} props.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    * @param {boolean} [props.limitToOneQuestionPerTube] - limits questions to one per tube
    * @param {boolean} [props.enablePassageByAllCompetences] - enable or disable the passage through all competences
@@ -23,7 +22,7 @@ export class FlashAssessmentAlgorithmConfiguration {
    * @param {number} [props.defaultCandidateCapacity] - starting candidate capacity for first challenge
    */
   constructor({
-    maximumAssessmentLength = config.v3Certification.numberOfChallengesPerCourse,
+    maximumAssessmentLength,
     challengesBetweenSameCompetence,
     limitToOneQuestionPerTube = false,
     enablePassageByAllCompetences = false,

--- a/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/shared/domain/models/FlashAssessmentAlgorithmConfiguration.js
@@ -19,7 +19,7 @@ export class FlashAssessmentAlgorithmConfiguration {
    * @param {boolean} [props.limitToOneQuestionPerTube] - limits questions to one per tube
    * @param {boolean} [props.enablePassageByAllCompetences] - enable or disable the passage through all competences
    * @param {number} props.variationPercent
-   * @param {number} [props.defaultCandidateCapacity] - starting candidate capacity for first challenge
+   * @param {number} props.defaultCandidateCapacity - starting candidate capacity for first challenge
    */
   constructor({
     maximumAssessmentLength,

--- a/api/src/certification/shared/domain/models/Version.js
+++ b/api/src/certification/shared/domain/models/Version.js
@@ -15,6 +15,8 @@ export class Version {
       .valid(...Object.values(Scopes)),
     challengesConfiguration: Joi.object()
       .keys({
+        maximumAssessmentLength: Joi.number().integer().min(0).required(),
+        challengesBetweenSameCompetence: Joi.number().integer().min(0).required(),
         defaultCandidateCapacity: Joi.number().required(),
       })
       .unknown(true)
@@ -26,6 +28,8 @@ export class Version {
    * @param {number} params.id - version identifier
    * @param {Scopes} params.scope - Certification scope (CORE, DROIT, etc.)
    * @param {Object} params.challengesConfiguration - Challenges configuration
+   * @param {number} params.challengesConfiguration.maximumAssessmentLength - limit for assessment length
+   * @param {number} params.challengesConfiguration.challengesBetweenSameCompetence - define a number of questions before getting another one on the same competence
    * @param {number} params.challengesConfiguration.defaultCandidateCapacity - capacity when none has been yet determined
    */
   constructor({ id, scope, challengesConfiguration }) {

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -461,7 +461,6 @@ const configuration = (function () {
       expirationDelaySeconds: ms(process.env.ANONYMOUS_USER_TOKEN_TEMPORARY_STORAGE_LIFESPAN || '1d') / 1000,
     },
     v3Certification: {
-      numberOfChallengesPerCourse: 32,
       defaultProbabilityToPickChallenge: parseInt(process.env.V3_CERTIFICATION_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
       scoring: {
         minimumAnswersRequiredToValidateACertification: 20,

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/versions-repository_test.js
@@ -9,11 +9,11 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
   describe('#create', function () {
     it('should create a certification version and link challenges', async function () {
       // given
-      const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+      const challengesConfiguration = {
         maximumAssessmentLength: 32,
         limitToOneQuestionPerTube: true,
         defaultCandidateCapacity: -8,
-      });
+      };
       const version = domainBuilder.certification.configuration.buildVersion({
         scope: Scopes.PIX_PLUS_DROIT,
         startDate: new Date('2025-06-01'),
@@ -98,11 +98,11 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
       await databaseBuilder.commit();
 
       const newExpirationDate = new Date('2025-10-21T10:00:00Z');
-      const newChallengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+      const newChallengesConfiguration = {
         maximumAssessmentLength: 32,
         limitToOneQuestionPerTube: true,
         defaultCandidateCapacity: 1,
-      });
+      };
       const versionToUpdate = domainBuilder.certification.configuration.buildVersion({
         id: existingVersion.id,
         scope: existingVersion.scope,
@@ -119,7 +119,7 @@ describe('Certification | Configuration | Integration | Repository | Versions', 
       const updatedVersion = await knex('certification_versions').where({ id: existingVersion.id }).first();
 
       expect(updatedVersion.expirationDate).to.deep.equal(newExpirationDate);
-      expect(updatedVersion.challengesConfiguration).to.deep.equal(newChallengesConfiguration);
+      expect(updatedVersion.challengesConfiguration).to.deep.equal(versionToUpdate.challengesConfiguration);
       expect(updatedVersion.scope).to.equal(existingVersion.scope);
       expect(updatedVersion.startDate).to.deep.equal(existingVersion.startDate);
     });

--- a/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/create-certification-version_test.js
@@ -172,6 +172,7 @@ describe('Certification | Configuration | Unit | UseCase | create-certification-
           assessmentDuration: DEFAULT_SESSION_DURATION_MINUTES,
           challengesConfiguration: new FlashAssessmentAlgorithmConfiguration({
             challengesBetweenSameCompetence: 0,
+            maximumAssessmentLength: 32,
             variationPercent: 1,
             defaultCandidateCapacity: 0,
           }),

--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v3_test.js
@@ -207,8 +207,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           .withArgs({
             challenges,
             allAnswers: answers,
-            capacity: sinon.match.number,
-            variationPercent: undefined,
+            capacity: version.challengesConfiguration.defaultCandidateCapacity,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns({
             capacity: expectedCapacity,
@@ -218,8 +218,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
           .withArgs({
             challenges: challengeCalibrationsWithoutLiveAlerts,
             allAnswers: answers,
-            capacity: sinon.match.number,
-            variationPercent: undefined,
+            capacity: version.challengesConfiguration.defaultCandidateCapacity,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns([
             {
@@ -377,8 +377,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -407,8 +407,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -521,8 +521,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({
                   challenges: answeredChallenges,
                   allAnswers: answers,
-                  capacity: sinon.match.number,
-                  variationPercent: undefined,
+                  capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                  variationPercent: version.challengesConfiguration.variationPercent,
                 })
                 .returns({
                   capacity: expectedCapacity,
@@ -531,8 +531,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({
                   challenges: challengeCalibrationsWithoutLiveAlerts,
                   allAnswers: answers,
-                  capacity: sinon.match.number,
-                  variationPercent: undefined,
+                  capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                  variationPercent: version.challengesConfiguration.variationPercent,
                 })
                 .returns([
                   {
@@ -647,8 +647,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({
                   challenges: allChallenges,
                   allAnswers: answers,
-                  capacity: sinon.match.number,
-                  variationPercent: undefined,
+                  capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                  variationPercent: version.challengesConfiguration.variationPercent,
                 })
                 .returns({
                   capacity: expectedCapacity,
@@ -658,8 +658,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
                 .withArgs({
                   challenges: challengeCalibrationsWithoutLiveAlerts,
                   allAnswers: answers,
-                  capacity: sinon.match.number,
-                  variationPercent: undefined,
+                  capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                  variationPercent: version.challengesConfiguration.variationPercent,
                 })
                 .returns([
                   {
@@ -815,8 +815,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -826,8 +826,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -938,8 +938,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -949,8 +949,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -1074,8 +1074,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -1085,8 +1085,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -1205,8 +1205,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: [challengeExcludedFromCalibration, ...challengesAfterCalibration],
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -1215,8 +1215,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -1331,8 +1331,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -1342,8 +1342,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -1459,8 +1459,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: answeredChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -1470,8 +1470,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {
@@ -1585,8 +1585,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: allChallenges,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns({
                 capacity: expectedCapacity,
@@ -1596,8 +1596,8 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V3', f
               .withArgs({
                 challenges: challengeCalibrationsWithoutLiveAlerts,
                 allAnswers: answers,
-                capacity: sinon.match.number,
-                variationPercent: undefined,
+                capacity: version.challengesConfiguration.defaultCandidateCapacity,
+                variationPercent: version.challengesConfiguration.variationPercent,
               })
               .returns([
                 {

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-certification-course_test.js
@@ -37,8 +37,9 @@ describe('Unit | UseCase | get-certification-course', function () {
       getByScopeAndReconciliationDate: sinon.stub(),
     };
 
-    const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 42 });
-    version = domainBuilder.certification.shared.buildVersion({ challengesConfiguration });
+    version = domainBuilder.certification.shared.buildVersion({
+      challengesConfiguration: { maximumAssessmentLength: 42 },
+    });
   });
 
   it('should get the certificationCourse with numberOfChallenges from version', async function () {

--- a/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
+++ b/api/tests/certification/evaluation/unit/domain/usecases/get-next-challenge_test.js
@@ -130,7 +130,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             allAnswers: [],
             challenges: [nextCalibratedChallenge],
             capacity: version.challengesConfiguration.defaultCandidateCapacity,
-            variationPercent: undefined,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns({ capacity: 0 });
 
@@ -238,7 +238,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               allAnswers: [],
               challenges: [nextCalibratedChallenge, accessibleChallenge],
               capacity: version.challengesConfiguration.defaultCandidateCapacity,
-              variationPercent: undefined,
+              variationPercent: version.challengesConfiguration.variationPercent,
             })
             .returns({ capacity: 0 });
 
@@ -401,7 +401,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             allAnswers: [answerStillValid, answerWithOutdatedChallenge],
             challenges: [alreadyAnsweredChallenge, outdatedChallenge, nextCalibratedChallenge],
             capacity: version.challengesConfiguration.defaultCandidateCapacity,
-            variationPercent: undefined,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns({ capacity: 0 });
 
@@ -496,7 +496,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             allAnswers: [],
             challenges: [nextCalibratedChallenge],
             capacity: version.challengesConfiguration.defaultCandidateCapacity,
-            variationPercent: undefined,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns({ capacity: 0 });
 
@@ -606,7 +606,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
             allAnswers: [],
             challenges: [calibratedChallengeWithOtherSkill],
             capacity: version.challengesConfiguration.defaultCandidateCapacity,
-            variationPercent: undefined,
+            variationPercent: version.challengesConfiguration.variationPercent,
           })
           .returns({ capacity: 0 });
 
@@ -677,8 +677,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
           getCapacityAndErrorRate: sinon.stub(),
         };
 
-        const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({ maximumAssessmentLength: 1 });
-        version = domainBuilder.certification.shared.buildVersion({ challengesConfiguration });
+        version = domainBuilder.certification.shared.buildVersion({
+          challengesConfiguration: { maximumAssessmentLength: 1 },
+        });
         versionRepository.getByScopeAndReconciliationDate.resolves(version);
 
         answerRepository.findByAssessmentExcludingChallengeIds
@@ -756,8 +757,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge', function () {
               version: AlgorithmEngineVersion.V3,
             });
 
-            const challengesConfiguration = domainBuilder.buildFlashAlgorithmConfiguration(flashConfiguration);
-            version = domainBuilder.certification.shared.buildVersion({ challengesConfiguration });
+            version = domainBuilder.certification.shared.buildVersion({ challengesConfiguration: flashConfiguration });
             versionRepository.getByScopeAndReconciliationDate.resolves(version);
 
             const assessment = domainBuilder.buildAssessment();

--- a/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
+++ b/api/tests/certification/shared/unit/domain/models/FlashAssessmentAlgorithmConfiguration_test.js
@@ -13,6 +13,28 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
       defaultCandidateCapacity: -3,
     };
     context('maximumAssessmentLength', function () {
+      it('should throw an EntityValidationError if it is missing', function () {
+        // given
+        delete params.maximumAssessmentLength;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
+
+      it('should throw an EntityValidationError if it is null', function () {
+        // given
+        params.maximumAssessmentLength = null;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
+
       it('should throw an EntityValidationError if it is not an integer', function () {
         // given
         params.maximumAssessmentLength = 1.5;
@@ -37,6 +59,17 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
     });
 
     context('challengesBetweenSameCompetence', function () {
+      it('should throw an EntityValidationError if it is missing', function () {
+        // given
+        delete params.challengesBetweenSameCompetence;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
+
       it('should throw an EntityValidationError if it is not an integer', function () {
         // given
         params.challengesBetweenSameCompetence = 1.5;
@@ -122,6 +155,17 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithmConfiguration', funct
     });
 
     context('defaultCandidateCapacity', function () {
+      it('should throw an EntityValidationError if it is missing', function () {
+        // given
+        delete params.defaultCandidateCapacity;
+
+        // when
+        const err = catchErrSync(() => new FlashAssessmentAlgorithmConfiguration(params))();
+
+        // then
+        expect(err).to.be.an.instanceOf(EntityValidationError);
+      });
+
       it('should throw an EntityValidationError if it is not a number', function () {
         // given
         params.defaultCandidateCapacity = 'not a number';

--- a/api/tests/certification/shared/unit/domain/models/Version_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Version_test.js
@@ -10,7 +10,11 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 123,
         scope: Scopes.CORE,
-        challengesConfiguration: { minChallenges: 5, maxChallenges: 10, defaultCandidateCapacity: 1 },
+        challengesConfiguration: {
+          challengesBetweenSameCompetence: 0,
+          maximumAssessmentLength: 10,
+          defaultCandidateCapacity: 1,
+        },
       };
 
       // when
@@ -21,8 +25,8 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version.id).to.equal(123);
       expect(version.scope).to.equal(Scopes.CORE);
       expect(version.challengesConfiguration).to.deep.equal({
-        minChallenges: 5,
-        maxChallenges: 10,
+        challengesBetweenSameCompetence: 0,
+        maximumAssessmentLength: 10,
         defaultCandidateCapacity: 1,
       });
     });
@@ -32,7 +36,11 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       const versionData = {
         id: 456,
         scope: Scopes.PIX_PLUS_DROIT,
-        challengesConfiguration: { defaultCandidateCapacity: -3 },
+        challengesConfiguration: {
+          challengesBetweenSameCompetence: 0,
+          maximumAssessmentLength: 10,
+          defaultCandidateCapacity: -3,
+        },
       };
 
       // when
@@ -42,7 +50,11 @@ describe('Unit | Certification | Evaluation | Domain | Models | Version', functi
       expect(version).to.be.instanceOf(Version);
       expect(version.id).to.equal(456);
       expect(version.scope).to.equal(Scopes.PIX_PLUS_DROIT);
-      expect(version.challengesConfiguration).to.deep.equal({ defaultCandidateCapacity: -3 });
+      expect(version.challengesConfiguration).to.deep.equal({
+        challengesBetweenSameCompetence: 0,
+        maximumAssessmentLength: 10,
+        defaultCandidateCapacity: -3,
+      });
     });
 
     it('should throw an EntityValidationError when id is missing', function () {

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-version.js
@@ -20,6 +20,6 @@ export const buildVersion = ({
     assessmentDuration,
     globalScoringConfiguration,
     competencesScoringConfiguration,
-    challengesConfiguration: challengesConfiguration ?? buildFlashAlgorithmConfiguration(),
+    challengesConfiguration: buildFlashAlgorithmConfiguration(challengesConfiguration),
   });
 };

--- a/api/tests/tooling/domain-builder/factory/certification/shared/build-version.js
+++ b/api/tests/tooling/domain-builder/factory/certification/shared/build-version.js
@@ -1,14 +1,11 @@
 import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
 import { Version } from '../../../../../../src/certification/shared/domain/models/Version.js';
+import { buildFlashAlgorithmConfiguration } from '../../build-flash-algorithm-configuration.js';
 
-export const buildVersion = ({
-  id = 1,
-  scope = Scopes.CORE,
-  challengesConfiguration = { defaultCandidateCapacity: -3 },
-} = {}) => {
+export const buildVersion = ({ id = 1, scope = Scopes.CORE, challengesConfiguration } = {}) => {
   return new Version({
     id,
     scope,
-    challengesConfiguration,
+    challengesConfiguration: buildFlashAlgorithmConfiguration(challengesConfiguration),
   });
 };


### PR DESCRIPTION
## ❄️ Problème

Il y a encore des endroits du code qui utilisent les valeurs de config.js au lieu des valeurs en BDD (table `certification-version`)

## 🛷 Proposition
- Supprimer tous les usages qui proviennent de config.js
- Puiser toujours la valeur depuis le referentiel de certification
- Seeds : la valeur est actuellement a null => la mettre a 2
- Ajouter le Joi pour ne jamais permettre une valeur undefined/null

## ☃️ Remarques

## 🧑‍🎄 Pour tester

- Créer une session et y ajouter des candidats
- Passer la certification
- Vérifier que la certification comporte le nombre de questions spécifié par la config
