### PR TITLE
[TECH] Correction des routes Mirage /token dans Pix Certif et Pix Orga, et ajout de tests d’erreur au login de Pix Orga

### DIFF
--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -49,13 +49,7 @@ function routes() {
         user_id: foundUser.id,
       };
     } else {
-      return new Response([
-        {
-          status: '401',
-          title: 'Unauthorized',
-          detail: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
-        },
-      ]);
+      return new Response(401, {}, { errors: [{ status: '401', code: 'MISSING_OR_INVALID_CREDENTIALS' }] });
     }
   });
 

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -59,13 +59,7 @@ function routes() {
         user_id: foundUser.id,
       };
     } else {
-      return new Response([
-        {
-          status: '401',
-          title: 'Unauthorized',
-          detail: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
-        },
-      ]);
+      return new Response(401, {}, { errors: [{ status: '401', code: 'MISSING_OR_INVALID_CREDENTIALS' }] });
     }
   });
 


### PR DESCRIPTION
## ❄️ Problème

Dans les tests de Pix Certif et de Pix Orga, les routes Mirage `/token` sont cassées dans le cas d’un utilisateur inexistant ou d’un mauvais mot de passe. Ces routes qui se comportent mal empêchent le développement de certains tests, notamment des tests de login sur Pix Orga.

Les routes Mirage `/token` sont cassées par une mauvaise utilisation du constructeur `Response` de Mirage.

## 🛷 Proposition

1. Corriger les routes Mirage `/token` de Pix Certif et Pix Orga en utilisant le constructeur de Response de manière conforme cf. https://github.com/miragejs/miragejs/blob/next/lib/response.js#L17-L19
2. Dans Pix Orga ajouter des tests nécessaires qui ne pouvaient pas être ajoutés auparavant

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

1. S’assurer que les tests de la CI passent
2. En local supprimer les 2 premiers commits et exécuter les tests `Acceptance | Login` de Pix Orga
3. Constater que les tests `Acceptance | Login` de Pix Orga sont en erreur
