### PR TITLE
[TECH] Corriger et améliorer les seeds de l’équipe Accès (PIX-20946)

### DIFF
--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -13,10 +13,10 @@ export async function buildCertificationCenters(databaseBuilder) {
     secondUserWithInvitation,
   ] = [
     {
-      firstName: 'Maude',
-      lastName: 'Erateur',
-      email: 'maude.erateur@example.net',
-      username: 'maude.erateur',
+      firstName: 'Certifs',
+      lastName: 'Accès',
+      email: 'certacces@example.net',
+      username: 'certacces',
     },
     {
       firstName: 'Otto',

--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -13,28 +13,22 @@ export async function buildCertificationCenters(databaseBuilder) {
     secondUserWithInvitation,
   ] = [
     {
-      firstName: 'James',
-      lastName: 'Palédroits',
-      email: 'james-paledroits@example.net',
-      username: 'james.paledroits',
+      firstName: 'Maude',
+      lastName: 'Erateur',
+      email: 'maude.erateur@example.net',
+      username: 'maude.erateur',
     },
     {
-      firstName: 'Agathe',
-      lastName: 'Zeublouse',
-      email: 'agathe-zeublouse@example.net',
-      username: 'agathe.zeublouse',
+      firstName: 'Otto',
+      lastName: 'Graf',
+      email: 'otto.graf@example.net',
+      username: 'otto.graf',
     },
     {
-      firstName: 'Marc-Alex',
-      lastName: 'Terrieur',
-      email: 'marc-alex-terrieur@example.net',
-      username: 'marc-alex-terrieur',
-    },
-    {
-      firstName: 'Harry',
-      lastName: 'Cover',
-      email: 'harry-cover@example.net',
-      username: 'harry.cover',
+      firstName: 'Édith',
+      lastName: 'Orial',
+      email: 'edith.orial@example.net',
+      username: 'edith.orial',
     },
     {
       firstName: 'Renée',
@@ -43,17 +37,22 @@ export async function buildCertificationCenters(databaseBuilder) {
       username: 'renee.sens',
     },
     {
-      firstName: 'Camille',
-      lastName: 'Onette',
-      email: 'camille-onette@example.net',
-      username: 'camille.onette',
+      firstName: 'Harry',
+      lastName: 'Cover',
+      email: 'harry-cover@example.net',
+      username: 'harry.cover',
     },
-
     {
-      firstName: 'Lee',
-      lastName: 'Tige',
-      email: 'lee-tige@example.net',
-      username: 'lee.tige',
+      firstName: 'Vivien',
+      lastName: 'Chezmoi',
+      email: 'vivien.chezmoi@example.net',
+      username: 'vivien.chezmoi',
+    },
+    {
+      firstName: 'Agathe',
+      lastName: 'Zeublouse',
+      email: 'agathe-zeublouse@example.net',
+      username: 'agathe.zeublouse',
     },
   ].map((user) => _buildUsersWithDefaultPassword({ databaseBuilder, ...user }));
 

--- a/api/db/seeds/data/team-acces/build-certification-centers.js
+++ b/api/db/seeds/data/team-acces/build-certification-centers.js
@@ -58,7 +58,7 @@ export async function buildCertificationCenters(databaseBuilder) {
   ].map((user) => _buildUsersWithDefaultPassword({ databaseBuilder, ...user }));
 
   const { certificationCenterId } = await createCertificationCenter({
-    name: 'Accèssorium',
+    name: 'Accessorium',
     certificationCenterId: CERTIFICATION_CENTER_OFFSET_ID,
     databaseBuilder,
     members: [
@@ -72,7 +72,7 @@ export async function buildCertificationCenters(databaseBuilder) {
   });
 
   await createCertificationCenter({
-    name: 'Accèssovolt',
+    name: 'Accessovolt',
     certificationCenterId: CERTIFICATION_CENTER_OFFSET_ID + 1,
     databaseBuilder,
     members: [{ id: userWithAdminRole1.id }],
@@ -80,7 +80,7 @@ export async function buildCertificationCenters(databaseBuilder) {
   });
 
   await createCertificationCenter({
-    name: 'Accèstral',
+    name: 'Accestral',
     certificationCenterId: CERTIFICATION_CENTER_OFFSET_ID + 2,
     databaseBuilder,
     members: [{ id: userWithAdminRole1.id, role: 'ADMIN' }],

--- a/api/db/seeds/data/team-acces/build-organization-users.js
+++ b/api/db/seeds/data/team-acces/build-organization-users.js
@@ -1,29 +1,29 @@
 import { acceptPixOrgaTermsOfService } from '../common/tooling/legal-documents.js';
 
-export const PIX_ORGA_ALL_ORGA_ID = 10001;
+export const PIX_ORGA_ADMIN_ID = 10001;
 export const PIX_ORGA_ADMIN_LEAVING_ID = 10002;
-export const PIX_ORGA_CGU_UPDATED_ID = 10003;
+export const PIX_ORGA_ADMIN_WITH_CGU_UPDATED_ID = 10003;
 
 export function buildOrganizationUsers(databaseBuilder) {
   [
     {
-      id: PIX_ORGA_ALL_ORGA_ID,
-      firstName: 'Jean',
-      lastName: 'Registre',
-      email: 'allorga@example.net',
+      id: PIX_ORGA_ADMIN_ID,
+      firstName: 'Orgas',
+      lastName: 'Accès',
+      email: 'orgacces@example.net',
       cguVersion: 'v2',
     },
     {
       id: PIX_ORGA_ADMIN_LEAVING_ID,
       firstName: 'Admin',
       lastName: 'Leaving',
-      email: 'admin.leaving@example.net',
+      email: 'orgacces.leaving@example.net',
     },
     {
-      id: PIX_ORGA_CGU_UPDATED_ID,
+      id: PIX_ORGA_ADMIN_WITH_CGU_UPDATED_ID,
       firstName: 'John',
       lastName: 'With CGU updated',
-      email: 'cgu.updated@example.net',
+      email: 'orgacces.cgu.updated@example.net',
       cguVersion: 'v1',
     },
   ].forEach(_buildUser(databaseBuilder));

--- a/api/db/seeds/data/team-acces/build-organization-users.js
+++ b/api/db/seeds/data/team-acces/build-organization-users.js
@@ -8,8 +8,8 @@ export function buildOrganizationUsers(databaseBuilder) {
   [
     {
       id: PIX_ORGA_ALL_ORGA_ID,
-      firstName: 'Rhaenyra',
-      lastName: 'Targaryen',
+      firstName: 'Jean',
+      lastName: 'Registre',
       email: 'allorga@example.net',
       cguVersion: 'v2',
     },

--- a/api/db/seeds/data/team-acces/build-organizations.js
+++ b/api/db/seeds/data/team-acces/build-organizations.js
@@ -15,9 +15,9 @@ function _buildOrganizationWithoutAdmins(databaseBuilder) {
   const tag1 = databaseBuilder.factory.buildTag({ name: 'tag1' });
   const tag2 = databaseBuilder.factory.buildTag({ name: 'tag2' });
   databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
-    firstName: 'justin',
-    lastName: 'instant',
-    email: 'justin-instant@example.net',
+    firstName: 'Claire',
+    lastName: 'Voyance',
+    email: 'claire.voyance@example.net',
     organizationId: organization.id,
   });
   databaseBuilder.factory.buildOrganizationTag({

--- a/api/db/seeds/data/team-acces/build-organizations.js
+++ b/api/db/seeds/data/team-acces/build-organizations.js
@@ -7,7 +7,7 @@ export function buildOrganizations(databaseBuilder) {
 function _buildOrganizationWithoutAdmins(databaseBuilder) {
   const organization = databaseBuilder.factory.buildOrganization({
     type: 'PRO',
-    name: 'Accis',
+    name: 'Accessorama',
     administrationTeamId: ADMINISTRATION_TEAM_SOLO_ID,
     countryCode: COUNTRY_CANADA_CODE,
   });

--- a/api/db/seeds/data/team-acces/build-sco-organization-learners.js
+++ b/api/db/seeds/data/team-acces/build-sco-organization-learners.js
@@ -17,14 +17,14 @@ function _buildScoOrganizationLearnerWithAllConnectionTypes(databaseBuilder) {
   const scoUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Eliza',
     lastName: 'Delajungle',
-    email: 'eliza-dlj@school.net',
+    email: 'eliza-dlj@example.net',
     username: 'eliza.delajungle.0101',
   });
 
   const scoNoGarUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Kelly',
     lastName: 'Coptere',
-    email: 'kelly-coptere@school.net',
+    email: 'kelly-coptere@example.net',
     username: 'kelly.coptere.0101',
   });
 
@@ -89,14 +89,14 @@ function _buildScoOrganizationLearnerWithUsernameAndEmail(databaseBuilder) {
   const scoUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Naruto',
     lastName: 'Uzumaki',
-    email: 'hokage@school.net',
+    email: 'hokage@example.net',
     username: 'naruto.uzumaki.0303',
   });
 
   const scoNoGarUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Jean',
     lastName: 'Serien',
-    email: 'jean.serien@school.net',
+    email: 'jean.serien@example.net',
     username: 'jean.serien.0303',
   });
 
@@ -123,21 +123,21 @@ function _buildScoOrganizationLearnerWithEmailAndMediacentre(databaseBuilder) {
   const scoUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Bart',
     lastName: 'Simpson',
-    email: 'bart@school.net',
+    email: 'bart@example.net',
     username: null,
   });
 
   const scoOtherUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Chihiro',
     lastName: 'Ogino',
-    email: 'chihiro.ogino@miyazaki.net',
+    email: 'chihiro.ogino@example.net',
     username: null,
   });
 
   const scoNoGarUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Emma',
     lastName: 'Gnolia',
-    email: 'emma.gnolia@school.net',
+    email: 'emma.gnolia@example.net',
     username: null,
   });
 
@@ -174,14 +174,14 @@ function _buildScoOrganizationLearnerWithEmail(databaseBuilder) {
   const scoUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Hermione',
     lastName: 'Granger',
-    email: 'hermione@school.net',
+    email: 'hermione@example.net',
     username: null,
   });
 
   const scoNoGarUser = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Melanie',
     lastName: 'Croche',
-    email: 'melanie.croche@school.net',
+    email: 'melanie.croche@example.net',
     username: null,
   });
 

--- a/api/db/seeds/data/team-acces/build-sco-organizations.js
+++ b/api/db/seeds/data/team-acces/build-sco-organizations.js
@@ -8,9 +8,9 @@ import {
   REAL_PIX_SUPER_ADMIN_ID,
 } from '../common/constants.js';
 import {
+  PIX_ORGA_ADMIN_ID,
   PIX_ORGA_ADMIN_LEAVING_ID,
-  PIX_ORGA_ALL_ORGA_ID,
-  PIX_ORGA_CGU_UPDATED_ID,
+  PIX_ORGA_ADMIN_WITH_CGU_UPDATED_ID,
 } from './build-organization-users.js';
 import {
   ACCESS_SCO_BAUDELAIRE_EXTERNAL_ID,
@@ -57,7 +57,7 @@ function _buildCollegeHouseOfTheDragonOrganization(databaseBuilder) {
 
   [
     {
-      userId: PIX_ORGA_ALL_ORGA_ID,
+      userId: PIX_ORGA_ADMIN_ID,
       organizationId: organization.id,
       organizationRole: Membership.roles.ADMIN,
     },
@@ -67,7 +67,7 @@ function _buildCollegeHouseOfTheDragonOrganization(databaseBuilder) {
       organizationRole: Membership.roles.ADMIN,
     },
     {
-      userId: PIX_ORGA_CGU_UPDATED_ID,
+      userId: PIX_ORGA_ADMIN_WITH_CGU_UPDATED_ID,
       organizationId: organization.id,
       organizationRole: Membership.roles.ADMIN,
     },
@@ -78,8 +78,8 @@ function _buildCollegeHouseOfTheDragonOrganization(databaseBuilder) {
     code: 'SCOBADGE1',
     type: 'ASSESSMENT',
     organizationId: organization.id,
-    creatorId: PIX_ORGA_ALL_ORGA_ID,
-    ownerId: PIX_ORGA_ALL_ORGA_ID,
+    creatorId: PIX_ORGA_ADMIN_ID,
+    ownerId: PIX_ORGA_ADMIN_ID,
     targetProfileId: PIX_PUBLIC_TARGET_PROFILE_ID,
     assessmentMethod: 'SMART_RANDOM',
     title: null,
@@ -105,7 +105,7 @@ function _buildJosephineBaker(databaseBuilder) {
 
   [
     {
-      userId: PIX_ORGA_ALL_ORGA_ID,
+      userId: PIX_ORGA_ADMIN_ID,
       organizationId: organization.id,
       organizationRole: Membership.roles.ADMIN,
     },
@@ -129,7 +129,7 @@ function _buildScoManagingStudentsNoGarOrganization(databaseBuilder) {
 
   [
     {
-      userId: PIX_ORGA_ALL_ORGA_ID,
+      userId: PIX_ORGA_ADMIN_ID,
       organizationId: organization.id,
       organizationRole: Membership.roles.ADMIN,
     },

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -1,5 +1,63 @@
 import { OIDC_PROVIDER_EXAMPLE_NET_IDENTITY_PROVIDER } from './constants.js';
 
+function _buildUsers(databaseBuilder) {
+  // User bare
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Salvor',
+    lastName: 'Hardin',
+    username: 'salvor.hardin',
+    email: 'salvor.hardin@example.net',
+  });
+
+  // User with a specific lastLoggedAt
+  const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Gaal',
+    lastName: 'Dornick',
+    username: 'gaal.dornick',
+    email: 'gaal.dornick@example.net',
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+
+  // User with a specific createdAt
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Chrono',
+    lastName: 'Post',
+    username: 'chrono.post',
+    email: 'chrono.post@example.net',
+    createdAt: new Date('2000-12-31'),
+  });
+
+  // User with an old lastLoggedAt (>1 year) and no email confirmation date
+  const userWithOldLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Old',
+    lastName: 'Connexion',
+    email: 'old-connexion@example.net',
+    emailConfirmedAt: null,
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+
+  // User without lastLoggedAt
+  const userWithoutLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'without',
+    lastName: 'LastLoggedAt',
+    email: 'without-lastlogged@example.net',
+    emailConfirmedAt: null,
+  });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
+}
+
+function _buildOidcUser(databaseBuilder) {
+  const user = databaseBuilder.factory.buildUser({
+    firstName: 'Oidc',
+    lastName: 'OIDC',
+    email: 'oidc-user@example.net',
+  });
+  databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
+    userId: user.id,
+    identityProvider: OIDC_PROVIDER_EXAMPLE_NET_IDENTITY_PROVIDER,
+  });
+}
+
 function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
   const user = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Paul',
@@ -24,65 +82,9 @@ function _buildGarUser(databaseBuilder) {
   });
 }
 
-function _buildOidcUser(databaseBuilder) {
-  const user = databaseBuilder.factory.buildUser({
-    firstName: 'Oidc',
-    lastName: 'OIDC',
-    email: 'oidc-user@example.net',
-  });
-  databaseBuilder.factory.buildAuthenticationMethod.withOidcProviderAsIdentityProvider({
-    userId: user.id,
-    identityProvider: OIDC_PROVIDER_EXAMPLE_NET_IDENTITY_PROVIDER,
-  });
-}
-
-function _buildUsers(databaseBuilder) {
-  databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Salvor',
-    lastName: 'Hardin',
-    username: 'salvor.hardin',
-    email: 'salvor.hardin@example.net',
-  });
-
-  const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Gaal',
-    lastName: 'Dornick',
-    username: 'gaal.dornick',
-    email: 'gaal.dornick@example.net',
-  });
-  databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
-
-  // User with a specific createdAt
-  databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Chrono',
-    lastName: 'Post',
-    username: 'chrono.post',
-    email: 'chrono.post@example.net',
-    createdAt: new Date('2000-12-31'),
-  });
-
-  // user with an old last logged-at date (>1 year) and no email confirmation date
-  const userWithOldLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Old',
-    lastName: 'Connexion',
-    email: 'old-connexion@example.net',
-    emailConfirmedAt: null,
-  });
-  databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
-
-  // user without lastLoggedAt
-  const userWithoutLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'without',
-    lastName: 'LastLoggedAt',
-    email: 'without-lastlogged@example.net',
-    emailConfirmedAt: null,
-  });
-  databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });
-}
-
 export function buildUsers(databaseBuilder) {
   _buildUsers(databaseBuilder);
+  _buildOidcUser(databaseBuilder);
   _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder);
   _buildGarUser(databaseBuilder);
-  _buildOidcUser(databaseBuilder);
 }

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -5,7 +5,6 @@ function _buildUsers(databaseBuilder) {
   databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Salvor',
     lastName: 'Hardin',
-    username: 'salvor.hardin',
     email: 'salvor.hardin@example.net',
   });
 
@@ -13,7 +12,6 @@ function _buildUsers(databaseBuilder) {
   const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Gaal',
     lastName: 'Dornick',
-    username: 'gaal.dornick',
     email: 'gaal.dornick@example.net',
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
@@ -22,7 +20,6 @@ function _buildUsers(databaseBuilder) {
   databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Chrono',
     lastName: 'Post',
-    username: 'chrono.post',
     email: 'chrono.post@example.net',
     createdAt: new Date('2000-12-31'),
   });

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -41,14 +41,14 @@ function _buildUsers(databaseBuilder) {
     firstName: 'Salvor',
     lastName: 'Hardin',
     username: 'salvor.hardin',
-    email: 'salvor.hardin@foundation.verse',
+    email: 'salvor.hardin@example.net',
   });
 
   const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Gaal',
     lastName: 'Dornick',
     username: 'gaal.dornick',
-    email: 'gaal.dornick@foundation.verse',
+    email: 'gaal.dornick@example.net',
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
 

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -3,41 +3,44 @@ import { OIDC_PROVIDER_EXAMPLE_NET_IDENTITY_PROVIDER } from './constants.js';
 function _buildUsers(databaseBuilder) {
   // User bare
   databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Salvor',
-    lastName: 'Hardin',
-    email: 'salvor.hardin@example.net',
+    firstName: 'Justin',
+    lastName: 'Compte',
+    email: 'justin.compte@example.net',
   });
 
-  // User with a specific lastLoggedAt
+  // User with a recent lastLoggedAt and email confirmed
   const userWithLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Gaal',
-    lastName: 'Dornick',
-    email: 'gaal.dornick@example.net',
+    firstName: 'Justin',
+    lastName: 'Instant',
+    email: 'justin.instant@example.net',
+    emailConfirmedAt: new Date(),
   });
-  databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithLastLoggedAt.id, lastLoggedAt: new Date() });
 
-  // User with a specific createdAt
+  // User with an old createdAt (>1 year) and no email confirmation date
   databaseBuilder.factory.buildUser.withRawPassword({
+    createdAt: new Date('1985-10-26'),
     firstName: 'Chrono',
-    lastName: 'Post',
-    email: 'chrono.post@example.net',
-    createdAt: new Date('2000-12-31'),
+    lastName: 'Scaphe',
+    email: 'old-created-at@example.net',
+    emailConfirmedAt: null,
   });
 
   // User with an old lastLoggedAt (>1 year) and no email confirmation date
   const userWithOldLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'Old',
-    lastName: 'Connexion',
-    email: 'old-connexion@example.net',
+    createdAt: new Date('1985-10-26'),
+    firstName: 'Chrono',
+    lastName: 'Gyre',
+    email: 'old-last-logged-at@example.net',
     emailConfirmedAt: null,
   });
-  databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1970-01-01') });
+  databaseBuilder.factory.buildUserLogin({ userId: userWithOldLastLoggedAt.id, lastLoggedAt: new Date('1985-10-26') });
 
-  // User without lastLoggedAt
+  // User with a userLogin but without lastLoggedAt
   const userWithoutLastLoggedAt = databaseBuilder.factory.buildUser.withRawPassword({
-    firstName: 'without',
-    lastName: 'LastLoggedAt',
-    email: 'without-lastlogged@example.net',
+    firstName: 'Justin',
+    lastName: 'Login',
+    email: 'without-last-logged-at@example.net',
     emailConfirmedAt: null,
   });
   databaseBuilder.factory.buildUserLogin({ userId: userWithoutLastLoggedAt.id, lastLoggedAt: null });


### PR DESCRIPTION
## ❄️ Problème

Les seeds de l’équipe Accès ne sont pas toutes faciles à utiliser, en effet :
* certains comptes ont leur adresse email sur des noms de domaine n’existant pas ou n’ayant pas de `MX`, ce qui provoque le blocage de l’envoi d’invitations par Pix API
* certains comptes ont un `username` alors que ce ne sont pas des comptes SCO
* certains comptes et entités ont des noms dont il est difficile de se souvenir ou avec un sens qui va à l’opposé de ce que ces comptes sont

## 🛷 Proposition

* Utiliser systématiquement le nom de domaine `example.net` pour toutes les adresses email des comptes des seeds de l’équipe Accès, de manière à permettre l’envoi d’invitation à ces comptes
* Supprimer le `username` pour les comptes non-SCO
* Changer les noms de certains comptes pour qu’ils reflètent ce que sont ces comptes, notamment : 
   * `allorga@example.net`, `Rhaenyra Targaryen`→`orgacces@example.net` , `Orgas Accès`
   * `james-paledroits@example.net`, `James Palédroits`→`certacces@example.net` , `Certifs Accès`

:information_source: En effet `allorga@example.net` n’est pas du tout adapté car le compte associé est admin uniquement ces orgas de l’équipe Accès.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

* Lire les fichiers modifiés dans leur intégralité pour bien évaluer la cohérence des noms choisis
* Se connecter à _Pix App_ avec `justin.compte@example.net` et évaluer si cela est plus facile qu’avec les valeurs précédentes des seeds
* Se connecter à _Pix Orga_ avec `orgacces@example.net` et évaluer si cela est plus facile qu’avec les valeurs précédentes des seeds
* Se connecter à _Pix Certif_ avec `certacces@example.net` et évaluer si cela est plus facile qu’avec les valeurs précédentes des seeds
