### PR TITLE
[FEATURE] Ajouter le signalement pour la modalité Custom (PIX-20886)

### DIFF
--- a/mon-pix/app/components/module/element/_custom-draft.scss
+++ b/mon-pix/app/components/module/element/_custom-draft.scss
@@ -24,7 +24,7 @@
 }
 
 .element-custom-draft-buttons {
-  &__retry {
+  &__reset {
     padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
     background-color: var(--pix-primary-100);
     border: none;

--- a/mon-pix/app/components/module/element/_custom-element.scss
+++ b/mon-pix/app/components/module/element/_custom-element.scss
@@ -26,8 +26,31 @@ message-conversation::part(conversation) {
     color: var(--pix-primary-700);
   }
 
-  &__reset {
+  &__buttons {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__button {
     display: flex;
     justify-content: flex-end;
+  }
+
+  &--reset-state{
+    background-color: var(--pix-primary-10);
+    border-radius: 16px 16px 16px 0;
+  }
+
+  &--reset-intercative-state{
+    border-radius: 16px 16px 16px 0;
+  }
+}
+
+.element-custom-buttons {
+  &__reset {
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+    background-color: var(--pix-primary-100);
+    border: none;
+    border-radius: 0 0 8px 8px;
   }
 }

--- a/mon-pix/app/components/module/element/custom-draft.gjs
+++ b/mon-pix/app/components/module/element/custom-draft.gjs
@@ -61,7 +61,7 @@ export default class ModulixCustomDraft extends ModuleElement {
 
       <div class="element-custom-draft__buttons">
         <PixButton
-          class="element-custom-draft-buttons__retry"
+          class="element-custom-draft-buttons__reset"
           @iconBefore="refresh"
           @variant="tertiary"
           @triggerAction={{this.resetEmbed}}

--- a/mon-pix/app/components/module/element/custom-element.gjs
+++ b/mon-pix/app/components/module/element/custom-element.gjs
@@ -7,11 +7,14 @@ import { t } from 'ember-intl';
 import htmlUnsafe from 'mon-pix/helpers/html-unsafe';
 import didInsert from 'mon-pix/modifiers/modifier-did-insert';
 
+import ModulixIssueReportBlock from '../issue-report/issue-report-block';
 import ModuleElement from './module-element';
 
 export default class ModulixCustomElement extends ModuleElement {
   @tracked
   customElement;
+
+  @tracked reportInfo = { answer: null, elementId: this.args.component.id };
 
   @tracked
   resetButtonDisplayed = false;
@@ -56,7 +59,10 @@ export default class ModulixCustomElement extends ModuleElement {
       {{/if}}
 
       {{#if this.isInteractive}}
-        <fieldset class="element-custom__container">
+        <fieldset
+          class="element-custom__container
+            {{if this.resetButtonDisplayed 'element-custom--reset-intercative-state' ''}}"
+        >
           <legend class="element-custom__legend">
             <PixIcon @name="leftClick" @plainIcon={{false}} @ariaHidden={{true}} />
             <span>{{t "pages.modulix.interactiveElement.label"}}</span>
@@ -64,19 +70,25 @@ export default class ModulixCustomElement extends ModuleElement {
           <div {{didInsert this.mountCustomElement}} />
         </fieldset>
       {{else}}
-        <div {{didInsert this.mountCustomElement}} />
+        <div
+          class={{if this.resetButtonDisplayed "element-custom--reset-state" ""}}
+          {{didInsert this.mountCustomElement}}
+        />
       {{/if}}
 
-      {{#if this.resetButtonDisplayed}}
-        <div class="element-custom__reset">
+      <div class={{if this.resetButtonDisplayed "element-custom__buttons" "element-custom__button"}}>
+        {{#if this.resetButtonDisplayed}}
           <PixButton
+            class="element-custom-buttons__reset"
             @iconBefore="refresh"
             @variant="tertiary"
             @triggerAction={{this.resetCustomElement}}
             aria-label="{{t 'pages.modulix.buttons.interactive-element.reset.ariaLabel'}}"
           >{{t "pages.modulix.buttons.interactive-element.reset.name"}}</PixButton>
-        </div>
-      {{/if}}
+        {{/if}}
+
+        <ModulixIssueReportBlock @reportInfo={{this.reportInfo}} />
+      </div>
     </div>
   </template>
 }

--- a/mon-pix/tests/integration/components/module/custom-element_test.gjs
+++ b/mon-pix/tests/integration/components/module/custom-element_test.gjs
@@ -1,0 +1,220 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ModulixCustomElement from 'mon-pix/components/module/element/custom-element';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { waitForDialog } from '../../../helpers/wait-for';
+
+module('Integration | Component | Module | Custom Element', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when isModulixIssueReportDisplayed FT is enabled', function () {
+    test('should display report button', async function (assert) {
+      const customElement = {
+        id: 'id',
+        title: 'mon-custom-test',
+        instruction: 'Test POI quiz image',
+        tagName: 'image-quiz',
+        props: {
+          name: 'Liste d‘applications',
+          imageChoicesSize: 'icon',
+          choices: [
+            {
+              name: 'Google',
+              image: {
+                width: 534,
+                height: 544,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
+              },
+            },
+            {
+              name: 'LibreOffice Writer',
+              image: {
+                width: 205,
+                height: 246,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
+              },
+            },
+            {
+              name: 'Explorateur',
+              image: {
+                width: 128,
+                height: 128,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
+              },
+            },
+            {
+              name: 'Geogebra',
+              image: {
+                width: 640,
+                height: 640,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
+              },
+            },
+          ],
+        },
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+
+      // when
+      const screen = await render(<template><ModulixCustomElement @component={{customElement}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).exists();
+    });
+
+    module('when user clicks on report button', function () {
+      test('should display issue-report modal with a form inside', async function (assert) {
+        // given
+        const customElement = {
+          id: 'b0e9d79f-1727-4861-ac89-bd834473d62b',
+          title: 'mon-custom-test',
+          instruction: 'Test POI quiz image',
+          tagName: 'image-quiz',
+          props: {
+            name: 'Liste d‘applications',
+            imageChoicesSize: 'icon',
+            choices: [
+              {
+                name: 'Google',
+                image: {
+                  width: 534,
+                  height: 544,
+                  loading: 'lazy',
+                  decoding: 'async',
+                  src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
+                },
+              },
+              {
+                name: 'LibreOffice Writer',
+                image: {
+                  width: 205,
+                  height: 246,
+                  loading: 'lazy',
+                  decoding: 'async',
+                  src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
+                },
+              },
+              {
+                name: 'Explorateur',
+                image: {
+                  width: 128,
+                  height: 128,
+                  loading: 'lazy',
+                  decoding: 'async',
+                  src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
+                },
+              },
+              {
+                name: 'Geogebra',
+                image: {
+                  width: 640,
+                  height: 640,
+                  loading: 'lazy',
+                  decoding: 'async',
+                  src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
+                },
+              },
+            ],
+          },
+        };
+        const featureToggles = this.owner.lookup('service:featureToggles');
+        sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: true });
+
+        // when
+        const screen = await render(
+          <template>
+            <div id="modal-container"></div>
+            <ModulixCustomElement @component={{customElement}} />
+          </template>,
+        );
+        await click(screen.getByRole('button', { name: t('pages.modulix.issue-report.aria-label') }));
+        await waitForDialog();
+
+        // then
+        assert.dom(screen.getByRole('dialog')).exists();
+        assert
+          .dom(screen.getByRole('heading', { name: t('pages.modulix.issue-report.modal.title'), level: 1 }))
+          .exists();
+      });
+    });
+  });
+
+  module('when isModulixIssueReportDisplayed FT is disabled', function () {
+    test('should not display report button', async function (assert) {
+      // given
+      const customElement = {
+        id: 'b0e9d79f-1727-4861-ac89-bd834473d62b',
+        title: 'mon-custom-test',
+        instruction: 'Test POI quiz image',
+        tagName: 'image-quiz',
+        props: {
+          name: 'Liste d‘applications',
+          imageChoicesSize: 'icon',
+          choices: [
+            {
+              name: 'Google',
+              image: {
+                width: 534,
+                height: 544,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/Google.B1bcY5Go_1BynY8.svg',
+              },
+            },
+            {
+              name: 'LibreOffice Writer',
+              image: {
+                width: 205,
+                height: 246,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/writer.3bR8N2DK_Z1iWuJ9.webp',
+              },
+            },
+            {
+              name: 'Explorateur',
+              image: {
+                width: 128,
+                height: 128,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/windows-file-explorer.CnF8MYwI_23driA.webp',
+              },
+            },
+            {
+              name: 'Geogebra',
+              image: {
+                width: 640,
+                height: 640,
+                loading: 'lazy',
+                decoding: 'async',
+                src: 'https://epreuves.pix.fr/_astro/geogebra.CZH9VYqc_19v4nj.webp',
+              },
+            },
+          ],
+        },
+      };
+      const featureToggles = this.owner.lookup('service:featureToggles');
+      sinon.stub(featureToggles, 'featureToggles').value({ isModulixIssueReportDisplayed: false });
+
+      // when
+      const screen = await render(<template><ModulixCustomElement @component={{customElement}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: t('pages.modulix.issue-report.aria-label') })).doesNotExist();
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

On n'a pas ajouté le bouton "Signaler" pour les éléments `custom-element`d'un module.

## 🛷 Proposition

L'ajouter. Prendre en compte quand on peut, ou non, réinitialiser le module, pour afficher correctement le bouton Signaler en bas à droite.

## ☃️ Remarques

- Il a fallu gérer le design du container du POI en fonction de s'il y a le bouton "Réinitialiser", avec le fond violet, en bas à gauche de l'élément.

## 🧑‍🎄 Pour tester
### Bac-a-sable
- Ouvrir le [bac-a-sable](https://app-pr14504.review.pix.fr/modules/6a68bf32/bac-a-sable/details)
- Parcourir le module pour afficher le POI confessions-nocturnes
- Vérifier qu'on a bien le bouton "Signaler" et le bouton "Réinitialiser", et que c'est joli.
- Cliquer sur "Signaler". Vérifier que la modale s'ouvre correctement.
- Remplir le formulaire de signalement. Cliquer sur "Envoyer"
- La modale se ferme et on voit le module.

### Demo-epreuves-components
- Ouvrir le module [demo-epreuves-components](https://app-pr14504.review.pix.fr/modules/0aefd71f/demo-epreuves-components/passage)
- Vérifier que le premier POI s'affiche bien, et que la bordure s'adapte au bouton "Réessayer"