### PR TITLE
[TECH] :recycle: Utilise le terme `invigilator` plutôt que `supervisor` dans les traduction (Pix-20947)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.gjs
+++ b/admin/app/components/certifications/certification/details-v3.gjs
@@ -77,7 +77,7 @@ const assessmentResultStatusLabelAndColor = (status) => ({
 
 const assessmentStateMap = {
   [assessmentStates.ENDED_BY_INVIGILATOR]: {
-    label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-supervisor',
+    label: 'pages.certifications.certification.details.v3.assessment-state.ended-by-invigilator',
     color: secondaryColor,
   },
   [assessmentStates.ENDED_DUE_TO_FINALIZATION]: {
@@ -166,7 +166,7 @@ export default class DetailsV3 extends Component {
 
   get completionDateTooltipContent() {
     if (this.args.details.wasEndedByInvigilator) {
-      return 'pages.certifications.certification.details.v3.completion-date-tooltip.ended-by-supervisor';
+      return 'pages.certifications.certification.details.v3.completion-date-tooltip.ended-by-invigilator';
     }
     if (this.args.details.wasFinalized) {
       return 'pages.certifications.certification.details.v3.completion-date-tooltip.ended-due-to-finalization';

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1110,11 +1110,11 @@
               "validated": "Validated"
             },
             "assessment-state": {
-              "ended-by-supervisor": "The invigilator",
+              "ended-by-invigilator": "The invigilator",
               "ended-due-to-finalization": "Session finalised"
             },
             "completion-date-tooltip": {
-              "ended-by-supervisor": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
+              "ended-by-invigilator": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
               "ended-due-to-finalization": "Date et heure d'affichage de la dernière question proposée au candidat."
             },
             "general-informations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1113,11 +1113,11 @@
               "validated": "Validée"
             },
             "assessment-state": {
-              "ended-by-supervisor": "Le surveillant",
+              "ended-by-invigilator": "Le surveillant",
               "ended-due-to-finalization": "Finalisation session"
             },
             "completion-date-tooltip": {
-              "ended-by-supervisor": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
+              "ended-by-invigilator": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
               "ended-due-to-finalization": "Date et heure d’affichage de la dernière question proposée au candidat."
             },
             "general-informations": {

--- a/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/CertificationAssessment_test.js
@@ -483,7 +483,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     });
   });
 
-  describe('#endBySupervisor', function () {
+  describe('#endByInvigilator', function () {
     it('should change the assessment state to "endBySupervisor"', function () {
       // given
       const now = new Date('2020-12-31');

--- a/api/translations/es-419.json
+++ b/api/translations/es-419.json
@@ -128,7 +128,7 @@
     "examiner-information": {
       "invigilated-by": "Supervisado por :",
       "signature": "Firma(s) :",
-      "title": "El supervisor o supervisores"
+      "title": "El vigilante o vigilantes"
     },
     "file-name": "hoja de inscripción-sesión-",
     "header": {
@@ -237,7 +237,7 @@
       "room-name": "Nombre de la sala",
       "session-certification": "La sesión de certificación",
       "session-invigilates-by": "Sesión supervisada por :",
-      "session-invigilators": "Firma del supervisor o supervisores :",
+      "session-invigilators": "Firma del vigilante o vigilantes :",
       "session-number": "Número de sesión",
       "site-name": "Nombre del sitio"
     },
@@ -426,11 +426,11 @@
   "jury": {
     "comment": {
       "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
-        "candidate": "Uno o varios problemas técnicos comunicados a su supervisor durante la sesión de certificación afectaron a la calidad de la prueba de certificación. Lamentablemente, debido al gran número de preguntas que no pudo responder correctamente, no podemos calcular una puntuación fiable ni emitir un certificado. Se anulará la certificación y se informará al prescriptor de su certificación (si procede).",
-        "organization": "Uno o varios problemas técnicos, comunicados por este candidato al supervisor de la sesión de certificación, han afectado al buen desarrollo de la prueba de certificación. No podemos certificar al candidato y, por lo tanto, su certificación queda anulada. Esta información debe tenerse en cuenta y puede llevarle a proponer una nueva sesión de certificación para este candidato."
+        "candidate": "Uno o varios problemas técnicos comunicados a su vigilante durante la sesión de certificación afectaron a la calidad de la prueba de certificación. Lamentablemente, debido al gran número de preguntas que no pudo responder correctamente, no podemos calcular una puntuación fiable ni emitir un certificado. Se anulará la certificación y se informará al prescriptor de su certificación (si procede).",
+        "organization": "Uno o varios problemas técnicos, comunicados por este candidato al vigilante de la sesión de certificación, han afectado al buen desarrollo de la prueba de certificación. No podemos certificar al candidato y, por lo tanto, su certificación queda anulada. Esta información debe tenerse en cuenta y puede llevarle a proponer una nueva sesión de certificación para este candidato."
       },
       "CANCELLED_DUE_TO_NEUTRALIZATION": {
-        "candidate": "Uno o varios problemas técnicos comunicados a su supervisor durante la sesión de certificación han afectado a la calidad de la prueba de certificación. Debido a que no se pudieron responder demasiadas preguntas, no podemos expedir la certificación. Se anulará su certificación y se informará al prescriptor de la misma (si procede).",
+        "candidate": "Uno o varios problemas técnicos comunicados a su vigilante durante la sesión de certificación han afectado a la calidad de la prueba de certificación. Debido a que no se pudieron responder demasiadas preguntas, no podemos expedir la certificación. Se anulará su certificación y se informará al prescriptor de la misma (si procede).",
         "organization": "Uno o varios problemas técnicos han afectado a la prueba de certificación. No podemos entregar la certificación y, por lo tanto, queda anulada. Esta información puede llevarle a proponer una nueva sesión de certificación para este candidato."
       },
       "FRAUD": {

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -128,7 +128,7 @@
     "examiner-information": {
       "invigilated-by": "Supervisado por :",
       "signature": "Firma(s) :",
-      "title": "El supervisor o supervisores"
+      "title": "El vigilante o vigilantes"
     },
     "file-name": "hoja de inscripción-sesión-",
     "header": {
@@ -237,7 +237,7 @@
       "room-name": "Nombre de la sala",
       "session-certification": "La sesión de certificación",
       "session-invigilates-by": "Sesión supervisada por :",
-      "session-invigilators": "Firma del supervisor o supervisores :",
+      "session-invigilators": "Firma del vigilante o vigilantes :",
       "session-number": "Número de sesión",
       "site-name": "Nombre del sitio"
     },
@@ -426,11 +426,11 @@
   "jury": {
     "comment": {
       "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
-        "candidate": "Uno o varios problemas técnicos comunicados a su supervisor durante la sesión de certificación afectaron a la calidad de la prueba de certificación. Lamentablemente, debido al gran número de preguntas que no pudo responder correctamente, no podemos calcular una puntuación fiable ni emitir un certificado. Se anulará la certificación y se informará al prescriptor de su certificación (si procede).",
-        "organization": "Uno o varios problemas técnicos, comunicados por este candidato al supervisor de la sesión de certificación, han afectado al buen desarrollo de la prueba de certificación. No podemos certificar al candidato y, por lo tanto, su certificación queda anulada. Esta información debe tenerse en cuenta y puede llevarle a proponer una nueva sesión de certificación para este candidato."
+        "candidate": "Uno o varios problemas técnicos comunicados a su vigilante durante la sesión de certificación afectaron a la calidad de la prueba de certificación. Lamentablemente, debido al gran número de preguntas que no pudo responder correctamente, no podemos calcular una puntuación fiable ni emitir un certificado. Se anulará la certificación y se informará al prescriptor de su certificación (si procede).",
+        "organization": "Uno o varios problemas técnicos, comunicados por este candidato al vigilante de la sesión de certificación, han afectado al buen desarrollo de la prueba de certificación. No podemos certificar al candidato y, por lo tanto, su certificación queda anulada. Esta información debe tenerse en cuenta y puede llevarle a proponer una nueva sesión de certificación para este candidato."
       },
       "CANCELLED_DUE_TO_NEUTRALIZATION": {
-        "candidate": "Uno o varios problemas técnicos comunicados a su supervisor durante la sesión de certificación han afectado a la calidad de la prueba de certificación. Debido a que no se pudieron responder demasiadas preguntas, no podemos expedir la certificación. Se anulará su certificación y se informará al prescriptor de la misma (si procede).",
+        "candidate": "Uno o varios problemas técnicos comunicados a su vigilante durante la sesión de certificación han afectado a la calidad de la prueba de certificación. Debido a que no se pudieron responder demasiadas preguntas, no podemos expedir la certificación. Se anulará su certificación y se informará al prescriptor de la misma (si procede).",
         "organization": "Uno o varios problemas técnicos han afectado a la prueba de certificación. No podemos entregar la certificación y, por lo tanto, queda anulada. Esta información puede llevarle a proponer una nueva sesión de certificación para este candidato."
       },
       "FRAUD": {

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -128,7 +128,7 @@
     "examiner-information": {
       "invigilated-by": "Bewaakt door :",
       "signature": "Handtekening(en) :",
-      "title": "De supervisor(s)"
+      "title": "De toezichthouder(s)"
     },
     "file-name": "registratie-sessieblad-",
     "header": {
@@ -237,7 +237,7 @@
       "room-name": "Naam van de kamer",
       "session-certification": "De certificeringssessie",
       "session-invigilates-by": "Sessie begeleid door :",
-      "session-invigilators": "Handtekening van supervisor(s) :",
+      "session-invigilators": "Handtekening van toezichthouder(s) :",
       "session-number": "Sessienummer",
       "site-name": "Naam van de site"
     },
@@ -427,7 +427,7 @@
     "comment": {
       "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
         "candidate": "Een of meer technische problemen die tijdens de certificeringssessie aan uw surveillant zijn gemeld, hebben de kwaliteit van de certificeringstest beïnvloed. Helaas zijn we door het grote aantal vragen dat u niet goed kon beantwoorden niet in staat om een betrouwbare score te berekenen en een certificaat uit te reiken. De certificering wordt geannuleerd en de voorschrijver van uw certificering (indien van toepassing) wordt hiervan op de hoogte gesteld.",
-        "organization": "Een of meer technische problemen, gemeld door deze kandidaat aan de supervisor van de certificeringssessie, hebben het vlotte verloop van de certificeringstest beïnvloed. We kunnen de kandidaat niet certificeren en zijn/haar certificering is daarom geannuleerd. Deze informatie moet in aanmerking worden genomen en kan ertoe leiden dat u een nieuwe certificeringssessie voor deze kandidaat voorstelt."
+        "organization": "Een of meer technische problemen, gemeld door deze kandidaat aan de toezichthouder van de certificeringssessie, hebben het vlotte verloop van de certificeringstest beïnvloed. We kunnen de kandidaat niet certificeren en zijn/haar certificering is daarom geannuleerd. Deze informatie moet in aanmerking worden genomen en kan ertoe leiden dat u een nieuwe certificeringssessie voor deze kandidaat voorstelt."
       },
       "CANCELLED_DUE_TO_NEUTRALIZATION": {
         "candidate": "Ten minste één technisch probleem, gemeld aan je surveillant tijdens de certificeringssessie, heeft de kwaliteit van het certificeringsexamen beïnvloed. Vanwege het aantal vragen dat u niet heeft kunnen beantwoorden, kunnen we geen certificering afgeven. Het is geannuleerd, de specificeerder van uw certificeringsexamen (indien van toepassing) is op de hoogte gesteld.",

--- a/docs/security/certification/authenticate.puml
+++ b/docs/security/certification/authenticate.puml
@@ -23,16 +23,16 @@ BDD -> API: 0 rows found
 API -> navigateur : 200 OK \n{ (..) type: ""allowed-certification-center-access" \n pix-certif-terms-of-service-accepted: false (…)}}
 utilisateur -> navigateur: Saisie N° de la session \n et mot de passe de la session
 navigateur -> API : POST api/supervise-session
-API -> BDD: INSERT INTO supervisor-access (..) \n VALUES (<SESSION_ID, <USER_ID>)
+API -> BDD: INSERT INTO invigilator_accesses (..) \n VALUES (<SESSION_ID, <USER_ID>)
 navigateur -> API: GET api/<SESSION_ID>/certification-session-candidate \n + token
-API -> BDD: SELECT * FROM supervisor-access \n WHERE sessionId = <SESSION_ID> \n and userId = <USER_ID>
+API -> BDD: SELECT * FROM invigilator_accesses \n WHERE sessionId = <SESSION_ID> \n and userId = <USER_ID>
 BDD -> API: 1 row found
 API -> navigateur:  200 OK \n{ (..) type: "certification-session-candidate " (…)}}
 navigateur -> utilisateur: affichage des candidats
 
 == Tentative de fraude ==
 utilisateur -> API: GET api/<SESSION_ID>/certification-session-candidate \n + token
-API -> BDD: SELECT * FROM supervisor-access \n WHERE sessionId = <SESSION_ID> \n and userId = <USER_ID>
+API -> BDD: SELECT * FROM invigilator_accesses \n WHERE sessionId = <SESSION_ID> \n and userId = <USER_ID>
 BDD -> API: 0 row found
 API -> utilisateur: 401_UNAUTHORIZED
 

--- a/mon-pix/app/components/certifications/certification-ender.gjs
+++ b/mon-pix/app/components/certifications/certification-ender.gjs
@@ -28,7 +28,7 @@ export default class CertificationEnder extends Component {
           <h1 class="certification-ender-candidate__title">{{t "pages.certification-ender.candidate.title"}}</h1>
           {{#if @isEndedByInvigilator}}
             <p class="certification-ender-candidate__message">
-              {{t "pages.certification-ender.candidate.ended-by-supervisor"}}
+              {{t "pages.certification-ender.candidate.ended-by-invigilator"}}
             </p>
           {{/if}}
           {{#if @hasBeenEndedDueToFinalization}}

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -391,7 +391,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
         assert.dom(screen.getByRole('heading', { name: 'Test terminé !' })).exists();
       });
 
-      module('when test was ended by supervisor', function () {
+      module('when test was ended by invigilator', function () {
         test('should display "Votre surveillant a mis fin…"', async function (assert) {
           // given
           const user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
@@ -418,7 +418,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
       });
 
       module('when user has already started the certification', function () {
-        module('when test was ended by supervisor', function () {
+        module('when test was ended by invigilator', function () {
           test('should redirect to "Votre surveillant a mis fin…"', async function (assert) {
             // given
             user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });

--- a/mon-pix/tests/integration/components/certifications/certification-ender-test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender-test.js
@@ -72,7 +72,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
       );
 
       // then
-      assert.notOk(screen.queryByText(t('pages.certification-ender.candidate.ended-by-supervisor')));
+      assert.notOk(screen.queryByText(t('pages.certification-ender.candidate.ended-by-invigilator')));
     });
   });
 
@@ -87,7 +87,7 @@ module('Integration | Component | Certifications | CertificationEnder', function
       );
 
       // then
-      assert.ok(screen.getByText(t('pages.certification-ender.candidate.ended-by-supervisor')));
+      assert.ok(screen.getByText(t('pages.certification-ender.candidate.ended-by-invigilator')));
     });
   });
 

--- a/mon-pix/tests/integration/components/certifications/certification-ender-test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender-test.js
@@ -61,8 +61,8 @@ module('Integration | Component | Certifications | CertificationEnder', function
     assert.ok(screen.getByText(t('pages.certification-ender.candidate.remote-certification')));
   });
 
-  module('when the assessment status is not ended by supervisor', function () {
-    test('should not display the ended by supervisor text', async function (assert) {
+  module('when the assessment status is not ended by invigilator', function () {
+    test('should not display the ended by invigilator text', async function (assert) {
       // given
       stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 
@@ -76,8 +76,8 @@ module('Integration | Component | Certifications | CertificationEnder', function
     });
   });
 
-  module('when the assessment status is ended by supervisor', function () {
-    test('should display the ended by supervisor text', async function (assert) {
+  module('when the assessment status is ended by invigilator', function () {
+    test('should display the ended by invigilator text', async function (assert) {
       // given
       stubCurrentUserService(this.owner, { firstName: 'Jim', lastName: 'Halpert' });
 

--- a/mon-pix/tests/unit/components/challenge/challenge-item-test.js
+++ b/mon-pix/tests/unit/components/challenge/challenge-item-test.js
@@ -314,7 +314,7 @@ module('Unit | Component | Challenge | Item', function (hooks) {
           });
       });
     });
-    module('when assessment has been ended by supervisor', function () {
+    module('when assessment has been ended by invigilator', function () {
       test('should redirect candidate to end test screen when trying to answer', async function (assert) {
         // given
         const error = {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1084,7 +1084,7 @@
         "certification": "We have detected a page switch. Your answer will not be validated. If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
         "default": "We have detected a page switch. During a certification test, your answer would not be validated.",
         "v3-accessible-certification": "We have detected a page switch. If you have been forced to change pages in order to use a digital accessibility tool (such as a screen reader or virtual keyboard), please answer the question anyways.",
-        "v3-certification": "We have detected a page change. Your answer will be counted as wrong. If you have been forced to change page, tell your supervisor so that he or she can see this and report it, if necessary."
+        "v3-certification": "We have detected a page change. Your answer will be counted as wrong. If you have been forced to change page, tell your invigilator so that he or she can see this and report it, if necessary."
       },
       "illustration": {
         "placeholder": "Image loading"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -718,7 +718,7 @@
       "candidate": {
         "disconnect": "Log out of my account",
         "disconnect-tip": "If this is not your computer, please remember to log out.",
-        "ended-by-supervisor": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
+        "ended-by-invigilator": "Your invigilator has marked your certification test as completed. You cannot continue to answer questions.",
         "ended-due-to-finalization": "Your certification centre has ended the session. You can no longer answer questions.",
         "remote-certification": "If you're taking your Pix certificate remotely, please make sure you log out from the monitoring tool once your test is finished.",
         "title": "Your test is finished!"

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -713,7 +713,7 @@
       "candidate": {
         "disconnect": "Desconectar mi cuenta",
         "disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
-        "ended-by-supervisor": "El vigilante ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
+        "ended-by-invigilator": "El vigilante ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
         "ended-due-to-finalization": "Tu centro de certificación ha finalizado la sesión. Ya no puedes continuar respondiendo a las preguntas.",
         "remote-certification": "Si estás realizando tu certificación Pix de forma remota, asegúrate de desconectarte de la herramienta de supervisión una vez que hayas finalizado la prueba.",
         "title": "¡Prueba finalizada!"

--- a/mon-pix/translations/es-419.json
+++ b/mon-pix/translations/es-419.json
@@ -87,7 +87,7 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
-        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el supervisor.",
+        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el vigilante.",
         "link": "Acceder a la documentación",
         "title": "La extensión Pix Companion<br /> no se detecta"
       }
@@ -713,7 +713,7 @@
       "candidate": {
         "disconnect": "Desconectar mi cuenta",
         "disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
-        "ended-by-supervisor": "El supervisor ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
+        "ended-by-supervisor": "El vigilante ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
         "ended-due-to-finalization": "Tu centro de certificación ha finalizado la sesión. Ya no puedes continuar respondiendo a las preguntas.",
         "remote-certification": "Si estás realizando tu certificación Pix de forma remota, asegúrate de desconectarte de la herramienta de supervisión una vez que hayas finalizado la prueba.",
         "title": "¡Prueba finalizada!"
@@ -785,7 +785,7 @@
             "1": "Ir al final de la página",
             "2": "Seleccione \"Informar de un problema con la pregunta\".",
             "3": "Haga clic en \"Sí, estoy seguro\".",
-            "4": "Llama al supervisor que intervendrá para ayudarte"
+            "4": "Llama al vigilante que intervendrá para ayudarte"
           },
           "text": "'<strong>'En caso de problema técnico'</strong>' (por ejemplo, la imagen se niega a mostrarse), sigue estos pasos:",
           "title": "¿Qué hacer en caso de problema?"
@@ -822,7 +822,7 @@
       },
       "error-messages": {
         "generic": {
-          "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de inscripción.",
+          "check-personal-info": "Comprueba con el vigilante que tus datos personales coinciden con los de la hoja de inscripción.",
           "check-session-number": "Comprueba el número de sesión.",
           "disclaimer": "La información introducida no corresponde a ningún candidato inscrito en la sesión."
         },
@@ -831,7 +831,7 @@
         "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
-        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al supervisor.",
+        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al vigilante.",
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
@@ -850,7 +850,7 @@
           "birth-year": "año de nacimiento (AAAA)",
           "first-name": "Nombre",
           "session-number": "Número de sesión",
-          "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+          "session-number-information": "Comunicado únicamente por el vigilante al inicio de la sesión"
         },
         "fields-validation": {
           "session-number-error": "El número de sesión se compone únicamente de dígitos."
@@ -870,7 +870,7 @@
       "action": {
         "back": "Volver a la página de inicio"
       },
-      "text": "Para que tu perfil esté certificado, debes haber alcanzado un nivel superior a 0 en al menos 5 competencias.",
+      "text": "Para que tu perfil esté certificado, debes haber alcanzado un nivel vigilante a 0 en al menos 5 competencias.",
       "title": "Tu perfil todavía no se puede certificar."
     },
     "certification-results": {
@@ -887,7 +887,7 @@
       "title": "Prueba finalizada"
     },
     "certification-start": {
-      "access-code": "Código de acceso comunicado por el supervisor",
+      "access-code": "Código de acceso comunicado por el vigilante",
       "actions": {
         "submit": "Empezar mi prueba"
       },
@@ -896,13 +896,13 @@
           "email": "dpo@pix.fr",
           "info": "De conformidad con la Ley francesa de «Informática y libertades», puedes ejercer tu derecho de acceso y rectificación de tus datos personales enviando un correo electrónico a "
         },
-        "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el supervisor se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
+        "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el vigilante se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
       },
       "core-and-complementary-subscriptions": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
       "error-messages": {
         "access-code-error": "Este código no existe o ya no es válido.",
-        "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
-        "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al supervisor.",
+        "candidate-not-authorized-to-resume": "Ponte en contacto con el vigilante para que autorice la reanudación de tu examen.",
+        "candidate-not-authorized-to-start": "El vigilante no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al vigilante.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
         "missing-code": "You have not entered your access code.",
         "session-not-accessible": "La sesión de certificación ya no está disponible.",
@@ -946,7 +946,7 @@
         "skip-go-to-next": "Paso y voy a la siguiente pregunta",
         "validate": "Valido",
         "validate-go-to-next": "Valido y voy a la siguiente pregunta",
-        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el supervisor"
+        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el vigilante"
       },
       "already-answered": "Ya has respondido a esta pregunta",
       "answer-input": {
@@ -965,7 +965,7 @@
           "send-feedback": "Sí, estoy seguro/a"
         },
         "description": "¿Estás seguro/a de que quieres informar de un problema?",
-        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
+        "information": "Al informar de un problema, tu certificación se pausa hasta que el vigilante intervenga para validar o invalidar tu informe."
       },
       "embed-simulator": {
         "actions": {
@@ -1012,7 +1012,7 @@
                 "download": {
                   "edit-failure": {
                     "label": "No puedo modificar el archivo",
-                    "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
+                    "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte vigilante del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
                   },
                   "lost": {
                     "label": "No encuentro el archivo descargado",
@@ -1077,10 +1077,10 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor y responde a la pregunta en su presencia.",
+        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante y responde a la pregunta en su presencia.",
         "default": "Hemos detectado un cambio de página.",
         "v3-accessible-certification": "Hemos detectado un cambio de página. Si has tenido que cambiar de página para utilizar una herramienta de accesibilidad digital (como un lector de pantalla o un teclado virtual), responde a la pregunta de todos modos.",
-        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor para que pueda constatarlo e informar de ello, dado el caso."
+        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante para que pueda constatarlo e informar de ello, dado el caso."
       },
       "illustration": {
         "placeholder": "Cargando la imagen"
@@ -1094,13 +1094,13 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Avisa al supervisor para que identifique el problema."
+          "message": "Avisa al vigilante para que identifique el problema."
         },
         "companion": {
-          "message": "Póngase en contacto con su supervisor para confirmar la presencia de la extensión."
+          "message": "Póngase en contacto con su vigilante para confirmar la presencia de la extensión."
         },
         "refresh": "Actualizar la página",
-        "waiting-information": "Esperando al supervisor..."
+        "waiting-information": "Esperando al vigilante..."
       },
       "parts": {
         "answer-input": "Tu respuesta",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -785,7 +785,7 @@
             "1": "Ir al final de la página",
             "2": "Seleccione \"Informar de un problema con la pregunta\".",
             "3": "Haga clic en \"Sí, estoy seguro\".",
-            "4": "Llama al supervisor que intervendrá para ayudarte"
+            "4": "Llama al vigilante que intervendrá para ayudarte"
           },
           "text": "'<strong>'En caso de problema técnico'</strong>' (por ejemplo, la imagen se niega a mostrarse), sigue estos pasos:",
           "title": "¿Qué hacer en caso de problema?"
@@ -822,7 +822,7 @@
       },
       "error-messages": {
         "generic": {
-          "check-personal-info": "Comprueba con el supervisor que tus datos personales coinciden con los de la hoja de inscripción.",
+          "check-personal-info": "Comprueba con el vigilante que tus datos personales coinciden con los de la hoja de inscripción.",
           "check-session-number": "Comprueba el número de sesión.",
           "disclaimer": "La información introducida no corresponde a ningún candidato inscrito en la sesión."
         },
@@ -831,7 +831,7 @@
         "missing-center-habilitation": "No puede unirse a la sesión. El centro de certificación no está autorizado para realizar esta certificación.",
         "session-not-accessible": "La sesión a la que intentas unirte ya no está disponible.",
         "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya está conectado con otra cuenta. Comprueba que te has conectado con la cuenta que inició la certificación.",
-        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al supervisor.",
+        "wrong-account-sco": "Actualmente estás utilizando una cuenta que no está vinculada a tu centro. Conéctate a la cuenta con la que completaste tus tests o pide ayuda al vigilante.",
         "wrong-account-sco-link": {
           "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
@@ -850,7 +850,7 @@
           "birth-year": "año de nacimiento (AAAA)",
           "first-name": "Nombre",
           "session-number": "Número de sesión",
-          "session-number-information": "Comunicado únicamente por el supervisor al inicio de la sesión"
+          "session-number-information": "Comunicado únicamente por el vigilante al inicio de la sesión"
         },
         "fields-validation": {
           "session-number-error": "El número de sesión se compone únicamente de dígitos."
@@ -887,7 +887,7 @@
       "title": "Prueba finalizada"
     },
     "certification-start": {
-      "access-code": "Código de acceso comunicado por el supervisor",
+      "access-code": "Código de acceso comunicado por el vigilante",
       "actions": {
         "submit": "Empezar mi prueba"
       },
@@ -896,13 +896,13 @@
           "email": "dpo@pix.fr",
           "info": "De conformidad con la Ley francesa de «Informática y libertades», puedes ejercer tu derecho de acceso y rectificación de tus datos personales enviando un correo electrónico a "
         },
-        "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el supervisor se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
+        "info": "Al hacer clic en «Empezar mi prueba», acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el vigilante se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del tribunal para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarle mis resultados."
       },
       "core-and-complementary-subscriptions": "Además de la certificación Pix, estás inscrito en la siguiente certificación complementaria:",
       "error-messages": {
         "access-code-error": "Este código no existe o ya no es válido.",
-        "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
-        "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al supervisor.",
+        "candidate-not-authorized-to-resume": "Ponte en contacto con el vigilante para que autorice la reanudación de tu examen.",
+        "candidate-not-authorized-to-start": "El vigilante no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al vigilante.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
         "missing-code": "You have not entered your access code.",
         "session-not-accessible": "La sesión de certificación ya no está disponible.",
@@ -946,7 +946,7 @@
         "skip-go-to-next": "Paso y voy a la siguiente pregunta",
         "validate": "Valido",
         "validate-go-to-next": "Valido y voy a la siguiente pregunta",
-        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el supervisor"
+        "wait-for-invigilator": "Las acciones se detienen hasta que llegue el vigilante"
       },
       "already-answered": "Ya has respondido a esta pregunta",
       "answer-input": {
@@ -965,7 +965,7 @@
           "send-feedback": "Sí, estoy seguro/a"
         },
         "description": "¿Estás seguro/a de que quieres informar de un problema?",
-        "information": "Al informar de un problema, tu certificación se pausa hasta que el supervisor intervenga para validar o invalidar tu informe."
+        "information": "Al informar de un problema, tu certificación se pausa hasta que el vigilante intervenga para validar o invalidar tu informe."
       },
       "embed-simulator": {
         "actions": {
@@ -1012,7 +1012,7 @@
                 "download": {
                   "edit-failure": {
                     "label": "No puedo modificar el archivo",
-                    "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte superior del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
+                    "solution": "Es probable que el archivo esté abierto en «Sólo lectura» o «Modo protegido». '<br>'Haz clic en «Activar modificación» o «Editar documento» en el banner de la parte vigilante del archivo si aparece. '<br>'Si no es así, guarda el archivo con otro nombre y abre este nuevo archivo."
                   },
                   "lost": {
                     "label": "No encuentro el archivo descargado",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -87,7 +87,7 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
-        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el supervisor.",
+        "description": "Es posible que la extensión no esté instalada o activada. Consulte el siguiente documento para reanudar la sesión de certificación.  Si es necesario, póngase en contacto con el vigilante.",
         "link": "Acceder a la documentación",
         "title": "La extensión Pix Companion<br /> no se detecta"
       }
@@ -713,7 +713,7 @@
       "candidate": {
         "disconnect": "Desconectar mi cuenta",
         "disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
-        "ended-by-supervisor": "El supervisor ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
+        "ended-by-invigilator": "El vigilante ha dado por terminada la prueba de certificación. Ya no puedes continuar respondiendo a las preguntas.",
         "ended-due-to-finalization": "Tu centro de certificación ha finalizado la sesión. Ya no puedes continuar respondiendo a las preguntas.",
         "remote-certification": "Si estás realizando tu certificación Pix de forma remota, asegúrate de desconectarte de la herramienta de supervisión una vez que hayas finalizado la prueba.",
         "title": "¡Prueba finalizada!"
@@ -1077,10 +1077,10 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor y responde a la pregunta en su presencia.",
+        "certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante y responde a la pregunta en su presencia.",
         "default": "Hemos detectado un cambio de página.",
         "v3-accessible-certification": "Hemos detectado un cambio de página. Si has tenido que cambiar de página para utilizar una herramienta de accesibilidad digital (como un lector de pantalla o un teclado virtual), responde a la pregunta de todos modos.",
-        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al supervisor para que pueda constatarlo e informar de ello, dado el caso."
+        "v3-certification": "Hemos detectado un cambio de página. Tu respuesta se contabilizará como incorrecta. Si te has visto obligado a cambiar de página, informa al vigilante para que pueda constatarlo e informar de ello, dado el caso."
       },
       "illustration": {
         "placeholder": "Cargando la imagen"
@@ -1094,13 +1094,13 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Avisa al supervisor para que identifique el problema."
+          "message": "Avisa al vigilante para que identifique el problema."
         },
         "companion": {
-          "message": "Póngase en contacto con su supervisor para confirmar la presencia de la extensión."
+          "message": "Póngase en contacto con su vigilante para confirmar la presencia de la extensión."
         },
         "refresh": "Actualizar la página",
-        "waiting-information": "Esperando al supervisor..."
+        "waiting-information": "Esperando al vigilante..."
       },
       "parts": {
         "answer-input": "Tu respuesta",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -718,7 +718,7 @@
       "candidate": {
         "disconnect": "Déconnecter mon compte",
         "disconnect-tip": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.",
-        "ended-by-supervisor": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
+        "ended-by-invigilator": "Votre surveillant a mis fin à votre test de certification. Vous ne pouvez plus continuer de répondre aux questions.",
         "ended-due-to-finalization": "La session a été finalisée par votre centre de certification. Vous ne pouvez plus continuer de répondre aux questions.",
         "remote-certification": "Si vous passez votre certification Pix à distance, veillez à bien vous déconnecter de l’outil de surveillance une fois votre test terminé.",
         "title": "Test terminé !"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -716,7 +716,7 @@
       "candidate": {
         "disconnect": "Afmelden bij mijn account",
         "disconnect-tip": "Als dit niet jouw computer is, vergeet dan niet uit te loggen.",
-        "ended-by-supervisor": "Je toezichthouder heeft je certificeringstest beëindigd. Je kunt niet doorgaan met het beantwoorden van de vragen.",
+        "ended-by-invigilator": "Je toezichthouder heeft je certificeringstest beëindigd. Je kunt niet doorgaan met het beantwoorden van de vragen.",
         "ended-due-to-finalization": "De sessie is afgerond door uw certificeringscentrum. U kunt niet langer doorgaan met het beantwoorden van vragen.",
         "remote-certification": "Als je je Pix-certificering op afstand doet, zorg er dan voor dat je de verbinding met de monitoring tool verbreekt zodra je klaar bent met je test.",
         "title": "Test over!"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -87,7 +87,7 @@
       },
       "install-documentation-url": "https://cloud.pix.fr/s/KocingDC4mFJ3R6",
       "not-detected": {
-        "description": "De extensie is mogelijk niet geïnstalleerd of geactiveerd. Raadpleeg het volgende document om uw certificeringssessie te hervatten.  Neem indien nodig contact op met de supervisor.",
+        "description": "De extensie is mogelijk niet geïnstalleerd of geactiveerd. Raadpleeg het volgende document om uw certificeringssessie te hervatten.  Neem indien nodig contact op met de toezichthouder.",
         "link": "Toegang tot de documentatie",
         "title": "De extensie Pix Companion<br /> is niet gedetecteerd"
       }
@@ -716,7 +716,7 @@
       "candidate": {
         "disconnect": "Afmelden bij mijn account",
         "disconnect-tip": "Als dit niet jouw computer is, vergeet dan niet uit te loggen.",
-        "ended-by-supervisor": "Je surveillant heeft je certificeringstest beëindigd. Je kunt niet doorgaan met het beantwoorden van de vragen.",
+        "ended-by-supervisor": "Je toezichthouder heeft je certificeringstest beëindigd. Je kunt niet doorgaan met het beantwoorden van de vragen.",
         "ended-due-to-finalization": "De sessie is afgerond door uw certificeringscentrum. U kunt niet langer doorgaan met het beantwoorden van vragen.",
         "remote-certification": "Als je je Pix-certificering op afstand doet, zorg er dan voor dat je de verbinding met de monitoring tool verbreekt zodra je klaar bent met je test.",
         "title": "Test over!"
@@ -788,7 +788,7 @@
             "1": "Ga naar het einde van de pagina",
             "2": "Selecteer \"Een probleem met de vraag melden\".",
             "3": "Klik op \"Ja, ik weet het zeker\".",
-            "4": "Bel de supervisor die zal ingrijpen om je te helpen"
+            "4": "Bel de toezichthouder die zal ingrijpen om je te helpen"
           },
           "text": "'<strong>'In het geval van een technisch probleem'</strong>' (de afbeelding wordt bijvoorbeeld niet weergegeven), volg dan deze stappen:",
           "title": "Wat te doen in geval van een probleem?"
@@ -826,7 +826,7 @@
       "error-messages": {
         "candidate-not-eligible": "<strong>Het account waarmee u op dit moment bent ingelogd komt niet in aanmerking voor deze certificeringssessie.</strong> '<br>' De ingevoerde informatie komt overeen met een kandidaat die alleen is geregistreerd voor de sessie aanvullende certificering. '<br>' Controleer of u bent ingelogd op het account dat in aanmerking komt om alleen de aanvullende certificering te volgen.",
         "generic": {
-          "check-personal-info": "Controleer bij de supervisor of je persoonlijke gegevens overeenkomen met die op het inschrijfformulier.",
+          "check-personal-info": "Controleer bij de toezichthouder of je persoonlijke gegevens overeenkomen met die op het inschrijfformulier.",
           "check-session-number": "Controleer het sessienummer.",
           "disclaimer": "De ingevoerde informatie komt niet overeen met een kandidaat die is ingeschreven voor de sessie."
         },
@@ -835,7 +835,7 @@
         "missing-center-habilitation": "U kunt niet deelnemen aan de sessie. Het certificeringscentrum is niet bevoegd om u deze certificering te laten afleggen.",
         "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
-        "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de supervisor om hulp.",
+        "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de toezichthouder om hulp.",
         "wrong-account-sco-link": {
           "label": "Hoe vind ik de rekening die aan de vestiging is gekoppeld?",
           "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
@@ -891,7 +891,7 @@
       "title": "Test voltooid"
     },
     "certification-start": {
-      "access-code": "Toegangscode gegeven door de supervisor",
+      "access-code": "Toegangscode gegeven door de toezichthouder",
       "actions": {
         "submit": "Mijn test starten"
       },
@@ -950,7 +950,7 @@
         "skip-go-to-next": "Ik ga door naar de volgende vraag",
         "validate": "Bevestigen",
         "validate-go-to-next": "Ik valideer en ga naar de volgende vraag",
-        "wait-for-invigilator": "Acties worden gepauzeerd tot de supervisor arriveert"
+        "wait-for-invigilator": "Acties worden gepauzeerd tot de toezichthouder arriveert"
       },
       "already-answered": "U hebt deze vraag al beantwoord",
       "answer-input": {
@@ -969,7 +969,7 @@
           "send-feedback": "Ja, ik weet het zeker"
         },
         "description": "Weet je zeker dat je een probleem wilt melden?",
-        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren."
+        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de toezichthouder ingrijpt om je melding te valideren of ongeldig te verklaren."
       },
       "embed-simulator": {
         "actions": {
@@ -1081,10 +1081,10 @@
         }
       },
       "has-focused-out-of-window": {
-        "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend. Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
+        "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend. Als je gedwongen werd om van pagina te wisselen, informeer dan je toezichthouder en beantwoord de vraag in zijn of haar aanwezigheid.",
         "default": "We hebben een paginawijziging gedetecteerd. In certificering zou uw antwoord niet worden gevalideerd.",
         "v3-accessible-certification": "We hebben een paginawissel gedetecteerd. Als je van pagina moest veranderen om een hulpmiddel voor digitale toegankelijkheid (zoals een schermlezer of virtueel toetsenbord) te gebruiken, beantwoord de vraag dan toch.",
-        "v3-certification": "We hebben een paginawijziging gedetecteerd. Je antwoord wordt als fout geteld. Als je gedwongen werd om van pagina te veranderen, vertel dit dan aan je supervisor zodat hij of zij dit kan zien en rapporteren, indien nodig."
+        "v3-certification": "We hebben een paginawijziging gedetecteerd. Je antwoord wordt als fout geteld. Als je gedwongen werd om van pagina te veranderen, vertel dit dan aan je toezichthouder zodat hij of zij dit kan zien en rapporteren, indien nodig."
       },
       "illustration": {
         "placeholder": "De huidige afbeelding laden"
@@ -1098,13 +1098,13 @@
       },
       "live-alerts": {
         "challenge": {
-          "message": "Vertel het je supervisor zodat hij of zij kan uitzoeken wat het probleem is."
+          "message": "Vertel het je toezichthouder zodat hij of zij kan uitzoeken wat het probleem is."
         },
         "companion": {
-          "message": "Neem contact op met je supervisor om de aanwezigheid van de uitbreiding te bevestigen."
+          "message": "Neem contact op met je toezichthouder om de aanwezigheid van de uitbreiding te bevestigen."
         },
         "refresh": "Pagina verversen",
-        "waiting-information": "Wachten op de supervisor..."
+        "waiting-information": "Wachten op de toezichthouder..."
       },
       "parts": {
         "answer-input": "Uw antwoord.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1283,7 +1283,7 @@
             "admin": {
               "head": "Step 1 : <b>Please</b>",
               "link": "import the student database",
-              "tail": "<b>from Onde</b> (exportable file in the Lists & documents Extractions > School students or their supervisors menu <b>by selecting cycle 3 pupils only</b>)."
+              "tail": "<b>from Onde</b> (exportable file in the Lists & documents Extractions > School students or their invigilators menu <b>by selecting cycle 3 pupils only</b>)."
             },
             "non-admin": "Step1 : <b>Ask the Pix Orga administrator</b> in your area to import students"
           },


### PR DESCRIPTION
## ❄️ Problème

La traduction de surveillant en supervisor n’est pas approprié… Invigilator est la version correcte.

Quand on fait les traductions en espagnol ou en neerlandais à partir du terme anglais `invigilator`, la traduction est plus juste.

## 🛷 Proposition

Modifier les clefs et les textes pour utiliser un terme qui s'appuie sur `invigilator`
Soit directement `invigilator`, soit le terme traduit à partir d'`invigilator`?

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

- Allez sur l'espace surveillant de la certif, les textes doivent s'afficher correctement.
- Faire une certif, et en tant que candidat, faire un signalement et s'assurer que les messages sont écrits correctement.


