### PR TITLE
[FEATURE] Ajouter une page de listing des schémas de parcours combinés dans Admin (PIX-20726) 

### DIFF
--- a/admin/app/components/combined-course-blueprints/list-summary-items.gjs
+++ b/admin/app/components/combined-course-blueprints/list-summary-items.gjs
@@ -1,0 +1,52 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { t } from 'ember-intl';
+import formatDate from 'ember-intl/helpers/format-date';
+
+import RequirementTag from '../common/combined-courses/requirement-tag';
+
+<template>
+  {{#if @summaries}}
+    <PixTable
+      @variant="admin"
+      @data={{@summaries}}
+      @caption={{t "components.combined-course-blueprints.list.table.caption"}}
+      class="table"
+    >
+      <:columns as |blueprint context|>
+        <PixTableColumn @context={{context}} class="combinedCourseBlueprint__column--compact">
+          <:header>
+            {{t "common.fields.id"}}
+          </:header>
+          <:cell>
+            {{blueprint.id}}
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "common.fields.internalName"}}
+          </:header>
+          <:cell>
+            {{blueprint.internalName}}
+            <details>
+              <summary>{{t "components.combined-course-blueprints.list.content"}}</summary>
+              {{#each blueprint.content as |requirement|}}
+                <RequirementTag @type={{requirement.type}} @value={{requirement.value}} />
+              {{/each}}
+            </details>
+          </:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}} class="combinedCourseBlueprint__column--compact">
+          <:header>
+            {{t "common.fields.createdAt"}}
+          </:header>
+          <:cell>
+            {{formatDate blueprint.createdAt}}
+          </:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  {{else}}
+    <div class="table__empty">{{t "common.tables.empty-result"}}</div>
+  {{/if}}
+</template>

--- a/admin/app/components/common/combined-courses/requirement-tag.gjs
+++ b/admin/app/components/common/combined-courses/requirement-tag.gjs
@@ -1,0 +1,16 @@
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { t } from 'ember-intl';
+
+const getItemColor = (type) => (type === 'evaluation' ? 'purple' : 'blue');
+const getItemType = (type) =>
+  type === 'evaluation'
+    ? 'components.combined-course-blueprints.items.targetProfile'
+    : 'components.combined-course-blueprints.items.module';
+
+<template>
+  <PixTag @color={{getItemColor @type}}>
+    {{t (getItemType @type)}}
+    -
+    {{@value}}
+  </PixTag>
+</template>

--- a/admin/app/components/layout/sidebar.gjs
+++ b/admin/app/components/layout/sidebar.gjs
@@ -81,6 +81,16 @@ export default class Sidebar extends Component {
         {{/if}}
 
         {{#if this.currentUser.adminMember.isSuperAdmin}}
+          <PixNavigationButton
+            class="sidebar__link"
+            @route="authenticated.combined-course-blueprints.list"
+            @icon="studyLesson"
+          >
+            {{t "components.layout.sidebar.combined-course-blueprints"}}
+          </PixNavigationButton>
+        {{/if}}
+
+        {{#if this.currentUser.adminMember.isSuperAdmin}}
           <PixNavigationButton class="sidebar__link" @route="authenticated.team" @icon="users">
             {{t "components.layout.sidebar.team"}}
           </PixNavigationButton>

--- a/admin/app/models/combined-course-blueprint.js
+++ b/admin/app/models/combined-course-blueprint.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CombinedCourseBlueprint extends Model {
+  @attr('string') internalName;
+  @attr('date') createdAt;
+  @attr() content;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -178,6 +178,10 @@ Router.map(function () {
     this.route('smart-random-simulator', function () {
       this.route('get-next-challenge');
     });
+
+    this.route('combined-course-blueprints', function () {
+      this.route('list');
+    });
   });
 
   this.route('authentication', { path: '/connexion' }, function () {

--- a/admin/app/routes/authenticated/combined-course-blueprints/list.js
+++ b/admin/app/routes/authenticated/combined-course-blueprints/list.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ListRoute extends Route {
+  @service('store') store;
+
+  model() {
+    return this.store.findAll('combined-course-blueprint');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -28,6 +28,7 @@
 /* components */
 @use 'components/quests/form' as *;
 @use 'components/combined-course/form' as *;
+@use 'components/combined-course-blueprints/list' as *;
 @use 'components/administration' as *;
 @use 'components/administration/certification/certification-scoring-configuration' as *;
 @use 'components/administration/certification/competence-scoring-configuration' as *;

--- a/admin/app/styles/components/combined-course-blueprints/list.scss
+++ b/admin/app/styles/components/combined-course-blueprints/list.scss
@@ -1,0 +1,16 @@
+.combinedCourseBlueprint {
+  &__column {
+    &--compact {
+      width: 1px;
+      white-space: nowrap;
+      vertical-align: top;
+    }
+  }
+}
+
+details {
+  & > summary {
+    width: fit-content;
+    cursor: pointer;
+  }
+}

--- a/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
+++ b/admin/app/templates/authenticated/combined-course-blueprints/list.gjs
@@ -1,0 +1,16 @@
+import { t } from 'ember-intl';
+import CombinedCourseBlueprintListSummaryItems from 'pix-admin/components/combined-course-blueprints/list-summary-items';
+
+<template>
+  <div class="page">
+    <header>
+      <h1>{{t "components.combined-course-blueprints.list.title"}}</h1>
+    </header>
+
+    <main class="page-body">
+      <section>
+        <CombinedCourseBlueprintListSummaryItems @summaries={{@model}} />
+      </section>
+    </main>
+  </div>
+</template>

--- a/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/list-summary-items-test.gjs
@@ -1,0 +1,30 @@
+import { render } from '@1024pix/ember-testing-library';
+import ListSummaryItems from 'pix-admin/components/combined-course-blueprints/list-summary-items';
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+
+module('Integration | Component | CombinedCourseBlueprints::ListSummaryItems', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display combined courses summary', async function (assert) {
+    // given
+    const combinedCourseBlueprint = {
+      id: 123,
+      internalName: 'Modèle de parcours apprenant',
+      createdAt: new Date('2025-12-25'),
+      content: [{ type: 'module', value: 'abc-123' }],
+    };
+
+    const summaries = [combinedCourseBlueprint];
+
+    // when
+    const screen = await render(<template><ListSummaryItems @summaries={{summaries}} /></template>);
+
+    // then
+    assert.dom(screen.getByText('123')).exists();
+    assert.dom(screen.getByText('Modèle de parcours apprenant')).exists();
+    assert.dom(screen.getByText('25/12/2025')).exists();
+    assert.dom(screen.getByText('Module', { exact: false })).exists();
+    assert.dom(screen.getByText('abc-123', { exact: false })).exists();
+  });
+});

--- a/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
+++ b/admin/tests/integration/components/common/combined-courses/requirement-tag-test.gjs
@@ -1,0 +1,31 @@
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import RequirementTag from 'pix-admin/components/common/combined-courses/requirement-tag';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  common/combined-courses/requirement-tag', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a module item when type is not evaluation', async function (assert) {
+    const item = {
+      type: 'module',
+      value: 'abc-123',
+    };
+    const screen = await renderScreen(
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
+    );
+    assert.ok(screen.getByText(t('components.combined-course-blueprints.items.module'), { exact: false }));
+  });
+  test('should display a target profile item when type is evaluation', async function (assert) {
+    const item = {
+      type: 'evaluation',
+      value: 1,
+    };
+    const screen = await renderScreen(
+      <template><RequirementTag @type={{item.type}} @value={{item.value}} /></template>,
+    );
+    assert.ok(screen.getByText(t('components.combined-course-blueprints.items.targetProfile'), { exact: false }));
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -27,15 +27,15 @@
       "pix-admin-login-from-password-disabled-error": "Email and password login is disabled. Please use SSO to log in."
     },
     "fields": {
-      "createdAt": "creation date",
-      "id": "id",
-      "internalName": "internal name",
-      "name": "name",
+      "createdAt": "Creation date",
+      "id": "Id",
+      "internalName": "Internal name",
+      "name": "Name",
       "required-field": "Required field",
-      "status": "status",
+      "status": "Status",
       "target-profile": {
         "category": {
-          "name": "category",
+          "name": "Category",
           "tags": {
             "BACK_TO_SCHOOL": "Back to school",
             "COMPETENCES": "Pix Competences",
@@ -438,6 +438,19 @@
         "placeholder": "Certification ID"
       }
     },
+    "combined-course-blueprints": {
+      "items": {
+        "module": "Module",
+        "targetProfile": "Target profile"
+      },
+      "list": {
+        "content": "Contenu",
+        "table": {
+          "caption": "List of combined course blueprints"
+        },
+        "title": "All learner courses"
+      }
+    },
     "combined-courses": {
       "create-form": {
         "addItemButton": "Add",
@@ -552,6 +565,7 @@
         "certification-frameworks": "Certif frameworks",
         "certification-frameworks-label": "Certification frameworks",
         "certifications": "Certifications",
+        "combined-course-blueprints": "Courses blueprints",
         "labels": {
           "close": "Close navigation",
           "main": "Main navigation",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -27,15 +27,15 @@
       "pix-admin-login-from-password-disabled-error": "La connexion par email et mot de passe est désactivée. Utilisez un SSO pour vous connecter."
     },
     "fields": {
-      "createdAt": "date de création",
+      "createdAt": "Date de création",
       "id": "ID",
-      "internalName": "nom interne",
-      "name": "nom",
+      "internalName": "Nom interne",
+      "name": "Nom",
       "required-field": "Champ obligatoire",
-      "status": "statut",
+      "status": "Statut",
       "target-profile": {
         "category": {
-          "name": "catégorie",
+          "name": "Catégorie",
           "tags": {
             "BACK_TO_SCHOOL": "Parcours de rentrée / 6e",
             "COMPETENCES": "Les 16 compétences",
@@ -438,6 +438,19 @@
         "placeholder": "ID de la certification"
       }
     },
+    "combined-course-blueprints": {
+      "items": {
+        "module": "Module",
+        "targetProfile": "Profil Cible"
+      },
+      "list": {
+        "content": "Contenu",
+        "table": {
+          "caption": "Liste des schémas de parcours combinés"
+        },
+        "title": "Tous les schémas de parcours combinés"
+      }
+    },
     "combined-courses": {
       "create-form": {
         "addItemButton": "Ajouter",
@@ -553,6 +566,7 @@
         "certification-frameworks": "Référentiels de certif",
         "certification-frameworks-label": "Référentiels de certification",
         "certifications": "Certifications",
+        "combined-course-blueprints": "Schémas de parcours",
         "labels": {
           "close": "Fermer la navigation",
           "main": "Navigation principale",

--- a/api/db/database-builder/factory/build-combined-course-blueprint.js
+++ b/api/db/database-builder/factory/build-combined-course-blueprint.js
@@ -1,0 +1,30 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildCombinedCourseBlueprint = function ({
+  id = databaseBuffer.getNextId(),
+  name = 'Mon parcours combiné',
+  internalName = 'Mon schéma de parcours combiné',
+  description = 'Le but de ma quête',
+  illustration = 'images/illustration.svg',
+  createdAt = new Date(),
+  updatedAt,
+  content,
+} = {}) {
+  const values = {
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    createdAt,
+    updatedAt: updatedAt ?? createdAt,
+    content: JSON.stringify(content),
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'combined_course_blueprints',
+    values,
+  });
+};
+
+export { buildCombinedCourseBlueprint };

--- a/api/db/seeds/data/team-prescription/build-combined-courses.js
+++ b/api/db/seeds/data/team-prescription/build-combined-courses.js
@@ -1,6 +1,8 @@
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { OrganizationLearnerParticipationTypes } from '../../../../src/quest/domain/models/OrganizationLearnerParticipation.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import { buildCombinedCourseBlueprint } from '../../../database-builder/factory/build-combined-course-blueprint.js';
 import { PRO_COMBINED_COURSE } from './fixtures/pro-combined-course.js';
 import { COMBINED_COURSE_WITHOUT_CAMPAIGN } from './fixtures/pro-combined-course-without-campaign.js';
 import { COMBINED_COURSE_WITHOUT_MODULES } from './fixtures/pro-combined-course-without-modules.js';
@@ -173,6 +175,19 @@ const buildCombinixQuest = (databaseBuilder, combinedCourseData) => {
         }
       }
     }
+  });
+};
+
+export const buildCombinedCourseBlueprints = (databaseBuilder) => {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile({
+    name: 'Mon profil cible de parcours combiné',
+  }).id;
+  const moduleId = 'eeeb4951-6f38-4467-a4ba-0c85ed71321a';
+
+  buildCombinedCourseBlueprint({
+    name: 'Mon parcours combiné 2',
+    internalName: 'Mon schéma de parcours combiné 2',
+    content: CombinedCourseBlueprint.buildContentItems([{ targetProfileId }, { moduleId }]),
   });
 };
 

--- a/api/db/seeds/data/team-prescription/data-builder.js
+++ b/api/db/seeds/data/team-prescription/data-builder.js
@@ -1,5 +1,5 @@
 import { buildCampaigns } from './build-campaigns.js';
-import { buildCombinedCourses } from './build-combined-courses.js';
+import { buildCombinedCourseBlueprints, buildCombinedCourses } from './build-combined-courses.js';
 import { buildOrganizationLearners } from './build-learners.js';
 import { buildOrganizationLearnersWithMultipleParticipations } from './build-organization-learners-with-multiple-participations.js';
 import { buildPlacesLots } from './build-places-lots.js';
@@ -13,6 +13,7 @@ async function teamPrescriptionDataBuilder({ databaseBuilder }) {
   await buildPlacesLots(databaseBuilder);
   await buildQuests(databaseBuilder);
   await buildCombinedCourses(databaseBuilder);
+  await buildCombinedCourseBlueprints(databaseBuilder);
   await buildOrganizationLearnersWithMultipleParticipations(databaseBuilder);
 }
 

--- a/api/src/quest/application/combined-course-blueprint-controller.js
+++ b/api/src/quest/application/combined-course-blueprint-controller.js
@@ -1,0 +1,7 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as combinedCourseBlueprintSerializer from '../infrastructure/serializers/combined-course-blueprint-serializer.js';
+
+export const findAll = async (request, _, dependencies = { combinedCourseBlueprintSerializer }) => {
+  const combinedCourseBlueprints = await usecases.findCombinedCourseBlueprints();
+  return dependencies.combinedCourseBlueprintSerializer.serialize(combinedCourseBlueprints);
+};

--- a/api/src/quest/application/combined-course-blueprint-route.js
+++ b/api/src/quest/application/combined-course-blueprint-route.js
@@ -1,0 +1,31 @@
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import * as combinedCourseBlueprintController from './combined-course-blueprint-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/combined-course-blueprints',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: combinedCourseBlueprintController.findAll,
+        notes: ['- Récupération de la liste des schémas de parcours combinés'],
+        tags: ['api', 'combined-course'],
+      },
+    },
+  ]);
+};
+
+const name = 'combined-course-blueprints-api';
+export { name, register };

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -1,0 +1,25 @@
+export class CombinedCourseBlueprint {
+  constructor({ id, name, internalName, description, illustration, content, createdAt, updatedAt }) {
+    this.id = id;
+    this.name = name;
+    this.internalName = internalName;
+    this.description = description;
+    this.illustration = illustration;
+    this.content = content;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static buildContentItems(items) {
+    return items.map(({ moduleId, targetProfileId }) =>
+      moduleId
+        ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleId }
+        : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUTION, value: targetProfileId },
+    );
+  }
+}
+
+export const COMBINED_COURSE_BLUEPRINT_ITEMS = {
+  MODULE: 'module',
+  EVALUTION: 'evaluation',
+};

--- a/api/src/quest/domain/usecases/find-combined-course-blueprints.js
+++ b/api/src/quest/domain/usecases/find-combined-course-blueprints.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Object} params
+ * @param {import('./index.js').CombinedCourseBlueprintRepository} params.combinedCourseBlueprintRepository
+ * @returns {Promise<import('../models/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
+ **/
+export const findCombinedCourseBlueprints = async ({ combinedCourseBlueprintRepository }) => {
+  return combinedCourseBlueprintRepository.findAll();
+};

--- a/api/src/quest/domain/usecases/index.js
+++ b/api/src/quest/domain/usecases/index.js
@@ -37,6 +37,7 @@ const dependencies = {
   combinedCourseDetailsService: injectedCombinedCourseDetailsService,
   organizationLearnerRepository,
   organizationLearnerPrescriptionRepository,
+  combinedCourseBlueprintRepository: repositories.combinedCourseBlueprintRepository,
   codeGenerator,
   logger,
 };
@@ -44,6 +45,7 @@ const dependencies = {
 import { checkUserQuest } from './check-user-quest-success.js';
 import { createCombinedCourses } from './create-combined-courses.js';
 import { createOrUpdateQuestsInBatch } from './create-or-update-quests-in-batch.js';
+import { findCombinedCourseBlueprints } from './find-combined-course-blueprints.js';
 import { findCombinedCourseByCampaignId } from './find-combined-course-by-campaign-id.js';
 import { findCombinedCourseByModuleIdAndUserId } from './find-combined-course-by-moduleId-and-user-id.js';
 import { findCombinedCourseParticipations } from './find-combined-course-participations.js';
@@ -68,6 +70,7 @@ const usecasesWithoutInjectedDependencies = {
   getCombinedCourseById,
   getCombinedCourseParticipationById,
   findCombinedCourseParticipations,
+  findCombinedCourseBlueprints,
   getCombinedCoursesByOrganizationId,
   getQuestResultsForCampaignParticipation,
   getVerifiedCode,

--- a/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprint-repository.js
@@ -1,0 +1,13 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { CombinedCourseBlueprint } from '../../domain/models/CombinedCourseBlueprint.js';
+
+/**
+ * @returns {Promise<import('../../domain/models/CombinedCourseBlueprint.js').CombinedCourseBlueprint[]>}
+ */
+
+export async function findAll() {
+  const knexConn = DomainTransaction.getConnection();
+
+  const results = await knexConn('combined_course_blueprints');
+  return results.map((data) => new CombinedCourseBlueprint(data));
+}

--- a/api/src/quest/infrastructure/repositories/index.js
+++ b/api/src/quest/infrastructure/repositories/index.js
@@ -13,6 +13,7 @@ import { temporaryStorage } from '../../../shared/infrastructure/key-value-stora
 import * as accessCodeRepository from '../../../shared/infrastructure/repositories/access-code-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as campaignRepository from './campaign-repository.js';
+import * as combinedCourseBlueprintRepository from './combined-course-blueprint-repository.js';
 import * as combinedCourseDetailsRepository from './combined-course-details-repository.js';
 import * as combinedCourseParticipantRepository from './combined-course-participant-repository.js';
 import * as combinedCourseParticipationRepository from './combined-course-participation-repository.js';
@@ -27,6 +28,10 @@ import * as rewardRepository from './reward-repository.js';
 import * as successRepository from './success-repository.js';
 import * as targetProfileRepository from './target-profile-repository.js';
 import * as userRepository from './user-repository.js';
+
+/**
+ * @typedef {combinedCourseBlueprintRepository} combinedCourseBlueprintRepository;
+ * **/
 
 const profileRewardTemporaryStorage = temporaryStorage.withPrefix('profile-rewards:');
 
@@ -46,6 +51,7 @@ const repositoriesWithoutInjectedDependencies = {
   userRepository,
   recommendedModuleRepository,
   targetProfileRepository,
+  combinedCourseBlueprintRepository,
 };
 
 const dependencies = {

--- a/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
+++ b/api/src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (combinedCourseBlueprint) {
+  return new Serializer('combined-course-blueprints', {
+    attributes: ['name', 'internalName', 'description', 'illustration', 'content', 'createdAt', 'updatedAt'],
+  }).serialize(combinedCourseBlueprint);
+};
+
+export { serialize };

--- a/api/src/quest/routes.js
+++ b/api/src/quest/routes.js
@@ -1,7 +1,8 @@
+import * as combinedCourseBlueprintRoute from './application/combined-course-blueprint-route.js';
 import * as combinedCourseRoute from './application/combined-course-route.js';
 import * as questRoute from './application/quest-route.js';
 import * as verifiedCodeRoute from './application/verified-code-route.js';
 
-const questRoutes = [combinedCourseRoute, questRoute, verifiedCodeRoute];
+const questRoutes = [combinedCourseRoute, questRoute, verifiedCodeRoute, combinedCourseBlueprintRoute];
 
 export { questRoutes };

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -1,0 +1,46 @@
+import { CombinedCourseBlueprint } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+} from '../../../test-helper.js';
+
+describe('Quest | Acceptance | Application | Combined course blueprint Route ', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/combined-course-blueprints', function () {
+    context('when user is admin ', function () {
+      it('should return the list of combined course blueprints', async function () {
+        // given
+        const adminUser = await insertUserWithRoleSuperAdmin();
+
+        databaseBuilder.factory.buildCombinedCourseBlueprint({
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module' }]),
+        });
+        databaseBuilder.factory.buildCombinedCourseBlueprint({
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module-abc' }]),
+        });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/combined-course-blueprints`,
+          headers: generateAuthenticatedUserRequestHeaders({ userId: adminUser.id }),
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.have.lengthOf(2);
+      });
+    });
+  });
+});

--- a/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
+++ b/api/tests/quest/integration/domain/usecases/find-combined-course-blueprints_test.js
@@ -1,0 +1,15 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Quest | Domain | UseCases | find-combined-course-blueprints', function () {
+  it('should return combined course blueprints array if at least a result is found', async function () {
+    databaseBuilder.factory.buildCombinedCourseBlueprint({
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }]),
+    });
+    await databaseBuilder.commit();
+    const results = await usecases.findCombinedCourseBlueprints();
+    expect(results).lengthOf(1);
+    expect(results[0]).to.be.instanceOf(CombinedCourseBlueprint);
+  });
+});

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -1,0 +1,22 @@
+import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import * as combinedCourseBluePrintRepository from '../../../../../src/quest/infrastructure/repositories/combined-course-blueprint-repository.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Integration | Repository | combined-course-blueprint', function () {
+  describe('#findAll', function () {
+    it('should return all combined course blueprints', async function () {
+      const expectedCombinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint();
+      databaseBuilder.factory.buildCombinedCourseBlueprint(expectedCombinedCourseBlueprint);
+      await databaseBuilder.commit();
+
+      const results = await combinedCourseBluePrintRepository.findAll();
+      expect(results).lengthOf(1);
+      expect(results[0]).to.be.instanceOf(CombinedCourseBlueprint);
+      expect(results[0]).to.deep.equal(expectedCombinedCourseBlueprint);
+    });
+    it('should return an empty array when no results are found', async function () {
+      const result = await combinedCourseBluePrintRepository.findAll();
+      expect(result).lengthOf(0);
+    });
+  });
+});

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -1,0 +1,47 @@
+import {
+  COMBINED_COURSE_BLUEPRINT_ITEMS,
+  CombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function () {
+  describe('#constructor', function () {
+    it('should construct object', function () {
+      // given
+      const values = {
+        id: 1,
+        name: 'name',
+        internalName: 'internaleName',
+        description: 'description',
+        illustration: 'illustration',
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleId: '123' }]),
+        createdAt: new Date('2024-01-25'),
+        updatedAt: new Date('2024-01-26'),
+      };
+      // when
+      const blueprint = new CombinedCourseBlueprint(values);
+
+      // then
+      expect(blueprint).deep.equal(values);
+    });
+  });
+  describe('#buildContentItems', function () {
+    it('should build blueprint content items for targetProfileId and moduleId', function () {
+      const requirements = CombinedCourseBlueprint.buildContentItems([
+        { targetProfileId: 123 },
+        { moduleId: 'az-123' },
+      ]);
+
+      expect(requirements).deep.equal([
+        {
+          type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUTION,
+          value: 123,
+        },
+        {
+          type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+          value: 'az-123',
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -1,0 +1,46 @@
+import {
+  COMBINED_COURSE_BLUEPRINT_ITEMS,
+  CombinedCourseBlueprint,
+} from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import * as combinedCourseBlueprintSerializer from '../../../../../src/quest/infrastructure/serializers/combined-course-blueprint-serializer.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprint', function () {
+  it('#serialize', function () {
+    // given
+    const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module' }, { targetProfileId: 123 }]),
+    });
+
+    // when
+    const serializedCombinedCourseBlueprints = combinedCourseBlueprintSerializer.serialize([combinedCourseBlueprint]);
+
+    // then
+    expect(serializedCombinedCourseBlueprints).to.deep.equal({
+      data: [
+        {
+          attributes: {
+            name: 'Mon parcours',
+            'internal-name': 'Mon modèle de parcours',
+            illustration: '/illustrations/image.svg',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            content: [
+              {
+                type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
+                value: 'mon-module',
+              },
+              {
+                type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUTION,
+                value: 123,
+              },
+            ],
+            'created-at': combinedCourseBlueprint.createdAt,
+            'updated-at': combinedCourseBlueprint.updatedAt,
+          },
+          type: 'combined-course-blueprints',
+          id: '1',
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/build-combined-course-blueprint.js
@@ -1,0 +1,28 @@
+import {
+  COMBINED_COURSE_BLUEPRINT_ITEMS,
+  CombinedCourseBlueprint,
+} from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+
+function buildCombinedCourseBlueprint({
+  id = 1,
+  name = 'Mon parcours',
+  internalName = 'Mon modèle de parcours',
+  description = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  illustration = '/illustrations/image.svg',
+  createdAt = new Date(),
+  updatedAt = new Date(),
+  content = [{ type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'module-123' }],
+} = {}) {
+  return new CombinedCourseBlueprint({
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    content,
+    createdAt,
+    updatedAt,
+  });
+}
+
+export { buildCombinedCourseBlueprint };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -68,6 +68,7 @@ import { buildChallenge, buildChallengeWithWebComponent } from './build-challeng
 import { buildChallengeLearningContentDataObject } from './build-challenge-learning-content-data-object.js';
 import { buildCleaCertifiedCandidate } from './build-clea-certified-candidate.js';
 import { buildClientApplication } from './build-client-application.js';
+import { buildCombinedCourseBlueprint } from './build-combined-course-blueprint.js';
 import {
   buildCombinedCourse,
   buildCombinedCourseDataForQuest,
@@ -436,6 +437,7 @@ export {
   buildCleaCertifiedCandidate,
   buildClientApplication,
   buildCombinedCourse,
+  buildCombinedCourseBlueprint,
   buildCombinedCourseDataForQuest,
   buildCombinedCourseDetails,
   buildCompetence,

--- a/api/tests/tooling/domain-builder/factory/prescription/combined-course-blueprint/combined-course-blueprint.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/combined-course-blueprint/combined-course-blueprint.js
@@ -1,0 +1,23 @@
+import { CombinedCourseBlueprint } from '../../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+
+export const buildCombinedCourseBlueprint = function ({
+  id = 1,
+  name = 'Mon parcours combiné',
+  internalName = 'Mon schéma de parcours combiné',
+  description = 'Le but de ma quête',
+  illustration = 'images/illustration.svg',
+  createdAt = new Date(),
+  updatedAt,
+  content = [CombinedCourseBlueprint.buildContentItems([{ moduleId: 'module-id' }, { targetProfileId: 123 }])],
+} = {}) {
+  return new CombinedCourseBlueprint({
+    id,
+    name,
+    internalName,
+    description,
+    illustration,
+    createdAt,
+    updatedAt,
+    content,
+  });
+};


### PR DESCRIPTION
## ❄️ Problème
On veut pouvoir consulter facilement dans Pix Admin le schéma d'un parcours combiné.

## 🛷 Proposition
- On crée un model CombinedCourseBlueprint 
- On crée une route pour récupérer tous les schémas
- On crée une page qui appelle cette route dans Admin

## 🧑‍🎄 Pour tester
Aller dans le lien "Schémas de parcours" du menu et vérifier qu'on a bien une ligne qui correspond aux seeds.