### PR TITLE
[FEATURE] Revoir le style global du formulaire de création d'organisation (PIX-20699)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -95,25 +95,31 @@ export default class OrganizationCreationForm extends Component {
 
   <template>
     <form class="admin-form" {{on "submit" @onSubmit}}>
-      <section class="admin-form__content admin-form__content--with-counters">
-        <Card class="admin-form__card" @title="Information générique">
+      <p class="admin-form__mandatory-text">
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
+      </p>
+      <section class="admin-form__content admin-form__content--with-counters organization-creation-form">
+        <Card class="admin-form__card organization-creation-form__card" @title="Information générique">
           {{#if @parentOrganizationName}}
-            <h2 class="admin-form__content title">
+            <h2 class="admin-form__content title organization-creation-form__parent-name--full">
               {{t
                 "components.organizations.creation.parent-organization-name"
                 parentOrganizationName=@parentOrganizationName
               }}
             </h2>
           {{/if}}
-          <PixInput
-            @id="organizationName"
-            onchange={{this.handleOrganizationNameChange}}
-            required={{true}}
-            aria-required={{true}}
-            @requiredLabel={{t "common.fields.required-field"}}
-          >
-            <:label>Nom</:label>
-          </PixInput>
+
+          <div class="organization-creation-form__input--full">
+            <PixInput
+              @id="organizationName"
+              onchange={{this.handleOrganizationNameChange}}
+              required={{true}}
+              aria-required={{true}}
+              @requiredLabel={{t "common.fields.required-field"}}
+            >
+              <:label>Nom</:label>
+            </PixInput>
+          </div>
 
           <PixSelect
             @onChange={{this.handleOrganizationTypeSelectionChange}}
@@ -129,10 +135,6 @@ export default class OrganizationCreationForm extends Component {
             <:default as |organizationType|>{{organizationType.label}}</:default>
           </PixSelect>
 
-          <PixInput @id="externalId" {{on "input" (fn this.handleInputChange "externalId")}}>
-            <:label>{{t "components.organizations.creation.external-id"}}</:label>
-          </PixInput>
-
           <PixSelect
             @onChange={{this.handleAdministrationTeamSelectionChange}}
             @options={{this.administrationTeamsOptions}}
@@ -145,10 +147,6 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>{{t "components.organizations.creation.administration-team.selector.label"}}</:label>
           </PixSelect>
-
-          <PixInput @id="provinceCode" {{on "input" (fn this.handleInputChange "provinceCode")}}>
-            <:label>{{t "components.organizations.creation.province-code"}}</:label>
-          </PixInput>
 
           <PixSelect
             @onChange={{this.handleCountrySelectionChange}}
@@ -164,24 +162,39 @@ export default class OrganizationCreationForm extends Component {
             <:label>{{t "components.organizations.creation.country.selector.label"}}</:label>
           </PixSelect>
 
+          <PixInput @id="provinceCode" {{on "input" (fn this.handleInputChange "provinceCode")}}>
+            <:label>{{t "components.organizations.creation.province-code"}}</:label>
+          </PixInput>
+
+          <div class="organization-creation-form__input--full">
+            <PixInput @id="externalId" {{on "input" (fn this.handleInputChange "externalId")}}>
+              <:label>{{t "components.organizations.creation.external-id"}}</:label>
+            </PixInput>
+          </div>
         </Card>
 
-        <Card class="admin-form__card" @title="Configuration">
-          <PixInput @id="documentationUrl" onchange={{this.handleDocumentationUrlChange}}>
-            <:label>Lien vers la documentation</:label>
-          </PixInput>
+        <Card class="admin-form__card organization-creation-form__card" @title="Configuration">
+          <div class="organization-creation-form__input--full">
+            <PixInput @id="documentationUrl" onchange={{this.handleDocumentationUrlChange}}>
+              <:label>Lien vers la documentation</:label>
+            </PixInput>
+          </div>
         </Card>
 
-        <Card class="admin-form__card" @title="Data Privacy Officer">
-          <PixInput @id="dataProtectionOfficerFirstName" onchange={{this.handleDataProtectionOfficerFirstNameChange}}>
-            <:label>Prénom du DPO</:label>
-          </PixInput>
+        <Card class="admin-form__card organization-creation-form__card" @title="Data Privacy Officer">
           <PixInput @id="dataProtectionOfficerLastName" onchange={{this.handleDataProtectionOfficerLastNameChange}}>
             <:label>Nom du DPO</:label>
           </PixInput>
-          <PixInput @id="dataProtectionOfficerEmail" onchange={{this.handleDataProtectionOfficerEmailChange}}>
-            <:label>Adresse e-mail du DPO</:label>
+
+          <PixInput @id="dataProtectionOfficerFirstName" onchange={{this.handleDataProtectionOfficerFirstNameChange}}>
+            <:label>Prénom du DPO</:label>
           </PixInput>
+
+          <div class="organization-creation-form__input--full">
+            <PixInput @id="dataProtectionOfficerEmail" onchange={{this.handleDataProtectionOfficerEmailChange}}>
+              <:label>Adresse e-mail du DPO</:label>
+            </PixInput>
+          </div>
         </Card>
       </section>
 

--- a/admin/app/components/organizations/creation-form.scss
+++ b/admin/app/components/organizations/creation-form.scss
@@ -1,0 +1,38 @@
+@use 'pix-design-tokens/typography';
+
+.organization-creation-form {
+  &__card {
+    .card__content {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: var(--pix-spacing-6x);
+      row-gap: var(--pix-spacing-6x);
+    }
+
+    .card__content > * + * {
+      margin-top: 0px;
+    }
+
+    .pix-select {
+      width: 100%;
+    }
+
+    .pix-input__input {
+      height: 42px;
+    }
+  }
+
+  &__input {
+    &--full {
+      grid-column: 1 / span 2;
+
+      .pix-input {
+        width: 100%;
+      }
+    }
+  }
+
+  &__parent-name--full {
+    grid-column: 1 / span 2;
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -113,3 +113,4 @@
 @use 'certification-centers/member-item' as *;
 @use 'certification-centers/membership-item' as *;
 @use 'certification-centers/invitations-action' as *;
+@use 'organizations/creation-form' as *;

--- a/admin/app/styles/components/card.scss
+++ b/admin/app/styles/components/card.scss
@@ -11,7 +11,7 @@
 
     padding: 11px 32px;
     color: var(--pix-neutral-0);
-    background: var(--pix-neutral-800);
+    background: var(--pix-primary-900);
     border-radius: 8px 8px 0 0;
   }
 
@@ -21,7 +21,8 @@
     @extend %pix-body-s;
 
     // add to pix-ui possibility to change the layout to a component
-    & > .pix-input, .pix-select {
+    & > .pix-input,
+    .pix-select {
       display: flex;
     }
   }

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -6,6 +6,7 @@
     height: auto;
   }
 
+  // TODO: replace elements that have this class, with admin-form__mandatory-text class defined below
   &__instructions {
     display: block;
     margin-bottom: 10px;
@@ -113,11 +114,11 @@
   grid-template-columns: 1fr;
   gap: var(--pix-spacing-6x);
 
-    .title {
-      @extend %pix-title-xs;
+  .title {
+    @extend %pix-title-xs;
 
-      color: var(--pix-neutral-900);
-    }
+    color: var(--pix-neutral-900);
+  }
 }
 
 .admin-form__card {


### PR DESCRIPTION
## ❄️ Problème

Dans le cadre de la refonte du formulaire de création d'organisation, le visuel doit changer.

## 🛷 Proposition

Revoir le style et la disposition des différents champs pour se conformer à la maquette.

## ☃️ Remarques

- Une future PR s'occupera de renommer et traduire les différents champs.
- Suite aux commentaires sur l'absence de titre h1 sur notre page, celui-ci sera ajouté dans un futur ticket (maquette en attente)
- La couleur des en-têtes des différentes sections a été changée pour se conformer à la couleur primaire de Pix Admin (pix-primary-900), et ce, à tous les endroits qui utilisent ce composant **Card**

## 🧑‍🎄 Pour tester

Sur Pix Admin,
- aller sur la page de création d'orga
- constater le nouveau style de la page
- aller voir aussi la page **Créer une orga fille** depuis une organisation mère avec un long nom
- ne pas hésiter à faire un tour sur les autres pages de Pix Admin utilisant des formulaires pour vérifier que leur style n'a pas été impacté

<img width="1086" height="801" alt="image" src="https://github.com/user-attachments/assets/f77d0088-5188-4223-952d-e8ef9bf06529" />

