### PR TITLE
[TECH] Refactoriser la manière de remplir le formulaire de création d'orga (PIX-20854)

### DIFF
--- a/admin/app/components/organizations/creation-form.gjs
+++ b/admin/app/components/organizations/creation-form.gjs
@@ -3,9 +3,9 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import Card from '../card';
@@ -13,6 +13,8 @@ import Card from '../card';
 export default class OrganizationCreationForm extends Component {
   @service store;
   @service intl;
+
+  @tracked form = {};
 
   organizationTypes = [
     { value: 'PRO', label: 'Organisation professionnelle' },
@@ -48,58 +50,21 @@ export default class OrganizationCreationForm extends Component {
     return `${this.intl.t('components.organizations.creation.dpo.definition')} (${this.intl.t('components.organizations.creation.dpo.acronym')})`;
   }
 
-  @action
-  handleOrganizationTypeSelectionChange(value) {
-    this.args.organization.type = value;
-  }
+  handleInputChange = (key, event) => {
+    this.form = { ...this.form, [key]: event.target.value };
+  };
 
-  @action
-  handleOrganizationNameChange(event) {
-    this.args.organization.name = event.target.value;
-  }
+  handleSelectChange = (key, value) => {
+    this.form = { ...this.form, [key]: value };
+  };
 
-  @action
-  handleAdministrationTeamSelectionChange(value) {
-    this.args.organization.administrationTeamId = value;
-  }
-
-  @action
-  handleCountrySelectionChange(value) {
-    this.args.organization.countryCode = value;
-  }
-
-  @action
-  handleDocumentationUrlChange(event) {
-    this.args.organization.documentationUrl = event.target.value;
-  }
-
-  @action
-  handleCreditsChange(event) {
-    this.args.organization.credit = +event.target.value;
-  }
-
-  @action
-  handleDataProtectionOfficerFirstNameChange(event) {
-    this.args.organization.dataProtectionOfficerFirstName = event.target.value;
-  }
-
-  @action
-  handleDataProtectionOfficerLastNameChange(event) {
-    this.args.organization.dataProtectionOfficerLastName = event.target.value;
-  }
-
-  @action
-  handleDataProtectionOfficerEmailChange(event) {
-    this.args.organization.dataProtectionOfficerEmail = event.target.value;
-  }
-
-  @action
-  handleInputChange(key, event) {
-    this.args.organization[key] = event.target.value;
-  }
+  handleSubmit = (event) => {
+    event.preventDefault();
+    this.args.onSubmit(this.form);
+  };
 
   <template>
-    <form class="admin-form" {{on "submit" @onSubmit}}>
+    <form class="admin-form" {{on "submit" this.handleSubmit}}>
       <p class="admin-form__mandatory-text">
         {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
@@ -120,7 +85,7 @@ export default class OrganizationCreationForm extends Component {
           <div class="organization-creation-form__input--full">
             <PixInput
               @id="organizationName"
-              onchange={{this.handleOrganizationNameChange}}
+              {{on "change" (fn this.handleInputChange "name")}}
               required={{true}}
               aria-required={{true}}
               @requiredLabel={{t "common.fields.required-field"}}
@@ -135,11 +100,11 @@ export default class OrganizationCreationForm extends Component {
           </div>
 
           <PixSelect
-            @onChange={{this.handleOrganizationTypeSelectionChange}}
+            @onChange={{fn this.handleSelectChange "type"}}
             @options={{this.organizationTypes}}
             @placeholder={{t "components.organizations.creation.type.placeholder"}}
             @hideDefaultOption={{true}}
-            @value={{@organization.type}}
+            @value={{this.form.type}}
             required
             aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
@@ -149,11 +114,11 @@ export default class OrganizationCreationForm extends Component {
           </PixSelect>
 
           <PixSelect
-            @onChange={{this.handleAdministrationTeamSelectionChange}}
+            @onChange={{fn this.handleSelectChange "administrationTeamId"}}
             @options={{this.administrationTeamsOptions}}
             @placeholder={{t "components.organizations.creation.administration-team.selector.placeholder"}}
             @hideDefaultOption={{true}}
-            @value={{@organization.administrationTeamId}}
+            @value={{this.form.administrationTeamId}}
             required
             aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
@@ -162,11 +127,11 @@ export default class OrganizationCreationForm extends Component {
           </PixSelect>
 
           <PixSelect
-            @onChange={{this.handleCountrySelectionChange}}
+            @onChange={{fn this.handleSelectChange "countryCode"}}
             @options={{this.countriesOptions}}
             @placeholder={{t "components.organizations.creation.country.selector.placeholder"}}
             @hideDefaultOption={{true}}
-            @value={{@organization.countryCode}}
+            @value={{this.form.countryCode}}
             required
             @aria-required={{true}}
             @requiredLabel={{t "common.fields.required-field"}}
@@ -177,7 +142,7 @@ export default class OrganizationCreationForm extends Component {
 
           <PixInput
             @id="provinceCode"
-            {{on "input" (fn this.handleInputChange "provinceCode")}}
+            {{on "change" (fn this.handleInputChange "provinceCode")}}
             placeholder={{concat (t "common.words.example-abbr") " 078"}}
           >
             <:label>{{t "components.organizations.creation.province-code"}}</:label>
@@ -186,7 +151,7 @@ export default class OrganizationCreationForm extends Component {
           <div class="organization-creation-form__input--full">
             <PixInput
               @id="externalId"
-              {{on "input" (fn this.handleInputChange "externalId")}}
+              {{on "change" (fn this.handleInputChange "externalId")}}
               placeholder={{t "components.organizations.creation.external-id.placeholder"}}
             >
               <:label>{{t "components.organizations.creation.external-id.label"}}</:label>
@@ -201,7 +166,7 @@ export default class OrganizationCreationForm extends Component {
           <div class="organization-creation-form__input--full">
             <PixInput
               @id="documentationUrl"
-              onchange={{this.handleDocumentationUrlChange}}
+              {{on "change" (fn this.handleInputChange "documentationUrl")}}
               placeholder={{concat (t "common.words.example-abbr") " https://www.documentation.org"}}
             >
               <:label>{{t "components.organizations.creation.documentation-link"}}</:label>
@@ -212,7 +177,7 @@ export default class OrganizationCreationForm extends Component {
         <Card class="admin-form__card organization-creation-form__card" @title={{this.dpoSectionTitle}}>
           <PixInput
             @id="dataProtectionOfficerLastName"
-            onchange={{this.handleDataProtectionOfficerLastNameChange}}
+            {{on "change" (fn this.handleInputChange "dataProtectionOfficerLastName")}}
             placeholder={{concat (t "common.words.example-abbr") " Dupont"}}
           >
             <:label>{{t "components.organizations.creation.dpo.lastname"}}
@@ -223,7 +188,7 @@ export default class OrganizationCreationForm extends Component {
 
           <PixInput
             @id="dataProtectionOfficerFirstName"
-            onchange={{this.handleDataProtectionOfficerFirstNameChange}}
+            {{on "change" (fn this.handleInputChange "dataProtectionOfficerFirstName")}}
             placeholder={{concat (t "common.words.example-abbr") " Jean"}}
           >
             <:label>{{t "components.organizations.creation.dpo.firstname"}}
@@ -235,7 +200,7 @@ export default class OrganizationCreationForm extends Component {
           <div class="organization-creation-form__input--full">
             <PixInput
               @id="dataProtectionOfficerEmail"
-              onchange={{this.handleDataProtectionOfficerEmailChange}}
+              {{on "change" (fn this.handleInputChange "dataProtectionOfficerEmail")}}
               placeholder={{concat (t "common.words.example-abbr") " jean-dupont@example.net"}}
             >
               <:label>{{t "components.organizations.creation.dpo.email"}}

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -53,6 +53,7 @@ export default class NewController extends Controller {
       this.router.transitionTo('authenticated.organizations.get.all-tags', organization.id);
     } catch {
       this.pixToast.sendErrorNotification({ message: 'Une erreur est survenue.' });
+      organization.rollbackAttributes();
     }
   }
 }

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -27,11 +27,9 @@ export default class NewRoute extends Route {
   }
 
   async model() {
-    const organization = await this.store.createRecord('organization');
     const administrationTeams = await this.store.findAll('administration-team');
     const countries = await this.store.findAll('country');
     return RSVP.hash({
-      organization,
       administrationTeams,
       countries,
     });

--- a/admin/app/templates/authenticated/organizations/new.gjs
+++ b/admin/app/templates/authenticated/organizations/new.gjs
@@ -15,7 +15,6 @@ import CreationForm from 'pix-admin/components/organizations/creation-form';
 
   <main class="main-admin-form">
     <CreationForm
-      @organization={{@model.organization}}
       @administrationTeams={{@model.administrationTeams}}
       @countries={{@model.countries}}
       @onSubmit={{@controller.addOrganization}}

--- a/admin/tests/integration/components/organizations/creation-form-test.gjs
+++ b/admin/tests/integration/components/organizations/creation-form-test.gjs
@@ -3,6 +3,7 @@ import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import CreationForm from 'pix-admin/components/organizations/creation-form';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -29,14 +30,10 @@ module('Integration | Component | organizations/creation-form', function (hooks)
 
   module('Render', function () {
     test('it renders', async function (assert) {
-      //given
-      const organization = store.createRecord('organization', { type: '' });
-
       // when
       const screen = await render(
         <template>
           <CreationForm
-            @organization={{organization}}
             @administrationTeams={{administrationTeams}}
             @countries={{countries}}
             @onSubmit={{onSubmit}}
@@ -92,24 +89,22 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     });
   });
 
-  module('when filling form', function () {
-    test('should update organization model', async function (assert) {
+  module('when submitting form', function () {
+    test('should call onSubmit function with form as argument', async function (assert) {
       // given
-      const organization = store.createRecord('organization');
+      const handleSubmitStub = sinon.stub();
 
       const screen = await render(
         <template>
           <CreationForm
-            @organization={{organization}}
             @administrationTeams={{administrationTeams}}
             @countries={{countries}}
-            @onSubmit={{onSubmit}}
+            @onSubmit={{handleSubmitStub}}
             @onCancel={{onCancel}}
           />
         </template>,
       );
 
-      // when
       await fillByLabel(`${t('components.organizations.creation.name.label')} *`, 'Organisation de Test');
 
       click(screen.getByRole('button', { name: `${t('components.organizations.creation.type.label')} *` }));
@@ -142,17 +137,24 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       await fillByLabel(`${t('components.organizations.creation.dpo.lastname')}DPO`, 'Ptipeu');
       await fillByLabel(`${t('components.organizations.creation.dpo.email')}DPO`, 'justin.ptipeu@example.net');
 
+      // when
+      await click(screen.getByRole('button', { name: t('common.actions.add') }));
+
       // then
-      assert.strictEqual(organization.name, 'Organisation de Test');
-      assert.strictEqual(organization.type, 'SCO');
-      assert.strictEqual(organization.externalId, 'Mon identifiant externe');
-      assert.strictEqual(organization.administrationTeamId, 'team-2');
-      assert.strictEqual(organization.provinceCode, '78');
-      assert.strictEqual(organization.countryCode, '99100');
-      assert.strictEqual(organization.documentationUrl, 'www.documentation.fr');
-      assert.strictEqual(organization.dataProtectionOfficerFirstName, 'Justin');
-      assert.strictEqual(organization.dataProtectionOfficerLastName, 'Ptipeu');
-      assert.strictEqual(organization.dataProtectionOfficerEmail, 'justin.ptipeu@example.net');
+      const expectedForm = {
+        name: 'Organisation de Test',
+        type: 'SCO',
+        externalId: 'Mon identifiant externe',
+        administrationTeamId: 'team-2',
+        provinceCode: '78',
+        countryCode: '99100',
+        documentationUrl: 'www.documentation.fr',
+        dataProtectionOfficerFirstName: 'Justin',
+        dataProtectionOfficerLastName: 'Ptipeu',
+        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+      };
+
+      assert.ok(handleSubmitStub.calledWith(expectedForm));
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/new-test.js
@@ -39,6 +39,7 @@ module('Unit | Controller | authenticated/organizations/new', function (hooks) {
         const organizationModelStub = {
           ...formWithParentOrganizationId,
           save: sinon.stub(),
+          rollbackAttributes: sinon.stub(),
         };
         createRecordStub.withArgs('organization', formWithParentOrganizationId).returns(organizationModelStub);
 
@@ -78,6 +79,7 @@ module('Unit | Controller | authenticated/organizations/new', function (hooks) {
         const organizationModelStub = {
           ...formWithoutParentOrganizationId,
           save: sinon.stub(),
+          rollbackAttributes: sinon.stub(),
         };
         createRecordStub.withArgs('organization', formWithoutParentOrganizationId).returns(organizationModelStub);
 


### PR DESCRIPTION
## ❄️ Problème

Actuellement, la façon dont on remplit le formulaire nous empêche notamment d’implémenter facilement la validation du formulaire. Les étapes sont actuellement les suivantes:

- on créé un record Ember-data vide pour la future organisation lorsqu’on accède à la route de création d’org
- on le  passe en argument dans le composant creation-form
- au fur et à mesure du remplissage du formulaire, on mute le modèle
- à la soumission, on save le modèle

Problèmes:
- ce n'est pas une bonne pratique de muter un objet passé en argument
- on créé un record dans le store qui ne sera potentiellement pas utilisé (si formulaire non remplit ou si on annule la création)
- soucis pour valider les données du formulaire car impossible de passer un record Ember au FormValidator

## 🛷 Proposition
 Refactoriser le code:
- créer un objet tracked de formulaire dans le composant
- au fur et à mesure du remplissage du formulaire, on mute cet objet
- à la soumission, on créé le Record avec les infos du formulaire et on save
- si erreur pendant la soumission (après validation), on supprime le record créé

## ☃️ Remarques
- Une fois ce refactor effectué, on pourra passer à la validation dynamique du formualire via le FormValidator et supprimer la validation manuelle actuellement faite dans le controller
- Des handlers génériques de remplissage d'Input et de Select ont été ajoutés afin de remplacer les handlers individuels

## 🧑‍🎄 Pour tester

Sur PixAdmin:
- vérifier qu'on peut toujours créer une organisation (classique et fille) -> https://admin-pr14479.review.pix.fr/organizations/new
- vérifier que les propriétés Nom, Type, Équipe en charge et Pays sont bien toujours requis
