### PR TITLE
[TECH] Créer des blueprints à partir des combined_courses déjà existants et les rattacher (PIX-20848)

### DIFF
--- a/api/db/database-builder/factory/build-combined-course.js
+++ b/api/db/database-builder/factory/build-combined-course.js
@@ -15,6 +15,7 @@ const buildCombinedCourse = function ({
   illustration = 'images/illustration.svg',
   createdAt = new Date(),
   updatedAt,
+  combinedCourseBlueprintId,
 } = {}) {
   organizationId = isUndefined(organizationId) ? buildOrganization().id : organizationId;
 
@@ -36,6 +37,7 @@ const buildCombinedCourse = function ({
     createdAt,
     updatedAt: updatedAt ?? createdAt,
     questId,
+    combinedCourseBlueprintId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -86,11 +86,11 @@ export class CombinedCourseBlueprint {
     }
   }
   static buildContentItems(items) {
-    return items.map(({ moduleShortId, targetProfileId }) =>
-      moduleShortId
+    return items.map(({ moduleShortId, targetProfileId }) => {
+      return moduleShortId
         ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
-        : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId },
-    );
+        : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId };
+    });
   }
 }
 

--- a/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
+++ b/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { CreateCombinedCourseBlueprint } from '../../../../scripts/prod/create-combined-course-blueprints-from-combined-courses.js';
+import { COMBINED_COURSE_BLUEPRINT_ITEMS } from '../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { Module } from '../../../../src/quest/domain/models/Module.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
@@ -50,8 +51,8 @@ describe('CreateCombinedCourseBlueprint', function () {
         expect(combinedCourseBlueprints[0].description).to.equal('Le but de ma quête');
         expect(combinedCourseBlueprints[0].illustration).to.equal('images/illustration.svg');
         expect(combinedCourseBlueprints[0].content).to.deep.equal([
-          { type: 'evaluation', value: targetProfile.id },
-          { type: 'module', value: 'short-module-id' },
+          { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfile.id },
+          { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: 'short-module-id' },
         ]);
       });
 

--- a/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
+++ b/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CreateCombinedCourseBlueprint } from '../../../../scripts/prod/create-combined-course-blueprints-from-combined-courses.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+describe('CreateCombinedCourseBlueprint', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const script = new CreateCombinedCourseBlueprint();
+      const { options } = script.metaInfo;
+
+      expect(options.dryRun).to.deep.include({
+        type: 'boolean',
+        describe: 'dry run mode (changes are not persisted in Db)',
+        default: true,
+      });
+    });
+  });
+
+  describe('Handle', function () {
+    let script;
+    let logger;
+
+    beforeEach(function () {
+      script = new CreateCombinedCourseBlueprint();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+    });
+
+    context('when dryRun is false', function () {
+      it('creates combined course blueprints', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCombinedCourse({
+          combinedCourseContents: [{ campaignId: campaign.id }, { moduleId: 'module-id' }],
+        });
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false }, logger });
+
+        const combinedCourseBlueprints = await knex.select('*').from('combined_course_blueprints');
+        expect(combinedCourseBlueprints).to.have.lengthOf(1);
+        expect(combinedCourseBlueprints[0].name).to.equal('Mon parcours combiné');
+        expect(combinedCourseBlueprints[0].internalName).to.equal('Modèle de Mon parcours combiné');
+        expect(combinedCourseBlueprints[0].description).to.equal('Le but de ma quête');
+        expect(combinedCourseBlueprints[0].illustration).to.equal('images/illustration.svg');
+        expect(combinedCourseBlueprints[0].content).to.deep.equal([
+          { type: 'evaluation', value: targetProfile.id },
+          { type: 'module', value: 'module-id' },
+        ]);
+      });
+
+      it('set combinedCourseBlueprint id with the newly created combined course blueprint id', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const combinedCourse = databaseBuilder.factory.buildCombinedCourse({
+          combinedCourseContents: [{ campaignId: campaign.id }, { moduleId: 'module-id' }],
+        });
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false }, logger });
+
+        const combinedCourseBlueprints = await knex.select('*').from('combined_course_blueprints').first();
+        const updatedCombinedCourse = await knex
+          .select('*')
+          .from('combined_courses')
+          .where({ id: combinedCourse.id })
+          .first();
+        expect(updatedCombinedCourse.combinedCourseBlueprintId).to.equal(combinedCourseBlueprints.id);
+      });
+
+      it('does not create blueprint if combined course has already a combinedCourseBlueprintId', async function () {
+        const combinedCourseBlueprint = databaseBuilder.factory.buildCombinedCourseBlueprint({
+          content: { moduleId: 'toto' },
+        });
+        databaseBuilder.factory.buildCombinedCourse({
+          combinedCourseBlueprintId: combinedCourseBlueprint.id,
+        });
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: false }, logger });
+
+        const combinedCourseBlueprints = await knex.select('*').from('combined_course_blueprints');
+
+        expect(combinedCourseBlueprints).lengthOf(1);
+      });
+    });
+
+    context('when dryRun is true', function () {
+      it('should not update combined course nor create combined course blueprint', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const combinedCourseId = databaseBuilder.factory.buildCombinedCourse({
+          combinedCourseContents: [{ campaignId: campaign.id }, { moduleId: 'module-id' }],
+        }).id;
+        await databaseBuilder.commit();
+
+        await script.handle({ options: { dryRun: true }, logger });
+
+        const combinedCourseBlueprints = await knex.select('*').from('combined_course_blueprints');
+        const combinedCourse = await knex.select('*').from('combined_courses').where({ id: combinedCourseId });
+        expect(combinedCourseBlueprints).to.have.lengthOf(0);
+        expect(combinedCourse.combinedCourseBlueprintId).to.be.undefined;
+      });
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
+++ b/api/tests/integration/scripts/prod/create-combined-course-blueprints-from-combined-courses_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { CreateCombinedCourseBlueprint } from '../../../../scripts/prod/create-combined-course-blueprints-from-combined-courses.js';
+import { Module } from '../../../../src/quest/domain/models/Module.js';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('CreateCombinedCourseBlueprint', function () {
@@ -21,9 +22,13 @@ describe('CreateCombinedCourseBlueprint', function () {
   describe('Handle', function () {
     let script;
     let logger;
+    let moduleRepository;
 
     beforeEach(function () {
-      script = new CreateCombinedCourseBlueprint();
+      moduleRepository = {
+        getByIds: sinon.stub().resolves([new Module({ id: 'module-id', shortId: 'short-module-id' })]),
+      };
+      script = new CreateCombinedCourseBlueprint(moduleRepository);
       logger = { info: sinon.spy(), error: sinon.spy() };
     });
 
@@ -46,7 +51,7 @@ describe('CreateCombinedCourseBlueprint', function () {
         expect(combinedCourseBlueprints[0].illustration).to.equal('images/illustration.svg');
         expect(combinedCourseBlueprints[0].content).to.deep.equal([
           { type: 'evaluation', value: targetProfile.id },
-          { type: 'module', value: 'module-id' },
+          { type: 'module', value: 'short-module-id' },
         ]);
       });
 


### PR DESCRIPTION
## ❄️ Problème
Avec l'introduction des schémas de parcours combinés, on souhaite pouvoir :
- créer des schémas pour les parcours combinés déjà existants ;
- rattacher les parcours combinés à ces blueprints.

## 🛷 Proposition
On ne veut pas 1 parcours combiné = 1 schéma.
On veut que plusieurs parcours combinés puissent utiliser un même schéma.
Le critère d'unicité va être le content. Si j'ai un content exactement identique entre deux parcours combinés, alors on va créer un seul schéma pour ces deux.

## 🧑‍🎄 Pour tester

Lancer le script create-combined-course-blueprints-from-combined-courses en dryRun true
Vérifier qu'aucune donnée n'est insérée ou modifiée en base (combined_course_blueprints et combined_courses).

Lancer le script create-combined-course-blueprints en dryRun false
Vérifier que : 
- pour tous les parcours combinés, on a un combinedCourseBlueprintId rattaché
- des combined_course_blueprints ont été créé et ont des contents différents
