### PR TITLE
[BUGFIX] Empêcher de multiples soumissions du form d'édition de session (PIX-20827).

### DIFF
--- a/certif/app/components/sessions/edition-form.gjs
+++ b/certif/app/components/sessions/edition-form.gjs
@@ -6,6 +6,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import get from 'lodash/get';
 
@@ -13,6 +14,8 @@ export default class SessionEditionFormComponent extends Component {
   @service router;
   @service intl;
   @service pixToast;
+
+  @tracked isSubmitting = false;
 
   get todayDate() {
     return new Date().toISOString().split('T')[0];
@@ -26,13 +29,17 @@ export default class SessionEditionFormComponent extends Component {
   async submitSession(event) {
     event.preventDefault();
 
-    if (!event.target.checkValidity()) {
+    if (!event.target.checkValidity() || this.isSubmitting) {
       return;
     }
+
+    this.isSubmitting = true;
 
     try {
       await this.args.session.save();
     } catch (responseError) {
+      this.isSubmitting = false;
+
       const error = responseError?.errors?.[0];
 
       if (error?.code) {
@@ -200,7 +207,7 @@ export default class SessionEditionFormComponent extends Component {
             </PixButton>
           </li>
           <li>
-            <PixButton @type='submit'>
+            <PixButton @type='submit' @isLoading={{this.isSubmitting}}>
               {{t
                 (if
                   this.isUpdateMode


### PR DESCRIPTION
## ❄️ Problème

Si l’utilisateur Pix Certif clique plusieurs fois sur le bouton “Créer la session” avec une mauvaise connexion réseau, alors de multiples sessions peuvent être créées par erreur en même temps.

## 🛷 Proposition

À la première soumission, le bouton de submit passe en mode "loading" et il devient alors impossible de le cliquer plusieurs fois.

En cas d'erreur, il revient à son état initial.

## 🧑‍🎄 Pour tester

- Aller sur PixCertif en RA et remplir le form de création de session
- Ouvrir son inspecteur, onglet "Réseau" et choisir une connexion de type 3G
- Tenter de cliquer plusieurs fois sur le bouton de soumission du formulaire et constater qu'il passe bien en état loading jusqu'à la fin
