### PR TITLE
[TECH] Retirer des champs de la table quête (PIX-20736)

### DIFF
--- a/api/db/migrations/20251211132305_delete-quests-columns.js
+++ b/api/db/migrations/20251211132305_delete-quests-columns.js
@@ -1,0 +1,34 @@
+const TABLE_NAME = 'quests';
+const COLUMN_NAMES = ['organizationId', 'code', 'name', 'description', 'illustration'];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropForeign('organizationId');
+  });
+  for (const columnName of COLUMN_NAMES) {
+    await knex.schema.table(TABLE_NAME, function (table) {
+      table.dropColumn(columnName);
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string('code').defaultTo(null).comment('Adds code on quests to use a quest object in a course');
+    table.integer('organizationId').defaultTo(null).unsigned().comment('Links a quest to an organization');
+    table.foreign('organizationId').references('organizations.id');
+    table.text('description').defaultTo(null).comment('Description for quests');
+    table.text('illustration').defaultTo(null).comment('URL for quest illustration');
+    table.string('name').defaultTo(null).comment('Name of the quest, used on landing page for combined courses');
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème
Dans le cadre des parcours combinés, on veut pouvoir utiliser la table "combined_courses" à la place de la table "quests" pour des questions de lisibilité et de définition des domaines.

## 🛷 Proposition
On supprime les attributs déjà présents dans la table "combined_courses" de la table "quests" (c'est-à-dire name, illustration, code, description, organizationId) et la clé étrangère associée à organizationId.

## ☃️ Remarques
On avait pas mis de contrainte d'unicité sur "code" quand on l'a ajouté dans quests.
Les champs name, description et illustration sont optionnels.

## 🧑‍🎄 Pour tester
Rollback la migration en RA puis la rejouer. Vérifier que les champs ont bien disparu de quests.