### PR TITLE
[TECH] Enlever les inserts dans les champs quest qui ne seront plus utilisés au moment de la création des parcours combinés (PIX-20781)

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-repository.js
@@ -75,7 +75,7 @@ const saveInBatch = async ({ combinedCourses }) => {
   const combinedCoursesToSave = combinedCourses.map(_toDTO);
   for (const combinedCourseToSave of combinedCoursesToSave) {
     const [{ id: questId }] = await knexConn('quests')
-      .insert({ ...combinedCourseToSave.quest, ...combinedCourseToSave.combinedCourse })
+      .insert({ ...combinedCourseToSave.quest })
       .returning('id');
     await knexConn('combined_courses').insert({ ...combinedCourseToSave.combinedCourse, questId });
   }
@@ -86,7 +86,6 @@ const _toDTO = (combinedCourse) => {
   return {
     quest: {
       ...questDTO,
-      id: combinedCourse.id,
       eligibilityRequirements: JSON.stringify([]),
       successRequirements: JSON.stringify(questDTO.successRequirements),
     },

--- a/api/tests/quest/acceptance/application/combined-course-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-route_test.js
@@ -51,7 +51,10 @@ ${organizationId};"{""name"":""Combinix"",""combinedCourseContent"":[],""descrip
         const response = await server.inject(options);
 
         // then
-        const createdQuest = await knex('quests').where('organizationId', organizationId).first();
+        const createdQuest = await knex('quests')
+          .join('combined_courses', 'combined_courses.questId', 'quests.id')
+          .where('combined_courses.organizationId', organizationId)
+          .first();
 
         expect(response.statusCode).to.equal(204);
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-repository_test.js
@@ -198,7 +198,7 @@ describe('Quest | Integration | Repository | combined-course', function () {
   });
 
   describe('#saveInBatch', function () {
-    it('should save given combined course on quests', async function () {
+    it('should create quests related to given combined courses', async function () {
       // given
       const firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
       const secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
@@ -247,20 +247,19 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await combinedCourseRepository.saveInBatch({ combinedCourses: [firstCombinedCourse, secondCombinedCourse] });
 
       // then
-      const firstSavedQuest = await knex('quests').where('organizationId', firstOrganizationId).first();
-      const secondSavedQuest = await knex('quests').where('organizationId', secondOrganizationId).first();
+      const firstSavedQuest = await knex('combined_courses')
+        .join('quests', 'quests.id', 'combined_courses.questId')
+        .where('combined_courses.organizationId', firstOrganizationId)
+        .first();
 
-      expect(firstSavedQuest.name).to.equal('firstCombinedCourse');
+      const secondSavedQuest = await knex('combined_courses')
+        .join('quests', 'quests.id', 'combined_courses.questId')
+        .where('combined_courses.organizationId', secondOrganizationId)
+        .first();
+
       expect(firstSavedQuest.successRequirements).to.deep.equal(successRequirements);
-      expect(firstSavedQuest.code).equal('firstCode');
-      expect(firstSavedQuest.description).equal('ma description');
-      expect(firstSavedQuest.illustration).equal('mon_illu.svg');
 
-      expect(secondSavedQuest.name).to.equal('secondCombinedCourse');
       expect(secondSavedQuest.successRequirements).to.deep.equal(successRequirements);
-      expect(secondSavedQuest.code).equal('secondCode');
-      expect(secondSavedQuest.description).null;
-      expect(secondSavedQuest.illustration).null;
     });
 
     it('should save given combined course on combined_courses', async function () {
@@ -312,11 +311,12 @@ describe('Quest | Integration | Repository | combined-course', function () {
       await combinedCourseRepository.saveInBatch({ combinedCourses: [firstCombinedCourse, secondCombinedCourse] });
 
       // then
-      const firstSavedQuest = await knex('quests').where('organizationId', firstOrganizationId).first();
-      const secondSavedQuest = await knex('quests').where('organizationId', secondOrganizationId).first();
-
-      const firstSavedCombinedCourse = await knex('combined_courses').where('questId', firstSavedQuest.id).first();
-      const secondSavedCombinedCourse = await knex('combined_courses').where('questId', secondSavedQuest.id).first();
+      const firstSavedCombinedCourse = await knex('combined_courses')
+        .where('combined_courses.organizationId', firstOrganizationId)
+        .first();
+      const secondSavedCombinedCourse = await knex('combined_courses')
+        .where('combined_courses.organizationId', secondOrganizationId)
+        .first();
 
       expect(firstSavedCombinedCourse.name).to.equal('firstCombinedCourse');
       expect(firstSavedCombinedCourse.description).equal('ma description');


### PR DESCRIPTION
## ❄️ Problème
On va progressivement arrêter de lier le contexte de "quests" aux parcours combinés.
Une première étape est d'enlever les champs quests qui sont redondants par rapport à la table combined_courses. 

## 🛷 Proposition
On commence par arrêter d'insérer des valeurs dans ces champs redondants (code, organizationId, name, description, illustration) au moment du saveInBatch dans le combinedCourseRepository.

## 🧑‍🎄 Pour tester
Aller sur PixAdmin et tester la création de parcours en masse de parcours combinés à l'aide d'un template