### PR TITLE
[FEATURE] Permettre de retenter les acquis préalablement échoué au démarrage d'une campagne (PIX-20839).

### DIFF
--- a/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/src/evaluation/domain/services/algorithm-methods/data-fetcher.js
@@ -25,6 +25,7 @@ async function fetchForCampaigns({
     _fetchKnowledgeElements({
       assessment,
       isRetrying,
+      keepRecentOrValidated: true,
       campaignParticipationRepository,
       knowledgeElementForParticipationService,
       knowledgeElementRepository,
@@ -45,6 +46,7 @@ async function fetchForCampaigns({
 async function _fetchKnowledgeElements({
   assessment,
   isRetrying = false,
+  keepRecentOrValidated = false,
   knowledgeElementForParticipationService,
   knowledgeElementRepository,
   improvementService,
@@ -58,7 +60,12 @@ async function _fetchKnowledgeElements({
   } else {
     knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
   }
-  return improvementService.filterKnowledgeElementsIfImproving({ knowledgeElements, assessment, isRetrying });
+  return improvementService.filterKnowledgeElementsIfImproving({
+    knowledgeElements,
+    assessment,
+    isRetrying,
+    keepRecentOrValidated,
+  });
 }
 
 async function _fetchSkillsAndChallenges({ campaignSkills, challengeRepository, locale }) {

--- a/api/src/evaluation/domain/services/improvement-service.js
+++ b/api/src/evaluation/domain/services/improvement-service.js
@@ -12,12 +12,18 @@ function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements,
   });
 }
 
-function filterKnowledgeElementsIfImproving({ knowledgeElements, assessment, isRetrying = false }) {
-  const minimumDelayInDays = isRetrying
-    ? constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING
-    : constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
+function filterKnowledgeElementsIfImproving({
+  knowledgeElements,
+  assessment,
+  isRetrying = false,
+  keepRecentOrValidated = false,
+}) {
+  const minimumDelayInDays =
+    isRetrying || keepRecentOrValidated
+      ? constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING
+      : constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
 
-  if (assessment.isImproving) {
+  if (keepRecentOrValidated || assessment.isImproving) {
     return _keepKnowledgeElementsRecentOrValidated({
       currentUserKnowledgeElements: knowledgeElements,
       assessment,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -275,7 +275,7 @@ const configuration = (function () {
     environment: process.env.NODE_ENV || 'development',
     features: {
       dayBeforeImproving: _getNumber(process.env.DAY_BEFORE_IMPROVING, 4),
-      dayBeforeRetrying: _getNumber(process.env.DAY_BEFORE_RETRYING, 4),
+      dayBeforeRetrying: _getNumber(process.env.DAY_BEFORE_RETRYING, 0),
       dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2, 7),
       garAccessV2: toBoolean(process.env.GAR_ACCESS_V2),
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),

--- a/api/tests/evaluation/unit/domain/services/improvement-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/improvement-service_test.js
@@ -17,6 +17,7 @@ describe('Unit | Service | ImprovementService', function () {
           assessment,
           knowledgeElements,
           isRetrying: false,
+          keepRecentOrValidated: false,
         });
 
         // then
@@ -35,7 +36,8 @@ describe('Unit | Service | ImprovementService', function () {
 
         assessment = domainBuilder.buildAssessment.ofTypeCampaign({
           state: 'started',
-          isImproving: true,
+          isImproving: false,
+          keepRecentOrValidated: false,
           createdAt: assessmentDate,
         });
 
@@ -56,6 +58,24 @@ describe('Unit | Service | ImprovementService', function () {
           assessment,
           knowledgeElements,
           isRetrying: true,
+          keepRecentOrValidated: false,
+        });
+
+        // then
+        expect(_.map(listOfKnowledgeElements, 'createdAt')).to.exactlyContain([
+          '2020-07-26',
+          '2020-07-27',
+          '2020-07-28',
+        ]);
+      });
+
+      it('should return the list of knowledge-elements filtered if keepRecentOrValidated is true', function () {
+        // when
+        const listOfKnowledgeElements = improvementService.filterKnowledgeElementsIfImproving({
+          assessment,
+          knowledgeElements,
+          isRetrying: false,
+          keepRecentOrValidated: true,
         });
 
         // then
@@ -110,6 +130,7 @@ describe('Unit | Service | ImprovementService', function () {
           assessment,
           knowledgeElements,
           isRetrying: false,
+          keepRecentOrValidated: false,
         });
 
         // then

--- a/high-level-tests/e2e-playwright/pages/pix-app/FinalCheckpointPage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/FinalCheckpointPage.ts
@@ -6,7 +6,7 @@ export class FinalCheckpointPage {
     const currentUrl = this.page.url();
     await Promise.all([
       this.page.waitForURL((url) => url.toString() !== currentUrl),
-      this.page.getByRole('link', { name: 'Voir et envoyer mes résultats' }).first().click(),
+      this.page.getByRole('link', { name: 'Voir mes résultats' }).first().click(),
     ]);
     const hasLoader = await this.page.locator('.app-loader').isVisible();
     if (hasLoader) {

--- a/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/combined-courses/combined-course.test.ts
@@ -48,7 +48,7 @@ test('Combined courses', async ({ page }) => {
       await page.getByRole('button', { name: 'Ignorer' }).click();
       await page.getByText('Oui.').click();
       await page.getByRole('button', { name: 'Je valide et je vais à la' }).click();
-      await page.getByRole('link', { name: 'Voir et envoyer mes résultats' }).first().click();
+      await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
       await page.getByRole('link', { name: 'Continuer' }).click();
     });
 

--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -23,7 +23,7 @@ test('pass a combined course as sco user and see the final result', async ({ pag
     await page.getByRole('button', { name: 'Je commence' }).click();
     await page.getByRole('button', { name: 'Ignorer' }).click();
     await page.getByRole('button', { name: 'Je passe et je vais à la prochaine question' }).click();
-    await page.getByRole('link', { name: 'Voir et envoyer mes résultats' }).first().click();
+    await page.getByRole('link', { name: 'Voir mes résultats' }).first().click();
     await page.getByRole('link', { name: 'Continuer' }).click();
   });
 

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -21,7 +21,7 @@ Fonctionnalité: Campagne d'évaluation
     Et je clique sur "Je valide"
     Alors je vois l'épreuve "Qui a dit « Toute méchanceté a sa source dans la faiblesse » ?"
     Lorsque je clique sur "Je passe"
-    Et je clique sur "Voir et envoyer mes résultats"
+    Et je clique sur "Voir mes résultats"
     Alors je vois 50% de réussite aux questions
     Alors je vois l'onglet de détails des résultats avec 2 compétences
     Alors je vois que j'ai envoyé les résultats

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1182,7 +1182,7 @@
       "actions": {
         "next-page": {
           "continue": "Continue",
-          "results": "View and send my results"
+          "results": "View my results"
         }
       },
       "answers": {

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1178,7 +1178,7 @@
       "actions": {
         "next-page": {
           "continue": "Continuar",
-          "results": "Ver y enviar mis resultados"
+          "results": "Ver mis resultados"
         }
       },
       "answers": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1178,7 +1178,7 @@
       "actions": {
         "next-page": {
           "continue": "Continuar",
-          "results": "Ver y enviar mis resultados"
+          "results": "Ver mis resultados"
         }
       },
       "answers": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1183,7 +1183,7 @@
       "actions": {
         "next-page": {
           "continue": "Continuer",
-          "results": "Voir et envoyer mes résultats"
+          "results": "Voir mes résultats"
         }
       },
       "answers": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1182,7 +1182,7 @@
       "actions": {
         "next-page": {
           "continue": "Ga verder met",
-          "results": "Mijn resultaten bekijken en verzenden"
+          "results": "Zie mijn resultaten"
         }
       },
       "answers": {


### PR DESCRIPTION
## ❄️ Problème

Depuis l'envoi automatique des résultats, il n'est plus possible de retenter des acquis échoué sauf si la campagne est à envoi multiple. ce qui est un petit peu embetant.

## 🛷 Proposition

Autoriser de poser les questions préalablement échoué au démarrrage de la campagne. Ne plus tenir compte de assessment.isImproving dans le cadre des campagnes.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Se connecter avec admin-orga@example.net
Complèter son profil sur en passant TOUTES les questions sur : 
 - [x] Gérer des données
 - [x] Partager et publier
 - [x] Résoudre des problèmes techniques
 - [x] Construire un environnement numérique

Faire une campagne `PROASSMUL`
Voir que l'on nous pose les questions des acquis échoué. 

Et VOILA !