### PR TITLE
[BUGFIX] Impossible de modifier un utilisateur dans Pix Admin (PIX-20796)

### DIFF
--- a/admin/app/components/users/user-overview.gjs
+++ b/admin/app/components/users/user-overview.gjs
@@ -128,7 +128,7 @@ export default class UserOverview extends Component {
   async updateUserDetails(event) {
     event.preventDefault();
 
-    const isValid = await this.validator.validate(this.form);
+    const isValid = this.validator.validate(this.form);
     if (!isValid) return;
 
     this.args.user.firstName = this.form.firstName.trim();
@@ -173,17 +173,17 @@ export default class UserOverview extends Component {
 
   @action
   onChangeLanguage(language) {
-    this.form.lang = language;
+    this.form = { ...this.form, lang: language };
   }
 
   @action
   onLocaleChange(locale) {
-    this.form.locale = locale;
+    this.form = { ...this.form, locale };
   }
 
   @action
   updateFormValue(key, event) {
-    this.form[key] = event.target.value;
+    this.form = { ...this.form, [key]: event.target.value };
     this.validator.validateField(key, this.form[key]);
   }
 
@@ -421,7 +421,7 @@ class UserFormValidator extends FormValidator {
     };
 
     if (user.username) {
-      // When user already has a username, then username require and email is optional
+      // When user has a username, then username require and email is optional
       schema.email = Joi.string().email().max(255).allow(null).empty(['']).optional().messages({
         'string.email': "L'adresse e-mail n'a pas le bon format.",
         'string.max': "La longueur de l'adresse e-mail ne doit pas excéder 255 caractères.",
@@ -431,8 +431,8 @@ class UserFormValidator extends FormValidator {
         'string.empty': "L'identifiant ne peut pas être vide.",
         'string.max': "La longueur de l'identifiant ne doit pas excéder 255 caractères.",
       });
-    } else {
-      // When user does not have user, then email required
+    } else if (user.email) {
+      // When user has email and does not have username, then only email is required
       schema.email = Joi.string().email().max(255).empty(['', null]).required().messages({
         'any.required': "L'adresse e-mail ne peut pas être vide.",
         'string.empty': "L'adresse e-mail ne peut pas être vide.",
@@ -440,6 +440,7 @@ class UserFormValidator extends FormValidator {
         'string.max': "La longueur de l'adresse e-mail ne doit pas excéder 255 caractères.",
       });
     }
-    super(Joi.object(schema));
+
+    super(Joi.object(schema), { allowUnknown: true });
   }
 }

--- a/admin/tests/integration/components/users/user-overview-test.gjs
+++ b/admin/tests/integration/components/users/user-overview-test.gjs
@@ -1,6 +1,7 @@
 import { clickByName, render, waitFor, within } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import { fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import UserOverview from 'pix-admin/components/users/user-overview';
 import { module, test } from 'qunit';
@@ -448,7 +449,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('when user has an email only', function () {
-        test('displays user’s email in edit mode', async function (assert) {
+        test('displays email as required', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -464,29 +465,34 @@ module('Integration | Component | users | user-overview', function (hooks) {
 
           // then
           assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail *' })).hasValue(user.email);
+          assert.dom(screen.queryByRole('textbox', { name: 'Identifiant *' })).doesNotExist();
         });
 
-        test('does not display username in edit mode', async function (assert) {
+        test('can edit the user', async function (assert) {
           // given
-          const user = EmberObject.create({
+          const user = {
             lastName: 'Harry',
             firstName: 'John',
             email: 'john.harry@gmail.com',
             username: null,
             authenticationMethods: [],
-          });
+            save: sinon.stub(),
+          };
 
           // when
           const screen = await render(<template><UserOverview @user={{user}} /></template>);
           await clickByName('Modifier');
+          const firstName = screen.queryByRole('textbox', { name: 'Prénom *' });
+          await fillIn(firstName, 'Johnny');
+          await clickByName('Modifier');
 
           // then
-          assert.dom(screen.queryByRole('textbox', { name: 'Identifiant *' })).doesNotExist();
+          assert.strictEqual(user.firstName, 'Johnny');
         });
       });
 
       module('when user has a username only', function () {
-        test('displays user’s username in edit mode', async function (assert) {
+        test('displays username as required and email as optional', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -502,39 +508,45 @@ module('Integration | Component | users | user-overview', function (hooks) {
 
           // then
           assert.dom(screen.getByRole('textbox', { name: 'Identifiant *' })).hasValue(user.username);
+          const emailInput = screen.getByRole('textbox', { name: 'Adresse e-mail' });
+          assert.dom(emailInput).exists();
+          assert.dom(emailInput).hasNoAttribute('required');
         });
 
-        test('displays not required email', async function (assert) {
+        test('can edit the user', async function (assert) {
           // given
-          const user = EmberObject.create({
+          const user = {
             lastName: 'Harry',
             firstName: 'John',
             email: null,
             username: 'user.name1212',
             authenticationMethods: [],
-          });
+            save: sinon.stub(),
+          };
 
           // when
           const screen = await render(<template><UserOverview @user={{user}} /></template>);
           await clickByName('Modifier');
+          const firstName = screen.queryByRole('textbox', { name: 'Prénom *' });
+          await fillIn(firstName, 'Johnny');
+          await clickByName('Modifier');
 
           // then
-          const emailInput = screen.getByRole('textbox', { name: 'Adresse e-mail' });
-          assert.dom(emailInput).exists();
-          assert.dom(emailInput).hasNoAttribute('required');
+          assert.strictEqual(user.firstName, 'Johnny');
         });
       });
 
       module('when user has no username and no email', function () {
         test('does not display email', async function (assert) {
           // given
-          const user = EmberObject.create({
+          const user = {
             lastName: 'Harry',
             firstName: 'John',
             email: null,
             username: undefined,
             authenticationMethods: [],
-          });
+            save: sinon.stub(),
+          };
 
           // when
           const screen = await render(<template><UserOverview @user={{user}} /></template>);
@@ -542,6 +554,28 @@ module('Integration | Component | users | user-overview', function (hooks) {
 
           // then
           assert.dom(screen.queryByRole('textbox', { name: 'Adresse e-mail *' })).doesNotExist();
+        });
+
+        test('can edit the user', async function (assert) {
+          // given
+          const user = {
+            lastName: 'Harry',
+            firstName: 'John',
+            email: null,
+            username: undefined,
+            authenticationMethods: [],
+            save: sinon.stub(),
+          };
+
+          // when
+          const screen = await render(<template><UserOverview @user={{user}} /></template>);
+          await clickByName('Modifier');
+          const firstName = screen.queryByRole('textbox', { name: 'Prénom *' });
+          await fillIn(firstName, 'Johnny');
+          await clickByName('Modifier');
+
+          // then
+          assert.strictEqual(user.firstName, 'Johnny');
         });
       });
     });


### PR DESCRIPTION
## ❄️ Problème

Quand on clique sur le bouton modifier de la page utilisateur, il ne se passe rien. 

## 🛷 Proposition

Le bug a été introduit par la PR https://github.com/1024pix/pix/pull/14382.
Dans certains cas, la validation ne se déclenchait pas avec les bonnes règles de gestion de validation de formulaire.

1. Si l'utilisateur a un `username` seulement ou un `username` et un `email`, alors le `username` est obligatoire et l'`email` optionnel.
2. Si l'utilisateur a un `email` seulement, alors l'`email` est obligatoire et pas de validation sur `username` (pas affiché dans le formulaire)
3. Si l'utilisateur n'a ni l'un, ni l'autre, pas de validation sur `email` et `username` (pas affiché dans le formulaire)

Un bug a été également corrigé sur la modification de locale et langue qui étaient non sélectionnables.

## ☃️ Remarques

Le bug n'a pas été identifié avant car il manquait des tests de modification du formulaire pour chacun de ces cas. Des tests d'intégration ont été ajoutés afin de s'assurer que l'édition est toujours possible dans ces différents cas.

## 🧑‍🎄 Pour tester

Pour chaque type d'utilisateur, vérifier que la modification fonctionne :
1. Si l'utilisateur a un `username` seulement ou un `username` et un `email`, alors le `username` est obligatoire et l'`email` optionnel. 
  - **Utilisateur :** `Bob Leponge`
  - https://admin-pr14443.review.pix.fr/users/108994
2. Si l'utilisateur a un `email` seulement, alors l'`email` est obligatoire et pas de validation sur `username` (pas affiché dans le formulaire).
  - **Utilisatrice :** `Hermione Granger`
  - https://admin-pr14443.review.pix.fr/users/109020
3. Si l'utilisateur n'a ni l'un, ni l'autre, pas de validation sur `email` et `username` (pas affiché dans le formulaire).
  - **Utilisateur :** `Paul Emploi`
  - https://admin-pr14443.review.pix.fr/users/108952
