### PR TITLE
[TECH] Masquer le statut TO_SHARE en Admin et convertir en STARTED (PIX-20707)

### DIFF
--- a/admin/app/components/campaigns/participation-row.gjs
+++ b/admin/app/components/campaigns/participation-row.gjs
@@ -18,8 +18,8 @@ export default class ParticipationRow extends Component {
   @tracked newParticipantExternalId;
 
   _checkIfParticipantExternalIdIsNull(newParticipantExternalId) {
-    const trimedNewParticipantExternalId = newParticipantExternalId.trim();
-    return trimedNewParticipantExternalId || null;
+    const trimmedNewParticipantExternalId = newParticipantExternalId.trim();
+    return trimmedNewParticipantExternalId || null;
   }
 
   @action

--- a/admin/app/components/quests/requirements/object/object-configuration.js
+++ b/admin/app/components/quests/requirements/object/object-configuration.js
@@ -150,7 +150,7 @@ const campaignParticipationsConfigField_status = new FieldConfiguration({
   name: 'status',
   type: FieldConfiguration.TYPES.STRING,
   refersToAnArray: false,
-  allowedValues: ['STARTED', 'TO_SHARE', 'SHARED'],
+  allowedValues: ['STARTED', 'SHARED'],
 });
 
 const campaignParticipationsConfiguration = new ObjectConfiguration({

--- a/admin/app/models/campaign-participation.js
+++ b/admin/app/models/campaign-participation.js
@@ -2,7 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export const campaignParticipationStatuses = {
   STARTED: 'En cours',
-  TO_SHARE: 'En attente d’envoi',
   SHARED: 'Envoyé',
 };
 

--- a/admin/app/models/user-participation.js
+++ b/admin/app/models/user-participation.js
@@ -2,7 +2,6 @@ import Model, { attr } from '@ember-data/model';
 
 export const campaignParticipationStatuses = {
   STARTED: 'En cours',
-  TO_SHARE: 'En attente d’envoi',
   SHARED: 'Envoyé',
 };
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-campaign-management-repository.js
@@ -23,7 +23,9 @@ const findPaginatedParticipationsForCampaignManagement = async function ({ campa
       userFirstName: 'users.firstName',
       userLastName: 'users.lastName',
       participantExternalId: 'campaign-participations.participantExternalId',
-      status: 'campaign-participations.status',
+      status: knex.raw(
+        `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`, // TODO: stop casting TO_SHARE once the migration is done
+      ),
       createdAt: 'campaign-participations.createdAt',
       sharedAt: 'campaign-participations.sharedAt',
       deletedAt: 'campaign-participations.deletedAt',

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/participations-for-user-management-repository.js
@@ -16,7 +16,9 @@ const findByUserId = async function (userId) {
         .select({
           campaignParticipationId: 'campaign-participations.id',
           participantExternalId: 'campaign-participations.participantExternalId',
-          status: 'campaign-participations.status',
+          status: knex.raw(
+            `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`, // TODO: stop casting TO_SHARE once the migration is done
+          ),
           campaignId: 'campaigns.id',
           campaignCode: 'campaigns.code',
           createdAt: knex.raw('COALESCE("campaign-participations"."createdAt", assessments."createdAt")'),
@@ -41,7 +43,9 @@ const findByUserId = async function (userId) {
           this.select({
             campaignParticipationId: 'campaign-participations.id',
             participantExternalId: 'campaign-participations.participantExternalId',
-            status: 'campaign-participations.status',
+            status: knex.raw(
+              `CASE WHEN "campaign-participations"."status" = 'TO_SHARE' THEN 'STARTED' ELSE "campaign-participations"."status" END`,
+            ),
             campaignId: 'campaigns.id',
             campaignCode: 'campaigns.code',
             createdAt: 'campaign-participations.createdAt',

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-campaign-management-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/participations-for-campaign-management-repository_test.js
@@ -6,6 +6,8 @@ import { CampaignParticipationStatuses } from '../../../../../../src/prescriptio
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../../test-helper.js';
 
+const { STARTED, TO_SHARE } = CampaignParticipationStatuses;
+
 describe('Integration | Repository | Participations-For-Campaign-Management', function () {
   describe('#updateParticipantExternalId', function () {
     context('When campaign participation is not null', function () {
@@ -269,7 +271,7 @@ describe('Integration | Repository | Participations-For-Campaign-Management', fu
       });
     });
 
-    context('whern participations have been anonymised', function () {
+    context('when participations have been anonymised', function () {
       it('should return participation with no userId', async function () {
         // given
         const user = databaseBuilder.factory.buildUser();
@@ -304,6 +306,28 @@ describe('Integration | Repository | Participations-For-Campaign-Management', fu
         // then
         expect(participationsForCampaignManagement).to.have.lengthOf(1);
         expect(participationsForCampaignManagement[0].id).to.equal(campaignParticipation.id);
+      });
+    });
+
+    context('when participation has TO_SHARE status', function () {
+      it('should convert TO_SHARE status to STARTED', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          status: TO_SHARE,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { models: participationsForCampaignManagement } =
+          await participationsForCampaignManagementRepository.findPaginatedParticipationsForCampaignManagement({
+            campaignId,
+            page,
+          });
+
+        // then
+        expect(participationsForCampaignManagement).to.have.lengthOf(1);
+        expect(participationsForCampaignManagement[0].status).to.equal(STARTED);
       });
     });
   });


### PR DESCRIPTION
## ❄️ Problème

Le statut `TO_SHARE` est vouée à disparaître. 

## 🛷 Proposition

### Changements Admin
- Retrait du statut `TO_SHARE` de la configuration des participations aux campagnes
- Mise à jour du composant `participation-row` pour ne plus afficher ce statut
- Mise à jour des modèles `campaign-participation` et `user-participation`

### Changements API
- Ajout de la conversion `TO_SHARE` → `STARTED` dans les repositories suivants :
  - `participations-for-campaign-management-repository`
  - `participations-for-user-management-repository`
- Ajout de tests d'intégration pour vérifier que la conversion fonctionne correctement dans les deux repositories

## ☃️ Remarques

- Cette modification est temporaire le temps de la migration complète du statut `TO_SHARE`
- Les commentaires TODO ont été ajoutés dans le code pour indiquer que ce casting doit être supprimé une fois la migration terminée

## 🧑‍🎄 Pour tester

- Vérifier que le statut `TO_SHARE` n'apparaît plus dans l'interface Admin
- Vérifier que les participations avec le statut `TO_SHARE` en base apparaissent comme `STARTED` dans l'Admin