### PR TITLE
[FEATURE] Afficher le compteur de certifs d'un utilisateur sur Admin (PIX-20910).

### DIFF
--- a/admin/app/components/users/user-certification-courses.gjs
+++ b/admin/app/components/users/user-certification-courses.gjs
@@ -3,27 +3,11 @@ import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
 
 export default class UserCertificationCourses extends Component {
   @service intl;
-  @service router;
-  @service store;
-
-  @tracked userCertificationCourses = [];
-
-  constructor() {
-    super(...arguments);
-
-    this.loadUserCertificationCourses();
-  }
-
-  async loadUserCertificationCourses() {
-    const userId = this.router.currentRoute.parent.params.user_id;
-    this.userCertificationCourses = await this.store.query('user-certification-course', { userId });
-  }
 
   <template>
     <header class="page-section__header">
@@ -32,10 +16,10 @@ export default class UserCertificationCourses extends Component {
       </h2>
     </header>
 
-    {{#if this.userCertificationCourses.length}}
+    {{#if @certificationCourses.length}}
       <PixTable
         @variant="admin"
-        @data={{this.userCertificationCourses}}
+        @data={{@certificationCourses}}
         @caption={{t "components.users.certification-centers.certification-courses.table-caption"}}
       >
         <:columns as |certificationCourse context|>

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -39,6 +39,7 @@ export default class User extends Model {
   @hasMany('authentication-method', { async: true, inverse: null }) authenticationMethods;
   @hasMany('last-application-connection', { async: false, inverse: null }) lastApplicationConnections;
   @hasMany('user-participation', { async: true, inverse: null }) participations;
+  @hasMany('user-certification-course', { async: true, inverse: null }) certificationCourses;
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
@@ -62,6 +63,10 @@ export default class User extends Model {
 
   get authenticationMethodCount() {
     return this.username && this.email ? this.authenticationMethods.length + 1 : this.authenticationMethods.length;
+  }
+
+  get certificationCoursesCount() {
+    return this.certificationCourses.length;
   }
 
   get orderedLastApplicationConnections() {

--- a/admin/app/routes/authenticated/users/get/certification-courses.js
+++ b/admin/app/routes/authenticated/users/get/certification-courses.js
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Route from '@ember/routing/route';
+
+export default class CertificationCoursesRoute extends Route {
+  async model() {
+    const user = this.modelFor('authenticated.users.get');
+    await user.hasMany('certificationCourses').reload();
+    const certificationCourses = await user.certificationCourses;
+    return certificationCourses;
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
+  }
+}

--- a/admin/app/templates/authenticated/users/get.gjs
+++ b/admin/app/templates/authenticated/users/get.gjs
@@ -52,6 +52,7 @@ import UserOverview from 'pix-admin/components/users/user-overview';
 
       <LinkTo @route="authenticated.users.get.certification-courses">
         {{t "pages.user-details.navbar.certification-courses"}}
+        ({{@model.certificationCoursesCount}})
       </LinkTo>
 
       <LinkTo

--- a/admin/app/templates/authenticated/users/get/certification-courses.gjs
+++ b/admin/app/templates/authenticated/users/get/certification-courses.gjs
@@ -1,2 +1,2 @@
 import UserCertificationCourses from 'pix-admin/components/users/user-certification-courses';
-<template><UserCertificationCourses /></template>
+<template><UserCertificationCourses @certificationCourses={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -32,6 +32,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     const expectedParticipationCount = 1;
     const expectedAuthenticationMethodCount = 3;
     const expectedCertificationCenterMembershipsCount = 3;
+    const expectedCertificationCoursesCount = 2;
     const connectionTabLabel = this.intl.t('pages.user-details.navbar.connections');
 
     // when
@@ -48,7 +49,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     assert.dom(userNavigation.getByRole('link', { name: 'Profil' })).exists();
     assert.dom(userNavigation.getByRole('link', { name: `Participations (${expectedParticipationCount})` })).exists();
     assert
-      .dom(userNavigation.getByLabelText('Organisations de l’utilisateur'))
+      .dom(userNavigation.getByRole('link', { name: 'Organisations de l’utilisateur' }))
       .hasText(`Pix Orga (${expectedOrganizationMembershipsCount})`);
     assert
       .dom(
@@ -58,7 +59,11 @@ module('Acceptance | authenticated/users/get', function (hooks) {
         `${this.intl.t('pages.user-details.navbar.certification-centers-list')} (${expectedCertificationCenterMembershipsCount})`,
       );
     assert
-      .dom(userNavigation.getByRole('link', { name: this.intl.t('pages.user-details.navbar.certification-courses') }))
+      .dom(
+        userNavigation.getByRole('link', {
+          name: `${this.intl.t('pages.user-details.navbar.certification-courses')} (${expectedCertificationCoursesCount})`,
+        }),
+      )
       .exists();
     assert
       .dom(userNavigation.getByRole('link', { name: this.intl.t('pages.user-details.navbar.cgu-aria-label') }))
@@ -371,7 +376,9 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       // when
       const userNavigation = within(screen.getByLabelText("Navigation de la section détails d'un utilisateur"));
       await click(
-        userNavigation.getByRole('link', { name: this.intl.t('pages.user-details.navbar.certification-courses') }),
+        userNavigation.getByRole('link', {
+          name: `${this.intl.t('pages.user-details.navbar.certification-courses')} (0)`,
+        }),
       );
 
       // then
@@ -394,6 +401,8 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     const certificationCenterMembership2 = server.create('certification-center-membership');
     const certificationCenterMembership3 = server.create('certification-center-membership');
     const participation = server.create('user-participation');
+    const certificationCourse1 = server.create('user-certification-course');
+    const certificationCourse2 = server.create('user-certification-course');
     const user = server.create('user', {
       'first-name': 'john',
       'last-name': 'harry',
@@ -408,6 +417,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       certificationCenterMembership3,
     ];
     user.participations = [participation];
+    user.certificationCourses = [certificationCourse1, certificationCourse2];
     user.organizationLearners = [organizationLearner];
     user.authenticationMethods = [pixAuthenticationMethod, garAuthenticationMethod];
     user.save();

--- a/admin/tests/integration/components/users/user-certification-courses-test.gjs
+++ b/admin/tests/integration/components/users/user-certification-courses-test.gjs
@@ -24,10 +24,12 @@ module('Integration | Component | Users | User certification courses', function 
   module('When user has no certification course', function () {
     test('displays a title and an info', async function (assert) {
       // given
-      sinon.stub(store, 'query').resolves([]);
+      const certificationCourses = [];
 
       // when
-      const screen = await render(<template><UserCertificationCourses /></template>);
+      const screen = await render(
+        <template><UserCertificationCourses @certificationCourses={{certificationCourses}} /></template>,
+      );
 
       // then
       assert
@@ -54,14 +56,19 @@ module('Integration | Component | Users | User certification courses', function 
         isPublished: true,
       });
       const certificationCourse2 = store.createRecord('user-certification-course', {
+        id: '2',
+        sessionId: 24,
+        createdAt: new Date('2025-04-02'),
         isPublished: false,
       });
       const certificationCourseCreatedAt = intl.formatDate(certificationCourse.createdAt);
 
-      sinon.stub(store, 'query').resolves([certificationCourse, certificationCourse2]);
+      const certificationCourses = [certificationCourse, certificationCourse2];
 
       // when
-      const screen = await render(<template><UserCertificationCourses /></template>);
+      const screen = await render(
+        <template><UserCertificationCourses @certificationCourses={{certificationCourses}} /></template>,
+      );
 
       // then
       assert

--- a/admin/tests/mirage/models/user.js
+++ b/admin/tests/mirage/models/user.js
@@ -9,4 +9,5 @@ export default Model.extend({
   authenticationMethods: hasMany('authenticationMethod'),
   lastApplicationConnections: hasMany('lastApplicationConnection'),
   participations: hasMany('userParticipation'),
+  certificationCourses: hasMany('userCertificationCourse'),
 });

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -340,8 +340,10 @@ export default function routes() {
     return certificationCenterMembership;
   });
 
-  this.get('/admin/users/:id/certification-courses', () => {
-    return { data: [] };
+  this.get('/admin/users/:id/certification-courses', (schema, request) => {
+    const userId = request.params.id;
+    const user = schema.users.find(userId);
+    return user.certificationCourses;
   });
 
   this.post('/admin/memberships', createOrganizationMembership);

--- a/admin/tests/mirage/serializers/user.js
+++ b/admin/tests/mirage/serializers/user.js
@@ -16,6 +16,9 @@ export default ApplicationSerializer.extend({
       participations: {
         related: `/api/admin/users/${user.id}/participations`,
       },
+      certificationCourses: {
+        related: `/api/admin/users/${user.id}/certification-courses`,
+      },
     };
   },
 });

--- a/admin/tests/unit/models/user-test.js
+++ b/admin/tests/unit/models/user-test.js
@@ -22,4 +22,32 @@ module('Unit | Model | user', function (hooks) {
       assert.strictEqual(fullName, 'Jean-Baptiste Poquelin');
     });
   });
+
+  module('#certificationCoursesCount', function () {
+    test('it should return the number of certification courses', function (assert) {
+      // given
+      const certificationCourse1 = store.createRecord('user-certification-course');
+      const certificationCourse2 = store.createRecord('user-certification-course');
+      const user = store.createRecord('user', {
+        certificationCourses: [certificationCourse1, certificationCourse2],
+      });
+
+      // when
+      const count = user.certificationCoursesCount;
+
+      // then
+      assert.strictEqual(count, 2);
+    });
+
+    test('it should return 0 when user has no certification courses', function (assert) {
+      // given
+      const user = store.createRecord('user', { certificationCourses: [] });
+
+      // when
+      const count = user.certificationCoursesCount;
+
+      // then
+      assert.strictEqual(count, 0);
+    });
+  });
 });

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.js
@@ -11,6 +11,7 @@ const serialize = function (usersDetailsForAdmin) {
       record.participations = null;
       record.organizationMemberships = null;
       record.certificationCenterMemberships = null;
+      record.certificationCourses = null;
       return record;
     },
     attributes: [
@@ -39,6 +40,7 @@ const serialize = function (usersDetailsForAdmin) {
       'participations',
       'organizationMemberships',
       'certificationCenterMemberships',
+      'certificationCourses',
       'userLogin',
       'isPixAgent',
     ],
@@ -107,6 +109,15 @@ const serialize = function (usersDetailsForAdmin) {
       relationshipLinks: {
         related: function (record, current, parent) {
           return `/api/admin/users/${parent.id}/certification-center-memberships`;
+        },
+      },
+    },
+    certificationCourses: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      relationshipLinks: {
+        related: function (record, current, parent) {
+          return `/api/admin/users/${parent.id}/certification-courses`;
         },
       },
     },

--- a/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user/user.admin.route.test.js
@@ -299,6 +299,11 @@ describe('Acceptance | Identity Access Management | Application | Route | Admin 
               related: `/api/admin/users/${user.id}/certification-center-memberships`,
             },
           },
+          'certification-courses': {
+            links: {
+              related: `/api/admin/users/${user.id}/certification-courses`,
+            },
+          },
           'organization-learners': {
             data: [],
           },

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/user-details-for-admin.serializer.test.js
@@ -72,6 +72,11 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
                 related: '/api/admin/users/123/certification-center-memberships',
               },
             },
+            'certification-courses': {
+              links: {
+                related: '/api/admin/users/123/certification-courses',
+              },
+            },
             'organization-learners': {
               data: [
                 {


### PR DESCRIPTION
## ❄️ Problème

Un onglet “Certification” a été ajouté sur la page d’informations de chaque utilisateur dans Pix Admin.

Cet onglet permet au Support notamment de savoir si cet utilisateur a déjà passé une certification et si oui quand, dans quelle session et quel est le statut de cette session.

Ces informations leur sont précieuses pour gagner du temps dans leur réponses aux demandes utilisateurs.

Pour gagner encore plus de temps, ils ont besoin de savoir, au premier coup d’oeil, s'il y a des lignes ou aucune dans l'intitulé de l'onglet “Certification” comme ils le font actuellement pour les onglets "Connexions", "Participations" et "Pix Orga/Pix Certif".

## 🛷 Proposition

Rajouter un compteur dans l’onglet “Certifications” à côté du titre sous la forme d’un chiffre/nombre entre parenthèses comme ce qui est déjà fait pour les onglets "Connexions", "Participations" et "Pix Orga/Pix Certif".

## 🧑‍🎄 Pour tester

- Sur la RA, visualiser un [utilisateur avec des certifs](https://admin-pr14496.review.pix.fr/users/7101) : voir le bon nombre de certifs dans l'onglet
- Visualiser un [utilisateur sans certif](https://admin-pr14496.review.pix.fr/users/1000) et voir le compteur à 0
