### PR TITLE
[BUGFIX] Supprimer la valeur par défaut de INFORMATION_BANNER_POLLING_TIME dans le scope 'test' (PIX-20809)

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -202,7 +202,6 @@ module.exports = function (environment) {
 
     ENV.APP.BANNER_CONTENT = '';
     ENV.APP.BANNER_TYPE = '';
-    ENV.APP.INFORMATION_BANNER_POLLING_TIME = 1000 * 60;
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;


### PR DESCRIPTION
## ❄️ Problème

Récemment des tests sont devenus KO sur la branche `dev`, côté Module App Layout. ll y a une forte corrélation avec la récente mise à jour des variables d'env du scope 'test' par #14391, notamment la variable `INFORMATION_BANNER_POLLING_TIME`.

## 🛷 Proposition

La valeur par défaut de `INFORMATION_BANNER_POLLING_TIME` doit être à 60, et non 1000*60.
Sinon, la fonction `_getEnvironmentVariableAsNumber` retourne 1000 * 60, valeur multipliée elle-même par 1000... 😱 

*UPDATE: les tests ne passant pas, pour un timeout, j'ai supprimé la variable du scope "test" dans le fichier, comme autrefois.*

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

CI super green.
