### PR TITLE
[TECH] Remettre en place l’action "Check node version availability on Scalingo"

### DIFF
--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -1,0 +1,15 @@
+name: Check node version availability on Scalingo
+
+on: [push]
+
+jobs:
+  check-node-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0
+        with:
+          directory: 'api'
+

--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -1,15 +1,15 @@
 name: Check node version availability on Scalingo
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   check-node-compatibility:
+    if: github.head_ref == 'renovate/node' || (startsWith(github.head_ref, 'renovate/major-') && endsWith(github.head_ref, '-node'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0
-        with:
-          directory: 'api'
-
+      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@main


### PR DESCRIPTION
## ❄️ Problème

Cette Github action avait été supprimée en décembre 2024, entre temps les reviews apps ont été rendues facultatives, ce qui permet de merger une mise à jour de Node avec une version indisponible sur Scalingo.

## 🛷 Proposition

Remettre en place la github action, en ne l’exécutant que sur les PRs Renovate de mise à jour de Node (nom de branche `renovate/node` ou `renovate/major-xx-node`).

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier que l’action est skipped sur cette PR.
Vérifier que l’action s’exécute bien sur #14419.