### PR TITLE
[BUGFIX] Les badges ne peuvent plus être mis à jour (PIX-20881).

### DIFF
--- a/api/src/evaluation/application/badges/badges-controller.js
+++ b/api/src/evaluation/application/badges/badges-controller.js
@@ -5,7 +5,7 @@ import { badgeSerializer } from '../../infrastructure/serializers/jsonapi/badge-
 
 const updateBadge = async function (request, h) {
   const badgeId = request.params.id;
-  const badge = badgeSerializer.deserialize(request.payload);
+  const badge = await badgeSerializer.deserialize(request.payload);
 
   const updatedBadge = await evaluationUsecases.updateBadge({ badgeId, badge });
 

--- a/api/tests/evaluation/acceptance/application/badges/index_test.js
+++ b/api/tests/evaluation/acceptance/application/badges/index_test.js
@@ -10,7 +10,7 @@ import {
 
 const { omit } = lodash;
 
-describe('Acceptance | Route | target-profiles', function () {
+describe('Acceptance | Route | badges', function () {
   let server;
 
   beforeEach(async function () {
@@ -223,6 +223,44 @@ describe('Acceptance | Route | target-profiles', function () {
         expect(response.statusCode).to.equal(422);
         expect(response.result).to.deep.equal(expectedError);
       });
+    });
+  });
+
+  describe('PATCH /api/admin/badges/{badgeId}', function () {
+    it('should update a badge', async function () {
+      const userId = databaseBuilder.factory.buildUser.withRole().id;
+      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      const badgeId = databaseBuilder.factory.buildBadge({ targetProfileId, title: 'ancien titre' }).id;
+      await databaseBuilder.commit();
+
+      const badgeToUpdate = {
+        key: '1',
+        title: 'titre du badge modifié',
+        message: 'Message modifié',
+        'alt-message': 'Message alternatif modifié',
+        'image-url': 'https://assets.pix.org/badges/new_badge_url.svg',
+        'is-certifiable': true,
+        'is-always-visible': true,
+      };
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/admin/badges/${badgeId}`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId }),
+        payload: {
+          data: {
+            type: 'badges',
+            attributes: badgeToUpdate,
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+
+      const badgeUpdated = await knex('badges').where('id', badgeId).first();
+      expect(badgeUpdated.title).to.deep.equal(badgeToUpdate.title);
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

On nous a remonté un problème lors de la mise à jour d'un badge via Pix Admin. Le formulaire indique que le badge a été mis à jour avec succès, pourtant aucune modification n'a été pris en compte.

## 🛷 Proposition

Ajout d'un await manquant dans le controller du badge.

## ☃️ Remarques

[Une PR récente](https://github.com/1024pix/pix/pull/14400) a modifié le deserialize des infos d'un badge pour améliorer la gestion de l'url du badge. Cette modification a entrainée un bug et le manque de test d'acceptance pour cette route a empeché les devs d'être informé du soucis.

thks @Alexandre-Monney pour l'identification du soucis.


## 🧑‍🎄 Pour tester

- Se connecter sur Pix Admin
- aller ici https://admin-pr14485.review.pix.fr/target-profiles/56/badges/57
- Modifier l'ensemble des infos de ce badge (pour check qu'ils sont tous pris en compte)
- Constater que les infos sont bien mises à jour (F5 pour check sûr - sinon check de la table `badges`)
