### PR TITLE
[FEATURE] Ajouter une route récupérant la liste des référentiels de certif (PIX-20771).

### DIFF
--- a/api/src/certification/configuration/application/certification-framework-controller.js
+++ b/api/src/certification/configuration/application/certification-framework-controller.js
@@ -1,0 +1,13 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as certificationFrameworkSerializer from '../infrastructure/serializers/certification-framework-serializer.js';
+
+const findCertificationFrameworks = async function () {
+  const frameworks = await usecases.findCertificationFrameworks();
+  return certificationFrameworkSerializer.serialize(frameworks);
+};
+
+const certificationFrameworkController = {
+  findCertificationFrameworks,
+};
+
+export { certificationFrameworkController };

--- a/api/src/certification/configuration/application/certification-framework-route.js
+++ b/api/src/certification/configuration/application/certification-framework-route.js
@@ -1,0 +1,34 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { certificationFrameworkController } from './certification-framework-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/certification-frameworks',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationFrameworkController.findCertificationFrameworks,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin, Support, Certif et Métier',
+          'Elle renvoie la liste des référentiels de certification existants.',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'certification-frameworks-api';
+export { name, register };

--- a/api/src/certification/configuration/domain/models/Frameworks.js
+++ b/api/src/certification/configuration/domain/models/Frameworks.js
@@ -1,0 +1,18 @@
+/**
+ * Certification frameworks
+ * @readonly
+ * @enum {string}
+ */
+const FRAMEWORKS = Object.freeze({
+  CORE: 'CORE',
+  DROIT: 'DROIT',
+  EDU_1ER_DEGRE: 'EDU_1ER_DEGRE',
+  EDU_2ND_DEGRE: 'EDU_2ND_DEGRE',
+  EDU_CPE: 'EDU_CPE',
+  PRO_SANTE: 'PRO_SANTE',
+  CLEA: 'CLEA',
+});
+
+export const Frameworks = {
+  ...FRAMEWORKS,
+};

--- a/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
+++ b/api/src/certification/configuration/domain/usecases/find-certification-frameworks.js
@@ -1,0 +1,26 @@
+import { Frameworks } from '../models/Frameworks.js';
+
+/**
+ * @param {Object} params
+ * @param {VersionsRepository} params.versionsRepository
+ * @returns {Promise<Array<{id: string, name: string, versionStartDate: Date|null}>>}
+ */
+const findCertificationFrameworks = async function ({ versionsRepository }) {
+  const frameworkNames = Object.values(Frameworks);
+
+  const frameworksWithVersions = await Promise.all(
+    frameworkNames.map(async (name) => {
+      const activeVersion = await versionsRepository.findActiveByScope({ scope: name });
+
+      return {
+        id: name,
+        name,
+        activeVersionStartDate: activeVersion?.startDate ?? null,
+      };
+    }),
+  );
+
+  return frameworksWithVersions;
+};
+
+export { findCertificationFrameworks };

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -54,6 +54,7 @@ import { calibrateFrameworkVersion } from './calibrate-framework-version.js';
 import { catchingUpCandidateReconciliation } from './catching-up-candidate-reconciliation.js';
 import { createCertificationVersion } from './create-certification-version.js';
 import { exportScoWhitelist } from './export-sco-whitelist.js';
+import { findCertificationFrameworks } from './find-certification-frameworks.js';
 import { findComplementaryCertifications } from './find-complementary-certifications.js';
 import { getActiveVersionByScope } from './get-active-version-by-scope.js';
 import { getComplementaryCertificationForTargetProfileAttachmentRepository } from './get-complementary-certification-for-target-profile-attachment.js';
@@ -71,6 +72,7 @@ const usecasesWithoutInjectedDependencies = {
   catchingUpCandidateReconciliation,
   createCertificationVersion,
   exportScoWhitelist,
+  findCertificationFrameworks,
   findComplementaryCertifications,
   getCurrentFrameworkVersion,
   getActiveVersionByScope,

--- a/api/src/certification/configuration/infrastructure/serializers/certification-framework-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/certification-framework-serializer.js
@@ -1,0 +1,9 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+export function serialize(frameworks) {
+  return new Serializer('certification-framework', {
+    attributes: ['name', 'activeVersionStartDate'],
+  }).serialize(frameworks);
+}

--- a/api/src/certification/configuration/routes.js
+++ b/api/src/certification/configuration/routes.js
@@ -1,11 +1,12 @@
 import * as attachTargetProfile from './application/attach-target-profile-route.js';
+import * as certificationFramework from './application/certification-framework-route.js';
 import * as certificationVersion from './application/certification-version-route.js';
 import * as complementaryCertification from './application/complementary-certification-route.js';
 import * as scoBlockedAccessDates from './application/sco-blocked-access-dates-route.js';
 import * as scoWhitelist from './application/sco-whitelist-route.js';
 
 const attachTargetProfileRoutes = [attachTargetProfile];
-const certificationConfigurationRoutes = [certificationVersion, complementaryCertification];
+const certificationConfigurationRoutes = [certificationVersion, complementaryCertification, certificationFramework];
 const scoBlockedAccessDatesRoutes = [scoBlockedAccessDates];
 const scoWhitelistRoutes = [scoWhitelist];
 

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -1,0 +1,103 @@
+import { Frameworks } from '../../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { Scopes } from '../../../../../src/certification/shared/domain/models/Scopes.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateAuthenticatedUserRequestHeaders,
+  insertUserWithRoleSuperAdmin,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Application | Certification | ComplementaryCertification | certification-framework-route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/certification-frameworks', function () {
+    it('should return 200 HTTP status code with all frameworks', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const options = {
+        method: 'GET',
+        url: '/api/admin/certification-frameworks',
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      const coreStartDate = new Date('2025-01-15');
+
+      databaseBuilder.factory.buildCertificationVersion({
+        scope: Scopes.CORE,
+        startDate: coreStartDate,
+        expirationDate: null,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.have.deep.members([
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.CORE,
+          attributes: {
+            name: Frameworks.CORE,
+            'active-version-start-date': coreStartDate,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.DROIT,
+          attributes: {
+            name: Frameworks.DROIT,
+            'active-version-start-date': null,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.EDU_1ER_DEGRE,
+          attributes: {
+            name: Frameworks.EDU_1ER_DEGRE,
+            'active-version-start-date': null,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.EDU_2ND_DEGRE,
+          attributes: {
+            name: Frameworks.EDU_2ND_DEGRE,
+            'active-version-start-date': null,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.EDU_CPE,
+          attributes: {
+            name: Frameworks.EDU_CPE,
+            'active-version-start-date': null,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.PRO_SANTE,
+          attributes: {
+            name: Frameworks.PRO_SANTE,
+            'active-version-start-date': null,
+          },
+        },
+        {
+          type: 'certification-frameworks',
+          id: Frameworks.CLEA,
+          attributes: {
+            name: Frameworks.CLEA,
+            'active-version-start-date': null,
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/find-certification-frameworks_test.js
@@ -1,0 +1,80 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
+import { Scopes } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Certification | Configuration | Integration | Domain | UseCase | find-certification-frameworks', function () {
+  it('should return all frameworks with their active version start dates', async function () {
+    // given
+    const coreStartDate = new Date('2025-01-15');
+    const droitStartDate = new Date('2025-06-01');
+    const edu1erDegreStartDate = new Date('2025-03-01');
+
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: Scopes.CORE,
+      startDate: coreStartDate,
+      expirationDate: null,
+    });
+
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: Scopes.PIX_PLUS_DROIT,
+      startDate: droitStartDate,
+      expirationDate: null,
+    });
+
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: Scopes.PIX_PLUS_EDU_1ER_DEGRE,
+      startDate: new Date(2020, 12, 12),
+      expirationDate: new Date(2020, 12, 14),
+    });
+    databaseBuilder.factory.buildCertificationVersion({
+      scope: Scopes.PIX_PLUS_EDU_1ER_DEGRE,
+      startDate: edu1erDegreStartDate,
+      expirationDate: null,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const frameworks = await usecases.findCertificationFrameworks();
+
+    // then
+    expect(frameworks).to.have.deep.members([
+      {
+        id: Frameworks.CORE,
+        name: Frameworks.CORE,
+        activeVersionStartDate: coreStartDate,
+      },
+      {
+        id: Frameworks.DROIT,
+        name: Frameworks.DROIT,
+        activeVersionStartDate: droitStartDate,
+      },
+      {
+        id: Frameworks.EDU_1ER_DEGRE,
+        name: Frameworks.EDU_1ER_DEGRE,
+        activeVersionStartDate: edu1erDegreStartDate,
+      },
+      {
+        id: Frameworks.EDU_2ND_DEGRE,
+        name: Frameworks.EDU_2ND_DEGRE,
+        activeVersionStartDate: null,
+      },
+      {
+        id: Frameworks.EDU_CPE,
+        name: Frameworks.EDU_CPE,
+        activeVersionStartDate: null,
+      },
+      {
+        id: Frameworks.PRO_SANTE,
+        name: Frameworks.PRO_SANTE,
+        activeVersionStartDate: null,
+      },
+      {
+        id: Frameworks.CLEA,
+        name: Frameworks.CLEA,
+        activeVersionStartDate: null,
+      },
+    ]);
+  });
+});

--- a/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-framework-route_test.js
@@ -1,0 +1,57 @@
+import { certificationFrameworkController } from '../../../../../src/certification/configuration/application/certification-framework-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/configuration/application/certification-framework-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Certification | Configuration | Application | Router | certification-framework-route', function () {
+  describe('GET /api/admin/certification-frameworks', function () {
+    describe('when the user authenticated has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(certificationFrameworkController, 'findCertificationFrameworks').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/admin/certification-frameworks');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationFrameworkController.findCertificationFrameworks);
+      });
+    });
+
+    const authorizedRoles = [
+      { role: 'SuperAdmin', stub: 'checkAdminMemberHasRoleSuperAdmin' },
+      { role: 'Support', stub: 'checkAdminMemberHasRoleSupport' },
+      { role: 'Certif', stub: 'checkAdminMemberHasRoleCertif' },
+      { role: 'Metier', stub: 'checkAdminMemberHasRoleMetier' },
+    ];
+
+    authorizedRoles.forEach(({ role, stub }) => {
+      describe(`when the user has ${role} role`, function () {
+        it('should return 200 HTTP status code', async function () {
+          // given
+          sinon.stub(securityPreHandlers, stub).callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').callsFake((_handlers) => {
+            return () => true;
+          });
+          sinon.stub(certificationFrameworkController, 'findCertificationFrameworks').returns('ok');
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('GET', '/api/admin/certification-frameworks');
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          sinon.assert.calledOnce(certificationFrameworkController.findCertificationFrameworks);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/models/Frameworks_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Frameworks_test.js
@@ -1,0 +1,17 @@
+import { Frameworks } from '../../../../../../src/certification/configuration/domain/models/Frameworks.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Configuration | Domain | Models | Frameworks', function () {
+  it('should contain all supported certification frameworks', function () {
+    expect(Frameworks.CORE).to.equal('CORE');
+    expect(Frameworks.DROIT).to.equal('DROIT');
+    expect(Frameworks.EDU_1ER_DEGRE).to.equal('EDU_1ER_DEGRE');
+    expect(Frameworks.EDU_2ND_DEGRE).to.equal('EDU_2ND_DEGRE');
+    expect(Frameworks.EDU_CPE).to.equal('EDU_CPE');
+    expect(Frameworks.PRO_SANTE).to.equal('PRO_SANTE');
+    expect(Frameworks.CLEA).to.equal('CLEA');
+
+    const frameworkValues = Object.values(Frameworks);
+    expect(frameworkValues).to.have.lengthOf(7);
+  });
+});

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/certification-framework-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/certification-framework-serializer_test.js
@@ -1,0 +1,48 @@
+import * as certificationFrameworkSerializer from '../../../../../../src/certification/configuration/infrastructure/serializers/certification-framework-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Configuration | Serializer | certification-framework-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize certification frameworks with their active version start date', function () {
+      // given
+      const frameworks = [
+        { id: 'CORE', name: 'CORE', activeVersionStartDate: new Date('2025-01-15') },
+        { id: 'DROIT', name: 'DROIT', activeVersionStartDate: new Date('2025-06-01') },
+        { id: 'CLEA', name: 'CLEA', activeVersionStartDate: null },
+      ];
+
+      // when
+      const serialized = certificationFrameworkSerializer.serialize(frameworks);
+
+      // then
+      expect(serialized).to.deep.equal({
+        data: [
+          {
+            type: 'certification-frameworks',
+            id: 'CORE',
+            attributes: {
+              name: 'CORE',
+              'active-version-start-date': new Date('2025-01-15'),
+            },
+          },
+          {
+            type: 'certification-frameworks',
+            id: 'DROIT',
+            attributes: {
+              name: 'DROIT',
+              'active-version-start-date': new Date('2025-06-01'),
+            },
+          },
+          {
+            type: 'certification-frameworks',
+            id: 'CLEA',
+            attributes: {
+              name: 'CLEA',
+              'active-version-start-date': null,
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/certification/shared/unit/domain/models/Scopes_test.js
+++ b/api/tests/certification/shared/unit/domain/models/Scopes_test.js
@@ -2,7 +2,7 @@ import { Scopes } from '../../../../../../src/certification/shared/domain/models
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 
-describe('Scopes', function () {
+describe('Unit | Certification | Shared | Domain | Models | Scopes', function () {
   describe('getByName', function () {
     it('should return the scope when it exists', function () {
       // Given


### PR DESCRIPTION
## ❄️ Problème

Sur PixAdmin, dans l'écran “Référentiels de certif”, nous listons uniquement ce que nous appelions jusqu'à présent les “certifications complémentaires” (car c’est comme ça que se nommait la page [historiquement](https://github.com/1024pix/pix/pull/14223)).

Dorénavant, nous souhaitons aussi afficher le référentiel Pix Coeur.

## 🛷 Proposition

Ajouter une route `GET /api/admin/certification-frameworks` listant TOUS les référentiels de certification.

## ☃️ Remarques

[Un travail](https://github.com/1024pix/pix/pull/14414) a été fait pour renommer l'ancien modèle Frameworks en Scopes.

Maintenant, un nouveau modèle Frameworks est créé dans le but de lister tous les référentiels de certif.

## 🧑‍🎄 Pour tester

```shell
TOKEN=$(curl --insecure 'https://admin-pr14455.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123'  -H 'x-forwarded-host' 'admin' -H 'x-forwarded-proto' 'HTTP'  -X POST | jq -r .access_token)

curl https://admin-pr14455.review.pix.fr/api/admin/certification-frameworks \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X GET
``` 

Vous devriez obtenir la liste des 7 référentiels, avec `"active-version-start-date"` valant `null` **pour les référentiels sans version dans les seeds** (dont Cléa).
