### PR TITLE
[TECH] Corrige le test e2e d'import generique (PIX-20775)

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-orga/PixOrgaPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-orga/PixOrgaPage.ts
@@ -14,14 +14,15 @@ export class PixOrgaPage {
     await this.page.getByRole('button', { name: 'Accepter et continuer' }).click();
   }
 
-  async waitForUploadSuccess(page: Page) {
-    let inProgress = false;
-    await page.getByRole('heading').waitFor();
+  async waitForTheImportToComplete(page: Page) {
+    let done = false;
+    await page.getByRole('heading', { name: 'Importer des' }).waitFor();
     do {
+      await page.waitForTimeout(1000);
       await page.reload({ waitUntil: 'load' });
-      await page.getByRole('heading').waitFor();
-      inProgress = await page.getByRole('paragraph').filter({ hasText: 'un import est en cours' }).isVisible();
-    } while (inProgress);
+      await page.getByRole('heading', { name: 'Importer des' }).waitFor();
+      done = await page.getByRole('paragraph').filter({ hasText: 'Dernier fichier importé avec succès' }).isVisible();
+    } while (!done);
   }
 
   async waitForParticipationScoreComputed(score: string, page: Page) {

--- a/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
@@ -54,17 +54,15 @@ test('Managing sco learners', async ({ page }) => {
   await test.step('Import Learners', async () => {
     await page.getByRole('link', { name: 'Élèves' }).click();
     await page.getByRole('link', { name: 'Importer', exact: true }).click();
-    await page
-      .getByRole('textbox', { name: 'Importer la liste' })
-      .setInputFiles(path.join(os.tmpdir(), `sco-${UAJ}.xml`));
+    await page.locator('#students-file-upload').setInputFiles(path.join(os.tmpdir(), `sco-${UAJ}.xml`));
 
     const hasLoader = await page.locator('.app-loader').isVisible();
     if (hasLoader) {
       await page.waitForSelector('.app-loader', { state: 'detached' });
     }
 
+    await orgaPage.waitForTheImportToComplete(page);
     await page.getByRole('link', { name: 'Élèves' }).click();
-    await orgaPage.waitForUploadSuccess(page);
     await expect(
       page.getByRole('paragraph').filter({ hasText: 'Les participants ont bien été importés' }),
     ).toBeVisible();

--- a/high-level-tests/e2e-playwright/tests/pix-orga/sup-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sup-students-management.test.ts
@@ -32,7 +32,7 @@ test('Managing sup students', async ({ page }) => {
     await page.getByRole('button', { name: 'Importer une nouvelle liste' }).click();
     await page.getByText('Je confirme avoir bien').click();
     await page
-      .getByRole('textbox', { name: 'Oui, je remplace' })
+      .locator('#students-file-upload-replace')
       .setInputFiles(path.join(import.meta.dirname, '..', '..', 'fixtures', 'sup-ok.csv'));
 
     const hasLoader = await page.locator('.app-loader').isVisible();
@@ -40,10 +40,10 @@ test('Managing sup students', async ({ page }) => {
       await page.waitForSelector('.app-loader', { state: 'detached' });
     }
 
-    await page.getByRole('link', { name: 'Étudiants' }).click();
-    await orgaPage.waitForUploadSuccess(page);
+    await orgaPage.waitForTheImportToComplete(page);
   });
   await test.step('show learners', async () => {
+    await page.getByRole('link', { name: 'Étudiants' }).click();
     await expect(
       page.getByRole('paragraph').filter({ hasText: 'Les participants ont bien été importés' }),
     ).toBeVisible();


### PR DESCRIPTION
## ❄️ Problème

Le test de la PR #14388 est flaky.

## 🛷 Proposition

Modifier le test pour attendre correctement la fin de l'import avant de poursuivre.

## ☃️ Remarques

Il n'y a pas de message de succès après l'import sur la liste des participants pour l'import générique, ca peut faire l'objet d'un ticket.
J'ai rajoute un `waitForTimeout(1000)` pour éviter de massacrer les performances de la review app. Sans ca, le reload est beaucoup trop violent, en local, il parvient à recharger la page une trentaine de fois avant la fin de l'import.

## 🧑‍🎄 Pour tester

🟢 