### PR TITLE
[BUGFIX] Mise à jour des URLs de documentation (PIX-20807).

### DIFF
--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -189,8 +189,8 @@
     },
     "urls": {
       "documentation": {
-        "other": "https://cloud.pix.fr/s/fLSG4mYCcX7GDRF",
-        "sco-managing-students": "https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
+        "other": "https://cloud.pix.fr/s/ypq3K7GmgpEdwop",
+        "sco-managing-students": "https://cloud.pix.fr/s/opiFxfjygR76S8y"
       },
       "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download",
       "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",


### PR DESCRIPTION
## ❄️ Problème

Un problème lié à notre hébergement de fichiers nous oblige à changer les URLs de documentation.

## 🛷 Proposition

Mise à jour des URLs

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Sur Pix-Certif, vérifier que les liens renvoient vers la documentation.
