### PR TITLE
[TECH]Montée de version d'épreuve component 2.2.2 -> 2.2.4

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.2.2",
+        "@1024pix/epreuves-components": "^2.2.4",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
-      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
+      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.2.2",
+    "@1024pix/epreuves-components": "^2.2.4",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_IND.json
@@ -865,7 +865,7 @@
                   "randomSlides": false,
                   "titleLevel": 2,
                   "disableAnimation": false,
-                  "disableLoop": false
+                  "enableLoop": true
                 }
               }
             },
@@ -907,10 +907,7 @@
                     "diagnosis": "<p>Vous avez peut-être oublié un exemple ou vu un détail qui n’était pas forcément un biais.</p><p>Voici un indice&nbsp;: les exemples qui comportent des biais renforcent des stéréotypes. N’hésitez pas à recommencer.</p>"
                   }
                 },
-                "solutions": [
-                  "2",
-                  "4"
-                ]
+                "solutions": ["2", "4"]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenBiais_NOV_alt.json
@@ -783,7 +783,7 @@
                   "randomSlides": false,
                   "titleLevel": 2,
                   "disableAnimation": false,
-                  "disableLoop": false
+                  "enableLoop": true
                 }
               }
             },
@@ -825,10 +825,7 @@
                     "diagnosis": "<p>Vous avez peut-être oublié un exemple, ou bien vu un détail qui n’était pas forcément un biais.</p><p>Voici un indice&nbsp;: les exemples qui comportent des biais renforcent des stéréotypes. N’hésitez pas à recommencer.</p>"
                   }
                 },
-                "solutions": [
-                  "2",
-                  "4"
-                ]
+                "solutions": ["2", "4"]
               }
             }
           ]
@@ -876,10 +873,7 @@
                     "diagnosis": "<p>Les biais de confirmation sont des erreurs humaines qui nous poussent à croire les choses que nous pensons déjà. C’est le cas pour plusieurs des personnes ci-dessus. N’hésitez pas à réessayer.</p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "3"
-                ]
+                "solutions": ["1", "3"]
               }
             }
           ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_NOV.json
@@ -198,11 +198,7 @@
                           "placeholder": "votre mot",
                           "ariaLabel": "zone de saisie",
                           "defaultValue": "",
-                          "tolerances": [
-                            "t1",
-                            "t2",
-                            "t3"
-                          ],
+                          "tolerances": ["t1", "t2", "t3"],
                           "solutions": [
                             "beurre",
                             "sucre",
@@ -345,11 +341,7 @@
                         ],
                         "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                         "llmMessage": "On peut mettre du ",
-                        "wordsToAdd": [
-                          "beurre",
-                          "et",
-                          "du ?"
-                        ]
+                        "wordsToAdd": ["beurre", "et", "du ?"]
                       }
                     }
                   ]
@@ -441,7 +433,6 @@
                   "randomSlides": false,
                   "titleLevel": 2,
                   "disableAnimation": false,
-                  "disableLoop": true,
                   "imageTextDisplay": "1:1"
                 }
               }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenImpact_NOV.json
@@ -263,8 +263,7 @@
                   ],
                   "randomSlides": false,
                   "titleLevel": 0,
-                  "disableAnimation": true,
-                  "disableLoop": true
+                  "disableAnimation": true
                 }
               }
             },
@@ -503,8 +502,7 @@
                   ],
                   "randomSlides": false,
                   "titleLevel": 0,
-                  "disableAnimation": true,
-                  "disableLoop": true
+                  "disableAnimation": true
                 }
               }
             }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenPrompt_IND.json
@@ -145,12 +145,7 @@
                     "diagnosis": "<p>Il faut donner le plus de précisions possible. Plus l’IA a d’informations sur la situation, meilleure sera sa réponse.&nbsp;<br></p>"
                   }
                 },
-                "solutions": [
-                  "1",
-                  "2",
-                  "3",
-                  "4"
-                ]
+                "solutions": ["1", "2", "3", "4"]
               }
             }
           ]
@@ -443,10 +438,7 @@
                           "diagnosis": "<p>Ici, le <strong>format </strong>est le <strong>dialogue </strong>et le <strong>contexte</strong>, celui du <strong>match de volley.</strong></p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2"
-                      ]
+                      "solutions": ["1", "2"]
                     }
                   ]
                 },
@@ -485,11 +477,7 @@
                           "diagnosis": "<p>Ici, le <strong>format </strong>est un court <strong>discours</strong>, le <strong>ton </strong>est <strong>amusant</strong>. Le <strong>contexte </strong>est le <strong>pot de départ </strong>d’un joueur de volley, décrit avec des éléments précis comme ses qualités et ses défauts.</p>"
                         }
                       },
-                      "solutions": [
-                        "1",
-                        "2",
-                        "3"
-                      ]
+                      "solutions": ["1", "2", "3"]
                     }
                   ]
                 }
@@ -624,8 +612,7 @@
                   ],
                   "randomSlides": false,
                   "titleLevel": 0,
-                  "disableAnimation": false,
-                  "disableLoop": false
+                  "disableAnimation": false
                 }
               }
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/NR-Datacenter-NOV.json
@@ -285,7 +285,7 @@
                   "randomSlides": false,
                   "titleLevel": 2,
                   "disableAnimation": false,
-                  "disableLoop": false,
+                  "enableLoop": true,
                   "imageTextDisplay": "1:1"
                 }
               }
@@ -785,11 +785,7 @@
                     "placeholder": "",
                     "ariaLabel": "a faire",
                     "defaultValue": "",
-                    "tolerances": [
-                      "un centre de données",
-                      "de votre appareil",
-                      "un serveur"
-                    ],
+                    "tolerances": ["un centre de données", "de votre appareil", "un serveur"],
                     "options": [
                       {
                         "id": "1",
@@ -804,9 +800,7 @@
                         "content": "de votre appareil"
                       }
                     ],
-                    "solutions": [
-                      "3"
-                    ]
+                    "solutions": ["3"]
                   },
                   {
                     "type": "text",
@@ -819,11 +813,7 @@
                     "placeholder": "",
                     "ariaLabel": "a faire",
                     "defaultValue": "",
-                    "tolerances": [
-                      "un serveur",
-                      "un centre de données",
-                      "de votre appareil"
-                    ],
+                    "tolerances": ["un serveur", "un centre de données", "de votre appareil"],
                     "options": [
                       {
                         "id": "1",
@@ -838,9 +828,7 @@
                         "content": "un centre de données"
                       }
                     ],
-                    "solutions": [
-                      "3"
-                    ]
+                    "solutions": ["3"]
                   },
                   {
                     "type": "text",
@@ -853,11 +841,7 @@
                     "placeholder": "",
                     "ariaLabel": "a faire",
                     "defaultValue": "10",
-                    "tolerances": [
-                      "votre appareil",
-                      "serveurs",
-                      "centre de donnée"
-                    ],
+                    "tolerances": ["votre appareil", "serveurs", "centre de donnée"],
                     "options": [
                       {
                         "id": "1",
@@ -872,9 +856,7 @@
                         "content": "centre de donnée"
                       }
                     ],
-                    "solutions": [
-                      "2"
-                    ]
+                    "solutions": ["2"]
                   }
                 ],
                 "feedbacks": {

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.2",
+        "@1024pix/epreuves-components": "^2.2.4",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
-      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
+      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.2.2",
+    "@1024pix/epreuves-components": "^2.2.4",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.2",
+        "@1024pix/epreuves-components": "^2.2.4",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.2.tgz",
-      "integrity": "sha512-OsMLDuR/IK0ZAPJciV3y44phHmOokIpVrFLoGu42zu6oQgbAPs7rJHyD/xT58UV34HMo60Lb3TzHsq8qfskmgQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
+      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.2.2",
+    "@1024pix/epreuves-components": "^2.2.4",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème

Le package epreuves-components n'est pas a jour.

## 🛷 Proposition

Faire la montée de version manuellement
## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI OK