### PR TITLE
[TECH] Supprime la table `combined_course_participations` (PIX-20375).

### DIFF
--- a/api/db/migrations/20251211144211_drop-combined-course-participations-table.js
+++ b/api/db/migrations/20251211144211_drop-combined-course-participations-table.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'combined_course_participations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (t) {
+    t.increments().primary();
+    t.integer('organizationLearnerId').unsigned().references('organization-learners.id').index();
+    t.integer('questId').unsigned().references('quests.id').index();
+    t.enum('status', ['started', 'completed']).defaultTo('started');
+    t.timestamps(true, true, true);
+    t.integer('combinedCourseId').defaultTo(null).index().references('combined_courses.id');
+    t.integer('organizationLearnerParticipationId')
+      .defaultTo(null)
+      .index()
+      .references('organization_learner_participations.id');
+  });
+};
+
+export { down, up };

--- a/api/package.json
+++ b/api/package.json
@@ -150,6 +150,7 @@
     "db:empty": "node --env-file-if-exists=.env scripts/database/empty-database --name db",
     "db:migrate": "knex --knexfile db/knexfile.js migrate:latest && node --env-file-if-exists=.env scripts/database/pg-boss-migration.js",
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
+    "db:rollback": "knex --knexfile db/knexfile.js migrate:down $migrationname",
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
     "db:seed": "NODE_OPTIONS=\"--max-old-space-size=380\" knex --knexfile db/knexfile.js seed:run",
     "db:reload": "npm run db:empty && npm run db:seed",


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Il n’y a plus d’usage de la table `combined_course_participations` au profit d’une centralisation dans organization_learner_participations qui sera la table où nous enregistrons toutes les participations de n’importe quelle typologie.

## 🛷 Proposition

On ajoute une migration pour supprimer cette table.
On prend soin de recréer la table à l'indentique dans la partie `down` de la migration en cas de rollback.
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Une PR est passée avec une migration datée au 28/12/2025 ...
cela signifie que la migration de cette PR ne peut pas être rollback avec la commande `npm run rollback:latest` (knex se base sur le nom des fichiers pour connaître l'ordre des migrations).
Il faut utiliser `npx knex --knexfile=db/knexfile.js migrate:down <nom-de-la-migration>`.
Une commande a été ajoutée : `npm run rollback <nom-de-la-migration>` pour faciliter cette opération.

## 🧑‍🎄 Pour tester

Vérifier que la table n'existe plus.
Se connecter au conteneur et rollback la migration afin de vérifier que la table est correctement recréer si besoin.
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
