### PR TITLE
[TECH] Supprimer les décorateurs computed dans Pix Admin

### DIFF
--- a/admin/app/controllers/authenticated/sessions/certification/informations.js
+++ b/admin/app/controllers/authenticated/sessions/certification/informations.js
@@ -1,8 +1,5 @@
 import Controller from '@ember/controller';
-/* eslint-disable ember/no-computed-properties-in-native-classes */
 import { action } from '@ember/object';
-import { alias } from '@ember/object/computed';
-/* eslint-enable ember/no-computed-properties-in-native-classes */
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import cloneDeep from 'lodash/cloneDeep';
@@ -14,13 +11,15 @@ export default class CertificationInformationsController extends Controller {
   MAX_REACHABLE_LEVEL = ENV.APP.MAX_REACHABLE_LEVEL;
 
   // Properties
-  @alias('model.certification') certification;
   @service pixToast;
   @service intl;
 
   @tracked displayJuryLevelSelect = false;
-
   @tracked selectedJuryLevel = null;
+
+  get certification() {
+    return this.model.certification;
+  }
 
   get juryLevelOptions() {
     const translatedDefaultJuryOptions = this.certification.complementaryCertificationCourseResultWithExternal

--- a/admin/app/controllers/authenticated/sessions/certification/neutralization.js
+++ b/admin/app/controllers/authenticated/sessions/certification/neutralization.js
@@ -1,13 +1,14 @@
 import Controller from '@ember/controller';
-import { action, set } from '@ember/object';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { alias } from '@ember/object/computed';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class NeutralizationController extends Controller {
-  @alias('model') certificationDetails;
   @service pixToast;
   @service accessControl;
+
+  get certificationDetails() {
+    return this.model;
+  }
 
   @action
   async neutralize(challengeRecId, questionIndex) {
@@ -52,9 +53,16 @@ export default class NeutralizationController extends Controller {
   }
 
   _updateModel(challengeRecId, neutralized) {
-    const neutralizedChallenge = this.certificationDetails.listChallengesAndAnswers.find((challengeAndAnswer) => {
-      return challengeAndAnswer.challengeId === challengeRecId;
+    const updatedChallenges = this.certificationDetails.listChallengesAndAnswers.map((challenge) => {
+      if (challenge.challengeId === challengeRecId) {
+        return {
+          ...challenge,
+          isNeutralized: neutralized,
+        };
+      }
+      return challenge;
     });
-    set(neutralizedChallenge, 'isNeutralized', neutralized);
+
+    this.certificationDetails.listChallengesAndAnswers = updatedChallenges;
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/controllers/authenticated/sessions/list/with-required-action.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -9,7 +8,6 @@ export default class AuthenticatedSessionsWithRequiredActionListController exten
 
   @tracked assignedToSelfOnly = false;
 
-  @computed('assignedToSelfOnly', 'currentUser.adminMember.fullName', 'model.withRequiredAction')
   get sessionsList() {
     const sessions = this.model;
     if (this.assignedToSelfOnly) {

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -1,7 +1,5 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { alias } from '@ember/object/computed';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -17,8 +15,6 @@ export default class IndexController extends Controller {
   @service intl;
   @service store;
 
-  @alias('model') sessionModel;
-
   @tracked modalTitle = '';
   @tracked modalMessage = '';
   @tracked modalConfirmAction = this.cancelModal;
@@ -26,6 +22,10 @@ export default class IndexController extends Controller {
 
   @tracked isCopyButtonClicked = false;
   @tracked copyButtonText = 'Copié';
+
+  get sessionModel() {
+    return this.model;
+  }
 
   get sessionStatusLabel() {
     return statusToDisplayName[this.sessionModel.status];

--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 import { service } from '@ember/service';
 import Model, { attr } from '@ember-data/model';
 import groupBy from 'lodash/groupBy';
@@ -20,7 +18,6 @@ export default class CertificationDetails extends Model {
   @attr() listChallengesAndAnswers;
   version = 2;
 
-  @computed('listChallengesAndAnswers', 'listChallengesAndAnswers.@each.isNeutralized')
   get answers() {
     return this.listChallengesAndAnswers.map((answer, index) => {
       answer.order = index + 1;
@@ -28,7 +25,6 @@ export default class CertificationDetails extends Model {
     });
   }
 
-  @computed('answers', 'competencesWithMark')
   get competences() {
     const answersByCompetence = groupBy(this.answers, 'competence');
 
@@ -49,12 +45,10 @@ export default class CertificationDetails extends Model {
     return sortBy(competences, 'index');
   }
 
-  @computed('createdAt')
   get creationDate() {
     return this.intl.formatDate(this.createdAt, { format: 'long' });
   }
 
-  @computed('completedAt')
   get completionDate() {
     return this.intl.formatDate(this.completedAt, { format: 'long' });
   }

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 import { service } from '@ember/service';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
@@ -60,22 +58,18 @@ export default class Certification extends Model {
 
   @hasMany('certification-issue-report', { async: true, inverse: 'certification' }) certificationIssueReports;
 
-  @computed('createdAt')
   get creationDate() {
     return this.intl.formatDate(this.createdAt, { format: 'long' });
   }
 
-  @computed('completedAt')
   get completionDate() {
     return this.completedAt ? this.intl.formatDate(this.completedAt, { format: 'long' }) : null;
   }
 
-  @computed('status')
   get statusLabelAndValue() {
     return certificationStatuses.find((certificationStatus) => certificationStatus.value === this.status);
   }
 
-  @computed('isPublished')
   get publishedText() {
     const value = this.isPublished;
     return value ? 'Oui' : 'Non';
@@ -92,7 +86,6 @@ export default class Certification extends Model {
     );
   }
 
-  @computed('competencesWithMark')
   get indexedCompetences() {
     const competencesWithMarks = this.competencesWithMark;
     return competencesWithMarks.reduce((result, value) => {
@@ -101,7 +94,6 @@ export default class Certification extends Model {
     }, {});
   }
 
-  @computed('indexedCompetences')
   get competences() {
     const indexedCompetences = this.indexedCompetences;
     return Object.keys(indexedCompetences)

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 import { service } from '@ember/service';
 import Model, { attr } from '@ember-data/model';
 import find from 'lodash/find';
@@ -27,35 +25,29 @@ export default class JuryCertificationSummary extends Model {
   @attr() isFlaggedAborted;
   @attr() numberOfCertificationIssueReportsWithRequiredAction;
 
-  @computed('createdAt')
   get creationDate() {
     return this.intl.formatDate(this.createdAt, { format: 'long' });
   }
 
-  @computed('completedAt')
   get completionDate() {
     return this.completedAt ? this.intl.formatDate(this.completedAt, { format: 'long' }) : null;
   }
 
-  @computed('numberOfCertificationIssueReportsWithRequiredAction')
   get numberOfCertificationIssueReportsWithRequiredActionLabel() {
     return this.numberOfCertificationIssueReportsWithRequiredAction > 0
       ? this.numberOfCertificationIssueReportsWithRequiredAction
       : '';
   }
 
-  @computed('status')
   get statusLabel() {
     const statusWithLabel = find(statuses, { value: this.status });
     return statusWithLabel?.label;
   }
 
-  @computed('status')
   get isCertificationStarted() {
     return this.status === 'started';
   }
 
-  @computed('status')
   get isCertificationInError() {
     return this.status === 'error';
   }

--- a/admin/app/models/organization-invitation.js
+++ b/admin/app/models/organization-invitation.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { equal } from '@ember/object/computed';
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class OrganizationInvitation extends Model {
@@ -13,8 +11,13 @@ export default class OrganizationInvitation extends Model {
 
   @belongsTo('organization', { async: true, inverse: null }) organization;
 
-  @equal('status', 'pending') isPending;
-  @equal('status', 'accepted') isAccepted;
+  get isPending() {
+    return this.status === 'pending';
+  }
+
+  get isAccepted() {
+    return this.status === 'accepted';
+  }
 
   get roleInFrench() {
     switch (this.role) {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { equal } from '@ember/object/computed';
 import { service } from '@ember/service';
 import Model, { attr, hasMany } from '@ember-data/model';
 import pick from 'lodash/pick';
@@ -32,8 +30,6 @@ export default class Organization extends Model {
   @attr('string') administrationTeamName;
   @attr('number') countryCode;
   @attr('string') countryName;
-  @equal('type', 'SCO') isOrganizationSCO;
-  @equal('type', 'SUP') isOrganizationSUP;
 
   @hasMany('organization-membership', { async: true, inverse: 'organization' }) organizationMemberships;
   @hasMany('target-profile-summary', { async: true, inverse: null }) targetProfileSummaries;
@@ -63,6 +59,14 @@ export default class Organization extends Model {
       'SHOW_SKILLS',
       'PLACES_MANAGEMENT',
     );
+  }
+
+  get isOrganizationSCO() {
+    return this.type === 'SCO';
+  }
+
+  get isOrganizationSUP() {
+    return this.type === 'SUP';
   }
 
   get isLearnerImportEnabled() {

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import isEmpty from 'lodash/isEmpty';
 import trim from 'lodash/trim';
@@ -47,12 +45,10 @@ export default class Session extends Model {
   @belongsTo('user', { async: true, inverse: null }) assignedCertificationOfficer;
   @belongsTo('user', { async: true, inverse: null }) juryCommentAuthor;
 
-  @computed('status')
   get isFinalized() {
     return this.status === FINALIZED || this.status === IN_PROCESS || this.status === PROCESSED;
   }
 
-  @computed('examinerGlobalComment')
   get hasExaminerGlobalComment() {
     return !isEmpty(trim(this.examinerGlobalComment));
   }
@@ -61,12 +57,10 @@ export default class Session extends Model {
     return Boolean(this.hasIncident || this.hasJoiningIssue);
   }
 
-  @computed('publishedAt')
   get isPublished() {
     return this.publishedAt !== null;
   }
 
-  @computed('status')
   get displayStatus() {
     return statusToDisplayName[this.status];
   }

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 const orderedApplicationNames = ['app', 'orga', 'certif'];
@@ -42,7 +40,6 @@ export default class User extends Model {
   @hasMany('last-application-connection', { async: false, inverse: null }) lastApplicationConnections;
   @hasMany('user-participation', { async: true, inverse: null }) participations;
 
-  @computed('firstName', 'lastName')
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }

--- a/admin/tests/acceptance/authenticated/sessions/certification/neutralization-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/certification/neutralization-test.js
@@ -185,6 +185,14 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | neutr
                 skill: '',
                 isNeutralized: true,
               },
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recABCDEF123456',
+                competence: '1.2',
+                skill: '',
+                isNeutralized: false,
+              },
             ];
 
             const certificationId = this.server.create('certification').id;
@@ -200,7 +208,8 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | neutr
             await clickByName('Dé-neutraliser');
 
             // then
-            assert.dom(await screen.findByRole('button', { name: 'Neutraliser' })).exists();
+            assert.dom(await screen.queryByRole('button', { name: 'Dé-neutraliser' })).doesNotExist();
+            assert.strictEqual((await screen.findAllByRole('button', { name: 'Neutraliser' })).length, 2);
           });
         });
 
@@ -217,6 +226,14 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | neutr
                 skill: '',
                 isNeutralized: false,
               },
+              {
+                result: 'ok',
+                value: 'Dummy value',
+                challengeId: 'recABCDEF123456',
+                competence: '1.2',
+                skill: '',
+                isNeutralized: true,
+              },
             ];
 
             const certificationId = this.server.create('certification').id;
@@ -232,7 +249,8 @@ module('Acceptance | Route | routes/authenticated/sessions/certification | neutr
             await clickByName('Neutraliser');
 
             // then
-            assert.dom(await screen.findByRole('button', { name: 'Dé-neutraliser' })).exists();
+            assert.dom(await screen.queryByRole('button', { name: 'Neutraliser' })).doesNotExist();
+            assert.strictEqual((await screen.findAllByRole('button', { name: 'Dé-neutraliser' })).length, 2);
           });
         });
       });

--- a/admin/tests/unit/controllers/authenticated/sessions/certification/neutralization-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/certification/neutralization-test.js
@@ -9,7 +9,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('neutralizes a challenge', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
@@ -34,7 +34,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('notifies a successful neutralization and updates model', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
@@ -67,7 +67,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('notifies a failed neutralization', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
@@ -101,7 +101,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('deneutralizes a challenge', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
@@ -126,7 +126,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('notifies a successful deneutralization and updates model', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],
@@ -151,7 +151,7 @@ module('Unit | Controller | authenticated/sessions/certification/neutralization'
     test('notifies a failed deneutralization', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/certification/neutralization');
-      controller.certificationDetails = {
+      controller.model = {
         id: 'certificationCourseId',
         save: sinon.stub(),
         listChallengesAndAnswers: [{ challengeId: 'challengeRecId123', isNeutralized: false }],


### PR DESCRIPTION
## ❄️ Problème

Historiquement, `@computed` servait à déclarer des propriétés dérivées : une valeur calculée automatiquement à partir d’autres propriétés, avec mise en cache et invalidation quand les dépendances changeaient.

Depuis Ember Octane (2019), la recommandation est de ne plus utiliser `@computed` dans la plupart des cas et de préférer :
- `@tracked` pour l’état mutable
- des getters JavaScript natifs pour les valeurs dérivées

## 🛷 Proposition

La majorité des `@computed` utilisés sont dans des modèles `ember-data` et se basent sur des attributs `@attr` qui sont par défaut "tracked" par `ember-data`. Donc on peut simplement supprimé `@computed` et utiliser le getter natif de la classe JS.

## ☃️ Remarques

🚨 **Important** @1024pix/team-certification 

J'ai un doute sur le `@computed` du modèle `CertificationDetails`, qui se base sur une propriété des éléments du tableau : 
```js
// admin/app/models/certification-details.js
@computed('listChallengesAndAnswers', 'listChallengesAndAnswers.@each.isNeutralized')
  get answers() {
    return this.listChallengesAndAnswers.map((answer, index) => {
      answer.order = index + 1;
      return answer;
    });
  }
```
Je ne sais pas le comportement attendu et tous les test semblent passer. Quelles est la fonctionnalité derrière ce `@computed`.

EDIT: Traité par @Jeyffrey 

## 🧑‍🎄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
