### PR TITLE
[TECH] Harmoniser provinceCode vide (PIX-20749)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -149,7 +149,7 @@ class OrganizationForAdmin {
   }
 
   set provinceCode(provinceCode) {
-    this.#provinceCode = provinceCode ? provinceCode.padStart(PAD_TARGET_LENGTH, PAD_STRING) : '';
+    this.#provinceCode = provinceCode ? provinceCode.padStart(PAD_TARGET_LENGTH, PAD_STRING) : null;
   }
 
   get archivistFullName() {

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -162,7 +162,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'DPOFirstName' ||
           columnName === 'DPOLastName' ||
           columnName === 'DPOEmail' ||
-          columnName === 'parentOrganizationId'
+          columnName === 'parentOrganizationId' ||
+          columnName === 'provinceCode'
         ) {
           value = null;
         }

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -301,7 +301,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(givenOrganization.externalId).to.equal(newExternalId);
     });
 
-    it('updates organization province code even if empty value', function () {
+    it('updates organization province code to null if empty value', function () {
       // given
       const initialProvinceCode = '888';
       const newProvinceCode = '';
@@ -316,7 +316,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       });
 
       // then
-      expect(givenOrganization.provinceCode).to.equal(newProvinceCode);
+      expect(givenOrganization.provinceCode).to.be.null;
     });
 
     it('updates organization administration team id', function () {


### PR DESCRIPTION
## ❄️ Problème

Actuellement, lors de la création, modification, création en masse d'organisation, on enregistre '' en base quand il n'y a pas de provinceCode

## 🛷 Proposition

S’assurer que le champ provinceCode soit toujours enregistré en base à NULL lorsqu’il est laissé vide, et non comme une chaîne de caractères vide "".


## 🧑‍🎄 Pour tester

- Depuis pix-admin
- Vérifier que null est bien enregistré en base lors de la création, modification, création en masse d'organisation