### PR TITLE
[FEATURE] Ajouter des boutons de signalement pour les embed et QAB dans Pix App (PIX-20792).

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -22,7 +22,12 @@
   }
 
   &__report-button {
-    color: var(--modulix-feedback-state-color);
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      color: var(--modulix-feedback-state-color);
+    }
   }
 
   @media (not (prefers-reduced-motion: reduce)) {

--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -15,11 +15,17 @@
     display: flex;
     justify-content: space-between;
   }
+
+  &__container {
+    padding: var(--pix-spacing-2x);
+    border: 2px dashed var(--pix-primary-700);
+    border-radius: 8px 8px 8px 0;
+  }
 }
 
 .element-custom-draft-buttons {
   &__retry {
-    padding: 0 var(--pix-spacing-4x);
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
     background-color: var(--pix-primary-100);
     border: none;
     border-radius: 0 0 8px 8px;

--- a/mon-pix/app/components/module/element/_embed.scss
+++ b/mon-pix/app/components/module/element/_embed.scss
@@ -12,7 +12,12 @@
     font-weight: var(--pix-font-bold);
   }
 
-  &__reset {
+  &__buttons {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__button {
     display: flex;
     justify-content: flex-end;
   }
@@ -41,5 +46,14 @@
     height: 100%;
     background-color: var(--embed-overlay-color);
     border-radius: var(--modulix-radius-xs);
+  }
+}
+
+.element-embed-buttons {
+  &__retry {
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+    background-color: var(--pix-primary-100);
+    border: none;
+    border-radius: 0 0 8px 8px;
   }
 }

--- a/mon-pix/app/components/module/element/_embed.scss
+++ b/mon-pix/app/components/module/element/_embed.scss
@@ -5,6 +5,16 @@
 .element-embed {
   &__container {
     position: relative;
+    padding: var(--pix-spacing-2x);
+    border: 2px dashed var(--pix-primary-700);
+
+    &--with-retry-button {
+      border-radius: 8px 8px 8px 0;
+    }
+
+    &--without-retry-button {
+      border-radius: 8px;
+    }
   }
 
   &__instruction {

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -58,6 +58,11 @@
 
 .element-qcu-declarative-feedback {
   &__report-button {
-    color: var(--pix-neutral-0);
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      color: var(--pix-neutral-0);
+    }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -46,6 +46,11 @@
 
 .element-qcu-discovery-feedback {
   &__report-button {
-    color: var(--pix-info-700);
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      color: var(--pix-info-700);
+    }
   }
 }

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -48,7 +48,7 @@ export default class ModulixCustomDraft extends ModuleElement {
         </div>
       {{/if}}
 
-      <fieldset class="element-custom__container">
+      <fieldset class="element-custom-draft__container">
         <legend class="element-custom__legend">
           <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
           <span>{{t "pages.modulix.interactiveElement.label"}}</span>
@@ -64,6 +64,14 @@ export default class ModulixCustomDraft extends ModuleElement {
       </fieldset>
 
       <div class="element-custom-draft__buttons">
+        <PixButton
+          class="element-custom-draft-buttons__retry"
+          @iconBefore="refresh"
+          @variant="tertiary"
+          @triggerAction={{this.resetEmbed}}
+          aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
+        >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
+
         {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
           <PixButton
             @variant="tertiary"
@@ -74,14 +82,6 @@ export default class ModulixCustomDraft extends ModuleElement {
 
           <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
         {{/if}}
-
-        <PixButton
-          class="element-custom-draft-buttons__retry"
-          @iconBefore="refresh"
-          @variant="tertiary"
-          @triggerAction={{this.resetEmbed}}
-          aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
-        >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
       </div>
     </div>
   </template>

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -7,6 +7,7 @@ import { t } from 'ember-intl';
 import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import didInsert from '../../../modifiers/modifier-did-insert';
 import { isEmbedAllowedOrigin } from '../../../utils/embed-allowed-origins';
+import ModulixIssueReportModal from '../issue-report/issue-report-modal';
 import ModuleElement from './module-element';
 
 export default class ModulixEmbed extends ModuleElement {
@@ -26,6 +27,7 @@ export default class ModulixEmbed extends ModuleElement {
 
   @service
   passageEvents;
+  @service featureToggles;
 
   @tracked
   isSimulatorLaunched = false;
@@ -35,6 +37,7 @@ export default class ModulixEmbed extends ModuleElement {
 
   @tracked
   embedHeight;
+  @tracked showModal = false;
 
   iframe;
   messageHandler = null;
@@ -137,6 +140,16 @@ export default class ModulixEmbed extends ModuleElement {
     window.removeEventListener('message', this.messageHandler);
   }
 
+  @action
+  onReportClick() {
+    this.showModal = true;
+  }
+
+  @action
+  hideModal() {
+    this.showModal = false;
+  }
+
   <template>
     <div class="element-embed">
       {{#if @embed.instruction}}
@@ -170,16 +183,28 @@ export default class ModulixEmbed extends ModuleElement {
         {{/unless}}
       </div>
 
-      {{#if this.resetButtonDisplayed}}
-        <div class="element-embed__reset">
+      <div class={{if this.resetButtonDisplayed "element-embed__buttons" "element-embed__button"}}>
+        {{#if this.resetButtonDisplayed}}
           <PixButton
+            class="element-embed-buttons__retry"
             @iconBefore="refresh"
             @variant="tertiary"
             @triggerAction={{this.resetEmbed}}
             aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
           >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
-        </div>
-      {{/if}}
+        {{/if}}
+
+        {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+          <PixButton
+            @variant="tertiary"
+            @iconBefore="flag"
+            @triggerAction={{this.onReportClick}}
+            aria-label={{t "pages.modulix.issue-report.aria-label"}}
+          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+
+          <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
+        {{/if}}
+      </div>
     </div>
   </template>
 }

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -158,7 +158,14 @@ export default class ModulixEmbed extends ModuleElement {
         </div>
       {{/if}}
 
-      <div class="element-embed__container">
+      <div
+        class="element-embed__container
+          {{if
+            this.resetButtonDisplayed
+            'element-embed__container--with-retry-button'
+            'element-embed__container--without-retry-button'
+          }}"
+      >
         <iframe
           class="element-embed-container__iframe
             {{unless this.isSimulatorLaunched 'element-embed-container__iframe--blurred'}}"

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -46,6 +46,15 @@
       margin-top: 0;
     }
   }
+
+  &__report-button {
+    display: flex;
+    justify-content: flex-end;
+
+    button {
+      color: var(--pix-info-700);
+    }
+  }
 }
 
 .element-qab-cards {

--- a/mon-pix/app/components/module/element/qab/qab.gjs
+++ b/mon-pix/app/components/module/element/qab/qab.gjs
@@ -9,6 +9,7 @@ import QabScoreCard from 'mon-pix/components/module/element/qab/qab-score-card';
 import { TrackedArray, TrackedMap } from 'tracked-built-ins';
 
 import { htmlUnsafe } from '../../../../helpers/html-unsafe';
+import ModulixIssueReportModal from '../../issue-report/issue-report-modal';
 import ModuleElement from '../module-element';
 
 const NEXT_CARD_REMOVE_DELAY = 400;
@@ -24,8 +25,10 @@ export default class ModuleQab extends ModuleElement {
   @tracked displayedCards;
   @tracked cardStatuses = new TrackedMap();
   @tracked removedCards = new TrackedMap();
+  @tracked showModal = false;
 
   @service passageEvents;
+  @service featureToggles;
 
   constructor() {
     super(...arguments);
@@ -142,6 +145,16 @@ export default class ModuleQab extends ModuleElement {
     return this.removedCards.get(card.id) || false;
   }
 
+  @action
+  onReportClick() {
+    this.showModal = true;
+  }
+
+  @action
+  hideModal() {
+    this.showModal = false;
+  }
+
   <template>
     <form onSubmit={{this.onSubmit}} class="element-qab" aria-describedby="instruction-{{this.element.id}}">
       <fieldset class="element-qab__container">
@@ -181,6 +194,19 @@ export default class ModuleQab extends ModuleElement {
     {{#if this.shouldDisplayFeedback}}
       <div class="feedback element-qab__feedback" role="status" tabindex="-1">
         {{htmlUnsafe this.feedback}}
+
+        {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
+          <div class="element-qab__report-button">
+            <PixButton
+              @variant="tertiary"
+              @iconBefore="flag"
+              @triggerAction={{this.onReportClick}}
+              aria-label={{t "pages.modulix.issue-report.aria-label"}}
+            >{{t "pages.modulix.issue-report.button"}}</PixButton>
+          </div>
+
+          <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
+        {{/if}}
       </div>
     {{/if}}
     {{#if this.shouldDisplayScore}}

--- a/mon-pix/app/components/module/element/qcu-declarative.gjs
+++ b/mon-pix/app/components/module/element/qcu-declarative.gjs
@@ -101,13 +101,14 @@ export default class ModuleQcuDeclarative extends ModuleElement {
         {{htmlUnsafe this.selectedProposalFeedback}}
 
         {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
-          <PixButton
-            @variant="tertiary"
-            @iconBefore="flag"
-            @triggerAction={{this.onReportClick}}
-            class="element-qcu-declarative-feedback__report-button"
-            aria-label={{t "pages.modulix.issue-report.aria-label"}}
-          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+          <div class="element-qcu-declarative-feedback__report-button">
+            <PixButton
+              @variant="tertiary"
+              @iconBefore="flag"
+              @triggerAction={{this.onReportClick}}
+              aria-label={{t "pages.modulix.issue-report.aria-label"}}
+            >{{t "pages.modulix.issue-report.button"}}</PixButton>
+          </div>
 
           <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
         {{/if}}

--- a/mon-pix/app/components/module/element/qcu-discovery.gjs
+++ b/mon-pix/app/components/module/element/qcu-discovery.gjs
@@ -103,13 +103,14 @@ export default class ModuleQcuDiscovery extends ModuleElement {
         {{htmlUnsafe this.selectedProposalFeedback}}
 
         {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
-          <PixButton
-            @variant="tertiary"
-            @iconBefore="flag"
-            @triggerAction={{this.onReportClick}}
-            class="element-qcu-discovery-feedback__report-button"
-            aria-label={{t "pages.modulix.issue-report.aria-label"}}
-          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+          <div class="element-qcu-discovery-feedback__report-button">
+            <PixButton
+              @variant="tertiary"
+              @iconBefore="flag"
+              @triggerAction={{this.onReportClick}}
+              aria-label={{t "pages.modulix.issue-report.aria-label"}}
+            >{{t "pages.modulix.issue-report.button"}}</PixButton>
+          </div>
 
           <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
         {{/if}}

--- a/mon-pix/app/components/module/feedback.gjs
+++ b/mon-pix/app/components/module/feedback.gjs
@@ -34,13 +34,14 @@ export default class ModulixFeedback extends Component {
       {{htmlUnsafe @feedback.diagnosis}}
 
       {{#if this.featureToggles.featureToggles.isModulixIssueReportDisplayed}}
-        <PixButton
-          class="feedback__report-button"
-          @variant="tertiary"
-          @iconBefore="flag"
-          aria-label={{t "pages.modulix.issue-report.aria-label"}}
-          @triggerAction={{this.onReportClick}}
-        >{{t "pages.modulix.issue-report.button"}}</PixButton>
+        <div class="feedback__report-button">
+          <PixButton
+            @variant="tertiary"
+            @iconBefore="flag"
+            aria-label={{t "pages.modulix.issue-report.aria-label"}}
+            @triggerAction={{this.onReportClick}}
+          >{{t "pages.modulix.issue-report.button"}}</PixButton>
+        </div>
 
         <ModulixIssueReportModal @showModal={{this.showModal}} @hideModal={{this.hideModal}} />
       {{/if}}


### PR DESCRIPTION
## ❄️ Problème

Nous souhaitons que les utilisateurs puissent nous contacter en cas de module contenant des bugs/fautes/etc..

## 🛷 Proposition

Ajouter des boutons de signalement pour les `embed` et `QAB`
ET reprise du placement des boutons déjà ajoutées dans cette PR https://github.com/1024pix/pix/pull/14377

## ☃️ Remarques

Les embed ont des comportements différents sur l'affichage.
**EDIT** : résolu grâce à l'ajout d'une bordure comme les POI. Merci pour l'info @er-lim 🚀 

## 🧑‍🎄 Pour tester

Aller sur [Bac-a-sable](https://app-pr14466.review.pix.fr/modules/6a68bf32/bac-a-sable/details)

- Voir que les boutons de signalement des feedbacks, des qca déclaratif et discovery sont placés à droite.

<img width="452" height="580" alt="Capture d’écran 2025-12-17 à 15 01 39" src="https://github.com/user-attachments/assets/de022ff3-9b55-4814-a257-cabc3ec1566a" />
<img width="409" height="552" alt="Capture d’écran 2025-12-17 à 15 01 55" src="https://github.com/user-attachments/assets/7a1c6662-c150-42ef-b884-4ec4793bac42" />
<img width="409" height="552" alt="Capture d’écran 2025-12-17 à 15 02 04" src="https://github.com/user-attachments/assets/1f8f29c7-c1b4-43b0-b5c0-bbc87d742e30" />

- Voir que les boutons réessayer et signaler ont changé de place pour les POI.

<img width="518" height="731" alt="Capture d’écran 2025-12-17 à 15 05 17" src="https://github.com/user-attachments/assets/1f59997d-28e2-4419-b6c1-7f4faa9e8b3b" />


- Voir que le bouton de signalement apparaît pour le QAB dans son feedback. Pour le voir, il faut répondre entièrement aux questions du QAB.

<img width="518" height="657" alt="Capture d’écran 2025-12-17 à 15 05 39" src="https://github.com/user-attachments/assets/c39dada0-d819-445d-9858-35bec76c1a5c" />

- Voir que le bouton de signalement apparaît à droite pour l'embed sans bouton réessayer.

<img width="661" height="623" alt="Capture d’écran 2025-12-18 à 09 56 52" src="https://github.com/user-attachments/assets/3c0a9b64-c646-4399-8720-a37aa3c352d9" />


- Voir que le bouton de signalement apparaît pour l'embed sans bouton réessayer. Dès que l'embed est lancé, voir le bouton réessayer apparaître à gauche.

CONTROLE-PARENTAL
<img width="673" height="816" alt="Capture d’écran 2025-12-18 à 09 58 07" src="https://github.com/user-attachments/assets/7ad7fef2-067c-4471-a1b9-d1eafd41762c" />


