### PR TITLE
[FEATURE] Valider l'existence du profil cible au moment de la création de schéma parcours combiné (PIX-20811)

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -79,16 +79,14 @@ export default class CombineCourseBluePrintForm extends Component {
       });
       this.router.transitionTo('authenticated.combined-course-blueprints.list');
     } catch (responseError) {
-      if (responseError.errors) {
-        responseError.errors.forEach((error) => {
-          if (['400', '404', '412'].includes(error.status)) {
-            return this.pixToast.sendErrorNotification({ message: error.detail });
-          }
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t('components.combined-course-blueprints.create.notifications.error'),
-          });
+      if (!responseError.errors) {
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t('components.combined-course-blueprints.create.notifications.error'),
         });
       }
+      return responseError.errors
+        .filter((error) => ['400', '404', '412'].includes(error.status))
+        .forEach((error) => this.pixToast.sendErrorNotification({ message: error.detail }));
     }
   }
 

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -73,15 +73,22 @@ export default class CombineCourseBluePrintForm extends Component {
   @action
   async save() {
     try {
-      this.blueprint.save();
+      await this.blueprint.save();
       this.pixToast.sendSuccessNotification({
         message: this.intl.t('components.combined-course-blueprints.create.notifications.success'),
       });
       this.router.transitionTo('authenticated.combined-course-blueprints.list');
-    } catch {
-      this.pixToast.sendErrorNotification({
-        message: this.intl.t('components.combined-course-blueprints.create.notifications.error'),
-      });
+    } catch (responseError) {
+      if (responseError.errors) {
+        responseError.errors.forEach((error) => {
+          if (['400', '404', '412'].includes(error.status)) {
+            return this.pixToast.sendErrorNotification({ message: error.detail });
+          }
+          return this.pixToast.sendErrorNotification({
+            message: this.intl.t('components.combined-course-blueprints.create.notifications.error'),
+          });
+        });
+      }
     }
   }
 

--- a/api/src/quest/domain/usecases/create-combined-course-blueprint.js
+++ b/api/src/quest/domain/usecases/create-combined-course-blueprint.js
@@ -1,3 +1,13 @@
-export const createCombinedCourseBlueprint = async ({ combinedCourseBlueprint, combinedCourseBlueprintRepository }) => {
+import { COMBINED_COURSE_BLUEPRINT_ITEMS } from '../models/CombinedCourseBlueprint.js';
+
+export const createCombinedCourseBlueprint = async ({
+  combinedCourseBlueprint,
+  combinedCourseBlueprintRepository,
+  targetProfileRepository,
+}) => {
+  const targetProfileIds = combinedCourseBlueprint.content
+    .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION)
+    .map(({ value }) => value);
+  await targetProfileRepository.findByIds({ ids: targetProfileIds });
   return combinedCourseBlueprintRepository.save(combinedCourseBlueprint);
 };

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -1,16 +1,20 @@
 import { CombinedCourseBlueprint } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
 import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
-import { expect, knex } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Combined course | Domain | UseCases | create-combined-course-blueprint', function () {
   it('should create a combined course blueprint', async function () {
     // given
+    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    await databaseBuilder.commit();
+
     const combinedCourseBlueprint = {
       name: 'Mon épure',
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }, { targetProfileId: 123 }]),
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }, { targetProfileId }]),
     };
 
     await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
@@ -24,5 +28,18 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     expect(result[0].content).to.deep.equal(combinedCourseBlueprint.content);
     expect(result[0].updatedAt).to.be.instanceOf(Date);
     expect(result[0].createdAt).to.be.instanceOf(Date);
+  });
+  it('should return error if a targetProfileId in content is not found', async function () {
+    // given
+    const combinedCourseBlueprint = {
+      name: 'Mon épure',
+      internalName: 'Une épure pour tel niveau',
+      illustration: 'illustrations/mon-epure.png',
+      description: 'Description',
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }, { targetProfileId: 123 }]),
+    };
+
+    const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });
+    expect(error).to.be.instanceOf(NotFoundError);
   });
 });


### PR DESCRIPTION
## ❄️ Problème
On veut éviter la création de schémas de parcours combiné non fonctionnels avec des profils cibles qui n'existent pas.

## 🛷 Proposition
On ajoute de la validation sur l'existence des profil cibles du schéma côté back et on affiche un message d'erreur approprié sur le front. 

## ☃️ Remarques
On se laisse la validation des ids de modules pour plus tard (après réflexion, on veut pouvoir utiliser le shortId au lieu de l'id du module).

## 🧑‍🎄 Pour tester
Aller sur le lien "Schéma des parcours combinés" dans PixAdmin. Cliquer sur le lien de création.
Dans le formulaire de création, ajouter un PC avec un id à 1000 (il n'existe pas).
Vérifier qu'on a bien le PixToast erreur qui apparaît avec le message 'Le profil cible id 1000 n'existe pas'.