### PR TITLE
[BUGFIX] Mise à jour des URLs de documentation (PIX-20923).

### DIFF
--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -160,7 +160,7 @@ module('Acceptance | Session Details', function (hooks) {
           // then
           assert
             .dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" }))
-            .hasAttribute('href', 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download');
+            .hasAttribute('href', 'https://cloud.pix.fr/s/ff8sYPWPyCo3MrN/download');
         });
       });
 

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -192,7 +192,7 @@ module('Unit | Service | url', function (hooks) {
       const urlToDownloadSessionV3IssueReportSheet = service.urlToDownloadSessionV3IssueReportSheet;
 
       // then
-      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download');
+      assert.strictEqual(urlToDownloadSessionV3IssueReportSheet, 'https://cloud.pix.fr/s/ff8sYPWPyCo3MrN/download');
     });
 
     test('should return the session V3 issue report sheet url in English', async function (assert) {

--- a/certif/tests/unit/services/url-test.js
+++ b/certif/tests/unit/services/url-test.js
@@ -154,7 +154,7 @@ module('Unit | Service | url', function (hooks) {
       const fraudReportUrl = service.fraudReportUrl;
 
       // then
-      assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download');
+      assert.strictEqual(fraudReportUrl, 'https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download');
     });
   });
 

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -192,7 +192,7 @@
         "other": "https://cloud.pix.fr/s/ypq3K7GmgpEdwop",
         "sco-managing-students": "https://cloud.pix.fr/s/opiFxfjygR76S8y"
       },
-      "fraud": "https://cloud.pix.fr/s/LiXkoBq9GD5aLbN/download",
+      "fraud": "https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download",
       "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",
       "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download"
     }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -194,7 +194,7 @@
       },
       "fraud": "https://cloud.pix.fr/s/AgDytb8yHxrmjFk/download",
       "session-issue-report-sheet": "https://cloud.pix.fr/s/B76yA8ip9Radej9/download",
-      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/wJc6N3sZNZRC4MZ/download"
+      "session-v3-issue-report-sheet": "https://cloud.pix.fr/s/ff8sYPWPyCo3MrN/download"
     }
   },
   "components": {

--- a/mon-pix/tests/integration/components/companion/blocker-test.gjs
+++ b/mon-pix/tests/integration/components/companion/blocker-test.gjs
@@ -62,7 +62,7 @@ module('Integration | Component | Companion | blocker', function (hooks) {
     assert.dom(screen.queryByText(t('common.companion.not-detected.description'))).exists();
     assert
       .dom(screen.getByRole('link', { name: t('common.companion.not-detected.link') }))
-      .hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
+      .hasAttribute('href', 'https://cloud.pix.fr/s/g76RwDwsZmZPZZ6');
     assert.dom(screen.getByRole('button', { name: t('common.actions.refresh-page') })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/companion/check-test.gjs
+++ b/mon-pix/tests/integration/components/companion/check-test.gjs
@@ -66,7 +66,7 @@ module('Integration | Component | Companion | check', function (hooks) {
               .exists();
             assert
               .dom(screen.getByRole('link', { name: 'Accéder à la documentation' }))
-              .hasAttribute('href', 'https://cloud.pix.fr/s/KocingDC4mFJ3R6');
+              .hasAttribute('href', 'https://cloud.pix.fr/s/g76RwDwsZmZPZZ6');
           });
         },
       );

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -85,7 +85,7 @@
           "link": "Accéder à la documentation"
         }
       },
-      "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
+      "install-documentation-url": "https://cloud.pix.fr/s/g76RwDwsZmZPZZ6",
       "not-detected": {
         "description": "L’extension n’est peut-être pas installée ou activée. Consultez le document suivant afin de reprendre votre session de certification. Si besoin contactez le surveillant.",
         "link": "Accéder à la documentation",


### PR DESCRIPTION
## ❄️ Problème

Un problème lié à notre hébergement de fichiers nous oblige à changer les URLs de documentation.

## 🛷 Proposition

Mise à jour des URLs de: 

- Téléchargement du PV de fraude
- Téléchargement du PV d'incident
- Téléchargement du guide d'installation de PixCompanion

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Vérifier que les liens mentionnés ci-dessus fonctionnent.
