### PR TITLE
[TECH] :recycle: Renommer la table `supervisor-accesses` pour utiliser le terme `invigilator`

### DIFF
--- a/api/db/database-builder/factory/build-supervisor-access.js
+++ b/api/db/database-builder/factory/build-supervisor-access.js
@@ -19,7 +19,7 @@ const buildSupervisorAccess = function ({
     authorizedAt,
   };
   return databaseBuffer.pushInsertable({
-    tableName: 'supervisor-accesses',
+    tableName: 'invigilator_accesses',
     values,
   });
 };

--- a/api/db/migrations/20251211142821_rename-table-supervisor-accesses-into-invigilator-accesses.js
+++ b/api/db/migrations/20251211142821_rename-table-supervisor-accesses-into-invigilator-accesses.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.renameTable('supervisor-accesses', 'invigilator_accesses');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.renameTable('invigilator_accesses', 'supervisor-accesses');
+};
+
+export { down, up };

--- a/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/session-repository.js
@@ -70,10 +70,10 @@ export async function remove({ id }) {
     const certificationCandidateIdsInSession = await knex('certification-candidates')
       .where({ sessionId: id })
       .pluck('id');
-    const invigilatorAccessIds = await knex('supervisor-accesses').where({ sessionId: id }).pluck('id');
+    const invigilatorAccessIds = await knex('invigilator_accesses').where({ sessionId: id }).pluck('id');
 
     if (invigilatorAccessIds) {
-      await trx('supervisor-accesses').whereIn('id', invigilatorAccessIds).del();
+      await trx('invigilator_accesses').whereIn('id', invigilatorAccessIds).del();
     }
 
     if (certificationCandidateIdsInSession.length) {

--- a/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/invigilator-access-repository.js
@@ -2,12 +2,12 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 
 export async function create({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn('supervisor-accesses').insert({ sessionId, userId });
+  await knexConn('invigilator_accesses').insert({ sessionId, userId });
 }
 
 export async function isUserInvigilatorForSession({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
-  const result = await knexConn.select(1).from('supervisor-accesses').where({ sessionId, userId }).first();
+  const result = await knexConn.select(1).from('invigilator_accesses').where({ sessionId, userId }).first();
   return Boolean(result);
 }
 
@@ -15,9 +15,9 @@ export async function isUserInvigilatorForSessionCandidate({ invigilatorId, cert
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn
     .select(1)
-    .from('supervisor-accesses')
-    .innerJoin('certification-candidates', 'supervisor-accesses.sessionId', 'certification-candidates.sessionId')
-    .where({ 'certification-candidates.id': certificationCandidateId, 'supervisor-accesses.userId': invigilatorId })
+    .from('invigilator_accesses')
+    .innerJoin('certification-candidates', 'invigilator_accesses.sessionId', 'certification-candidates.sessionId')
+    .where({ 'certification-candidates.id': certificationCandidateId, 'invigilator_accesses.userId': invigilatorId })
     .first();
   return Boolean(result);
 }

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -206,7 +206,7 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
 
           // then
           const foundSession = await knex('sessions').select('id').where({ id: sessionId }).first();
-          const supervisorAccesses = await knex('supervisor-accesses').where({ sessionId });
+          const supervisorAccesses = await knex('invigilator_accesses').where({ sessionId });
           expect(foundSession).to.be.undefined;
           expect(supervisorAccesses).to.be.empty;
         });

--- a/api/tests/certification/session-management/acceptance/application/supervise-controller-supervise_test.js
+++ b/api/tests/certification/session-management/acceptance/application/supervise-controller-supervise_test.js
@@ -44,7 +44,7 @@ describe('Acceptance | Controller | Certification | Session management | session
     const response = await server.inject(options);
 
     // then
-    const supervisedSessionInDB = await knex('supervisor-accesses').where({ userId, sessionId: session.id }).first();
+    const supervisedSessionInDB = await knex('invigilator_accesses').where({ userId, sessionId: session.id }).first();
     expect(supervisedSessionInDB).to.exist;
     expect(response.statusCode).to.equal(204);
   });

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
@@ -13,7 +13,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       await invigilatorAccessRepository.create({ sessionId, userId });
 
       // then
-      const invigilatorAccessInDB = await knex.from('supervisor-accesses').first();
+      const invigilatorAccessInDB = await knex.from('invigilator_accesses').first();
       expect(invigilatorAccessInDB.sessionId).to.equal(sessionId);
       expect(invigilatorAccessInDB.userId).to.equal(userId);
     });


### PR DESCRIPTION
## ❄️ Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/ac058792-c130-4202-a633-6f7f7b47b382" />


## 🛷 Proposition

Renommer la table pour remplacer le terme `supervisor` par `invigilator`

## ☃️ Remarques

J'en profite pour utiliser un `_` plutôt qu'un `-` comme évoqué dans le document https://github.com/1024pix/pix/blob/dev/docs/database.md#tables

## 🧑‍🎄 Pour tester

Les tests doivent rester verts.

Rejoindre l'espace surveillant, tout doit continuer de fonctionner normalement.
