### PR TITLE
[FEATURE] Gérer la couleur du bouton de signalement en cas de hover/focus (PIX-20828).

### DIFF
--- a/mon-pix/app/components/module/_feedback.scss
+++ b/mon-pix/app/components/module/_feedback.scss
@@ -6,12 +6,16 @@
 
   &--success {
     --modulix-feedback-state-color: var(--pix-success-700);
+    --modulix-feedback-hover-color: var(--pix-success-500);
+    --modulix-feedback-focus-color: var(--pix-success-900);
 
     background-color: var(--pix-success-50);
   }
 
   &--error {
     --modulix-feedback-state-color: var(--pix-warning-700);
+    --modulix-feedback-hover-color: var(--pix-warning-500);
+    --modulix-feedback-focus-color: var(--pix-warning-900);
 
     background-color: var(--pix-warning-50);
   }
@@ -25,8 +29,16 @@
     display: flex;
     justify-content: flex-end;
 
-    button {
+    button:not([aria-disabled="true"]) {
       color: var(--modulix-feedback-state-color);
+
+      &:hover {
+        color: var(--modulix-feedback-hover-color);
+      }
+
+      &:focus, &:active {
+        color: var(--modulix-feedback-focus-color);
+      }
     }
   }
 

--- a/mon-pix/app/components/module/element/_qcu-declarative.scss
+++ b/mon-pix/app/components/module/element/_qcu-declarative.scss
@@ -61,8 +61,16 @@
     display: flex;
     justify-content: flex-end;
 
-    button {
+    button:not([aria-disabled="true"]) {
       color: var(--pix-neutral-0);
+
+      &:hover {
+        color: var(--pix-neutral-100);
+      }
+
+      &:focus, &:active {
+        color: var(--pix-neutral-0);
+      }
     }
   }
 }

--- a/mon-pix/app/components/module/element/_qcu-discovery.scss
+++ b/mon-pix/app/components/module/element/_qcu-discovery.scss
@@ -49,8 +49,16 @@
     display: flex;
     justify-content: flex-end;
 
-    button {
+    button:not([aria-disabled="true"]) {
       color: var(--pix-info-700);
+
+      &:hover {
+        color: var(--pix-info-500);
+      }
+
+      &:focus, &:active {
+        color: var(--pix-info-900);
+      }
     }
   }
 }

--- a/mon-pix/app/components/module/element/qab/_qab.scss
+++ b/mon-pix/app/components/module/element/qab/_qab.scss
@@ -51,8 +51,16 @@
     display: flex;
     justify-content: flex-end;
 
-    button {
+    button:not([aria-disabled="true"]) {
       color: var(--pix-info-700);
+
+      &:hover {
+        color: var(--pix-info-500);
+      }
+
+      &:focus, &:active {
+        color: var(--pix-info-900);
+      }
     }
   }
 }


### PR DESCRIPTION

## ❄️ Problème

Nous souhaitons que les utilisateurs puissent nous contacter en cas de module contenant des bugs/fautes/etc..

Les boutons de signalements ont des couleurs différentes selon l'état du feedback. Mais le focus et le hover n'ont pas été gérés.

## 🛷 Proposition

Gérer la couleur du bouton de signalement en cas de hover/focus

## 🧑‍🎄 Pour tester

https://app-pr14473.review.pix.fr/modules/6a68bf32/bac-a-sable/passage

Voir les états des boutons : QCU déclaratif, QCU discovery, feedback succès, feedback erreur, QAB


https://github.com/user-attachments/assets/1d6d1874-10ef-4883-9204-59147ef8f2dc


https://github.com/user-attachments/assets/5071dcc2-16aa-4d8e-892c-7a36f9d4d533

