### PR TITLE
[TECH] :recycle: Renomme le constructeur `buildSupervisorAccess` pour utiliser le terme `invigilator` (pix-20789)

### DIFF
--- a/api/db/database-builder/factory/build-supervisor-access.js
+++ b/api/db/database-builder/factory/build-supervisor-access.js
@@ -4,7 +4,7 @@ import { databaseBuffer } from '../database-buffer.js';
 import { buildSession } from './build-session.js';
 import { buildUser } from './build-user.js';
 
-const buildSupervisorAccess = function ({
+export function buildInvigilatorAccess({
   id = databaseBuffer.getNextId(),
   sessionId,
   userId,
@@ -22,6 +22,4 @@ const buildSupervisorAccess = function ({
     tableName: 'invigilator_accesses',
     values,
   });
-};
-
-export { buildSupervisorAccess };
+}

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -147,7 +147,7 @@ async function _createSessionAndReturnId({ certificationCenterId, databaseBuilde
     createdAt: new Date(),
   });
 
-  _buildSupervisorAccess({ databaseBuilder, sessionId: id, userId: userIds.at(0) });
+  _buildInvigilatorAccess({ databaseBuilder, sessionId: id, userId: userIds.at(0) });
   return id;
 }
 
@@ -362,9 +362,9 @@ async function _createUser({ firstName, lastName, birthdate, email, organization
   return { userId, organizationLearnerId };
 }
 
-function _buildSupervisorAccess({ databaseBuilder, sessionId }) {
+function _buildInvigilatorAccess({ databaseBuilder, sessionId }) {
   const supervisor = databaseBuilder.factory.buildUser({ firstName: `supervisor${sessionId}` });
-  databaseBuilder.factory.buildSupervisorAccess({
+  databaseBuilder.factory.buildInvigilatorAccess({
     sessionId,
     userId: supervisor.id,
     authorizedAt: new Date(),

--- a/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
@@ -29,7 +29,7 @@ describe('Acceptance | Controller | session-controller-get-invigilator-kit-pdf',
       });
 
       sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-      databaseBuilder.factory.buildSupervisorAccess({ userId: user.id, sessionId: sessionIdAllowed });
+      databaseBuilder.factory.buildInvigilatorAccess({ userId: user.id, sessionId: sessionIdAllowed });
 
       await databaseBuilder.commit();
     });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/session-repository_test.js
@@ -196,8 +196,8 @@ describe('Integration | Repository | certification | enrolment | SessionEnrolmen
         it('should remove invigilator accesses and delete the session', async function () {
           // given
           const sessionId = databaseBuilder.factory.buildSession().id;
-          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
-          databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+          databaseBuilder.factory.buildInvigilatorAccess({ sessionId });
+          databaseBuilder.factory.buildInvigilatorAccess({ sessionId });
 
           await databaseBuilder.commit();
 

--- a/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/certification-candidate-route_test.js
@@ -41,7 +41,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           });
 
           const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
-          databaseBuilder.factory.buildSupervisorAccess({
+          databaseBuilder.factory.buildInvigilatorAccess({
             userId: invigilatorUserId,
             sessionId,
           });
@@ -95,7 +95,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           });
 
           const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
-          databaseBuilder.factory.buildSupervisorAccess({
+          databaseBuilder.factory.buildInvigilatorAccess({
             userId: invigilatorUserId,
             sessionId,
           });
@@ -155,7 +155,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
           });
 
           const invigilatorUserId = databaseBuilder.factory.buildUser({}).id;
-          databaseBuilder.factory.buildSupervisorAccess({
+          databaseBuilder.factory.buildInvigilatorAccess({
             userId: invigilatorUserId,
             sessionId,
           });

--- a/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/companion-alert-route_test.js
@@ -40,7 +40,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         status: CertificationCompanionLiveAlertStatus.ONGOING,
       });
 
-      const { userId: invigilatorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId });
+      const { userId: invigilatorId } = databaseBuilder.factory.buildInvigilatorAccess({ sessionId });
 
       await databaseBuilder.commit();
 
@@ -68,7 +68,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         const { id: sessionId } = databaseBuilder.factory.buildSession({ certificationCenterId });
         const { id: otherSessionId } = databaseBuilder.factory.buildSession({ certificationCenterId });
 
-        const { userId: invigilatorId } = databaseBuilder.factory.buildSupervisorAccess({ sessionId: otherSessionId });
+        const { userId: invigilatorId } = databaseBuilder.factory.buildInvigilatorAccess({ sessionId: otherSessionId });
 
         await databaseBuilder.commit();
 

--- a/api/tests/certification/session-management/acceptance/application/session-for-supervising-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-for-supervising-route_test.js
@@ -25,7 +25,7 @@ describe('Certification | Session Management | Acceptance | Application | Routes
         complementaryCertificationId: 99,
       });
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+      databaseBuilder.factory.buildInvigilatorAccess({ userId, sessionId: 121 });
       await databaseBuilder.commit();
 
       const headers = generateAuthenticatedUserRequestHeaders({ userId, source: 'pix-certif' });

--- a/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-live-alert-route_test.js
@@ -24,7 +24,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
           sessionId: session.id,
         });
         const invigilatorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
@@ -72,7 +72,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
           sessionId: session.id,
         });
         const invigilatorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const userNotLinkedToTheSessionId = databaseBuilder.factory.buildUser().id;
 
@@ -111,7 +111,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
           name: 'IMAGE_NOT_DISPLAYING',
           issueReportCategoryId: 5,
         });
-        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const assessment = databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
@@ -164,7 +164,7 @@ describe('Certification | Session | Acceptance | Application | Routes | session-
           sessionId: session.id,
         });
         const invigilatorUserId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildSupervisorAccess({ userId: invigilatorUserId, sessionId: session.id });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId: invigilatorUserId, sessionId: session.id });
 
         const userNotLinkedToTheSessionId = databaseBuilder.factory.buildUser().id;
 

--- a/api/tests/certification/session-management/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session-management/acceptance/application/session-route_test.js
@@ -136,7 +136,7 @@ describe('Certification | Session Management | Acceptance | Application | Route 
         certificationCenterId: certificationCenter.id,
         certificationCenter: certificationCenter.name,
       });
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId: expectedJurySession.id });
+      databaseBuilder.factory.buildInvigilatorAccess({ sessionId: expectedJurySession.id });
       databaseBuilder.factory.buildSession({ id: 1000099 });
       options = {
         method: 'GET',

--- a/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
+++ b/api/tests/certification/session-management/integration/application/pre-handlers/authorization_test.js
@@ -130,7 +130,7 @@ describe('Certification | Session-Management | Integration | Application | Pre-H
         const { id: sessionId } = databaseBuilder.factory.buildSession({
           certificationCenterId,
         });
-        databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId, sessionId });
         await databaseBuilder.commit();
 
         const options = {

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/invigilator-access-repository_test.js
@@ -24,7 +24,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId });
+      databaseBuilder.factory.buildInvigilatorAccess({ sessionId, userId });
       await databaseBuilder.commit();
 
       // when
@@ -41,7 +41,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // given
       const sessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId });
+      databaseBuilder.factory.buildInvigilatorAccess({ sessionId, userId });
       await databaseBuilder.commit();
 
       // when
@@ -60,7 +60,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // given
       const invigilatorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: invigilatorId });
+      databaseBuilder.factory.buildInvigilatorAccess({ sessionId, userId: invigilatorId });
       const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({ sessionId }).id;
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId });
       await databaseBuilder.commit();
@@ -79,7 +79,7 @@ describe('Integration | Repository | invigilator-access-repository', function ()
       // given
       const invigilatorId = databaseBuilder.factory.buildUser().id;
       const sessionId = databaseBuilder.factory.buildSession().id;
-      databaseBuilder.factory.buildSupervisorAccess({ sessionId, userId: invigilatorId });
+      databaseBuilder.factory.buildInvigilatorAccess({ sessionId, userId: invigilatorId });
       const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate().id;
       databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId });
       await databaseBuilder.commit();

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -167,7 +167,7 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         databaseBuilder.factory.buildSession({ id: 121, certificationCenterId: 345 });
         const candidate = databaseBuilder.factory.buildCertificationCandidate({ sessionId: 121 });
         databaseBuilder.factory.buildCoreSubscription({ certificationCandidateId: candidate.id });
-        databaseBuilder.factory.buildSupervisorAccess({ userId, sessionId: 121 });
+        databaseBuilder.factory.buildInvigilatorAccess({ userId, sessionId: 121 });
         await databaseBuilder.commit();
 
         const options = generateInjectOptions({


### PR DESCRIPTION
## ❄️ Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

<img width="870" height="204" alt="image" src="https://github.com/user-attachments/assets/e3ccccb3-28c2-4530-bb68-69da03917757" />

Le `builder` utilise encore le terme `supervisor`

## 🛷 Proposition

Renommer `buildSupervisorAccess` pour utiliser le terme `invigilator` 

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Les tests doivent être verts (le builder est utilisé dans un test de repository).
Le builder est aussi utilisé dans un script qui construit un groupe de données. Je ne sais pas si ce script est encore utilisé (et s'il faut le tester).
