### PR TITLE
[BUMP] Mise à jour de epreuves-components en 2.3.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -80,7 +80,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@1024pix/epreuves-components": "^2.2.4",
+        "@1024pix/epreuves-components": "^2.3.0",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
-      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.3.0.tgz",
+      "integrity": "sha512-0OkdfotdzyPHca9NLAtGZ1lKkol1EBU3SzS1vtyVtMrOpeY6uft7cIEXd0SLe1b509YkvcEddesKLAkROeY29g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@1024pix/epreuves-components": "^2.2.4",
+    "@1024pix/epreuves-components": "^2.3.0",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -9,9 +9,7 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement tous les composants Pix Épreuves.</p>",
     "duration": 2,
     "level": "novice",
-    "objectives": [
-      "<p>Non régression sur les composants Pix Épreuves.</p>"
-    ],
+    "objectives": ["<p>Non régression sur les composants Pix Épreuves.</p>"],
     "tabletSupport": "comfortable"
   },
   "sections": [
@@ -260,11 +258,7 @@
                   ],
                   "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                   "llmMessage": "On peut mettre du ",
-                  "wordsToAdd": [
-                    "beurre",
-                    "et",
-                    "du ?"
-                  ]
+                  "wordsToAdd": ["beurre", "et", "du"]
                 }
               }
             }

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.4",
+        "@1024pix/epreuves-components": "^2.3.0",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
-      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.3.0.tgz",
+      "integrity": "sha512-0OkdfotdzyPHca9NLAtGZ1lKkol1EBU3SzS1vtyVtMrOpeY6uft7cIEXd0SLe1b509YkvcEddesKLAkROeY29g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.2.4",
+    "@1024pix/epreuves-components": "^2.3.0",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-api-actions": "^1.1.0",
         "@1024pix/ember-testing-library": "^3.0.25",
-        "@1024pix/epreuves-components": "^2.2.4",
+        "@1024pix/epreuves-components": "^2.3.0",
         "@1024pix/eslint-plugin": "^2.1.14",
         "@1024pix/pix-ui": "^55.32.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.2.4.tgz",
-      "integrity": "sha512-krmhNIQIbAL3/b9l086nRgJXMUCecMsJwTauO0NJSlYFd89SUwXLSgldySe9K8Lux7YERIlBlFB3GX2qg+B7Pg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-2.3.0.tgz",
+      "integrity": "sha512-0OkdfotdzyPHca9NLAtGZ1lKkol1EBU3SzS1vtyVtMrOpeY6uft7cIEXd0SLe1b509YkvcEddesKLAkROeY29g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.25",
-    "@1024pix/epreuves-components": "^2.2.4",
+    "@1024pix/epreuves-components": "^2.3.0",
     "@1024pix/eslint-plugin": "^2.1.14",
     "@1024pix/pix-ui": "^55.32.2",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ❄️ Problème

Il y a une nouvelle version de epreuves-components.

## 🛷 Proposition

Mettre à jour.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier l’affichage de complete-phrase sur le module demo-epreuves-components