### PR TITLE
[FEATURE] Renommer et traduire les champs du formulaire de création d'organisation (PIX-20698)

### DIFF
--- a/admin/app/components/organizations/breadcrumb.gjs
+++ b/admin/app/components/organizations/breadcrumb.gjs
@@ -1,12 +1,15 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Breadcrumb extends Component {
+  @service intl;
+
   get links() {
     return [
       {
         route: 'authenticated.organizations.list',
-        label: 'Toutes les organisations',
+        label: this.intl.t('pages.organizations.breadcrumb.parent-page'),
       },
       {
         label: this.args.currentPageLabel,

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -1,7 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
-import { fn } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -98,8 +98,11 @@ export default class OrganizationCreationForm extends Component {
       <p class="admin-form__mandatory-text">
         {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
-      <section class="admin-form__content admin-form__content--with-counters organization-creation-form">
-        <Card class="admin-form__card organization-creation-form__card" @title="Information générique">
+      <section class="admin-form__content organization-creation-form">
+        <Card
+          class="admin-form__card organization-creation-form__card"
+          @title={{t "components.organizations.creation.general-information"}}
+        >
           {{#if @parentOrganizationName}}
             <h2 class="admin-form__content title organization-creation-form__parent-name--full">
               {{t
@@ -116,22 +119,27 @@ export default class OrganizationCreationForm extends Component {
               required={{true}}
               aria-required={{true}}
               @requiredLabel={{t "common.fields.required-field"}}
+              placeholder={{concat
+                (t "common.words.example-abbr")
+                " "
+                (t "components.organizations.creation.name.placeholder")
+              }}
             >
-              <:label>Nom</:label>
+              <:label>{{t "components.organizations.creation.name.label"}}</:label>
             </PixInput>
           </div>
 
           <PixSelect
             @onChange={{this.handleOrganizationTypeSelectionChange}}
             @options={{this.organizationTypes}}
-            @placeholder="Type d'organisation"
+            @placeholder={{t "components.organizations.creation.type.placeholder"}}
             @hideDefaultOption={{true}}
             @value={{@organization.type}}
             required
             aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
           >
-            <:label>Sélectionner un type d'organisation</:label>
+            <:label>{{t "components.organizations.creation.type.label"}}</:label>
             <:default as |organizationType|>{{organizationType.label}}</:default>
           </PixSelect>
 
@@ -162,37 +170,80 @@ export default class OrganizationCreationForm extends Component {
             <:label>{{t "components.organizations.creation.country.selector.label"}}</:label>
           </PixSelect>
 
-          <PixInput @id="provinceCode" {{on "input" (fn this.handleInputChange "provinceCode")}}>
+          <PixInput
+            @id="provinceCode"
+            {{on "input" (fn this.handleInputChange "provinceCode")}}
+            placeholder={{concat (t "common.words.example-abbr") " 078"}}
+          >
             <:label>{{t "components.organizations.creation.province-code"}}</:label>
           </PixInput>
 
           <div class="organization-creation-form__input--full">
-            <PixInput @id="externalId" {{on "input" (fn this.handleInputChange "externalId")}}>
-              <:label>{{t "components.organizations.creation.external-id"}}</:label>
+            <PixInput
+              @id="externalId"
+              {{on "input" (fn this.handleInputChange "externalId")}}
+              placeholder={{concat
+                (t "common.words.example-abbr")
+                " "
+                (t "components.organizations.creation.external-id.placeholder")
+              }}
+            >
+              <:label>{{t "components.organizations.creation.external-id.label"}}</:label>
             </PixInput>
           </div>
         </Card>
 
-        <Card class="admin-form__card organization-creation-form__card" @title="Configuration">
+        <Card
+          class="admin-form__card organization-creation-form__card"
+          @title={{t "components.organizations.creation.configuration"}}
+        >
           <div class="organization-creation-form__input--full">
-            <PixInput @id="documentationUrl" onchange={{this.handleDocumentationUrlChange}}>
-              <:label>Lien vers la documentation</:label>
+            <PixInput
+              @id="documentationUrl"
+              onchange={{this.handleDocumentationUrlChange}}
+              placeholder={{concat (t "common.words.example-abbr") " https://www.documentation.org"}}
+            >
+              <:label>{{t "components.organizations.creation.documentation-link"}}</:label>
             </PixInput>
           </div>
         </Card>
 
-        <Card class="admin-form__card organization-creation-form__card" @title="Data Privacy Officer">
-          <PixInput @id="dataProtectionOfficerLastName" onchange={{this.handleDataProtectionOfficerLastNameChange}}>
-            <:label>Nom du DPO</:label>
+        <Card
+          class="admin-form__card organization-creation-form__card"
+          @title={{t "components.organizations.creation.dpo.title"}}
+        >
+          <PixInput
+            @id="dataProtectionOfficerLastName"
+            onchange={{this.handleDataProtectionOfficerLastNameChange}}
+            placeholder={{concat (t "common.words.example-abbr") " Dupont"}}
+          >
+            <:label>{{t "components.organizations.creation.dpo.lastname"}}
+              <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
+                  "components.organizations.creation.dpo.title"
+                }}</abbr></:label>
           </PixInput>
 
-          <PixInput @id="dataProtectionOfficerFirstName" onchange={{this.handleDataProtectionOfficerFirstNameChange}}>
-            <:label>Prénom du DPO</:label>
+          <PixInput
+            @id="dataProtectionOfficerFirstName"
+            onchange={{this.handleDataProtectionOfficerFirstNameChange}}
+            placeholder={{concat (t "common.words.example-abbr") " Jean"}}
+          >
+            <:label>{{t "components.organizations.creation.dpo.firstname"}}
+              <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
+                  "components.organizations.creation.dpo.title"
+                }}</abbr></:label>
           </PixInput>
 
           <div class="organization-creation-form__input--full">
-            <PixInput @id="dataProtectionOfficerEmail" onchange={{this.handleDataProtectionOfficerEmailChange}}>
-              <:label>Adresse e-mail du DPO</:label>
+            <PixInput
+              @id="dataProtectionOfficerEmail"
+              onchange={{this.handleDataProtectionOfficerEmailChange}}
+              placeholder={{concat (t "common.words.example-abbr") " jean-dupont@example.net"}}
+            >
+              <:label>{{t "components.organizations.creation.dpo.email"}}
+                <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
+                    "components.organizations.creation.dpo.title"
+                  }}</abbr></:label>
             </PixInput>
           </div>
         </Card>

--- a/admin/app/templates/authenticated/organizations/new.gjs
+++ b/admin/app/templates/authenticated/organizations/new.gjs
@@ -1,13 +1,15 @@
+import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import Breadcrumb from 'pix-admin/components/organizations/breadcrumb';
 import CreationForm from 'pix-admin/components/organizations/creation-form';
+
 <template>
   {{pageTitle "Nouvelle orga"}}
   <header class="page-header">
     {{#if @controller.parentOrganizationName}}
-      <Breadcrumb @currentPageLabel="Nouvelle organisation fille" />
+      <Breadcrumb @currentPageLabel={{t "pages.organizations.breadcrumb.new-child-organization-page"}} />
     {{else}}
-      <Breadcrumb @currentPageLabel="Nouvelle organisation" />
+      <Breadcrumb @currentPageLabel={{t "pages.organizations.breadcrumb.new-organization-page"}} />
     {{/if}}
   </header>
 

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -35,8 +35,8 @@ module('Acceptance | Organizations | Create', function (hooks) {
 
       // then
       assert.dom(screen.queryByText('Organisation mère', { exact: false })).doesNotExist();
-      assert.dom(screen.getByText('Nouvelle organisation')).exists();
-      assert.dom(screen.getByRole('button', { name: this.intl.t('common.actions.add') })).exists();
+      assert.dom(screen.getByText(t('pages.organizations.breadcrumb.new-organization-page'))).exists();
+      assert.dom(screen.getByRole('button', { name: t('common.actions.add') })).exists();
     });
 
     test('it redirects the user to organizations list when cancelling', async function (assert) {
@@ -78,7 +78,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
           }),
         )
         .exists();
-      assert.dom(screen.getByText('Nouvelle organisation fille')).exists();
+      assert.dom(screen.getByText(t('pages.organizations.breadcrumb.new-child-organization-page'))).exists();
       assert
         .dom(
           screen.getByRole('button', {

--- a/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization-test.js
@@ -14,7 +14,6 @@ module('Acceptance | Organizations | Create', function (hooks) {
   setupIntl(hooks);
 
   hooks.beforeEach(async function () {
-    this.intl = this.owner.lookup('service:intl');
     server.create('country', { code: '99100', name: 'France' });
 
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
@@ -25,7 +24,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
     const screen = await visit('/organizations/new');
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Organisations' })).hasClass('active');
+    assert.dom(screen.getByRole('link', { name: t('components.layout.sidebar.organizations') })).hasClass('active');
   });
 
   module('when creating an organization without a parent organization', function () {
@@ -44,7 +43,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
       const screen = await visit('/organizations/new');
 
       // when
-      const cancelButton = await screen.getByRole('button', { name: this.intl.t('common.actions.cancel') });
+      const cancelButton = await screen.getByRole('button', { name: t('common.actions.cancel') });
       await click(cancelButton);
 
       // then
@@ -71,7 +70,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
       assert
         .dom(
           screen.getByRole('heading', {
-            name: this.intl.t('components.organizations.creation.parent-organization-name', {
+            name: t('components.organizations.creation.parent-organization-name', {
               parentOrganizationName: parentOrganization.name,
             }),
             level: 2,
@@ -82,7 +81,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: this.intl.t('components.organizations.creation.actions.add-child-organization'),
+            name: t('components.organizations.creation.actions.add-child-organization'),
           }),
         )
         .exists();
@@ -96,7 +95,7 @@ module('Acceptance | Organizations | Create', function (hooks) {
         )}`,
       );
       // when
-      const cancelButton = await screen.getByRole('button', { name: this.intl.t('common.actions.cancel') });
+      const cancelButton = await screen.getByRole('button', { name: t('common.actions.cancel') });
       await click(cancelButton);
 
       // then
@@ -108,9 +107,9 @@ module('Acceptance | Organizations | Create', function (hooks) {
     test('it redirects the user on the organization details page on tags tab', async function (assert) {
       // given
       const screen = await visit('/organizations/new');
-      await fillByLabel('Nom *', 'Stark Corp.');
+      await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Stark Corp.');
 
-      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
+      await click(screen.getByRole('button', { name: `${t('components.organizations.creation.type.label')} *` }));
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
@@ -130,12 +129,12 @@ module('Acceptance | Organizations | Create', function (hooks) {
       await screen.findByRole('listbox');
       await click(screen.getByText('France (99100)'));
 
-      await fillByLabel('Prénom du DPO', 'Justin');
-      await fillByLabel('Nom du DPO', 'Ptipeu');
-      await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
+      await fillByLabel(`${t('components.organizations.creation.dpo.firstname')}DPO`, 'Justin');
+      await fillByLabel(`${t('components.organizations.creation.dpo.lastname')}DPO`, 'Ptipeu');
+      await fillByLabel(`${t('components.organizations.creation.dpo.email')}DPO`, 'justin.ptipeu@example.net');
 
       // when
-      await clickByName('Ajouter');
+      await clickByName(t('common.actions.add'));
 
       // then
       assert.strictEqual(currentURL(), '/organizations/1/all-tags');
@@ -144,10 +143,10 @@ module('Acceptance | Organizations | Create', function (hooks) {
     test('it shows validation errors if form is not correctly filled', async function (assert) {
       // given
       const screen = await visit('/organizations/new');
-      await fillByLabel('Nom *', 'Stark Corp.');
+      await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Stark Corp.');
 
       // when
-      await clickByName('Ajouter');
+      await clickByName(t('common.actions.add'));
 
       // then
       assert.dom(screen.getByText(t('components.organizations.creation.required-fields-error'))).exists();

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -46,17 +46,18 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: 'Nom *' })).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
-      assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
-      assert.ok(screen.getByRole('textbox', { name: 'Identifiant externe' }));
-      assert
-        .dom(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')))
-        .exists();
-      assert.ok(screen.getByRole('textbox', { name: 'Département (en 3 chiffres)' }));
+      assert.ok(screen.getByRole('textbox', { name: `${t('components.organizations.creation.name.label')} *` }));
+      assert.ok(screen.getByLabelText(`${t('components.organizations.creation.type.label')} *`));
+      assert.ok(screen.getByText(t('components.organizations.creation.administration-team.selector.placeholder')));
       assert.ok(screen.getByLabelText(`${t('components.organizations.creation.country.selector.label')} *`));
-      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
+      assert.ok(screen.getByRole('textbox', { name: t('components.organizations.creation.province-code') }));
+      assert.ok(screen.getByRole('textbox', { name: t('components.organizations.creation.external-id.label') }));
+      assert.ok(screen.getByRole('textbox', { name: t('components.organizations.creation.documentation-link') }));
+      assert.ok(screen.getByRole('textbox', { name: `${t('components.organizations.creation.dpo.lastname')}DPO` }));
+      assert.ok(screen.getByRole('textbox', { name: `${t('components.organizations.creation.dpo.firstname')}DPO` }));
+      assert.ok(screen.getByRole('textbox', { name: `${t('components.organizations.creation.dpo.email')}DPO` }));
+      assert.ok(screen.getByRole('button', { name: t('common.actions.cancel') }));
+      assert.ok(screen.getByRole('button', { name: t('common.actions.add') }));
     });
 
     test('should render countries options in list', async function (assert) {
@@ -109,13 +110,13 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
 
       // when
-      await fillByLabel('Nom *', 'Organisation de Test');
+      await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
 
-      click(screen.getByRole('button', { name: `Sélectionner un type d'organisation *` }));
+      click(screen.getByRole('button', { name: `${t('components.organizations.creation.type.label')} *` }));
       await screen.findByRole('listbox');
       click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
-      await fillByLabel(t('components.organizations.creation.external-id'), 'Mon identifiant externe');
+      await fillByLabel(t('components.organizations.creation.external-id.label'), 'Mon identifiant externe');
 
       click(
         screen.getByRole('button', {
@@ -135,11 +136,11 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       await screen.findByRole('listbox');
       click(await screen.findByRole('option', { name: 'France (99100)' }));
 
-      await fillByLabel('Lien vers la documentation', 'www.documentation.fr');
+      await fillByLabel(t('components.organizations.creation.documentation-link'), 'www.documentation.fr');
 
-      await fillByLabel('Prénom du DPO', 'Justin');
-      await fillByLabel('Nom du DPO', 'Ptipeu');
-      await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
+      await fillByLabel(`${t('components.organizations.creation.dpo.firstname')}DPO`, 'Justin');
+      await fillByLabel(`${t('components.organizations.creation.dpo.lastname')}DPO`, 'Ptipeu');
+      await fillByLabel(`${t('components.organizations.creation.dpo.email')}DPO`, 'justin.ptipeu@example.net');
 
       // then
       assert.strictEqual(organization.name, 'Organisation de Test');

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1221,6 +1221,11 @@
       "title": "Children organisations"
     },
     "organizations": {
+      "breadcrumb": {
+        "new-child-organization-page": "New child organization",
+        "new-organization-page": "New organization",
+        "parent-page": "All organizations"
+      },
       "notifications": {
         "errors": {
           "payload-too-large": "The weight of the logo exceeds the authorised limit of {maxSizeInMegaBytes} MB. Please reduce the weight of the logo and try again."

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -100,6 +100,7 @@
       "empty-result": "Aucun résultat"
     },
     "words": {
+      "example-abbr": "e.g.",
       "no": "No",
       "none": "None",
       "yes": "Yes"
@@ -655,20 +656,41 @@
         },
         "administration-team": {
           "selector": {
-            "label": "Choose an administration team",
-            "placeholder": "Administration team"
+            "label": "Administration team",
+            "placeholder": "Select one team"
           }
         },
+        "configuration": "Configuration",
         "country": {
           "selector": {
-            "label": "Choose a country",
-            "placeholder": "Country (INSEE code)"
+            "label": "Country (INSEE code)",
+            "placeholder": "Select one country"
           }
         },
-        "external-id": "External Identifier",
+        "documentation-link": "Link to the documentation",
+        "dpo": {
+          "definition": "Data Protection Officer",
+          "email": "E-mail address of ",
+          "firstname": "Firstname of ",
+          "lastname": "Lastname of ",
+          "title": "DPO"
+        },
+        "external-id": {
+          "label": "External Identifier",
+          "placeholder": "My great external identifier"
+        },
+        "general-information": "General information",
+        "name": {
+          "label": "Name of the organization",
+          "placeholder": "My new organization"
+        },
         "parent-organization-name": "Parent organization: {parentOrganizationName}",
         "province-code": "Province code (3 digits)",
-        "required-fields-error": "Please fill in all required fields."
+        "required-fields-error": "Please fill in all required fields.",
+        "type": {
+          "label": "Type of the organization",
+          "placeholder": "Select one type"
+        }
       },
       "editing": {
         "administration-team": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -100,6 +100,7 @@
       "empty-result": "Aucun résultat"
     },
     "words": {
+      "example-abbr": "ex:",
       "no": "Non",
       "none": "Aucun",
       "yes": "Oui"
@@ -656,20 +657,41 @@
         },
         "administration-team": {
           "selector": {
-            "label": "Sélectionner une équipe en charge",
-            "placeholder": "Équipe en charge"
+            "label": "Équipe en charge",
+            "placeholder": "Sélectionner une équipe"
           }
         },
+        "configuration": "Paramétrage",
         "country": {
           "selector": {
-            "label": "Sélectionner un pays",
-            "placeholder": "Pays (code INSEE)"
+            "label": "Pays (code INSEE)",
+            "placeholder": "Sélectionner un pays"
           }
         },
-        "external-id": "Identifiant externe",
+        "documentation-link": "Lien vers la documentation",
+        "dpo": {
+          "definition": "Délégué à la protection des données",
+          "email": "Adresse e-mail du ",
+          "firstname": "Prénom du ",
+          "lastname": "Nom du ",
+          "title": "DPO"
+        },
+        "external-id": {
+          "label": "Identifiant externe",
+          "placeholder": "Mon super idendifiant externe"
+        },
+        "general-information": "Informations générales",
+        "name": {
+          "label": "Nom de l'organisation",
+          "placeholder": "Ma nouvelle organisation"
+        },
         "parent-organization-name": "Organisation mère : {parentOrganizationName}",
         "province-code": "Département (en 3 chiffres)",
-        "required-fields-error": "Veuillez remplir tous les champs obligatoires."
+        "required-fields-error": "Veuillez remplir tous les champs obligatoires.",
+        "type": {
+          "label": "Type de l'organisation",
+          "placeholder": "Sélectionner un type"
+        }
       },
       "editing": {
         "administration-team": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1223,6 +1223,11 @@
       "title": "Organisations filles"
     },
     "organizations": {
+      "breadcrumb": {
+        "new-child-organization-page": "Nouvelle organisation fille",
+        "new-organization-page": "Nouvelle organisation",
+        "parent-page": "Toutes les organisations"
+      },
       "notifications": {
         "errors": {
           "payload-too-large": "Le poids du logo dépasse la limite autorisée de {maxSizeInMegaBytes} Mo. Veuillez réduire le poids du logo et essayer à nouveau."


### PR DESCRIPTION
## ❄️ Problème

Dans le cadre de la refonte du formulaire de création d'organisation sur Pix Admin, il faut homogénéiser les noms des champs et leurs placeholders.

## 🛷 Proposition

Changer les noms des champs concernés, et implémenter des clés de traduction.

## ☃️ Remarques

- les numéros des sections ont été enlevés, pour se conformer à la maquette de la nouvelle page de détail d'une organisation

## 🧑‍🎄 Pour tester

Sur Pix Admin:
- page de création d'orga en français [https://admin-pr14422.review.pix.fr/organizations/new](https://admin-pr14422.review.pix.fr/organizations/new)
- page de création d'orga en anglais [https://admin-pr14422.review.pix.org/organizations/new](https://admin-pr14422.review.pix.org/organizations/new)
 - vérifier la cohérence des textes selon les deux versions
<img width="1010" height="585" alt="Capture d’écran 2025-12-12 à 16 31 11" src="https://github.com/user-attachments/assets/49fbed0e-e7ab-44b8-9362-2f3ae2669a4f" />

<img width="1010" height="581" alt="Capture d’écran 2025-12-12 à 16 32 17" src="https://github.com/user-attachments/assets/95fc2a04-b73f-4250-8b7a-de27b99beeca" />

