### PR TITLE
[FEATURE] Ajouter la page de création de compte lors d'une connexion SSO (PIX-20540)

### DIFF
--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -1,0 +1,97 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import t from 'ember-intl/helpers/t';
+
+export default class OidcSignupForm extends Component {
+  @service oidcIdentityProviders;
+  @service intl;
+  @service url;
+
+  @tracked isTermsOfServiceValidated = false;
+  @tracked signupErrorMessage = null;
+  @tracked isLoading = false;
+
+  get userClaimsToDisplay() {
+    const { userClaims } = this.args;
+
+    const result = [];
+
+    if (userClaims) {
+      const { firstName, lastName, ...rest } = userClaims;
+      result.push(this.intl.t('pages.oidc.signup.claims.first-name-label-and-value', { firstName }));
+      result.push(this.intl.t('pages.oidc.signup.claims.last-name-label-and-value', { lastName }));
+
+      Object.entries(rest).map(([key, _value]) => {
+        let label = `${this.intl.t(`pages.oidc.signup.claims.${key}`)}`;
+
+        if (label.includes('Missing translation')) {
+          label = key;
+        }
+
+        return result.push(label);
+      });
+    }
+
+    return result;
+  }
+
+  get identityProviderOrganizationName() {
+    return this.oidcIdentityProviders.findBySlug(this.args.identityProviderSlug)?.organizationName;
+  }
+
+  @action
+  onChange(event) {
+    this.isTermsOfServiceValidated = !!event.target.checked;
+  }
+
+  @action
+  signup() {
+    //TODO signup user
+  }
+
+  <template>
+    <div>
+      <p class="oidc-signup-form__description">
+        {{t "pages.oidc.signup.description"}}
+        <em>{{this.identityProviderOrganizationName}}</em>&nbsp;:
+      </p>
+      <div class="oidc-signup-form__information">
+        <ul>
+          {{#each this.userClaimsToDisplay as |userClaimToDisplay|}}
+            <li>{{userClaimToDisplay}}</li>
+          {{/each}}
+        </ul>
+      </div>
+    </div>
+
+    <div class="oidc-signup-form__cgu-container">
+      <PixCheckbox {{on "change" this.onChange}}>
+        <:label>{{t "common.cgu.label"}}</:label>
+      </PixCheckbox>
+      <p>
+        {{t
+          "common.cgu.read-message"
+          cguUrl=this.url.cguUrl
+          dataProtectionPolicyUrl=this.url.dataProtectionPolicyUrl
+          htmlSafe=true
+        }}
+      </p>
+    </div>
+
+    {{#if this.signupErrorMessage}}
+      <PixNotificationAlert @type="error" class="oidc-signup-form__error">
+        {{this.signupErrorMessage}}
+      </PixNotificationAlert>
+    {{/if}}
+
+    <PixButton @type="submit" @triggerAction={{this.signup}} @isLoading={{this.isLoading}}>
+      {{t "pages.oidc.signup.signup-button"}}
+    </PixButton>
+  </template>
+}

--- a/orga/app/components/authentication/oidc-signup-form.scss
+++ b/orga/app/components/authentication/oidc-signup-form.scss
@@ -1,0 +1,63 @@
+@use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
+
+.oidc-signup-form {
+  display: flex;
+  flex-direction: column;
+  max-width: 1250px;
+  margin-bottom: 32px;
+  padding: 25px 50px;
+
+  @include breakpoints.device-is('desktop') {
+    padding: 50px;
+  }
+
+  &__description {
+    @extend %pix-body-m;
+
+    margin: 0;
+    padding-bottom: 24px;
+    color: var(--pix-neutral-500);
+  }
+
+  &__description em {
+    padding-right: 0.2rem;
+    padding-left: 0.2rem;
+    color: var(--pix-neutral-900);
+    font-style: normal;
+  }
+
+  &__information {
+    @extend %pix-body-m;
+
+    margin-bottom: 2rem;
+    color: var(--pix-neutral-500);
+
+    li {
+      overflow-wrap: anywhere;
+      list-style: none;
+    }
+  }
+
+  &__cgu-container {
+    @extend %pix-body-s;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+    padding: 0 0 24px;
+
+    label {
+      @extend %pix-body-s;
+    }
+
+    a {
+      font-weight: var(--pix-font-bold);
+      text-decoration: underline;
+    }
+  }
+
+  &__error {
+    margin-bottom: 20px;
+  }
+}

--- a/orga/app/controllers/authentication/oidc/login.js
+++ b/orga/app/controllers/authentication/oidc/login.js
@@ -18,10 +18,6 @@ export default class OidcLoginController extends Controller {
     return invitationStorage.get();
   }
 
-  get isWithInvitation() {
-    return Boolean(this.currentInvitation);
-  }
-
   get authenticationKey() {
     return oidcUserAuthenticationStorage.get()?.authenticationKey;
   }

--- a/orga/app/controllers/authentication/oidc/signup.js
+++ b/orga/app/controllers/authentication/oidc/signup.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
+
+const invitationStorage = new SessionStorageEntry('joinInvitationData');
+const oidcUserAuthenticationStorage = new SessionStorageEntry('oidcUserAuthentication');
+
+export default class OidcSignupController extends Controller {
+  get currentInvitation() {
+    return invitationStorage.get();
+  }
+
+  get userClaims() {
+    return oidcUserAuthenticationStorage.get()?.userClaims;
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -94,6 +94,7 @@
 @use 'sco-organization-participant/generate-username-password-modal' as *;
 @use 'analysis/global-positioning' as *;
 @use 'authentication/authentication-identity-providers' as *;
+@use 'authentication/oidc-signup-form' as *;
 @use 'authentication/oidc-association-confirmation' as *;
 @use 'authentication/oidc-provider-selector' as *;
 @use 'authentication/signup-form' as *;

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -1,3 +1,4 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -24,11 +25,16 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </div>
 
       <LoginForm
-        @isWithInvitation={{@controller.isWithInvitation}}
+        @isWithInvitation={{true}}
         @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.redirectToAssociationConfirmation}}
       />
+
+      <PixButtonLink @variant="secondary" @route="authentication.oidc.signup" @model={{@model.identity_provider_slug}}>
+        {{t "pages.oidc.login.signup-button"}}
+      </PixButtonLink>
+
     </:content>
   </AuthenticationLayout>
 </template>

--- a/orga/app/templates/authentication/oidc/signup.gjs
+++ b/orga/app/templates/authentication/oidc/signup.gjs
@@ -1,3 +1,40 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import t from 'ember-intl/helpers/t';
+import pageTitle from 'ember-page-title/helpers/page-title';
+import OidcSignupForm from 'pix-orga/components/authentication/oidc-signup-form';
+import AuthenticationLayout from 'pix-orga/components/authentication-layout/index';
+
 <template>
-  <div>SIGNUP PAGE TO BE DONE</div>
+  {{pageTitle (t "pages.oidc.signup.title")}}
+
+  <AuthenticationLayout class="signin-page-layout">
+    <:content>
+      {{#if @controller.currentInvitation}}
+        <PixNotificationAlert @type="communication-orga">
+          {{t "pages.login.join-invitation" organizationName=@controller.currentInvitation.organizationName}}
+        </PixNotificationAlert>
+      {{/if}}
+
+      <div>
+        <h1 class="pix-title-m">{{t "pages.oidc.signup.title"}}</h1>
+        <h2 class="pix-body-l">{{t "pages.oidc.signup.sub-title"}}</h2>
+      </div>
+      {{#if @controller.userClaims}}
+
+        <OidcSignupForm
+          @userClaims={{@controller.userClaims}}
+          @identityProviderSlug={{@model.identity_provider_slug}}
+        />
+
+        <PixButtonLink @variant="secondary" @route="authentication.oidc.login" @model={{@model.identity_provider_slug}}>
+          {{t "pages.oidc.signup.login-button"}}
+        </PixButtonLink>
+      {{else}}
+        <PixNotificationAlert @type="error" class="oidc-signup-form__error">
+          {{t "pages.oidc.signup.error"}}
+        </PixNotificationAlert>
+      {{/if}}
+    </:content>
+  </AuthenticationLayout>
 </template>

--- a/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
+++ b/orga/tests/acceptance/oidc/oidc-authentication-signup-test.js
@@ -1,0 +1,97 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { Response } from 'miragejs';
+import Location from 'pix-orga/utils/location';
+import { SessionStorageEntry } from 'pix-orga/utils/session-storage-entry';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | OIDC | authentication signup', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  const invitationStorage = new SessionStorageEntry('joinInvitationData');
+
+  hooks.beforeEach(function () {
+    sinon.stub(Location, 'assign');
+
+    invitationStorage.set({ invitationId: '123', code: 'ABC', organizationName: 'Super orga avec SSO' });
+  });
+
+  hooks.afterEach(function () {
+    Location.assign.restore();
+    invitationStorage.remove();
+  });
+
+  test('the user signs up', async function (assert) {
+    // given
+    const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+    // when
+    const loginTitle = await screen.findByRole('heading', { name: t('pages.oidc.login.title') });
+    assert.dom(loginTitle).exists();
+
+    const signupButton = await screen.findByRole('link', { name: t('pages.oidc.login.signup-button') });
+    await click(signupButton);
+
+    // then
+    const signUpTitle = await screen.findByRole('heading', { name: t('pages.oidc.signup.title') });
+    assert.dom(signUpTitle).exists();
+
+    const invitationText = await screen.findByText(
+      t('pages.login.join-invitation', { organizationName: 'Super orga avec SSO' }),
+    );
+    assert.dom(invitationText).exists();
+
+    const firstName = await screen.findByText(
+      t('pages.oidc.signup.claims.first-name-label-and-value', { firstName: 'test' }),
+    );
+    const lastName = await screen.findByText(
+      t('pages.oidc.signup.claims.last-name-label-and-value', { lastName: 'PIX' }),
+    );
+    assert.dom(firstName).exists();
+    assert.dom(lastName).exists();
+  });
+
+  module('When there are no user claims returned by the identity provider', function () {
+    test('displays claim error message', async function (assert) {
+      // given
+      this.server.post('/oidc/token', () => {
+        return new Response(
+          401,
+          {},
+          {
+            errors: [
+              {
+                code: 'SHOULD_VALIDATE_CGU',
+                meta: { authenticationKey: 'key', userClaims: null },
+              },
+            ],
+          },
+        );
+      });
+
+      const screen = await visit('/connexion/oidc-partner?code=code&state=state');
+
+      // when
+      const loginTitle = await screen.findByRole('heading', { name: t('pages.oidc.login.title') });
+      assert.dom(loginTitle).exists();
+
+      const signupButton = await screen.findByRole('link', { name: t('pages.oidc.login.signup-button') });
+      await click(signupButton);
+
+      // then
+      const signUpTitle = await screen.findByRole('heading', { name: t('pages.oidc.signup.title') });
+      assert.dom(signUpTitle).exists();
+
+      const claimErrorMessage = await screen.findByText(t('pages.oidc.signup.error'));
+      assert.dom(claimErrorMessage).exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/authentication/oidc-signup-form-test.gjs
+++ b/orga/tests/integration/components/authentication/oidc-signup-form-test.gjs
@@ -1,0 +1,47 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import OidcSignupForm from 'pix-orga/components/authentication/oidc-signup-form';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Authentication | OidcSignupForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    // given
+    const oidcIdentityProviders = this.owner.lookup('service:oidcIdentityProviders');
+    sinon
+      .stub(oidcIdentityProviders, 'list')
+      .value([{ id: 'sc', slug: 'sc', code: 'SC', organizationName: 'StarConnect', isVisible: true }]);
+
+    const userClaims = {
+      firstName: 'John',
+      lastName: 'Doe',
+      title: 'Proviseur',
+    };
+
+    // when
+    const screen = await render(
+      <template><OidcSignupForm @identityProviderSlug="sc" @userClaims={{userClaims}} /></template>,
+    );
+
+    // then
+    const providerName = await screen.findByText('StarConnect');
+    assert.dom(providerName).exists();
+
+    const firstName = await screen.findByText(
+      t('pages.oidc.signup.claims.first-name-label-and-value', { firstName: 'John' }),
+    );
+    assert.dom(firstName).exists();
+
+    const lastName = await screen.findByText(
+      t('pages.oidc.signup.claims.last-name-label-and-value', { lastName: 'Doe' }),
+    );
+    assert.dom(lastName).exists();
+
+    const title = await screen.findByText(t('pages.oidc.signup.claims.title'));
+    assert.dom(title).exists();
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1402,6 +1402,7 @@
     },
     "oidc": {
       "login": {
+        "signup-button": "I do not have an account, I am registering with my organisation",
         "sub-title": "to link it to your new access method",
         "title": "Use your Pix account"
       }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1405,6 +1405,25 @@
         "signup-button": "I do not have an account, I am registering with my organisation",
         "sub-title": "to link it to your new access method",
         "title": "Use your Pix account"
+      },
+      "signup": {
+        "claims": {
+          "FrEduFonctAdm": "Administrative function",
+          "FrEduNumenHash": "Technical identifier",
+          "discipline": "School subject",
+          "employeeNumber": "Employee number",
+          "first-name-label-and-value": "First name: {firstName}",
+          "last-name-label-and-value": "Last name: {lastName}",
+          "population": "Population",
+          "rne": "Establishment of assignment",
+          "title": "Title"
+        },
+        "description": "An account will be created based on the information sent by the organisation",
+        "error": "We were unable to retrieve your identity information from the service used. We invite you to contact this organisation's IT support.",
+        "login-button": "I already have an account, I'm logging in",
+        "signup-button": "Create my account",
+        "sub-title": "to access your Pix Orga workspace",
+        "title": "Create your Account"
       }
     },
     "organization-learner": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -341,7 +341,7 @@
         "login": {
           "heading": "Autres méthodes de connexion"
         },
-        "select-another-organization-link": "Choisir un autre méthode de connexion",
+        "select-another-organization-link": "Choisir une autre méthode de connexion",
         "signup": {
           "heading": "Autres méthodes d’inscription"
         }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1390,6 +1390,7 @@
     },
     "oidc": {
       "login": {
+        "signup-button": "Je n'ai pas de compte, je m'inscris avec mon organisation",
         "sub-title": "pour le lier à votre nouvelle méthode de connexion",
         "title": "Utilisez votre compte Pix"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1393,6 +1393,25 @@
         "signup-button": "Je n'ai pas de compte, je m'inscris avec mon organisation",
         "sub-title": "pour le lier à votre nouvelle méthode de connexion",
         "title": "Utilisez votre compte Pix"
+      },
+      "signup": {
+        "claims": {
+          "FrEduFonctAdm": "Fonction Administrative",
+          "FrEduNumenHash": "Identifiant technique",
+          "discipline": "Discipline",
+          "employeeNumber": "Numéro d'employé",
+          "first-name-label-and-value": "Prénom : {firstName}",
+          "last-name-label-and-value": "Nom : {lastName}",
+          "population": "Population",
+          "rne": "Etablissement d’affectation",
+          "title": "Fonction"
+        },
+        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
+        "error": "Nous n’avons pas pu récupérer vos informations d’identité auprès du service utilisé. Nous vous invitons à contacter le support informatique de cette organisation.",
+        "login-button": "J'ai déjà un compte, je me connecte",
+        "signup-button": "Je m'inscris sur Pix",
+        "sub-title": "pour accéder à votre espace Pix Orga",
+        "title": "Inscrivez-vous à Pix"
       }
     },
     "organization-learner": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1387,6 +1387,25 @@
         "signup-button": "Ik heb geen account, ik meld me aan met mijn organisatie",
         "sub-title": "om te koppelen aan uw nieuwe aanmeldingsmethode",
         "title": "Gebruik uw Pix-account"
+      },
+      "signup": {
+        "claims": {
+          "FrEduFonctAdm": "Administratieve functie",
+          "FrEduNumenHash": "Technische identificatiecode",
+          "discipline": "Discipline",
+          "employeeNumber": "Werknemersnummer",
+          "first-name-label-and-value": "Voornaam: {firstName}",
+          "last-name-label-and-value": "Naam: {lastName}",
+          "population": "Bevolking",
+          "rne": "Toewijzingsinstelling",
+          "title": "rol"
+        },
+        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt",
+        "error": "We konden uw identiteitsgegevens niet ophalen bij de gebruikte dienst. Neem contact op met de IT-ondersteuning van deze organisatie.",
+        "login-button": "Ik heb al een account, ik log in",
+        "signup-button": "Ik maak mijn account aan",
+        "sub-title": "om toegang te krijgen tot uw Pix Orga-werkruimte",
+        "title": "Registreer u bij Pix"
       }
     },
     "organization-learner": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1384,6 +1384,7 @@
     },
     "oidc": {
       "login": {
+        "signup-button": "Ik heb geen account, ik meld me aan met mijn organisatie",
         "sub-title": "om te koppelen aan uw nieuwe aanmeldingsmethode",
         "title": "Gebruik uw Pix-account"
       }


### PR DESCRIPTION
## ❄️ Problème
Afin de s’inscrire via SSO, il est nécessaire de mettre en place le mécanisme d’inscription de SSO sur l’URL /connexion/:oidc

Ce ticket traite uniquement le cas où le compte n’existe pas (via sub) et l’utilisateur créé un nouveau compte

## 🛷 Proposition
Utiliser la route /connexion/:oidc

Si le compte n’existe pas (non trouvé via le sub)

Afficher une page de login pour associer son compte existant.

L’utilisateur clique sur “Je n’ai pas de compte, je m’inscris avec mon organisation”

Afficher une page de création de compte via SSO

Les informations des claims utilisateur sont affichés et il peut créé son compte

## ☃️ Remarques

Le dernier commit 4c8ebaabf81f0c1701caed331061b42edd4a29a0 (do not display message for headteachers in oidc authentication login template) est destiné à appliquer simplement la règle d'affichage/non affichage du message destiné aux chefs d'établissement. (le message ne doit pas s'afficher au cours d'une authentification/connexion oidc).

L'idéal serait, dans une prochaine PR, de ne pas garder ce message dans le composant login form et de le déplacer dans le seul cas/template où il est utile : orga/app/templates/authentication/login.js (c'est à dire sur la page /connexion)
Un refacto est donc prévu dans un prochain ticket, voir https://1024pix.atlassian.net/browse/PIX-20894 

## 🧑‍🎄 Pour tester
A tester en local
Etape préliminaire : 
- récupérer le ficher OIDC_PROVIDERS.json depuis Lockself
- le placer à la racine du dossier API
- utiliser la commande `export OIDC_PROVIDERS=$(cat OIDC_PROVIDERS.json)` depuis la console api
- utiliser la commande npm run db:reset
Test fonctionnel : 
- Lancer Pix Orga et se connecter avec admin-orga@example.net
- Inviter un compte n'ayant pas de compte Pix à rejoindre l'organisation (possible de mettre une adresse mail random et d'utiliser [mailpit](http://localhost:8025/) pour intercepter le mail d'invitation)
- Suivre le lien d'invitation 
- Cliquer sur "Choisir une autre méthode de connexion"
- Choisir ProConnect dans la liste déroulante puis cliquer sur Je me connecte
- Sur ProConnect, utiliser l'adresse de test
- Une fois revenu sur Pix Orga, cliquer sur "Je n'ai pas de compte, je m'inscris avec mon organisation"
- Vérifier que les claims de l'utilisateur (prenom John, nom Doe) s'affichent
- Le reste ne fonctionne pas encore

