### PR TITLE
[TECH] Utiliser la clé de complémentaire dans la route de récupération des profils-cibles (PIX-20856).

### DIFF
--- a/admin/app/adapters/complementary-certification.js
+++ b/admin/app/adapters/complementary-certification.js
@@ -3,8 +3,9 @@ import ApplicationAdapter from './application';
 export default class ComplementaryCertificationAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/complementary-certifications/${id}/target-profiles`;
+  urlForFindRecord(id, modelName, snapshot) {
+    const key = snapshot.attr('key');
+    return `${this.host}/${this.namespace}/complementary-certifications/${key}/target-profiles`;
   }
 
   urlForUpdateRecord(id) {

--- a/admin/app/components/certification-frameworks/list.gjs
+++ b/admin/app/components/certification-frameworks/list.gjs
@@ -15,7 +15,7 @@ export default class List extends Component {
         name: framework.name,
         label: `components.certification-frameworks.labels.${framework.id}`,
         activeVersionStartDate: framework.activeVersionStartDate,
-        complementaryCertificationId: complementaryCertification?.id,
+        complementaryCertificationKey: complementaryCertification?.key,
       };
     });
   }
@@ -32,10 +32,10 @@ export default class List extends Component {
             {{t "components.certification-frameworks.list.name"}}
           </:header>
           <:cell>
-            {{#if framework.complementaryCertificationId}}
+            {{#if framework.complementaryCertificationKey}}
               <LinkTo
                 @route="authenticated.complementary-certifications.item"
-                @model={{framework.complementaryCertificationId}}
+                @model={{framework.complementaryCertificationKey}}
               >
                 {{t framework.label}}
               </LinkTo>

--- a/admin/app/components/complementary-certifications/item/framework.gjs
+++ b/admin/app/components/complementary-certifications/item/framework.gjs
@@ -13,7 +13,6 @@ import History from './target-profile/history';
 export default class ComplementaryCertificationFramework extends Component {
   @service currentUser;
   @service store;
-  @service router;
   @tracked targetProfilesHistory;
   @tracked currentConsolidatedFramework;
   @tracked frameworkHistory;
@@ -25,12 +24,8 @@ export default class ComplementaryCertificationFramework extends Component {
   }
 
   async #onMount() {
-    const routeParams = this.router.currentRoute.parent.parent.params;
-
-    const complementaryCertification = await this.store.peekRecord(
-      'complementary-certification',
-      routeParams.complementary_certification_id,
-    );
+    const complementaryCertification = this.args.complementaryCertification;
+    await complementaryCertification.reload();
 
     this.targetProfilesHistory = complementaryCertification.targetProfilesHistory;
 

--- a/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
+++ b/admin/app/components/complementary-certifications/item/framework/creation-form.gjs
@@ -29,9 +29,9 @@ export default class CreationForm extends Component {
     this.frameworks = foundFrameworks.map((framework) => framework);
 
     const routeParams = this.router.currentRoute.parent.parent.params;
-    this.complementaryCertification = await this.store.peekRecord(
-      'complementary-certification',
-      routeParams.complementary_certification_id,
+    const complementaryCertifications = this.store.peekAll('complementary-certification');
+    this.complementaryCertification = complementaryCertifications.find(
+      (cc) => cc.key === routeParams.complementary_certification_key,
     );
   }
 

--- a/admin/app/components/complementary-certifications/item/target-profile.gjs
+++ b/admin/app/components/complementary-certifications/item/target-profile.gjs
@@ -1,4 +1,3 @@
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -7,10 +6,6 @@ import History from './target-profile/history';
 import Information from './target-profile/information';
 
 export default class TargetProfile extends Component {
-  @service router;
-  @service store;
-
-  @tracked complementaryCertification;
   @tracked targetProfileId;
 
   constructor() {
@@ -18,29 +13,22 @@ export default class TargetProfile extends Component {
     this.#onMount();
   }
 
-  async #onMount() {
-    const currentComplementaryCertificationId =
-      this.router.currentRoute.parent.parent.params.complementary_certification_id;
-    this.complementaryCertification = await this.store.peekRecord(
-      'complementary-certification',
-      currentComplementaryCertificationId,
-    );
-
-    this.targetProfileId = this.complementaryCertification?.currentTargetProfiles?.[0].id;
+  #onMount() {
+    this.targetProfileId = this.args.complementaryCertification?.currentTargetProfiles?.[0].id;
   }
 
   get currentTargetProfile() {
-    return this.complementaryCertification?.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
+    return this.args.complementaryCertification?.currentTargetProfiles?.find(({ id }) => id === this.targetProfileId);
   }
 
   <template>
-    {{#unless this.complementaryCertification.hasComplementaryReferential}}
+    {{#unless @complementaryCertification.hasComplementaryReferential}}
       <Information
-        @complementaryCertification={{this.complementaryCertification}}
+        @complementaryCertification={{@complementaryCertification}}
         @currentTargetProfile={{this.currentTargetProfile}}
       />
       <BadgesList @currentTargetProfile={{this.currentTargetProfile}} />
     {{/unless}}
-    <History @targetProfilesHistory={{this.complementaryCertification.targetProfilesHistory}} />
+    <History @targetProfilesHistory={{@complementaryCertification.targetProfilesHistory}} />
   </template>
 }

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -112,7 +112,7 @@ Router.map(function () {
     });
 
     this.route('complementary-certifications', function () {
-      this.route('item', { path: '/:complementary_certification_id' }, function () {
+      this.route('item', { path: '/:complementary_certification_key' }, function () {
         this.route('framework', function () {
           this.route('new');
         });

--- a/admin/app/routes/authenticated/complementary-certifications/item.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item.js
@@ -10,9 +10,8 @@ export default class ItemRoute extends Route {
   }
 
   model(params) {
-    return this.store.findRecord('complementary-certification', params.complementary_certification_id, {
-      reload: true,
-    });
+    const complementaryCertifications = this.store.peekAll('complementary-certification');
+    return complementaryCertifications.find((cc) => cc.key === params.complementary_certification_key);
   }
 
   redirect(model, transition) {

--- a/admin/app/routes/authenticated/complementary-certifications/item/framework.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item/framework.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class FrameworkRoute extends Route {
+  model() {
+    return this.modelFor('authenticated.complementary-certifications.item');
+  }
+}

--- a/admin/app/routes/authenticated/complementary-certifications/item/target-profile.js
+++ b/admin/app/routes/authenticated/complementary-certifications/item/target-profile.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class TargetProfileRoute extends Route {
+  model() {
+    return this.modelFor('authenticated.complementary-certifications.item');
+  }
+}

--- a/admin/app/templates/authenticated/complementary-certifications/item/framework/index.gjs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/framework/index.gjs
@@ -1,2 +1,3 @@
 import Framework from 'pix-admin/components/complementary-certifications/item/framework';
-<template><Framework /></template>
+
+<template><Framework @complementaryCertification={{@model}} /></template>

--- a/admin/app/templates/authenticated/complementary-certifications/item/target-profile/index.gjs
+++ b/admin/app/templates/authenticated/complementary-certifications/item/target-profile/index.gjs
@@ -1,2 +1,3 @@
 import TargetProfile from 'pix-admin/components/complementary-certifications/item/target-profile';
-<template><TargetProfile /></template>
+
+<template><TargetProfile @complementaryCertification={{@model}} /></template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/list-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/list-test.js
@@ -79,7 +79,7 @@ module('Acceptance | Certification frameworks | list', function (hooks) {
       await click(screen.getByRole('link', { name: 'Pix+ Droit' }));
 
       // then
-      assert.strictEqual(currentURL(), '/complementary-certifications/1/framework');
+      assert.strictEqual(currentURL(), '/complementary-certifications/DROIT/framework');
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item-test.js
@@ -23,10 +23,10 @@ module('Acceptance | Complementary certifications | Complementary certification 
     });
 
     // when
-    await visit('/complementary-certifications/1');
+    await visit('/complementary-certifications/KEY');
 
     // then
-    assert.strictEqual(currentURL(), '/complementary-certifications/1/framework');
+    assert.strictEqual(currentURL(), '/complementary-certifications/KEY/framework');
   });
 
   test('it should render target profile page when complementary has no complementary referential', async function (assert) {
@@ -48,9 +48,9 @@ module('Acceptance | Complementary certifications | Complementary certification 
     });
 
     // when
-    await visit('/complementary-certifications/1');
+    await visit('/complementary-certifications/KEY');
 
     // then
-    assert.strictEqual(currentURL(), '/complementary-certifications/1/target-profile');
+    assert.strictEqual(currentURL(), '/complementary-certifications/KEY/target-profile');
   });
 });

--- a/admin/tests/acceptance/authenticated/complementary-certifications/item/attach-target-profile-test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/item/attach-target-profile-test.js
@@ -25,7 +25,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             id: 3,
             name: 'ALEX TARGET',
           });
-          const screen = await visit('/complementary-certifications/1/target-profile/3');
+          const screen = await visit('/complementary-certifications/KEY/target-profile/3');
 
           // then
           assert
@@ -52,7 +52,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               id: 3,
               name: 'ALEX TARGET',
             });
-            const screen = await visit('/complementary-certifications/1/target-profile/3');
+            const screen = await visit('/complementary-certifications/KEY/target-profile/3');
 
             const currentTargetProfileLinks = screen.getAllByRole('link', { name: 'ALEX TARGET' });
 
@@ -75,7 +75,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             label: 'MARIANNE CERTIF',
             targetProfilesHistory: [],
           });
-          const screen = await visit('/complementary-certifications/1/target-profile/-1');
+          const screen = await visit('/complementary-certifications/KEY/target-profile/-1');
 
           // then
           assert
@@ -108,7 +108,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [],
           });
-          const screen = await visit('/complementary-certifications/1/target-profile/3');
+          const screen = await visit('/complementary-certifications/KEY/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '3');
 
@@ -147,7 +147,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               name: 'ALEX TARGET',
               badges: [badge],
             });
-            const screen = await visit('/complementary-certifications/1/target-profile/3');
+            const screen = await visit('/complementary-certifications/KEY/target-profile/3');
             const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
             await fillIn(input, '5');
             await screen.findByRole('listbox');
@@ -191,7 +191,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               name: 'ALEX TARGET',
               badges: [badge],
             });
-            const screen = await visit('/complementary-certifications/1/target-profile/3');
+            const screen = await visit('/complementary-certifications/KEY/target-profile/3');
             const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
             await fillIn(input, '5');
             await screen.findByRole('listbox');
@@ -237,7 +237,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [badge],
           });
-          const screen = await visit('/complementary-certifications/1/target-profile/3');
+          const screen = await visit('/complementary-certifications/KEY/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '5');
           await screen.findByRole('listbox');
@@ -284,7 +284,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
               ),
             )
             .exists();
-          assert.strictEqual(currentURL(), '/complementary-certifications/1/target-profile');
+          assert.strictEqual(currentURL(), '/complementary-certifications/KEY/target-profile');
         });
       });
 
@@ -313,7 +313,7 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
             name: 'ALEX TARGET',
             badges: [badge],
           });
-          const screen = await visit('/complementary-certifications/1/target-profile/3');
+          const screen = await visit('/complementary-certifications/KEY/target-profile/3');
           const input = screen.getByRole('textbox', { name: 'ID du profil cible' });
           await fillIn(input, '5');
           await screen.findByRole('listbox');
@@ -368,10 +368,10 @@ module('Acceptance | Complementary certifications | item | attach-target-profile
           id: 3,
           name: 'ALEX TARGET',
         });
-        await visit('/complementary-certifications/1/target-profile/3');
+        await visit('/complementary-certifications/KEY/target-profile/3');
 
         // then
-        assert.strictEqual(currentURL(), '/complementary-certifications/1/target-profile');
+        assert.strictEqual(currentURL(), '/complementary-certifications/KEY/target-profile');
       });
     });
   });

--- a/admin/tests/integration/components/certification-frameworks/list-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/list-test.gjs
@@ -106,7 +106,7 @@ module('Integration | Component | certification-frameworks/list', function (hook
     // then
     const link = screen.getByRole('link', { name: t('components.certification-frameworks.labels.DROIT') });
     assert.dom(link).exists();
-    assert.dom(link).hasAttribute('href', '/complementary-certifications/123');
+    assert.dom(link).hasAttribute('href', '/complementary-certifications/DROIT');
   });
 
   test('it should display plain text when complementary certification does not exist', async function (assert) {

--- a/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework-test.gjs
@@ -15,22 +15,6 @@ module('Integration | Component | complementary-certifications/item/framework', 
     currentUser.adminMember = { isCertif: true };
 
     store = this.owner.lookup('service:store');
-
-    const serviceRouter = this.owner.lookup('service:router');
-    sinon.stub(serviceRouter, 'currentRoute').value({
-      parent: {
-        parent: {
-          params: {
-            complementary_certification_id: 'complementary-certification-id',
-          },
-        },
-      },
-    });
-
-    store.peekRecord = sinon.stub().resolves({
-      key: 'complementary-certification-key',
-      targetProfilesHistory: [],
-    });
     store.queryRecord = sinon.stub().resolves({});
   });
 
@@ -42,10 +26,17 @@ module('Integration | Component | complementary-certifications/item/framework', 
 
     test('it should display a framework creation button', async function (assert) {
       // given
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
       store.findRecord = sinon.stub().returns();
 
       // when
-      const screen = await render(<template><Framework /></template>);
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
       // then
       assert.dom(screen.getByText(t('components.complementary-certifications.item.framework.create-button'))).exists();
@@ -54,10 +45,17 @@ module('Integration | Component | complementary-certifications/item/framework', 
     module('when there is no current consolidated framework', function () {
       test('it should display the information and not the details component', async function (assert) {
         // given
+        const complementaryCertification = {
+          key: 'complementary-certification-key',
+          targetProfilesHistory: [],
+          reload: sinon.stub().resolves(),
+        };
         store.findRecord = sinon.stub().returns();
 
         // when
-        const screen = await render(<template><Framework /></template>);
+        const screen = await render(
+          <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        );
 
         // then
         assert
@@ -78,10 +76,17 @@ module('Integration | Component | complementary-certifications/item/framework', 
   module('when user has another accepted role', function () {
     test('it should not display a framework creation button', async function (assert) {
       // given
+      const complementaryCertification = {
+        key: 'complementary-certification-key',
+        targetProfilesHistory: [],
+        reload: sinon.stub().resolves(),
+      };
       store.findRecord = sinon.stub().returns();
 
       // when
-      const screen = await render(<template><Framework /></template>);
+      const screen = await render(
+        <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
       // then
       assert
@@ -94,6 +99,11 @@ module('Integration | Component | complementary-certifications/item/framework', 
     module('when a current consolidated framework exists', function () {
       test('it should display the details component', async function (assert) {
         // given
+        const complementaryCertification = {
+          key: 'complementary-certification-key',
+          targetProfilesHistory: [],
+          reload: sinon.stub().resolves(),
+        };
         store.findRecord = sinon.stub().resolves({
           hasMany: sinon.stub().returns({
             value: sinon.stub().returns([]),
@@ -101,7 +111,9 @@ module('Integration | Component | complementary-certifications/item/framework', 
         });
 
         // when
-        const screen = await render(<template><Framework /></template>);
+        const screen = await render(
+          <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+        );
 
         // then
         assert
@@ -118,6 +130,11 @@ module('Integration | Component | complementary-certifications/item/framework', 
       module('when there is no existing framework history', function () {
         test('it should not display the framework history', async function (assert) {
           // given
+          const complementaryCertification = {
+            key: 'complementary-certification-key',
+            targetProfilesHistory: [],
+            reload: sinon.stub().resolves(),
+          };
           store.findRecord = sinon.stub().resolves({
             hasMany: sinon.stub().returns({
               value: sinon.stub().returns([]),
@@ -126,7 +143,9 @@ module('Integration | Component | complementary-certifications/item/framework', 
           store.queryRecord = sinon.stub().resolves({ history: [] });
 
           // when
-          const screen = await render(<template><Framework /></template>);
+          const screen = await render(
+            <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+          );
 
           // then
           assert
@@ -142,6 +161,11 @@ module('Integration | Component | complementary-certifications/item/framework', 
       module('when there are existing framework versions', function () {
         test('it should display the framework history', async function (assert) {
           // given
+          const complementaryCertification = {
+            key: 'complementary-certification-key',
+            targetProfilesHistory: [],
+            reload: sinon.stub().resolves(),
+          };
           store.findRecord = sinon.stub().resolves({
             hasMany: sinon.stub().returns({
               value: sinon.stub().returns([]),
@@ -152,7 +176,9 @@ module('Integration | Component | complementary-certifications/item/framework', 
             .resolves({ history: ['20250101080000', '20240101080000', '20230101080000'] });
 
           // when
-          const screen = await render(<template><Framework /></template>);
+          const screen = await render(
+            <template><Framework @complementaryCertification={{complementaryCertification}} /></template>,
+          );
 
           // then
           assert

--- a/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/framework/creation-form-test.gjs
@@ -25,7 +25,7 @@ module('Integration | Component | complementary-certifications/item/framework/cr
     const serviceRouter = this.owner.lookup('service:router');
     sinon
       .stub(serviceRouter, 'currentRoute')
-      .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
+      .value({ parent: { parent: { params: { complementary_certification_key: complementaryCertification.key } } } });
 
     // when
     const screen = await render(<template><CreationForm /></template>);

--- a/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
+++ b/admin/tests/integration/components/complementary-certifications/item/target-profile-test.gjs
@@ -1,7 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import TargetProfile from 'pix-admin/components/complementary-certifications/item/target-profile';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest, { t } from '../../../../helpers/setup-intl-rendering';
 
@@ -12,7 +11,6 @@ module('Integration | Component | complementary-certifications/item/target-profi
     test('it should display target profile information, badge list and history', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const serviceRouter = this.owner.lookup('service:router');
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.adminMember = { isSuperAdmin: true };
       const complementaryCertification = store.createRecord('complementary-certification', {
@@ -33,12 +31,10 @@ module('Integration | Component | complementary-certifications/item/target-profi
         ],
       });
 
-      sinon
-        .stub(serviceRouter, 'currentRoute')
-        .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
-
       // when
-      const screen = await render(<template><TargetProfile /></template>);
+      const screen = await render(
+        <template><TargetProfile @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
       // then
       assert.dom(screen.getByText('Rattacher un nouveau profil cible')).exists();
@@ -66,7 +62,6 @@ module('Integration | Component | complementary-certifications/item/target-profi
     test('it should only display target profile history', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const serviceRouter = this.owner.lookup('service:router');
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.adminMember = { isSuperAdmin: true };
       const complementaryCertification = store.createRecord('complementary-certification', {
@@ -87,12 +82,10 @@ module('Integration | Component | complementary-certifications/item/target-profi
         ],
       });
 
-      sinon
-        .stub(serviceRouter, 'currentRoute')
-        .value({ parent: { parent: { params: { complementary_certification_id: complementaryCertification.id } } } });
-
       // when
-      const screen = await render(<template><TargetProfile /></template>);
+      const screen = await render(
+        <template><TargetProfile @complementaryCertification={{complementaryCertification}} /></template>,
+      );
 
       // then
       assert.dom(screen.queryByText('Rattacher un nouveau profil cible')).doesNotExist();

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -533,8 +533,8 @@ export default function routes() {
     return schema.complementaryCertifications.all();
   });
 
-  this.get('admin/complementary-certifications/:id/target-profiles', (schema, request) => {
-    return schema.complementaryCertifications.find(request.params.id);
+  this.get('admin/complementary-certifications/:key/target-profiles', (schema, request) => {
+    return schema.complementaryCertifications.findBy({ key: request.params.key });
   });
 
   this.get('admin/complementary-certifications/attachable-target-profiles', (schema, request) => {

--- a/api/src/certification/configuration/application/complementary-certification-controller.js
+++ b/api/src/certification/configuration/application/complementary-certification-controller.js
@@ -59,9 +59,9 @@ const getFrameworkHistory = async function (request) {
 };
 
 const getComplementaryCertificationTargetProfileHistory = async function (request) {
-  const complementaryCertificationId = request.params.complementaryCertificationId;
+  const complementaryCertificationKey = request.params.complementaryCertificationKey;
   const complementaryCertification = await usecases.getComplementaryCertificationTargetProfileHistory({
-    complementaryCertificationId,
+    complementaryCertificationKey,
   });
   return complementaryCertificationSerializer.serializeForAdmin(complementaryCertification);
 };

--- a/api/src/certification/configuration/application/complementary-certification-route.js
+++ b/api/src/certification/configuration/application/complementary-certification-route.js
@@ -188,11 +188,11 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/admin/complementary-certifications/{complementaryCertificationId}/target-profiles',
+      path: '/api/admin/complementary-certifications/{complementaryCertificationKey}/target-profiles',
       config: {
         validate: {
           params: Joi.object({
-            complementaryCertificationId: identifiersType.complementaryCertificationId,
+            complementaryCertificationKey: Joi.string().valid(...Object.values(ComplementaryCertificationKeys)),
           }),
         },
         pre: [

--- a/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
+++ b/api/src/certification/configuration/domain/usecases/get-complementary-certification-target-profile-history.js
@@ -6,17 +6,23 @@ import { ComplementaryCertificationTargetProfileHistory } from '../models/Comple
 
 /**
  * @param {Object} params
- * @param {number} params.complementaryCertificationId
+ * @param {string} params.complementaryCertificationKey
  * @param {TargetProfileHistoryRepository} params.targetProfileHistoryRepository
  * @param {ComplementaryCertificationForTargetProfileAttachmentRepository} params.complementaryCertificationForTargetProfileAttachmentRepository
  *
  * @returns {Promise<ComplementaryCertificationTargetProfileHistory>} all target profiles than were applicable for this complementary certification
  */
 const getComplementaryCertificationTargetProfileHistory = async function ({
-  complementaryCertificationId,
+  complementaryCertificationKey,
   targetProfileHistoryRepository,
   complementaryCertificationForTargetProfileAttachmentRepository,
 }) {
+  const complementaryCertification = await complementaryCertificationForTargetProfileAttachmentRepository.getByKey({
+    complementaryCertificationKey,
+  });
+
+  const complementaryCertificationId = complementaryCertification.id;
+
   const currentsTargetProfileHistoryWithBadgesByComplementaryCertification =
     await targetProfileHistoryRepository.getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId({
       complementaryCertificationId,
@@ -26,10 +32,6 @@ const getComplementaryCertificationTargetProfileHistory = async function ({
     await targetProfileHistoryRepository.getDetachedTargetProfilesHistoryByComplementaryCertificationId({
       complementaryCertificationId,
     });
-
-  const complementaryCertification = await complementaryCertificationForTargetProfileAttachmentRepository.getById({
-    complementaryCertificationId,
-  });
 
   return new ComplementaryCertificationTargetProfileHistory({
     ...complementaryCertification,

--- a/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js
@@ -19,4 +19,25 @@ const getById = async function ({ complementaryCertificationId }) {
   return _toDomain(complementaryCertification);
 };
 
-export { getById };
+/**
+ * @function
+ * @param {object} params
+ * @param {string} params.complementaryCertificationKey
+ *
+ * @returns {Promise<ComplementaryCertificationForTargetProfileAttachment>}
+ * @throws {NotFoundError}
+ */
+const getByKey = async function ({ complementaryCertificationKey }) {
+  const complementaryCertification = await knex
+    .from('complementary-certifications')
+    .where({ key: complementaryCertificationKey })
+    .first();
+
+  if (!complementaryCertification) {
+    throw new NotFoundError('The complementary certification does not exist');
+  }
+
+  return _toDomain(complementaryCertification);
+};
+
+export { getById, getByKey };

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/get-complementary-certification-target-profile-history_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/get-complementary-certification-target-profile-history_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | get-complementary-certification-target-profile-histor
       getDetachedTargetProfilesHistoryByComplementaryCertificationId: sinon.stub(),
     };
     complementaryCertificationForTargetProfileAttachmentRepository = {
-      getById: sinon.stub(),
+      getByKey: sinon.stub().resolves(domainBuilder.buildComplementaryCertificationForTargetProfileAttachment()),
     };
   });
 
@@ -19,9 +19,6 @@ describe('Unit | UseCase | get-complementary-certification-target-profile-histor
     // given
     const complementaryCertification = domainBuilder.buildComplementaryCertificationForTargetProfileAttachment();
     const complementaryCertificationId = complementaryCertification.id;
-    complementaryCertificationForTargetProfileAttachmentRepository.getById
-      .withArgs({ complementaryCertificationId })
-      .resolves(complementaryCertification);
 
     const attachedTargetProfileHistoryForAdmin = domainBuilder.buildTargetProfileHistoryForAdmin({
       detachedAt: null,

--- a/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/complementary-certification-route_test.js
@@ -152,17 +152,11 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
     });
   });
 
-  describe('GET /api/admin/complementary-certifications/{complementaryCertificationId}/target-profiles', function () {
+  describe('GET /api/admin/complementary-certifications/{complementaryCertificationKey}/target-profiles', function () {
     it('should return 200 HTTP status code', async function () {
       // given
       const server = await createServer();
-      const complementaryCertificationId = 1;
       const superAdmin = await insertUserWithRoleSuperAdmin();
-      const options = {
-        method: 'GET',
-        url: '/api/admin/complementary-certifications/' + complementaryCertificationId + '/target-profiles',
-        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
-      };
       const attachedAt = new Date('2019-01-01');
 
       databaseBuilder.factory.buildComplementaryCertification({
@@ -173,11 +167,17 @@ describe('Certification | Configuration | Acceptance | API | complementary-certi
       });
 
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
-        id: complementaryCertificationId,
+        id: 1,
         label: 'Pix+ Édu 2nd degré',
         hasExternalJury: true,
         key: ComplementaryCertificationKeys.PIX_PLUS_EDU_2ND_DEGRE,
       });
+
+      const options = {
+        method: 'GET',
+        url: `/api/admin/complementary-certifications/${complementaryCertification.key}/target-profiles`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
 
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 999, name: 'Target' });
 

--- a/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/configuration/unit/application/complementary-certification-route_test.js
@@ -224,7 +224,7 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
     });
   });
 
-  describe('/api/admin/complementary-certifications/{id}/target-profiles', function () {
+  describe('/api/admin/complementary-certifications/{complementaryCertificationKey}/target-profiles', function () {
     context('when user is an admin member', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
@@ -238,7 +238,7 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
         // when
         const { statusCode } = await httpTestServer.request(
           'GET',
-          '/api/admin/complementary-certifications/1/target-profiles',
+          `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/target-profiles`,
         );
 
         // then
@@ -264,7 +264,7 @@ describe('Certification | Configuration | Unit | Application | Router | compleme
         // when
         const { statusCode } = await httpTestServer.request(
           'GET',
-          '/api/admin/complementary-certifications/1/target-profiles',
+          `/api/admin/complementary-certifications/${ComplementaryCertificationKeys.PIX_PLUS_DROIT}/target-profiles`,
         );
 
         // then


### PR DESCRIPTION
## ❄️ Problème

On ne souhaite plus utiliser l'ID d'une complémentaire pour récupérer des informations associées.

## 🛷 Proposition

Utiliser la clé de complémentaire dans la route de récupération des profils-cibles reliés à une complémentaire.

## 🧑‍🎄 Pour tester

- Checker les référentiels de certification en RA
- Vérifier que la liste des profils-cibles s'affiche toujours bien pour les complémentaires hors Cléa
- Vérifier que le profil-cible actif s'affiche bien pour Cléa
