### PR TITLE
[TECH] Harmoniser les champs vides des organisations en base (PIX-20776)

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -217,7 +217,7 @@ class OrganizationForAdmin {
     this.credit = organization.credit;
     this.externalId = organization.externalId;
     this.provinceCode = organization.provinceCode;
-    this.documentationUrl = organization.documentationUrl;
+    this.documentationUrl = isEmpty(organization.documentationUrl) ? null : organization.documentationUrl;
     this.updateIsManagingStudents(organization.features);
     this.showSkills = organization.features[ORGANIZATION_FEATURE.SHOW_SKILLS.key].active;
     this.identityProviderForCampaigns = organization.identityProviderForCampaigns;

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import differenceBy from 'lodash/differenceBy.js';
+import isEmpty from 'lodash/isEmpty.js';
 
 import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { DataProtectionOfficer } from './DataProtectionOfficer.js';
@@ -212,7 +213,7 @@ class OrganizationForAdmin {
     if (organization.name) this.name = organization.name;
     if (organization.type) this.type = organization.type;
     if (organization.logoUrl) this.logoUrl = organization.logoUrl;
-    this.email = organization.email;
+    this.email = isEmpty(organization.email) ? null : organization.email;
     this.credit = organization.credit;
     this.externalId = organization.externalId;
     this.provinceCode = organization.provinceCode;

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -62,8 +62,8 @@ class OrganizationForAdmin {
     this.externalId = externalId;
     this.provinceCode = provinceCode;
     this.credit = credit;
-    this.email = email;
-    this.documentationUrl = documentationUrl;
+    this.email = this.#sanitizeEmptyStrings(email);
+    this.documentationUrl = this.#sanitizeEmptyStrings(documentationUrl);
     this.createdBy = createdBy;
     this.createdAt = createdAt;
     this.archivedAt = archivedAt;
@@ -235,6 +235,10 @@ class OrganizationForAdmin {
 
   setCountryName(countryName) {
     this.countryName = countryName;
+  }
+
+  #sanitizeEmptyStrings(value) {
+    return value?.trim(' ') === '' ? null : value;
   }
 }
 

--- a/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/create-organizations-with-tags-and-target-profiles.usecase.js
@@ -167,7 +167,7 @@ function _transformOrganizationsCsvData(organizationsCsvData) {
     const email =
       organizationCsvData.type === Organization.types.SCO || organizationCsvData.type === Organization.types.SCO1D
         ? organizationCsvData.emailForSCOActivation
-        : undefined;
+        : null;
     return {
       organization: new OrganizationForAdmin({
         ...organizationCsvData,

--- a/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-serializer.js
@@ -163,7 +163,8 @@ async function deserializeForOrganizationsImport(file) {
           columnName === 'DPOLastName' ||
           columnName === 'DPOEmail' ||
           columnName === 'parentOrganizationId' ||
-          columnName === 'provinceCode'
+          columnName === 'provinceCode' ||
+          columnName === 'emailForSCOActivation'
         ) {
           value = null;
         }

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -611,7 +611,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       });
 
       // then
-      expect(givenOrganization.documentationUrl).to.equal(newDocumentationUrl);
+      expect(givenOrganization.documentationUrl).to.be.null;
     });
 
     it('updates organization showSkills flag', function () {

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -4,6 +4,28 @@ import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin', function () {
+  describe('constructor', function () {
+    context('when email is an empty string', function () {
+      it('should set email to null', function () {
+        // when
+        const organization = new OrganizationForAdmin({ email: ' ' });
+
+        // then
+        expect(organization.email).to.be.null;
+      });
+    });
+
+    context('when documentationUrl is an empty string', function () {
+      it('should set documentationUrl to null', function () {
+        // when
+        const organization = new OrganizationForAdmin({ documentationUrl: '   ' });
+
+        // then
+        expect(organization.documentationUrl).to.be.null;
+      });
+    });
+  });
+
   describe('features', function () {
     it('should throw an error if a feature format is not valid', function () {
       expect(() => {

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -575,7 +575,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       });
 
       // then
-      expect(givenOrganization.email).to.equal(newEmail);
+      expect(givenOrganization.email).to.be.null;
     });
 
     it('updates organization credit even if null value', function () {


### PR DESCRIPTION
## ❄️ Problème

Actuellement, il y'a en base des `email` et `documentationUrl` en `''` au lien de `null`

## 🛷 Proposition

S’assurer que les champs `email` et `documentationUrl` soient toujours enregistrés en base à NULL lorsqu’il est laissé vide, et non comme une chaîne de caractères vide "".


## 🧑‍🎄 Pour tester

- Depuis pix-admin
- Vérifier que null est bien enregistré en base lors de la création, modification, création en masse d'organisation