### PR TITLE
[FEATURE] Ajouter un lien vers le schema de parcours combiné pour un parcours combiné (PIX-20849)"

### DIFF
--- a/api/db/migrations/20251218102838_add-combined-course-blueprint-id.js
+++ b/api/db/migrations/20251218102838_add-combined-course-blueprint-id.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'combined_courses';
+const COLUMN_NAME = 'combinedCourseBlueprintId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table
+      .integer(COLUMN_NAME)
+      .nullable()
+      .references('combined_course_blueprints.id')
+      .comment(
+        "Combined course blueprint used to create this combined course) - see 'combined_course_blueprints' table",
+      );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## ❄️ Problème

Il n'existe pas de moyen de remonter au schéma du parcours ayant servi à la création d'un parcours combiné.

## 🛷 Proposition

On rajoute une colonne la colonne `combinedCourseBlueprint`dans `combined_courses` pour faire le lien avec le template.

## ☃️ Remarques

ras

## 🧑‍🎄 Pour tester

- lancer pgsql-console dans scaling-cli
```sql
\d+ combined_courses
```
- voir la nouvelle colonne qui référence la table `combined_course_blueprints`
