### PR TITLE
[FEATURE] Vider le champ mot de passe du formulaire de connexion SCO suite à une erreur (PIX-20773).

### DIFF
--- a/mon-pix/app/components/routes/login-form.gjs
+++ b/mon-pix/app/components/routes/login-form.gjs
@@ -148,7 +148,10 @@ export default class LoginForm extends Component {
     const error = errorsApi?.responseJSON || errorsApi;
     const errorCode = get(error, 'errors[0].code');
 
-    if (errorCode === 'UNEXPECTED_USER_ACCOUNT') {
+    if (['MISSING_OR_INVALID_CREDENTIALS', 'USER_IS_TEMPORARY_BLOCKED'].includes(errorCode)) {
+      this.password = null;
+      this.errorMessage = this.errorMessages.getAuthenticationErrorMessage(error);
+    } else if (errorCode === 'UNEXPECTED_USER_ACCOUNT') {
       const unexpectedUserAccountErrorMessage = this.intl.t(
         'pages.sco-signup-or-login.login-form.unexpected-user-account-error',
       );

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -21,12 +21,12 @@ module('Integration | Component | routes/login-form', function (hooks) {
     assert.dom(screen.getByLabelText(/Mot de passe/)).exists();
   });
 
-  test('should display an error message when authentication fails', async function (assert) {
+  test('should display an error message and empty password input when authentication fails', async function (assert) {
     // given
     const errorResponse = {
       status: 401,
       responseJSON: {
-        errors: [{ status: '401' }],
+        errors: [{ status: '401', code: 'MISSING_OR_INVALID_CREDENTIALS' }],
       },
     };
 
@@ -42,6 +42,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
 
     // then
     assert.dom(screen.getByText(t('common.api-error-messages.login-unauthorized-error'))).exists();
+    assert.dom(screen.getByLabelText(/Mot de passe/)).hasValue('');
   });
 
   test('should display password when user click', async function (assert) {


### PR DESCRIPTION
## ❄️ Problème

Sur la double mire SCO, le message indiquant le nombre de tentatives restant s’affiche bien. En revanche, le champ ne se vide pas comme c’est le cas sur Pix App. On suppose que cette mire pourrait être une des raisons pour laquelle il y a encore beaucoup de comptes bloqués. 

## 🛷 Proposition
Si une erreur survient, vider le champ mot de passe.


## 🧑‍🎄 Pour tester

1. Se connecter avec le SSO GAR (faux GAR)  (RA: [https://gar.review.pix.fr](https://gar.review.pix.fr/)) ou démarrer en local)
2. Indiquer un samlId aléatoire, le prénom Hermione et le nom Granger  
3. Se connecter avec le bouton « Sign in »
4. Sur la page « Saisissez votre code » indiquer le code campagne SCOBADGE1
5. Cliquer sur le bouton « Accéder au parcours »
6. Cliquer sur le bouton « Je commence »
7. Indiquer la date de naissance 05-05-2013
8. Cliquer sur le bouton « C'est parti ! »
9. Cliquer sur le bouton « Continuer avec mon compte Pix »
10. Sur le formulaire « J’ai déjà un compte Pix » indiquer l'adresse email hermione@school.net
11. Rentrer un mauvais mot de passe puis cliquer sur Se connecter
12. Constater l'apparition d'une erreur et le vidage du champ Mot de passe
