### PR TITLE
[TECH] Augmenter la taille du conteneur du job de lint de mon-pix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,7 @@ jobs:
 
   mon_pix_lint:
     executor:
-      name: node-docker
+      name: node-docker-medium
     working_directory: ~/pix/mon-pix
     steps:
       - attach_workspace:


### PR DESCRIPTION
## ❄️ Problème

La branche `dev` est rouge à cause du job `mon_pix_lint`. L'erreur remontée par Circle CI indique un code 137, liée à un problème de RAM
<img width="1012" height="579" alt="image" src="https://github.com/user-attachments/assets/6791affc-5964-4503-b1eb-eae06d9c7078" />

## 🛷 Proposition

Utiliser l'exécuteur `node-docker-medium` au lieu de `node-docker` pour avoir plus de RAM.
Sur la [doc](https://circleci.com/docs/guides/execution-managed/using-docker/#x86) :
- Pour node docker, c'est un container [small](https://github.com/1024pix/pix/blob/dev/.circleci/config.yml#L50) donc 2 GB.
- Pour node-docker-medium, on passe sur 4 GB avec un container medium 🚀

## ☃️ Remarques

D'après les infos de pricing, l'utilisation de dimension `medium`double le nombre de crédits qu'on utilise : https://circleci.com/pricing/price-list/

## 🧑‍🎄 Pour tester

CI Green.
