### PR TITLE
[FEATURE] Supprimer le titre redondant "Analyse de résultats" dans l'onglet analyse d'une campagne (PIX-20853)

### DIFF
--- a/orga/app/components/analysis/analysis-header.gjs
+++ b/orga/app/components/analysis/analysis-header.gjs
@@ -33,7 +33,6 @@ export default class Analysis extends Component {
     });
   }
   <template>
-    <h2 class="result-analysis__title">{{t "pages.campaign-analysis.second-title"}}</h2>
     <div class="analysis-description">
       <b class="analysis-description__resume">{{t "pages.campaign-analysis.description.resume"}}</b>
       <p>{{t "pages.campaign-analysis.description.explanation"}}</p>

--- a/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/campaign/analysis.scss
@@ -1,19 +1,11 @@
 @use 'pix-design-tokens/typography';
 
-
 .result-analysis {
-  &__title {
-    @extend %pix-title-s;
-
-    margin-bottom: var(--pix-spacing-1x);
-  }
-
   &__global-information {
     display: flex;
     flex-direction: row;
     gap: var(--pix-spacing-1x);
     margin-bottom: var(--pix-spacing-10x);
-
   }
 
   &__global-positioning-explanation {
@@ -22,7 +14,7 @@
     white-space: nowrap;
 
     ul {
-      padding-left:var(--pix-spacing-6x);
+      padding-left: var(--pix-spacing-6x);
       list-style-type: circle;
     }
   }
@@ -33,13 +25,10 @@
 
   margin-bottom: var(--pix-spacing-8x);
 
-
   &__resume {
     font-weight: var(--pix-font-bold);
   }
 }
-
-
 
 .analysis-per-tube-or-competence {
   &__header {
@@ -49,7 +38,6 @@
 
     h2 {
       @extend %pix-title-s;
-
     }
 
     margin-bottom: var(--pix-spacing-1x);
@@ -57,7 +45,6 @@
 }
 
 .analysis {
-
   &__description {
     @extend %pix-body-s;
 
@@ -76,7 +63,8 @@
     width: 10%;
   }
 
-  &__competence-title, &__tube-title {
+  &__competence-title,
+  &__tube-title {
     @extend %pix-body-s;
 
     display: block;
@@ -84,7 +72,8 @@
     font-weight: var(--pix-font-bold);
   }
 
-  &__competence-description, &__tube-description {
+  &__competence-description,
+  &__tube-description {
     @extend %pix-body-s;
 
     display: block;
@@ -95,5 +84,4 @@
 
     margin-bottom: var(--pix-spacing-3x);
   }
-
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -743,7 +743,6 @@
         },
         "title": "levels correspondence"
       },
-      "second-title": "Results Analysis",
       "title": "Analysis"
     },
     "campaign-combined-courses": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -743,7 +743,6 @@
         },
         "title": "Correspondance des niveaux"
       },
-      "second-title": "Analyse de résultats",
       "title": "Analyse"
     },
     "campaign-creation": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -742,7 +742,6 @@
         },
         "title": "Correspondentie tussen niveaus"
       },
-      "second-title": "Analyse van resultaten",
       "title": "Uitleg"
     },
     "campaign-creation": {
@@ -1803,7 +1802,7 @@
         "message": "{providerName} Je wordt doorgestuurd naar de \" \" inlogpagina om je te identificeren op Pix."
       },
       "signup": {
-          "button": "Registreren"
+        "button": "Registreren"
       },
       "title": "Kies een andere organisatie"
     },


### PR DESCRIPTION
## ❄️ Problème

Un titre "Analyse de résultats" existe en haut du contenu de l'onglet Analyse d'une campagne. 
Il est un peu redondant avec le titre de l'onglet juste au dessus et les autres onglets du même niveau n'ont pas de titre comme ça.

## 🛷 Proposition

Le supprimer pour harmoniser l'affichage.

## ☃️ Remarques

Bonnes fêtes à tous ! 🎄🎅 🎁  

## 🧑‍🎄 Pour tester

Se connecter à Pix Orga
Afficher la page d'une Campagne
Sélectionner l'onglet Analyse
Voir que le titre "Analyse de résultats" n'existe plus 🎉 