### PR TITLE
[BUGFIX] Message d'erreur incorrecte quand l'accès à Pix Orga n'est pas autorisé (PIX-20846)

### DIFF
--- a/api/src/authorization/domain/constants.js
+++ b/api/src/authorization/domain/constants.js
@@ -9,8 +9,6 @@ const PIX_ADMIN = {
 };
 
 const PIX_ORGA = {
-  NOT_LINKED_ORGANIZATION_MSG:
-    "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
   ROLES: {
     ADMIN: 'ORGA_ADMIN',
   },

--- a/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/authenticate-user.usecase.js
@@ -1,6 +1,6 @@
-import { PIX_ADMIN, PIX_ORGA } from '../../../authorization/domain/constants.js';
+import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 import { config } from '../../../shared/config.js';
-import { ForbiddenAccess, UserNotFoundError } from '../../../shared/domain/errors.js';
+import { ForbiddenAccess, PixOrgaAccessNotAllowedError, UserNotFoundError } from '../../../shared/domain/errors.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { createWarningConnectionEmail } from '../emails/create-warning-connection.email.js';
 import {
@@ -123,7 +123,7 @@ async function _updateUserLocaleIfNeeded({ user, locale, userRepository }) {
 
 async function _assertUserHasAccessToApplication({ requestedApplication, user, adminMemberRepository }) {
   if (requestedApplication.isPixOrga && !user.isLinkedToOrganizations()) {
-    throw new ForbiddenAccess(PIX_ORGA.NOT_LINKED_ORGANIZATION_MSG);
+    throw new PixOrgaAccessNotAllowedError();
   }
 
   if (requestedApplication.isPixAdmin) {

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -353,6 +353,12 @@ class ForbiddenAccess extends DomainError {
   }
 }
 
+class PixOrgaAccessNotAllowedError extends ForbiddenAccess {
+  constructor() {
+    super('Pix Orga access not allowed', 'PIX_ORGA_ACCESS_NOT_ALLOWED');
+  }
+}
+
 class InvalidInputDataError extends DomainError {
   constructor({ code = 'INVALID_INPUT_DATA', message = 'Provided input data is invalid', meta } = {}) {
     super(message);
@@ -1110,6 +1116,7 @@ export {
   OrganizationNotFoundError,
   OrganizationTagNotFound,
   OrganizationWithoutEmailError,
+  PixOrgaAccessNotAllowedError,
   SendingEmailError,
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,

--- a/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/authenticate-user.usecase.test.js
@@ -7,7 +7,7 @@ import {
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { RequestedApplication } from '../../../../../src/identity-access-management/infrastructure/utils/network.js';
 import { config } from '../../../../../src/shared/config.js';
-import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
+import { ForbiddenAccess, PixOrgaAccessNotAllowedError } from '../../../../../src/shared/domain/errors.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | authenticate-user', function () {
@@ -360,7 +360,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | authenti
               // when & then
               await expect(
                 usecases.authenticateUser({ username: email, password, requestedApplication, audience }),
-              ).to.be.rejectedWith(ForbiddenAccess);
+              ).to.be.rejectedWith(PixOrgaAccessNotAllowedError);
             });
           });
         });

--- a/orga/app/components/authentication/login-form.gjs
+++ b/orga/app/components/authentication/login-form.gjs
@@ -68,7 +68,7 @@ export default class LoginForm extends Component {
       if (isInvitationAlreadyAcceptedByAnotherUser) {
         this.globalError = this.intl.t('pages.login-form.errors.status.409');
       } else {
-        this.globalError = this.#getErrorMessage(extractedError);
+        this.globalError = this.authErrorMessages.getAuthenticationErrorMessage(extractedError);
       }
     } finally {
       this.isLoading = false;
@@ -91,14 +91,6 @@ export default class LoginForm extends Component {
   updateLogin(event) {
     this.login = event.target.value?.trim();
     this.validation.login.validate(this.login);
-  }
-
-  #getErrorMessage(error) {
-    // TODO: should be managed with a code instead of status only
-    if (error.status === 403 && !error.code) {
-      return this.intl.t('pages.login-form.errors.status.403');
-    }
-    return this.authErrorMessages.getAuthenticationErrorMessage(error);
   }
 
   <template>

--- a/orga/app/services/auth-error-messages.js
+++ b/orga/app/services/auth-error-messages.js
@@ -56,6 +56,9 @@ const AUTHENTICATION_ERROR_CODES_MAPPING = {
     },
     getOptions: (error) => ({ remainingAttempts: error.meta?.remainingAttempts, htmlSafe: true }),
   },
+  PIX_ORGA_ACCESS_NOT_ALLOWED: {
+    i18nKey: 'pages.login-form.errors.access-not-allowed',
+  },
 };
 
 export default class AuthErrorMessagesService extends Service {

--- a/orga/tests/acceptance/login-test.js
+++ b/orga/tests/acceptance/login-test.js
@@ -3,6 +3,7 @@ import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { Response } from 'miragejs';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -84,6 +85,25 @@ module('Acceptance | Login', function (hooks) {
         name: t('components.index.organization-information.title'),
       });
       assert.dom(homepageHeading).exists();
+    });
+  });
+
+  module('when user is not allowed to access Pix Orga', function () {
+    test('displays an "access not allowed" error message', async function (assert) {
+      // given
+      this.server.post('/token', () => {
+        return new Response(403, {}, { errors: [{ status: '403', code: 'PIX_ORGA_ACCESS_NOT_ALLOWED' }] });
+      });
+
+      // when
+      const screen = await visit('/connexion');
+      await fillByLabel(t('pages.login-form.email.label'), 'user-not-allowed@example.net');
+      await fillByLabel(t('pages.login-form.password'), 'secret');
+      await clickByName(t('pages.login-form.login'));
+
+      // then
+      const errorMessage = screen.getByText(t('pages.login-form.errors.access-not-allowed'));
+      assert.dom(errorMessage).exists();
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1203,11 +1203,11 @@
         "placeholder": "e.g. john.smith@email.com"
       },
       "errors": {
+        "access-not-allowed": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
         "empty-email": "You have not entered your e-mail address.",
         "empty-password": "You have not entered your password.",
         "invalid-email": "Your email address is invalid.",
         "status": {
-          "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
           "404": "There was an error in the email address or password entered.",
           "409": "This invitation has been already accepted or cancelled."
         }
@@ -1215,7 +1215,6 @@
       "forgot-password": "Forgot your password?",
       "invitation-already-accepted": "This invitation has already been accepted. Please log in or contact the administrator of your Pix Orga space.",
       "invitation-was-cancelled": "This invitation is no longer valid. Please contact the administrator of your Pix Orga space.",
-      "is-only-accessible": "Pix Orga is only accessible to invited members. Please contact your Pix Orga administrator in order to be invited.",
       "login": "Log in",
       "only-for-admin": "only for school administrations",
       "password": "Password"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1191,11 +1191,11 @@
         "placeholder": "ex: jean.dupont@email.com"
       },
       "errors": {
+        "access-not-allowed": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
         "empty-email": "Votre adresse e-mail n’est pas renseignée.",
         "empty-password": "Votre mot de passe n’est pas renseigné.",
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
         "status": {
-          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
           "404": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
           "409": "Cette invitation a déjà été acceptée ou annulée."
         }
@@ -1203,7 +1203,6 @@
       "forgot-password": "Mot de passe oublié ?",
       "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
       "invitation-was-cancelled": "Cette invitation n’est plus valide. Contactez l’administrateur de votre espace Pix Orga.",
-      "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
       "login": "Je me connecte",
       "only-for-admin": "Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.",
       "password": "Mot de passe"

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1185,11 +1185,11 @@
         "placeholder": "b.v. jan.jansen@email.com"
       },
       "errors": {
+        "access-not-allowed": "Toegang tot Pix Orga is beperkt tot uitgenodigde leden. Elke ruimte wordt beheerd door een Pix Orga-beheerder die specifiek is voor de organisatie die het gebruikt. Neem contact met hem/haar op om je uit te nodigen.",
         "empty-email": "Uw e-mailadres is niet ingevuld.",
         "empty-password": "Uw wachtwoord is niet ingevoerd.",
         "invalid-email": "Je e-mailadres is ongeldig.",
         "status": {
-          "403": "Toegang tot Pix Orga is beperkt tot uitgenodigde leden. Elke ruimte wordt beheerd door een Pix Orga-beheerder die specifiek is voor de organisatie die het gebruikt. Neem contact met hem/haar op om je uit te nodigen.",
           "404": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist.",
           "409": "Deze uitnodiging is al geaccepteerd of geannuleerd."
         }
@@ -1197,7 +1197,6 @@
       "forgot-password": "Wachtwoord vergeten?",
       "invitation-already-accepted": "Deze uitnodiging is al geaccepteerd. Log in of neem contact op met de beheerder van je Pix Orga-ruimte.",
       "invitation-was-cancelled": "Deze uitnodiging is niet langer geldig. Neem contact op met de beheerder van je Pix Orga-ruimte.",
-      "is-only-accessible": "Toegang tot Pix Orga is beperkt tot uitgenodigde leden. Neem contact op met de Pix Orga-beheerder van je organisatie om je uit te nodigen.",
       "login": "Ik log in",
       "only-for-admin": "Gereserveerd voor directiepersoneel van openbare en privéscholen onder contract.",
       "password": "Wachtwoord"


### PR DESCRIPTION
## ❄️ Problème

Le message affiché lors d'une connexion à Pix Orga pour un utilisateur ayant un compte mais aucun membership n'est pas correct : 

> "Impossible de se connecter. Veuillez réessayer dans quelques instants. Si le problème persiste, contactez-nous via le centre d’aide." 

Cette erreur est une erreur par défaut ; or le message attendu est : 

> "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.".

## 🛷 Proposition

Le souci est dû au récent refactoring de la gestion des erreurs. Car les `responseJSON` de `ember-simple-auth` retourne le status d'erreur sous forme de string plutôt que de number. 

Par conséquent on ne passait plus dans cette condition :
```js
    if (error.status === 403 && !error.code) {
      return this.intl.t('pages.login-form.errors.status.403');
    }
```

Pour corriger ce bug, un code erreur `PIX_ORGA_ACCESS_NOT_ALLOWED` a été ajouté côté API et géré côté frontend, on se base sur ce code plutôt que le status.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

**Cas d'erreur :**
- Aller sur Pix Orga
- Se connecter avec `hermione@school.net`
- Voir le code `PIX_ORGA_ACCESS_NOT_ALLOWED` dans la requête `/api/token` en status 403.
- Voir le message d'erreur :
> "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.".

**Cas passant :**
- Aller sur Pix Orga
- Se connecter avec `allorga@example.net`
- Voir que l'utilisateur est connecté.
