### PR TITLE
[FEATURE] Renommer une colonne dans la table combined_course_blueprints (PIX-20736)

### DIFF
--- a/api/db/migrations/20251212104650_modify-success-requirements-in-combined_course_blueprints.js
+++ b/api/db/migrations/20251212104650_modify-success-requirements-in-combined_course_blueprints.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'combined_course_blueprints';
+const COLUMN_NAME = 'successRequirements';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.renameColumn(COLUMN_NAME, 'content');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.renameColumn('content', COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème
Après réflexion, on a une colonne 'successRequirements' dont le nom appartient trop au domaine de la quête.

## 🛷 Proposition
On veut donc lui donner le nom de "content".

## 🧑‍🎄 Pour tester
\d combined_course_blueprints pour vérifier le changement de nom de colonne