### PR TITLE
[FEATURE] Ajouter un script pour rattraper les participations supprimées avant l'activation de l'anonymization (Pix-20885).

### DIFF
--- a/api/scripts/prod/delete-and-anonymise-previous-participations.js
+++ b/api/scripts/prod/delete-and-anonymise-previous-participations.js
@@ -1,0 +1,106 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { CLIENTS, PIX_ADMIN } from '../../src/authorization/domain/constants.js';
+import { usecases } from '../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { Script } from '../../src/shared/application/scripts/script.js';
+import { ScriptRunner } from '../../src/shared/application/scripts/script-runner.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+
+export class DeleteAndAnonymisePreviousCampaignParticipationsScript extends Script {
+  constructor() {
+    super({
+      description:
+        'Update deleted participations and anonymise their related data not related to archived organization or deleted learner',
+      permanent: false,
+      options: {
+        startArchiveDate: {
+          type: 'date',
+          describe: 'date to start anonymisation',
+          demandOption: true,
+        },
+        dryRun: {
+          type: 'boolean',
+          describe: 'Run the script without making any database changes',
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const engineeringUserId = process.env.ENGINEERING_USER_ID;
+
+    await DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+      logger.info(
+        `BEGIN: Update deleted participations... on active campaigns not related on deleted learner or archived organizations before ${options.startArchiveDate}`,
+      );
+
+      try {
+        const organizationIds = await knexConn('organizations')
+          .where('archivedAt', '<', options.startArchiveDate)
+          .pluck('id');
+
+        const campaignIds = await knexConn('campaigns')
+          .select('id')
+          .whereNull('deletedAt')
+          .whereNotIn('organizationId', organizationIds)
+          .pluck('id');
+
+        const campaignParticipationIdsOnCampaigns = await knexConn('campaign-participations')
+          .select({
+            campaignId: 'campaignId',
+            organizationLearnerId: 'organizationLearnerId',
+            campaignParticipationId: 'campaign-participations.id',
+          })
+          .join('organization-learners', function () {
+            this.on('organization-learners.id', 'campaign-participations.organizationLearnerId').andOnVal(
+              'organization-learners.deletedAt',
+              knex.raw('IS'),
+              knex.raw('NULL'),
+            );
+          })
+          .whereIn('campaignId', campaignIds)
+          .where('campaign-participations.deletedAt', '<', options.startArchiveDate)
+          .where('isImproved', false)
+          .whereNotNull('campaign-participations.deletedAt');
+
+        if (campaignParticipationIdsOnCampaigns.length > 0) {
+          logger.info(`Processing :${campaignParticipationIdsOnCampaigns.length} for active campaigns`);
+
+          for (const campaignParticipationIdsOnCampaign of campaignParticipationIdsOnCampaigns) {
+            logger.info(
+              `deleted participations :${campaignParticipationIdsOnCampaign.campaignParticipationId} to update on campaign ${campaignParticipationIdsOnCampaign.campaignId}`,
+            );
+
+            await usecases.deleteCampaignParticipation({
+              userId: engineeringUserId,
+              campaignParticipationId: campaignParticipationIdsOnCampaign.campaignParticipationId,
+              campaignId: campaignParticipationIdsOnCampaign.campaignId,
+              userRole: PIX_ADMIN.ROLES.SUPER_ADMIN,
+              client: CLIENTS.SCRIPT,
+              keepPreviousDeleted: true,
+            });
+          }
+        }
+
+        if (options.dryRun) {
+          await knexConn.rollback();
+          logger.info(
+            `ROLLBACK: anonymise deleted participations... not related to archived organization before or deleted learner`,
+          );
+          logger.info(`--dryRun true to persist changes`);
+          return;
+        }
+
+        logger.info(
+          `COMMIT: anonymise deleted participations... not related to archived organization before  or deleted learner`,
+        );
+      } catch (error) {
+        await knexConn.rollback();
+        throw error;
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteAndAnonymisePreviousCampaignParticipationsScript);

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation.js
@@ -13,6 +13,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
   eventLoggingJobRepository,
   assessmentRepository,
   userRecommendedTrainingRepository,
+  keepPreviousDeleted = false,
 }) {
   const isAnonymizationWithDeletionEnabled = await featureToggles.get('isAnonymizationWithDeletionEnabled');
 
@@ -20,6 +21,7 @@ const deleteCampaignParticipation = withTransaction(async function ({
     await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
       campaignId,
       campaignParticipationId,
+      keepPreviousDeleted,
     });
 
   for (const campaignParticipation of campaignParticipations) {

--- a/api/tests/integration/scripts/prod/delete-and-anonymise-previous-participations_test.js
+++ b/api/tests/integration/scripts/prod/delete-and-anonymise-previous-participations_test.js
@@ -1,0 +1,695 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { DeleteAndAnonymisePreviousCampaignParticipationsScript } from '../../../../scripts/prod/delete-and-anonymise-previous-participations.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+describe('DeleteAndAnonymisePreviousCampaignParticipationsScript', function () {
+  describe('Options', function () {
+    it('has the correct options', function () {
+      const script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
+      const { options } = script.metaInfo;
+
+      expect(options.startArchiveDate).to.deep.include({
+        type: 'date',
+        describe: 'date to start anonymisation',
+        demandOption: true,
+      });
+    });
+  });
+
+  describe('Handle', function () {
+    let script;
+    let logger;
+    const ENGINEERING_USER_ID = 99999;
+    const startArchiveDate = '2025-01-01';
+
+    let now, clock;
+    let userId;
+    let targetProfileId;
+
+    const archivedOrganizationBeforeDate = {
+      organization: null,
+      campaignDeleted: null,
+      deletedLearner: null,
+      deletedParticipation: null,
+    };
+
+    const archivedOrganizationAtDate = {
+      organization: null,
+      campaignDeleted: null,
+      deletedLearner: null,
+      deletedParticipation: null,
+    };
+
+    const activeOrganization = {
+      organization: null,
+      campaignDeleted: null,
+      campaignActive: null,
+      activeLearner: null,
+      activeParticipation: null,
+      deletedParticipation: null,
+    };
+
+    beforeEach(async function () {
+      script = new DeleteAndAnonymisePreviousCampaignParticipationsScript();
+      logger = { info: sinon.spy(), error: sinon.spy() };
+      sinon.stub(process, 'env').value({ ENGINEERING_USER_ID });
+      now = new Date(startArchiveDate);
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUser({ id: ENGINEERING_USER_ID });
+
+      archivedOrganizationBeforeDate.organization = databaseBuilder.factory.buildOrganization({
+        createdAt: new Date('2020-01-01'),
+        archivedAt: new Date('2024-01-01'),
+      });
+      archivedOrganizationAtDate.organization = databaseBuilder.factory.buildOrganization({
+        createdAt: new Date('2020-01-01'),
+        archivedAt: now,
+      });
+      activeOrganization.organization = databaseBuilder.factory.buildOrganization({
+        createdAt: new Date('2020-01-01'),
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    describe('#campaigns', function () {
+      beforeEach(async function () {
+        // 1
+        targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        archivedOrganizationBeforeDate.campaignDeleted = databaseBuilder.factory.buildCampaign({
+          targetProfileId,
+          name: 'campaignDeleted name',
+          title: 'campaignDeleted title',
+          customLandingPageText: 'campaignDeleted landing',
+          externalIdHelpImageUrl: 'campaignDeleted help',
+          alternativeTextToExternalIdHelpImage: 'campaignDeleted alt help',
+          customResultPageText: 'campaignDeleted custom text',
+          customResultPageButtonText: 'campaignDeleted custom button',
+          customResultPageButtonUrl: 'campaignDeleted custom url',
+          organizationId: archivedOrganizationBeforeDate.organization.id,
+          deletedAt: new Date('2023-01-01'),
+          deletedBy: userId,
+          archivedAt: archivedOrganizationBeforeDate.organization.archivedAt,
+        });
+
+        // 2
+        archivedOrganizationAtDate.campaignDeleted = databaseBuilder.factory.buildCampaign({
+          targetProfileId,
+          name: 'campaignDeleted name',
+          title: 'campaignDeleted title',
+          customLandingPageText: 'campaignDeleted landing',
+          externalIdHelpImageUrl: 'campaignDeleted help',
+          alternativeTextToExternalIdHelpImage: 'campaignDeleted alt help',
+          customResultPageText: 'campaignDeleted custom text',
+          customResultPageButtonText: 'campaignDeleted custom button',
+          customResultPageButtonUrl: 'campaignDeleted custom url',
+          organizationId: archivedOrganizationAtDate.organization.id,
+          deletedAt: new Date('2023-01-01'),
+          deletedBy: userId,
+          archivedAt: null,
+        });
+
+        // 3
+        activeOrganization.campaignDeleted = databaseBuilder.factory.buildCampaign({
+          targetProfileId,
+          name: 'campaignDeleted name',
+          title: 'campaignDeleted title',
+          customLandingPageText: 'campaignDeleted landing',
+          externalIdHelpImageUrl: 'campaignDeleted help',
+          alternativeTextToExternalIdHelpImage: 'campaignDeleted alt help',
+          customResultPageText: 'campaignDeleted custom text',
+          customResultPageButtonText: 'campaignDeleted custom button',
+          customResultPageButtonUrl: 'campaignDeleted custom url',
+          organizationId: activeOrganization.organization.id,
+          deletedAt: new Date('2023-01-01'),
+          deletedBy: userId,
+          archivedAt: null,
+        });
+        activeOrganization.campaignActive = databaseBuilder.factory.buildCampaign({
+          targetProfileId,
+          name: 'campaignActive name',
+          title: 'campaignActive title',
+          customLandingPageText: 'campaignActive landing',
+          externalIdHelpImageUrl: 'campaignActive help',
+          alternativeTextToExternalIdHelpImage: 'campaignActive alt help',
+          customResultPageText: 'campaignActive custom text',
+          customResultPageButtonText: 'campaignActive custom button',
+          customResultPageButtonUrl: 'campaignActive custom url',
+          organizationId: activeOrganization.organization.id,
+          deletedAt: null,
+          deletedBy: null,
+          archivedAt: null,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      describe('#participations', function () {
+        beforeEach(async function () {
+          // 1
+          archivedOrganizationBeforeDate.deletedLearner =
+            databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              firstName: 'johnny',
+              lastName: 'five',
+              organizationId: archivedOrganizationBeforeDate.organization.id,
+              updatedAt: new Date('2024-01-25'),
+              deletedAt: new Date('2024-01-25'),
+              deletedBy: userId,
+            });
+
+          // 2
+          archivedOrganizationAtDate.deletedLearner =
+            databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              firstName: 'johnny',
+              lastName: 'not be good',
+              organizationId: archivedOrganizationAtDate.organization.id,
+              updatedAt: new Date('2024-01-25'),
+              deletedAt: new Date('2023-01-01'),
+              deletedBy: userId,
+            });
+
+          // 3
+          activeOrganization.activeLearner =
+            databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+              firstName: 'johnny',
+              lastName: 'be good',
+              organizationId: activeOrganization.organization.id,
+              deletedAt: null,
+              deletedBy: null,
+            });
+
+          await databaseBuilder.commit();
+        });
+
+        describe('#participations / assessment / recommended trainings / badge ', function () {
+          beforeEach(async function () {
+            // 1
+            archivedOrganizationBeforeDate.deletedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+              userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+              organizationLearnerId: archivedOrganizationBeforeDate.deletedLearner.id,
+              participantExternalId: 'another-learner',
+              campaignId: archivedOrganizationBeforeDate.campaignDeleted.id,
+              deletedAt: new Date('2023-01-01'),
+              deletedBy: userId,
+            });
+
+            // 2
+            archivedOrganizationAtDate.deletedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+              userId: archivedOrganizationAtDate.deletedLearner.userId,
+              organizationLearnerId: archivedOrganizationAtDate.deletedLearner.id,
+              participantExternalId: 'second',
+              campaignId: archivedOrganizationAtDate.campaignDeleted.id,
+              deletedAt: new Date('2023-01-01'),
+              deletedBy: userId,
+            });
+
+            // 3
+            activeOrganization.activeParticipation = databaseBuilder.factory.buildCampaignParticipation({
+              userId: activeOrganization.activeLearner.userId,
+              organizationLearnerId: activeOrganization.activeLearner.id,
+              participantExternalId: 'second',
+              isImproved: true,
+              campaignId: activeOrganization.campaignActive.id,
+              deletedAt: null,
+              deletedBy: null,
+            });
+
+            activeOrganization.deletedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+              userId: activeOrganization.activeLearner.userId,
+              organizationLearnerId: activeOrganization.activeLearner.id,
+              participantExternalId: 'second',
+              campaignId: activeOrganization.campaignDeleted.id,
+              deletedAt: new Date('2023-01-01'),
+              deletedBy: userId,
+            });
+
+            await databaseBuilder.commit();
+          });
+
+          describe('#participations', function () {
+            describe('#archivedOrganizationBeforeDate', function () {
+              it('should not update delete participation of deleted campaign on archived organization before date', async function () {
+                // when
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const deletedParticipation = await knex('campaign-participations')
+                  .select('userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .where('id', archivedOrganizationBeforeDate.deletedParticipation.id)
+                  .first();
+
+                // then
+                expect(deletedParticipation).deep.equal({
+                  userId: archivedOrganizationBeforeDate.deletedParticipation.userId,
+                  participantExternalId: archivedOrganizationBeforeDate.deletedParticipation.participantExternalId,
+                  deletedAt: archivedOrganizationBeforeDate.deletedParticipation.deletedAt,
+                  deletedBy: archivedOrganizationBeforeDate.deletedParticipation.deletedBy,
+                });
+              });
+            });
+
+            describe('#archivedOrganizationAtDate', function () {
+              it('should not update deleted participation of deleted campaigns on archived organization at date', async function () {
+                // when
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const deletedParticipation = await knex('campaign-participations')
+                  .select('userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .where('id', archivedOrganizationAtDate.deletedParticipation.id)
+                  .first();
+
+                // then
+                expect(deletedParticipation).deep.equal({
+                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
+                  participantExternalId: archivedOrganizationAtDate.deletedParticipation.participantExternalId,
+                  deletedAt: archivedOrganizationAtDate.deletedParticipation.deletedAt,
+                  deletedBy: archivedOrganizationAtDate.deletedParticipation.deletedBy,
+                });
+              });
+            });
+
+            describe('#activeOrganization', function () {
+              it('should not anonymise deleted participation of deleted campaign on active organization', async function () {
+                // when
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const deleteParticipation = await knex('campaign-participations')
+                  .select('userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .where('id', activeOrganization.deletedParticipation.id)
+                  .first();
+
+                // then
+                expect(deleteParticipation).deep.equal({
+                  userId: activeOrganization.deletedParticipation.userId,
+                  participantExternalId: activeOrganization.deletedParticipation.participantExternalId,
+                  deletedAt: activeOrganization.deletedParticipation.deletedAt,
+                  deletedBy: userId,
+                });
+              });
+
+              it('should not anonymise of active participation of active organization', async function () {
+                // when
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const activeParticipation = await knex('campaign-participations')
+                  .select('userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .where('id', activeOrganization.activeParticipation.id)
+                  .first();
+
+                // then
+                expect(activeParticipation).deep.equal({
+                  userId: activeOrganization.activeParticipation.userId,
+                  participantExternalId: activeOrganization.activeParticipation.participantExternalId,
+                  deletedAt: null,
+                  deletedBy: null,
+                });
+              });
+
+              it('should anonymise of deleted participation only of active campaign on active organization', async function () {
+                // when
+                const deletedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                  userId: activeOrganization.activeLearner.userId,
+                  organizationLearnerId: activeOrganization.activeLearner.id,
+                  participantExternalId: 'second',
+                  campaignId: activeOrganization.campaignActive.id,
+                  deletedAt: new Date('2024-01-01'),
+                  deletedBy: userId,
+                  isImproved: true,
+                });
+
+                const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                  userId: activeOrganization.activeLearner.userId,
+                  organizationLearnerId: activeOrganization.activeLearner.id,
+                  participantExternalId: 'second',
+                  isImproved: false,
+                  campaignId: activeOrganization.campaignActive.id,
+                  deletedAt: new Date('2024-02-01'),
+                  deletedBy: userId,
+                });
+
+                await databaseBuilder.commit();
+                await script.handle({
+                  options: { startArchiveDate },
+                  logger,
+                });
+
+                const activeParticipation = await knex('campaign-participations')
+                  .select('id', 'userId', 'participantExternalId', 'deletedAt', 'deletedBy')
+                  .whereNull('userId');
+
+                // then
+                expect(activeParticipation).deep.members([
+                  {
+                    id: deletedParticipationActiveCampaign.id,
+                    userId: null,
+                    participantExternalId: null,
+                    deletedAt: deletedParticipationActiveCampaign.deletedAt,
+                    deletedBy: deletedParticipationActiveCampaign.deletedBy,
+                  },
+                  {
+                    id: deletedImprovedParticipationActiveCampaign.id,
+                    userId: null,
+                    participantExternalId: null,
+                    deletedAt: deletedImprovedParticipationActiveCampaign.deletedAt,
+                    deletedBy: deletedImprovedParticipationActiveCampaign.deletedBy,
+                  },
+                ]);
+              });
+            });
+          });
+
+          describe('#assessments', function () {
+            it('should detach assessments and update updatedAt column only on deleted participations on active campaign', async function () {
+              // given
+              // 1
+              const assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate =
+                databaseBuilder.factory.buildAssessment({
+                  userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                  campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+                  updatedAt: new Date('2024-01-01'),
+                });
+
+              // 2
+              const assessmentFromDeletedParticipationOnArchivedOrganizationAtDate =
+                databaseBuilder.factory.buildAssessment({
+                  userId: archivedOrganizationAtDate.deletedLearner.userId,
+                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+                  updatedAt: new Date('2021-01-01'),
+                });
+
+              // 3
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              const assessmentFromDActiveParticipationOnActiveOrganization = databaseBuilder.factory.buildAssessment({
+                userId: activeOrganization.activeLearner.userId,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                updatedAt: new Date('2024-01-01'),
+              });
+
+              const assessmentFromDDeletedParticipationOnActiveOrganization = databaseBuilder.factory.buildAssessment({
+                userId: activeOrganization.activeLearner.userId,
+                campaignParticipationId: activeOrganization.deletedParticipation.id,
+                updatedAt: new Date('2024-01-01'),
+              });
+
+              await databaseBuilder.commit();
+
+              // when
+              await script.handle({ options: { startArchiveDate }, logger });
+
+              const anonymizedAssessments = await knex('assessments')
+                .select('id')
+                .where({ updatedAt: now })
+                .whereNull('campaignParticipationId')
+                .pluck('id');
+
+              const activeAssessments = await knex('assessments')
+                .select('id')
+                .whereNot({ updatedAt: now })
+                .whereNotNull('campaignParticipationId')
+                .pluck('id');
+
+              // then
+              expect(activeAssessments).lengthOf(3);
+              expect(activeAssessments).deep.members([
+                assessmentFromDDeletedParticipationOnActiveOrganization.id,
+                assessmentFromDeletedParticipationOnArchivedOrganizationAtDate.id,
+                assessmentFromDeletedParticipationOnArchivedOrganizationBeforeDate.id,
+              ]);
+
+              expect(anonymizedAssessments).lengthOf(1);
+              expect(anonymizedAssessments).deep.members([assessmentFromDActiveParticipationOnActiveOrganization.id]);
+            });
+          });
+
+          describe('#recommendedTrainings', function () {
+            it('should detach user recommended trainings only on archived organization before date', async function () {
+              // given
+              const training = databaseBuilder.factory.buildTraining();
+              const training2 = databaseBuilder.factory.buildTraining();
+
+              // 1
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: null,
+                trainingId: training.id,
+                userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                updatedAt: new Date('2025-10-01'),
+              });
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: null,
+                trainingId: training2.id,
+                userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                updatedAt: new Date('2025-10-01'),
+              });
+
+              // 2
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+                trainingId: training2.id,
+                userId: archivedOrganizationAtDate.deletedLearner.userId,
+                updatedAt: new Date('2024-01-01'),
+              });
+
+              // 3
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: activeOrganization.activeParticipation.id,
+                trainingId: training2.id,
+                userId: activeOrganization.activeLearner.userId,
+                updatedAt: new Date('2022-01-01'),
+              });
+
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: activeOrganization.deletedParticipation.id,
+                trainingId: training2.id,
+                userId: activeOrganization.activeLearner.userId,
+                updatedAt: new Date('2023-01-01'),
+              });
+
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildUserRecommendedTraining({
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                trainingId: training2.id,
+                userId: activeOrganization.activeLearner.userId,
+                updatedAt: new Date('2023-01-01'),
+              });
+
+              await databaseBuilder.commit();
+
+              // when
+              await script.handle({ options: { startArchiveDate }, logger });
+
+              const anonymizedRecommendedTrainingResults = await knex('user-recommended-trainings')
+                .select('campaignParticipationId', 'userId')
+                .whereNull('campaignParticipationId')
+                .where({ updatedAt: now });
+
+              const activeRecommendedTrainings = await knex('user-recommended-trainings')
+                .select('campaignParticipationId', 'userId', 'updatedAt')
+                .whereNotNull('campaignParticipationId');
+
+              // then
+              expect(anonymizedRecommendedTrainingResults).lengthOf(1);
+              expect(anonymizedRecommendedTrainingResults).deep.members([
+                {
+                  campaignParticipationId: null,
+                  userId: activeOrganization.activeLearner.userId,
+                },
+              ]);
+              expect(activeRecommendedTrainings).lengthOf(3);
+              expect(activeRecommendedTrainings).deep.members([
+                {
+                  campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+                  userId: archivedOrganizationAtDate.deletedParticipation.userId,
+                  updatedAt: new Date('2024-01-01'),
+                },
+                {
+                  campaignParticipationId: activeOrganization.activeParticipation.id,
+                  userId: activeOrganization.activeParticipation.userId,
+                  updatedAt: new Date('2022-01-01'),
+                },
+                {
+                  campaignParticipationId: activeOrganization.deletedParticipation.id,
+                  userId: activeOrganization.deletedParticipation.userId,
+                  updatedAt: new Date('2023-01-01'),
+                },
+              ]);
+            });
+          });
+
+          describe('#badges', function () {
+            let certifiableBadge, nonCertifiableBadge;
+
+            beforeEach(async function () {
+              certifiableBadge = databaseBuilder.factory.buildBadge.certifiable({
+                key: 'CERTIFIABLE_BADGE',
+                targetProfileId,
+              });
+              nonCertifiableBadge = databaseBuilder.factory.buildBadge.notCertifiable({
+                key: 'NON_CERTIFIABLE_BADGE',
+                targetProfileId,
+              });
+
+              await databaseBuilder.commit();
+            });
+
+            it('should detach non certifiable badges only on delete campaign not belonging to archived organization before date', async function () {
+              // given
+              // 1
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+              });
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+              });
+
+              // 2
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: archivedOrganizationAtDate.deletedLearner.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: archivedOrganizationAtDate.deletedParticipation.id,
+              });
+
+              // 3
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: activeOrganization.activeLearner.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: activeOrganization.activeParticipation.id,
+              });
+
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: activeOrganization.activeLearner.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: activeOrganization.deletedParticipation.id,
+              });
+
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: deletedImprovedParticipationActiveCampaign.userId,
+                badgeId: nonCertifiableBadge.id,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+              });
+
+              await databaseBuilder.commit();
+
+              // when
+              await script.handle({ options: { startArchiveDate }, logger });
+
+              const detachBadges = await knex('badge-acquisitions')
+                .select('badgeId', 'campaignParticipationId')
+                .whereNull('userId');
+
+              // then
+              expect(detachBadges).lengthOf(1);
+              expect(detachBadges).deep.members([
+                {
+                  badgeId: nonCertifiableBadge.id,
+                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                },
+              ]);
+            });
+
+            it('should not detach certifiable badge', async function () {
+              // given
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                badgeId: certifiableBadge.id,
+                campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+              });
+
+              const deletedImprovedParticipationActiveCampaign = databaseBuilder.factory.buildCampaignParticipation({
+                userId: activeOrganization.activeLearner.userId,
+                organizationLearnerId: activeOrganization.activeLearner.id,
+                participantExternalId: 'second',
+                isImproved: false,
+                campaignId: activeOrganization.campaignActive.id,
+                deletedAt: new Date('2024-02-01'),
+                deletedBy: userId,
+              });
+
+              databaseBuilder.factory.buildBadgeAcquisition({
+                userId: deletedImprovedParticipationActiveCampaign.userId,
+                badgeId: certifiableBadge.id,
+                campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+              });
+
+              await databaseBuilder.commit();
+
+              // when
+              await script.handle({ options: { startArchiveDate }, logger });
+
+              const attachBadges = await knex('badge-acquisitions').select(
+                'badgeId',
+                'campaignParticipationId',
+                'userId',
+              );
+
+              // then
+              expect(attachBadges).lengthOf(2);
+              expect(attachBadges).deep.equal([
+                {
+                  badgeId: certifiableBadge.id,
+                  campaignParticipationId: archivedOrganizationBeforeDate.deletedParticipation.id,
+                  userId: archivedOrganizationBeforeDate.deletedLearner.userId,
+                },
+                {
+                  badgeId: certifiableBadge.id,
+                  campaignParticipationId: deletedImprovedParticipationActiveCampaign.id,
+                  userId: deletedImprovedParticipationActiveCampaign.userId,
+                },
+              ]);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -725,6 +725,32 @@ describe('Integration | Repository | Campaign Participation', function () {
           campaignParticipationToDelete.id,
         ]);
       });
+
+      it('should return all deleted participations given options to true', async function () {
+        const userId = databaseBuilder.factory.buildUser().id;
+        const campaignParticipationToDelete = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+        });
+        const deletedParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          organizationLearnerId,
+          deletedBy: userId,
+          deletedAt: new Date('2021-06-07'),
+        });
+
+        await databaseBuilder.commit();
+
+        const participations = await DomainTransaction.execute(() => {
+          return campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
+            campaignId,
+            campaignParticipationId: campaignParticipationToDelete.id,
+            keepPreviousDeleted: true,
+          });
+        });
+
+        expect(participations.map((participation) => participation.id)).to.deep.members([deletedParticipation.id]);
+      });
     });
 
     context('When the participant has participations for differents campaigns', function () {


### PR DESCRIPTION
## ❄️ Problème

Depuis l'activation de l'anonymization blabla bla blabla bla .... il faut rattraper les données précedemment supprimées pour être ISO

## 🛷 Proposition

Ajouter un script qui parcours les participations supprimées sur des campagnes actives ( puisqu'un précédent script rattrape déjà les campagnes supprimés ), n'étant pas inclus dans les organization archivés précédemment  (puisqu'un script s'en occupe aussi ) et n'appartenant pas a des learners supprimés ( puisqu'un script s'occupe aussi de ces données là ) . 

ça va c'est clair ? Parceque des fois on s'y perd.

## ☃️ Remarques

ajout d'un boolean dans le repo / usecase qui permet de supprimer les participations pour mettre à jour celle déjà supprimé.

## 🧑‍🎄 Pour tester

TODO later :)