### PR TITLE
[TECH] Appliquer des correctifs sur la gestions des images des badges (PIX-20733).

### DIFF
--- a/admin/app/components/badges/badge.gjs
+++ b/admin/app/components/badges/badge.gjs
@@ -69,13 +69,15 @@ export default class Badge extends Component {
       await this.args.onUpdateBadge(badgeDTO);
       this.pixToast.sendSuccessNotification({ message: 'Le badge a été mis à jour.' });
       this.editMode = false;
-    } catch (err) {
+    } catch (error) {
       let errorMessage;
-      err.errors.forEach((error) => {
+      error.errors.forEach((error) => {
         if (error?.code === 'BADGE_KEY_UNIQUE_CONSTRAINT_VIOLATED') {
           errorMessage = this.intl.t('components.badges.api-error-messages.key-already-exists', {
             badgeKey: error.meta,
           });
+        } else if (error?.detail.includes('data.attributes.image-url')) {
+          errorMessage = this.intl.t('components.badges.api-error-messages.incorrect-image-url-format');
         } else {
           errorMessage = error.detail;
         }

--- a/api/src/evaluation/application/badges/badges-controller.js
+++ b/api/src/evaluation/application/badges/badges-controller.js
@@ -1,6 +1,6 @@
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import { sharedUsecases } from '../../../shared/domain/usecases/index.js';
-import { deserializer as badgeCreationDeserializer } from '../../infrastructure/serializers/jsonapi/badge-creation-serializer.js';
+import { badgeCreationDeserializer } from '../../infrastructure/serializers/jsonapi/badge-creation-serializer.js';
 import * as badgeSerializer from '../../infrastructure/serializers/jsonapi/badge-serializer.js';
 
 const updateBadge = async function (request, h) {

--- a/api/src/evaluation/application/badges/badges-controller.js
+++ b/api/src/evaluation/application/badges/badges-controller.js
@@ -1,7 +1,7 @@
 import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
 import { sharedUsecases } from '../../../shared/domain/usecases/index.js';
 import { badgeCreationDeserializer } from '../../infrastructure/serializers/jsonapi/badge-creation-serializer.js';
-import * as badgeSerializer from '../../infrastructure/serializers/jsonapi/badge-serializer.js';
+import { badgeSerializer } from '../../infrastructure/serializers/jsonapi/badge-serializer.js';
 
 const updateBadge = async function (request, h) {
   const badgeId = request.params.id;

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/badge-creation-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/badge-creation-serializer.js
@@ -2,8 +2,18 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Deserializer } = jsonapiSerializer;
 
-const deserializer = new Deserializer({
-  keyForAttribute: 'camelCase',
-});
+const deserialize = function (payload) {
+  return new Deserializer({
+    keyForAttribute: 'camelCase',
+  })
+    .deserialize(payload)
+    .then((record) => {
+      return {
+        ...record,
+        imageUrl: record.imageUrl.trim(),
+      };
+    });
+};
 
-export { deserializer };
+const badgeCreationDeserializer = { deserialize };
+export { badgeCreationDeserializer };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -1,6 +1,7 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
+const { Deserializer } = jsonapiSerializer;
 
 const serialize = function (badge = {}) {
   return new Serializer('badge', {
@@ -9,16 +10,23 @@ const serialize = function (badge = {}) {
   }).serialize(badge);
 };
 
-const deserialize = function (json) {
-  return {
-    key: json.data.attributes['key'],
-    altMessage: json.data.attributes['alt-message'],
-    message: json.data.attributes['message'],
-    title: json.data.attributes['title'],
-    isCertifiable: json.data.attributes['is-certifiable'],
-    isAlwaysVisible: json.data.attributes['is-always-visible'],
-    imageUrl: json.data.attributes['image-url'],
-  };
+const deserialize = function (payload) {
+  return new Deserializer({
+    keyForAttribute: 'camelCase',
+  })
+    .deserialize(payload)
+    .then((record) => {
+      return {
+        key: record.key,
+        altMessage: record.altMessage,
+        message: record.message,
+        title: record.title,
+        isCertifiable: record.isCertifiable,
+        isAlwaysVisible: record.isAlwaysVisible,
+        imageUrl: record.imageUrl.trim(),
+      };
+    });
 };
 
-export { deserialize, serialize };
+const badgeSerializer = { deserialize, serialize };
+export { badgeSerializer };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -13,7 +13,7 @@ const implementationType = {
   uuid: Joi.string().uuid(),
 };
 
-const badgeImageUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/badges\/.*.svg$/);
+const badgeImageUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/badges\/.*\.(svg|png)$/);
 const certificationVerificationCodeType = Joi.string().regex(/^P-[a-zA-Z0-9]{8}$/);
 const editorLogoUrlValidation = new RegExp(/^https:\/\/assets.pix.org\/contenu-formatif\/editeur\/.*\.svg$/);
 

--- a/api/tests/evaluation/integration/application/badges/index_test.js
+++ b/api/tests/evaluation/integration/application/badges/index_test.js
@@ -5,7 +5,7 @@ import * as badgesRouter from '../../../../../src/evaluation/application/badges/
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Application | Badges | Routes', function () {
+describe('Integration | Application | Badges | Routes', function () {
   describe('POST /api/admin/target-profiles/{id}/badges', function () {
     const method = 'POST';
     const url = '/api/admin/target-profiles/123/badges';
@@ -143,7 +143,7 @@ describe('Unit | Application | Badges | Routes', function () {
         });
       });
 
-      context('when the imageUrl is not a valid url (allow png ang svg only)', function () {
+      context('when the imageUrl is not a valid url (allow png and svg only)', function () {
         it('should return 400', async function () {
           // given
           const httpTestServer = new HttpTestServer();
@@ -299,7 +299,7 @@ describe('Unit | Application | Badges | Routes', function () {
         });
       });
 
-      context('when the imageUrl is not a valid url (allow png ang svg only)', function () {
+      context('when the imageUrl is not a valid url (allow png and svg only)', function () {
         it('should return 400', async function () {
           // given
           validPayload.data = {

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-creation-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-creation-serializer_test.js
@@ -1,4 +1,4 @@
-import { deserializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-creation-serializer.js';
+import { badgeCreationDeserializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-creation-serializer.js';
 import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | badge-creation-serializer', function () {
@@ -11,7 +11,7 @@ describe('Unit | Serializer | JSONAPI | badge-creation-serializer', function () 
           attributes: {
             key: 'BADGE_KEY',
             'alt-message': 'alt-message',
-            'image-url': 'https://assets.pix.org/badges/badge_url.svg',
+            'image-url': '    https://assets.pix.org/badges/badge_url.svg   ',
             message: 'message',
             title: 'title',
             'is-certifiable': false,
@@ -22,7 +22,7 @@ describe('Unit | Serializer | JSONAPI | badge-creation-serializer', function () 
       };
 
       // when
-      const badgeCreation = await deserializer.deserialize(jsonBadge);
+      const badgeCreation = await badgeCreationDeserializer.deserialize(jsonBadge);
 
       // then
       const expectedBadgeCreation = {

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -1,4 +1,4 @@
-import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-serializer.js';
+import { badgeSerializer } from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-serializer.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(badge);
+      const json = badgeSerializer.serialize(badge);
 
       // then
       expect(json).to.deep.equal(expectedSerializedBadge);
@@ -71,7 +71,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(badge);
+      const json = badgeSerializer.serialize(badge);
 
       // then
       expect(json).to.deep.equal(expectedSerializedBadge);
@@ -108,7 +108,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
       };
 
       // when
-      const json = serializer.serialize(badge);
+      const json = badgeSerializer.serialize(badge);
 
       // then
       expect(json).to.deep.equal(expectedSerializedBadge);
@@ -124,7 +124,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
           attributes: {
             key: 'BADGE_KEY',
             'alt-message': 'alt-message',
-            'image-url': 'https://example.net/image.svg',
+            'image-url': '    https://example.net/image.svg ',
             message: 'message',
             title: 'title',
             'is-certifiable': false,
@@ -135,7 +135,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function () {
       };
 
       // when
-      const badge = await serializer.deserialize(jsonBadge);
+      const badge = await badgeSerializer.deserialize(jsonBadge);
 
       // then
       const expectedBadge = {


### PR DESCRIPTION
## ❄️ Problème

Un chantier de migrations des images vers Pix Assets ) inclut un travail coté Pix Admin/API pour autoriser l'utilisateur à ne mettre que des urls complètes pour les images de badges, suivant un path bien spécifique ET terminant par SVG.
Or de nombreuses images de badges stockés sur Pix Assets sont aussi en PNG.

## 🛷 Proposition

Plusieurs choses ici : 
- Permettre la création de badge et la mise à jour en appliquant une url d'image en PNG ET SVG uniquement.
- Ajouter un message métier pour le message d'erreur de la mise à jour d'un badge avec une url au mauvais format
- Appliquer un trim coté API pour les urls

## ☃️ Remarques

On maintient le pattern SVG only pour les logos des contenus formatifs, car nous avons uniquement du SVG coté Pix Assets.
En cas d'ajout en PNG, le métier devra transformer le fichier en amont.

## 🧑‍🎄 Pour tester

- https://admin-pr14400.review.pix.fr/organizations/list
- Choisir un profil cible
- Aller dans l'onglet Clés de lecture
- Créer un nouveau badge
- Compléter le plus de champ possible (on teste ainsi le serializer API modifié dans cette PR)
- Dans le champ url du badge, mettre une url existante dans Pix Assets mais remplacer le type par JPG (ex :` https://assets.pix.org/badges/coucou-hibou.jpg` )
- Constater que le formulaire renvoit une erreur métier "format incorrect"
- Modifier l'url et ne pas mettre le type de l'image (ex: ` https://assets.pix.org/badges/coucou-hibou`) 
- Encore une erreur
- Modifier l'url et mettre PNG (ex: ` https://assets.pix.org/badges/coucou-hibou.png`) 
- Le badge est créé
- Constater que les champs sont bien remplis avec les infos
- Créer un autre badge avec SVG cette fois ci
- Le badge est créé
- Maintenant modifier un des badges avec les mêmes logiques (mettre JPG, mettre aucun type, puis PNG ou SVG)
