### PR TITLE
[TECH] Corriger des tests flaky de userReconciliationService (PIX-20945)

### DIFF
--- a/api/src/shared/domain/services/user-reconciliation-service.js
+++ b/api/src/shared/domain/services/user-reconciliation-service.js
@@ -121,7 +121,7 @@ export async function createUsernameByUser({ user: { firstName, lastName, birthd
   return await generateUsernameUntilAvailable({ firstPart, secondPart, userRepository });
 }
 
-export async function generateUsernameUntilAvailable({ firstPart, secondPart, userRepository }) {
+async function generateUsernameUntilAvailable({ firstPart, secondPart, userRepository }) {
   let randomPart = secondPart;
 
   let username;

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -567,7 +567,7 @@ describe('Unit | Service | user-reconciliation-service', function () {
     });
   });
 
-  describe('#createUsernameByUserAndStudentId', function () {
+  describe('#createUsernameByUser', function () {
     const user = {
       firstName: 'fakeFirst-Name',
       lastName: 'fake LastName',

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -567,59 +567,6 @@ describe('Unit | Service | user-reconciliation-service', function () {
     });
   });
 
-  describe('#generateUsernameUntilAvailable', function () {
-    let userRepository;
-
-    beforeEach(function () {
-      userRepository = {
-        isUsernameAvailable: sinon.stub(),
-      };
-    });
-
-    it('should generate a username with original inputs', async function () {
-      // given
-      const firstPart = 'firstname.lastname';
-      const secondPart = '0101';
-
-      userRepository.isUsernameAvailable.resolves();
-      const expectedUsername = firstPart + secondPart;
-
-      // when
-      const result = await userReconciliationService.generateUsernameUntilAvailable({
-        firstPart,
-        secondPart,
-        userRepository,
-      });
-
-      // then
-      expect(result).to.equal(expectedUsername);
-    });
-
-    it('should generate an other username when exist with original inputs', async function () {
-      // given
-      const firstPart = 'firstname.lastname';
-      const secondPart = '0101';
-
-      userRepository.isUsernameAvailable
-        .onFirstCall()
-        .rejects(new AlreadyRegisteredUsernameError())
-        .onSecondCall()
-        .resolves();
-
-      const originalUsername = firstPart + secondPart;
-
-      // when
-      const result = await userReconciliationService.generateUsernameUntilAvailable({
-        firstPart,
-        secondPart,
-        userRepository,
-      });
-
-      // then
-      expect(result).to.not.equal(originalUsername);
-    });
-  });
-
   describe('#createUsernameByUserAndStudentId', function () {
     const user = {
       firstName: 'fakeFirst-Name',

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -583,30 +583,34 @@ describe('Unit | Service | user-reconciliation-service', function () {
       };
     });
 
-    it('should generate a username with original user properties', async function () {
-      // given
-      userRepository.isUsernameAvailable.resolves();
+    context('when no other username based on user properties is already present in userRepository', function () {
+      it('generates a username based on user properties', async function () {
+        // given
+        userRepository.isUsernameAvailable.resolves();
 
-      // when
-      const result = await userReconciliationService.createUsernameByUser({ user, userRepository });
+        // when
+        const result = await userReconciliationService.createUsernameByUser({ user, userRepository });
 
-      // then
-      expect(result).to.equal(originaldUsername);
+        // then
+        expect(result).to.equal(originaldUsername);
+      });
     });
 
-    it('should generate a other username when exist whith original inputs', async function () {
-      // given
-      userRepository.isUsernameAvailable
-        .onFirstCall()
-        .rejects(new AlreadyRegisteredUsernameError())
-        .onSecondCall()
-        .resolves();
+    context('when another username based on user properties is already present in userRepository', function () {
+      it('generates another username with a random part', async function () {
+        // given
+        userRepository.isUsernameAvailable
+          .onFirstCall()
+          .rejects(new AlreadyRegisteredUsernameError())
+          .onSecondCall()
+          .resolves();
 
-      // when
-      const result = await userReconciliationService.createUsernameByUser({ user, userRepository });
+        // when
+        const result = await userReconciliationService.createUsernameByUser({ user, userRepository });
 
-      // then
-      expect(result).to.not.equal(originaldUsername);
+        // then
+        expect(result).to.not.equal(originaldUsername);
+      });
     });
   });
 


### PR DESCRIPTION
## ❄️ Problème

<img width="1280" height="244" alt="Screenshot-api_unit_test_user-reconciliation-service" src="https://github.com/user-attachments/assets/a746110d-6a88-4cac-b07e-bf6d6663921c" />

Certains stubs des tests génèrent des cas où `username == defaultUsername`. C’est peu probable, mais cela se produit quand même parfois. C’est la cause de ces tests flaky.

## 🛷 Proposition

1. Rendre une fonction, non-utilisée en-dehors du `userReconciliationService`, privée et d’enlever les tests unitaires (dont 1 flaky) qui y étaient associés
2. Modifier un test flaky restant en prenant en compte le cas `username == defaultUsername`, peu probable, mais qui se produit quand même parfois

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

* Constater que la CI est verte
