### PR TITLE
[TECH] Augmenter le nombre d'auto-reruns sur les tests d'acceptance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,6 +500,8 @@ jobs:
             MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: mocha-junit-reporter
           when: always
+          max_auto_reruns: 3
+          auto_rerun_delay: 10s
       - store_test_results:
           path: /home/circleci/test-results
       - store_artifacts:


### PR DESCRIPTION
## ❄️ Problème
Les tests d'acceptance sont parfois signalés comme flaky en CI. 

## 🛷 Proposition
On a augmenté le nombre de reruns automatiques sur les tests d'intégration pour éviter les flaky qui ne sont pas liés au code. On reproduit donc pour les tests d'acceptance.


## 🧑‍🎄 Pour tester
RAS