### PR TITLE
[FEATURE] Iframe de visionnage de tuto Youtube (PIX-20897)

### DIFF
--- a/mon-pix/public/youtube-video.html
+++ b/mon-pix/public/youtube-video.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <title>Youtube | Pix</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100vw;
+        height: 100vh;
+      }
+
+      iframe {
+        border-style: none;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe title="Youtube"></iframe>
+    <script>
+      const videoId = new URL(document.location).searchParams.get('v');
+      document.querySelector('iframe').src = `https://yout-ube.com/watch?v=${videoId}`;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## ❄️ Problème

Le site youtube-nocookie.com/embed/xxx (accédé aussi indirectement via yout-ube.com) est fait pour être "embeddé", donc dans une iframe.
On redirige l’utilisateur directement sur ce site, ce qui peut poser parfois problème (partage d’URL, etc).

## 🛷 Proposition

Créer une page HTML permettant d’embedder ce site pour éviter les problèmes.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller là : https://app-pr14489.review.pix.fr/youtube-video.html?v=--9kqhzQ-8Q