### PR TITLE
[FEATURE] Corriger quelques textes et titres dans le formulaire de création d'orga (PIX-20840)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -12,6 +12,7 @@ import Card from '../card';
 
 export default class OrganizationCreationForm extends Component {
   @service store;
+  @service intl;
 
   organizationTypes = [
     { value: 'PRO', label: 'Organisation professionnelle' },
@@ -41,6 +42,10 @@ export default class OrganizationCreationForm extends Component {
     return this.args.parentOrganizationName
       ? 'components.organizations.creation.actions.add-child-organization'
       : 'common.actions.add';
+  }
+
+  get dpoSectionTitle() {
+    return `${this.intl.t('components.organizations.creation.dpo.definition')} (${this.intl.t('components.organizations.creation.dpo.acronym')})`;
   }
 
   @action
@@ -204,10 +209,7 @@ export default class OrganizationCreationForm extends Component {
           </div>
         </Card>
 
-        <Card
-          class="admin-form__card organization-creation-form__card"
-          @title={{t "components.organizations.creation.dpo.title"}}
-        >
+        <Card class="admin-form__card organization-creation-form__card" @title={{this.dpoSectionTitle}}>
           <PixInput
             @id="dataProtectionOfficerLastName"
             onchange={{this.handleDataProtectionOfficerLastNameChange}}
@@ -215,7 +217,7 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>{{t "components.organizations.creation.dpo.lastname"}}
               <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
-                  "components.organizations.creation.dpo.title"
+                  "components.organizations.creation.dpo.acronym"
                 }}</abbr></:label>
           </PixInput>
 
@@ -226,7 +228,7 @@ export default class OrganizationCreationForm extends Component {
           >
             <:label>{{t "components.organizations.creation.dpo.firstname"}}
               <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
-                  "components.organizations.creation.dpo.title"
+                  "components.organizations.creation.dpo.acronym"
                 }}</abbr></:label>
           </PixInput>
 
@@ -238,7 +240,7 @@ export default class OrganizationCreationForm extends Component {
             >
               <:label>{{t "components.organizations.creation.dpo.email"}}
                 <abbr title={{t "components.organizations.creation.dpo.definition"}}>{{t
-                    "components.organizations.creation.dpo.title"
+                    "components.organizations.creation.dpo.acronym"
                   }}</abbr></:label>
             </PixInput>
           </div>

--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -182,11 +182,7 @@ export default class OrganizationCreationForm extends Component {
             <PixInput
               @id="externalId"
               {{on "input" (fn this.handleInputChange "externalId")}}
-              placeholder={{concat
-                (t "common.words.example-abbr")
-                " "
-                (t "components.organizations.creation.external-id.placeholder")
-              }}
+              placeholder={{t "components.organizations.creation.external-id.placeholder"}}
             >
               <:label>{{t "components.organizations.creation.external-id.label"}}</:label>
             </PixInput>

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -678,7 +678,7 @@
         },
         "external-id": {
           "label": "External Identifier",
-          "placeholder": "My great external identifier"
+          "placeholder": "Specify the UAI, SIRET etc"
         },
         "general-information": "General information",
         "name": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -670,11 +670,11 @@
         },
         "documentation-link": "Link to the documentation",
         "dpo": {
+          "acronym": "DPO",
           "definition": "Data Protection Officer",
           "email": "E-mail address of ",
           "firstname": "Firstname of ",
-          "lastname": "Lastname of ",
-          "title": "DPO"
+          "lastname": "Lastname of "
         },
         "external-id": {
           "label": "External Identifier",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -672,11 +672,11 @@
         },
         "documentation-link": "Lien vers la documentation",
         "dpo": {
+          "acronym": "DPO",
           "definition": "Délégué à la protection des données",
           "email": "Adresse e-mail du ",
           "firstname": "Prénom du ",
-          "lastname": "Nom du ",
-          "title": "DPO"
+          "lastname": "Nom du "
         },
         "external-id": {
           "label": "Identifiant externe",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -680,7 +680,7 @@
         },
         "external-id": {
           "label": "Identifiant externe",
-          "placeholder": "Mon super idendifiant externe"
+          "placeholder": "Spécifier l'UAI, le SIRET etc"
         },
         "general-information": "Informations générales",
         "name": {


### PR DESCRIPTION
## ❄️ Problème

Sur Pix Admin
- le texte du placeholder de l'identifiant externe dans le formulaire de création d'organisation ne reflète pas assez l'usage réel de ce champ.
- le titre de la section doit être plus explicite en précsant l'acronyme DPO

## 🛷 Proposition

Changer le texte du placeholder et el titre de la troisième section

## 🧑‍🎄 Pour tester

Sur Pix Admin:
- aller sur la page de création d'organisation
- constater le nouveau texte
- faire un tour sur la version anglaise (`.org` et `en` dans les cookies)
