### PR TITLE
[FEATURE] Afficher différentes catégories de signalement selon l'élément dans un module (PIX-20830).

### DIFF
--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -18,6 +18,7 @@ export default class ModulixCustomDraft extends ModuleElement {
     this.reportInfo = {
       answer: null,
       elementId: this.args.customDraft.id,
+      elementType: this.args.customDraft.type,
     };
   }
 

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -14,7 +14,7 @@ export default class ModulixCustomElement extends ModuleElement {
   @tracked
   customElement;
 
-  @tracked reportInfo = { answer: null, elementId: this.args.component.id };
+  @tracked reportInfo = { answer: null, elementId: this.args.component.id, elementType: this.args.component.type };
 
   @tracked
   resetButtonDisplayed = false;

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -21,6 +21,7 @@ export default class ModulixEmbed extends ModuleElement {
     this.reportInfo = {
       answer: null,
       elementId: this.args.embed.id,
+      elementType: this.args.embed.type,
     };
   }
 

--- a/mon-pix/app/components/module/issue-report/issue-report-block.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-block.gjs
@@ -43,6 +43,7 @@ export default class ModulixIssueReportBlock extends Component {
       >{{t "pages.modulix.issue-report.button"}}</PixButton>
 
       <ModulixIssueReportModal
+        @elementType={{@reportInfo.elementType}}
         @showModal={{this.showModal}}
         @hideModal={{this.hideModal}}
         @onSendReport={{this.onSend}}

--- a/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
+++ b/mon-pix/app/components/module/issue-report/issue-report-modal.gjs
@@ -11,27 +11,70 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import InElement from 'mon-pix/components/in-element';
 
-const categories = [
+import { categoriesKey } from '../../../models/module-issue-report';
+
+const defaultCategories = [
   {
-    value: 'accessibility',
-    label: 'Accessibilité de l‘épreuve',
+    value: categoriesKey.ACCESSIBILITY_ISSUE,
+    label: 'pages.modulix.issue-report.modal.categories.default.accessibility-issue',
   },
   {
-    value: 'answer',
-    label: 'La réponse',
-  },
-  {
-    value: 'other',
-    label: 'Autre',
+    value: categoriesKey.OTHER,
+    label: 'pages.modulix.issue-report.modal.categories.default.other',
   },
 ];
 
+const feedbackCategories = [
+  {
+    value: categoriesKey.QUESTION_ISSUE,
+    label: 'pages.modulix.issue-report.modal.categories.feedback.question-issue',
+  },
+  {
+    value: categoriesKey.RESPONSE_ISSUE,
+    label: 'pages.modulix.issue-report.modal.categories.feedback.response-issue',
+  },
+  {
+    value: categoriesKey.IMPROVEMENT,
+    label: 'pages.modulix.issue-report.modal.categories.feedback.improvement',
+  },
+  ...defaultCategories,
+];
+
+const customAndEmbedTypes = ['custom', 'custom-draft', 'embed'];
+
+const customAndEmbedCategories = [
+  {
+    value: categoriesKey.INSTRUCTION_ISSUE,
+    label: 'pages.modulix.issue-report.modal.categories.custom-and-embed.instruction-issue',
+  },
+  {
+    value: categoriesKey.EMBED_NOT_WORKING,
+    label: 'pages.modulix.issue-report.modal.categories.custom-and-embed.embed-not-working',
+  },
+  ...defaultCategories,
+];
+
 export default class ModulixIssueReportModal extends Component {
-  @tracked selectedCategory = categories[0].value;
+  @service intl;
+
+  @tracked selectedCategory = this.categories[0].value;
   @tracked comment = null;
   @tracked errorMessage = null;
 
-  @service intl;
+  get categories() {
+    let categories;
+
+    if (customAndEmbedTypes.includes(this.args.elementType)) {
+      categories = customAndEmbedCategories;
+    } else {
+      categories = feedbackCategories;
+    }
+
+    return categories.map(({ value, label }) => ({
+      value,
+      label: this.intl.t(label),
+    }));
+  }
 
   @action
   hideModal() {
@@ -61,7 +104,7 @@ export default class ModulixIssueReportModal extends Component {
   @action
   resetForm() {
     document.getElementById('module-issue-report-form').reset();
-    this.selectedCategory = categories[0].value;
+    this.selectedCategory = this.categories[0].value;
     this.comment = null;
   }
 
@@ -83,7 +126,7 @@ export default class ModulixIssueReportModal extends Component {
               <legend class="sr-only">{{t "pages.modulix.issue-report.modal.legend"}}</legend>
               <PixSelect
                 @hideDefaultOption={{true}}
-                @options={{categories}}
+                @options={{this.categories}}
                 @value={{this.selectedCategory}}
                 @onChange={{this.onChangeCategory}}
                 required

--- a/mon-pix/app/models/module-issue-report.js
+++ b/mon-pix/app/models/module-issue-report.js
@@ -1,5 +1,15 @@
 import Model, { attr } from '@ember-data/model';
 
+export const categoriesKey = {
+  ACCESSIBILITY_ISSUE: 'ACCESSIBILITY_ISSUE',
+  OTHER: 'OTHER',
+  QUESTION_ISSUE: 'QUESTION_ISSUE',
+  RESPONSE_ISSUE: 'RESPONSE_ISSUE',
+  IMPROVEMENT: 'IMPROVEMENT',
+  INSTRUCTION_ISSUE: 'INSTRUCTION_ISSUE',
+  EMBED_NOT_WORKING: 'EMBED_NOT_WORKING',
+};
+
 export default class ModuleIssueReport extends Model {
   @attr('string') moduleId;
   @attr('string') elementId;

--- a/mon-pix/tests/acceptance/module/send-issue-report_test.js
+++ b/mon-pix/tests/acceptance/module/send-issue-report_test.js
@@ -69,7 +69,7 @@ module('Acceptance | Module | Routes | sendIssueReport', function (hooks) {
 
       await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Accessibilité de l‘épreuve' }));
+      await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
 
       await fillIn(
         screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),

--- a/mon-pix/tests/integration/components/module/custom-draft_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-draft_test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
@@ -103,6 +103,7 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
           url: 'https://example.org',
           instruction: '<p>Instruction du POIC</p>',
           height: 400,
+          type: 'custom-draft',
         };
         const featureToggles = this.owner.lookup('service:featureToggles');
         sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
@@ -118,10 +119,10 @@ module('Integration | Component | Module | CustomDraft', function (hooks) {
         await waitForDialog();
 
         // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        const listbox = await screen.findByRole('listbox');
+        const options = within(listbox).getAllByRole('option');
+        assert.strictEqual(options.length, 4);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/custom-element_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-element_test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixCustomElement from 'mon-pix/components/module/element/custom-element';
@@ -129,6 +129,7 @@ module('Integration | Component | Module | Custom Element', function (hooks) {
               },
             ],
           },
+          type: 'custom',
         };
         const featureToggles = this.owner.lookup('service:featureToggles');
         sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
@@ -144,10 +145,10 @@ module('Integration | Component | Module | Custom Element', function (hooks) {
         await waitForDialog();
 
         // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        const listbox = await screen.findByRole('listbox');
+        const options = within(listbox).getAllByRole('option');
+        assert.strictEqual(options.length, 4);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
@@ -617,6 +617,7 @@ module('Integration | Component | Module | Embed', function (hooks) {
           isCompletionRequired: false,
           url: 'https://example.org',
           height: 800,
+          type: 'embed',
         };
 
         // when
@@ -630,10 +631,10 @@ module('Integration | Component | Module | Embed', function (hooks) {
         await waitForDialog();
 
         // then
-        assert.dom(screen.getByRole('dialog')).exists();
-        assert
-          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
-          .exists();
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+        const listbox = await screen.findByRole('listbox');
+        const options = within(listbox).getAllByRole('option');
+        assert.strictEqual(options.length, 4);
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-block_test.gjs
@@ -55,7 +55,7 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
           const recordStub = sinon.stub(issueReportService, 'record');
           const elementId = 'b37e8e8d-9875-4b15-85c0-0373ffbb0805';
           const answer = 42;
-          const categoryKey = 'accessibility';
+          const categoryKey = 'ACCESSIBILITY_ISSUE';
           const comment = 'Mon super commentaire de Noel et de joie';
           const reportInfo = { elementId, answer };
 
@@ -70,7 +70,7 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
 
           await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
           await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'Accessibilité de l‘épreuve' }));
+          await click(screen.getByRole('option', { name: 'Problème d’accessibilité' }));
 
           await fillIn(
             screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
@@ -111,7 +111,7 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
 
           await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
           await screen.findByRole('listbox');
-          await click(screen.getByRole('option', { name: 'La réponse' }));
+          await click(screen.getByRole('option', { name: 'Autre' }));
 
           await fillIn(
             screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
@@ -125,7 +125,7 @@ module('Integration | Component | Module | Issue Report | Issue Report Block', f
           await waitForDialog();
 
           // then
-          const allAccessibilityOptions = screen.getAllByText('Accessibilité de l‘épreuve');
+          const allAccessibilityOptions = screen.getAllByText('Je ne comprends pas la question');
           assert.strictEqual(allAccessibilityOptions.length, 2);
           assert
             .dom(screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }))

--- a/mon-pix/tests/integration/components/module/issue-report/issue-report-modal_test.gjs
+++ b/mon-pix/tests/integration/components/module/issue-report/issue-report-modal_test.gjs
@@ -1,7 +1,8 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ModulixIssueReportModal from 'mon-pix/components/module/issue-report/issue-report-modal';
+import { categoriesKey } from 'mon-pix/models/module-issue-report';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -47,7 +48,9 @@ module('Integration | Component | Module | Issue Report | Issue Report Modal', f
 
       await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'La réponse' }));
+      await click(
+        screen.getByRole('option', { name: t('pages.modulix.issue-report.modal.categories.feedback.question-issue') }),
+      );
 
       await fillIn(
         screen.getByRole('textbox', { name: t('pages.modulix.issue-report.modal.textarea-label') }),
@@ -58,7 +61,7 @@ module('Integration | Component | Module | Issue Report | Issue Report Modal', f
 
       // then
       sinon.assert.calledOnceWithExactly(onSendReport, {
-        categoryKey: 'answer',
+        categoryKey: categoriesKey.QUESTION_ISSUE,
         comment: 'Mon super commentaire',
       });
 
@@ -83,12 +86,127 @@ module('Integration | Component | Module | Issue Report | Issue Report Modal', f
 
       await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'La réponse' }));
+      await click(
+        screen.getByRole('option', { name: t('pages.modulix.issue-report.modal.categories.feedback.question-issue') }),
+      );
       await click(screen.getByRole('button', { name: t('common.actions.send') }));
 
       // then
       sinon.assert.notCalled(onSendReport);
       assert.dom(screen.getByText(t('pages.modulix.issue-report.error-messages.missing-comment'))).exists();
+    });
+  });
+
+  module('when user report an embed or custom element', function () {
+    test('should display specific categories on select', async function (assert) {
+      // given
+      const hideModal = sinon.stub();
+      const onSendReport = sinon.stub();
+      const elementType = 'custom';
+
+      // when
+      const screen = await render(
+        <template>
+          <div id="modal-container">
+            <ModulixIssueReportModal
+              @showModal={{true}}
+              @hideModal={{hideModal}}
+              @onSendReport={{onSendReport}}
+              @elementType={{elementType}}
+            />
+          </div>
+        </template>,
+      );
+
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+      const listbox = await screen.findByRole('listbox');
+
+      // then
+      const options = within(listbox).getAllByRole('option');
+      assert.strictEqual(options.length, 4);
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.custom-and-embed.instruction-issue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.custom-and-embed.embed-not-working'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.default.accessibility-issue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(screen.getByRole('option', { name: t('pages.modulix.issue-report.modal.categories.default.other') }))
+        .exists();
+    });
+  });
+
+  module('when user report an element with a feedback', function () {
+    test('should display specific categories on select', async function (assert) {
+      // given
+      const hideModal = sinon.stub();
+      const onSendReport = sinon.stub();
+      const elementType = 'qab';
+
+      // when
+      const screen = await render(
+        <template>
+          <div id="modal-container">
+            <ModulixIssueReportModal
+              @showModal={{true}}
+              @hideModal={{hideModal}}
+              @onSendReport={{onSendReport}}
+              @elementType={{elementType}}
+            />
+          </div>
+        </template>,
+      );
+
+      await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.modal.select-label') }));
+      const listbox = await screen.findByRole('listbox');
+
+      // then
+      const options = within(listbox).getAllByRole('option');
+      assert.strictEqual(options.length, 5);
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.feedback.question-issue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.feedback.response-issue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('option', { name: t('pages.modulix.issue-report.modal.categories.feedback.improvement') }),
+        )
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('option', {
+            name: t('pages.modulix.issue-report.modal.categories.default.accessibility-issue'),
+          }),
+        )
+        .exists();
+      assert
+        .dom(screen.getByRole('option', { name: t('pages.modulix.issue-report.modal.categories.default.other') }))
+        .exists();
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1680,6 +1680,21 @@
           "missing-comment": "Please enter a comment."
         },
         "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "The simulator/application does not work",
+              "instruction-issue": "I don't understand the instructions"
+            },
+            "default": {
+              "accessibility-issue": "Accessibility issue",
+              "other": "Other"
+            },
+            "feedback": {
+              "improvement": "I would like to suggest an improvement",
+              "question-issue": "I don't understand the question",
+              "response-issue": "I don't agree with the answer"
+            }
+          },
           "legend": "Information required to send a report",
           "select-label": "Reason for reporting",
           "textarea-label": "Comment",

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -1676,6 +1676,21 @@
           "missing-comment": "Por favor, introduzca un comentario."
         },
         "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "El simulador/la aplicación no funciona",
+              "instruction-issue": "No entiendo las instrucciones"
+            },
+            "default": {
+              "accessibility-issue": "Problema de accesibilidad",
+              "other": "Otro"
+            },
+            "feedback": {
+              "improvement": "Quiero proponer una mejora",
+              "question-issue": "No entiendo la pregunta",
+              "response-issue": "No estoy de acuerdo con la respuesta."
+            }
+          },
           "legend": "Información necesaria para enviar una denuncia",
           "select-label": "Motivo de la notificación",
           "textarea-label": "Comentario",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1676,6 +1676,21 @@
           "missing-comment": "Por favor, introduzca un comentario."
         },
         "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "El simulador/la aplicación no funciona",
+              "instruction-issue": "No entiendo las instrucciones"
+            },
+            "default": {
+              "accessibility-issue": "Problema de accesibilidad",
+              "other": "Otro"
+            },
+            "feedback": {
+              "improvement": "Quiero proponer una mejora",
+              "question-issue": "No entiendo la pregunta",
+              "response-issue": "No estoy de acuerdo con la respuesta"
+            }
+          },
           "legend": "Información necesaria para enviar una denuncia",
           "select-label": "Motivo de la notificación",
           "textarea-label": "Comentario",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1688,6 +1688,21 @@
           "missing-comment": "Veuillez saisir un commentaire."
         },
         "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "Le simulateur / l’application ne fonctionne pas",
+              "instruction-issue": "Je ne comprends pas la consigne"
+            },
+            "default": {
+              "accessibility-issue": "Problème d’accessibilité",
+              "other": "Autre"
+            },
+            "feedback": {
+              "improvement": "Je souhaite proposer une amélioration",
+              "question-issue": "Je ne comprends pas la question",
+              "response-issue": "Je ne suis pas d’accord avec la réponse"
+            }
+          },
           "legend": "Informations requises pour envoyer un signalement",
           "select-label": "Raison du signalement",
           "textarea-label": "Commentaire",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1680,6 +1680,21 @@
           "missing-comment": "Voer een opmerking in."
         },
         "modal": {
+          "categories": {
+            "custom-and-embed": {
+              "embed-not-working": "De simulator/app werkt niet",
+              "instruction-issue": "Ik begrijp de instructie niet"
+            },
+            "default": {
+              "accessibility-issue": "Probleem met toegankelijkheid",
+              "other": "Ander"
+            },
+            "feedback": {
+              "improvement": "Ik wil een verbetering voorstellen",
+              "question-issue": "Ik begrijp de vraag niet",
+              "response-issue": "Ik ben het niet eens met het antwoord"
+            }
+          },
           "legend": "Informatie die nodig is om een melding te versturen",
           "select-label": "Reden voor de melding",
           "textarea-label": "Opmerking",


### PR DESCRIPTION
## ❄️ Problème

Les catégories finales nous on été transmises pour le signalement des modules.

## 🛷 Proposition

Selon l'élément, afficher différentes catégories : 

- pour les `custom`, `custom-draft` et `embed` : afficher `4` catégories (instruction, embed en erreur, accessibilité et autre)
- pour les autres : afficher `5` catégories (question, réponse, amélioration, accessibilité et autre )

## 🧑‍🎄 Pour tester

- Aller sur [bac-a-sable](https://app-pr14503.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
- Faire différent signalement en sélectionnant différentes catégories et voir le résultat en BDD.


https://github.com/user-attachments/assets/fb4b995f-1483-4d0e-961f-45622a67b54e

