### PR TITLE
[TECH] Déplacer le message destiné aux chefs d'établissement du composant vers le template login (PIX-20894)

### DIFF
--- a/orga/app/components/authentication/login-form.gjs
+++ b/orga/app/components/authentication/login-form.gjs
@@ -4,7 +4,6 @@ import PixInputPassword from '@1024pix/pix-ui/components/pix-input-password';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -18,7 +17,6 @@ const VALIDATION_ERRORS = {
 };
 
 export default class LoginForm extends Component {
-  @service currentDomain;
   @service url;
   @service intl;
   @service authErrorMessages;
@@ -38,11 +36,6 @@ export default class LoginForm extends Component {
       error: VALIDATION_ERRORS.password,
     },
   });
-
-  get displayRecoveryLink() {
-    if (!this.currentDomain.isFranceDomain) return false;
-    return !this.args.isWithInvitation;
-  }
 
   @action
   async submit(event) {
@@ -157,20 +150,6 @@ export default class LoginForm extends Component {
       <PixButton @type="submit" @isLoading={{this.isLoading}}>
         {{t "pages.login-form.login"}}
       </PixButton>
-
-      {{#if this.displayRecoveryLink}}
-        <div class="authentication-login-form__recover-access">
-          <p class="authentication-login-form__recover-access__question">
-            {{t "pages.login-form.admin-role-question"}}
-          </p>
-          <LinkTo class="link link--black link--underlined" @route="join-request">
-            {{t "pages.login-form.active-or-retrieve"}}
-          </LinkTo>
-          <div class="authentication-login-form__recover-access__message">
-            ({{t "pages.login-form.only-for-admin"}})
-          </div>
-        </div>
-      {{/if}}
     </form>
   </template>
 }

--- a/orga/app/controllers/authentication/login.js
+++ b/orga/app/controllers/authentication/login.js
@@ -4,9 +4,14 @@ import { service } from '@ember/service';
 
 export default class LoginController extends Controller {
   @service session;
+  @service currentDomain;
 
   @action
   async authenticate(login, password) {
     await this.session.authenticate('authenticator:oauth2', login, password);
+  }
+
+  get displayRecoveryLink() {
+    return this.currentDomain.isFranceDomain;
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -61,6 +61,7 @@
 @use 'pages/sign-form' as *;
 @use 'pages/join' as *;
 @use 'pages/join-request' as *;
+@use 'pages/authentication/login' as *;
 @use 'pages/authentication/sso-selection' as *;
 @use 'pages/authenticated' as *;
 @use 'pages/authenticated/index' as *;

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -30,19 +30,4 @@
       width: 100%;
     }
   }
-
-  &__recover-access {
-    @extend %pix-body-s;
-
-    padding-top: var(--pix-spacing-8x);
-    text-align: left;
-
-    &__question {
-      font-weight: var(--pix-font-bold);
-    }
-
-    &__message {
-      color: var(--pix-neutral-500);
-    }
-  }
 }

--- a/orga/app/styles/pages/authentication/login.scss
+++ b/orga/app/styles/pages/authentication/login.scss
@@ -1,0 +1,22 @@
+@use 'pix-design-tokens/typography';
+
+.authentication-login {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-4x);
+
+  &__recover-access {
+    @extend %pix-body-s;
+
+    padding-top: var(--pix-spacing-8x);
+    text-align: left;
+
+    &__question {
+      font-weight: var(--pix-font-bold);
+    }
+
+    &__message {
+      color: var(--pix-neutral-500);
+    }
+  }
+}

--- a/orga/app/templates/authentication/login.gjs
+++ b/orga/app/templates/authentication/login.gjs
@@ -1,3 +1,4 @@
+import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import pageTitle from 'ember-page-title/helpers/page-title';
 import AuthenticationIdentityProviders from 'pix-orga/components/authentication/authentication-identity-providers';
@@ -18,11 +19,23 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </div>
 
       <LoginForm
-        @isWithInvitation={{false}}
         @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.authenticate}}
       />
+      {{#if @controller.displayRecoveryLink}}
+        <div class="authentication-login__recover-access">
+          <p class="authentication-login__recover-access__question">
+            {{t "pages.login-form.admin-role-question"}}
+          </p>
+          <LinkTo class="link link--black link--underlined" @route="join-request">
+            {{t "pages.login-form.active-or-retrieve"}}
+          </LinkTo>
+          <div class="authentication-login__recover-access__message">
+            ({{t "pages.login-form.only-for-admin"}})
+          </div>
+        </div>
+      {{/if}}
 
       <AuthenticationIdentityProviders />
     </:content>

--- a/orga/app/templates/authentication/oidc/login.gjs
+++ b/orga/app/templates/authentication/oidc/login.gjs
@@ -25,7 +25,6 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </div>
 
       <LoginForm
-        @isWithInvitation={{true}}
         @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.redirectToAssociationConfirmation}}

--- a/orga/app/templates/join/index.gjs
+++ b/orga/app/templates/join/index.gjs
@@ -27,7 +27,6 @@ import AuthenticationLayout from 'pix-orga/components/authentication-layout/inde
       </div>
 
       <LoginForm
-        @isWithInvitation={{true}}
         @hasInvitationAlreadyBeenAccepted={{@controller.hasInvitationAlreadyBeenAccepted}}
         @isInvitationCancelled={{@controller.isInvitationCancelled}}
         @onSubmit={{@controller.joinAndAuthenticate}}

--- a/orga/tests/integration/components/authentication/login-form-test.gjs
+++ b/orga/tests/integration/components/authentication/login-form-test.gjs
@@ -69,40 +69,4 @@ module('Integration | Component | LoginForm', function (hooks) {
       assert.dom(screen.getByText(t('pages.login-form.invitation-was-cancelled'))).exists();
     });
   });
-
-  module('recovery link', function () {
-    module('when domain is pix.org', function () {
-      test('does not display recovery link', async function (assert) {
-        // given
-        const onSubmitStub = sinon.stub();
-        const domainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(domainService, 'getExtension').returns('org');
-
-        // when
-        await render(<template><LoginForm @onSubmit={{onSubmitStub}} /></template>);
-
-        // then
-        assert.dom('.authentication-login-form__recover-access__question').doesNotExist();
-        assert.dom('.authentication-login-form__recover-access .link--underlined').doesNotExist();
-        assert.dom('.authentication-login-form__recover-access__message').doesNotExist();
-      });
-    });
-
-    module('when domain is pix.fr', function () {
-      test('displays recovery link', async function (assert) {
-        // given
-        const onSubmitStub = sinon.stub();
-        const domainService = this.owner.lookup('service:currentDomain');
-        sinon.stub(domainService, 'getExtension').returns('fr');
-
-        // when
-        await render(<template><LoginForm @onSubmit={{onSubmitStub}} /></template>);
-
-        // then
-        assert.dom('.authentication-login-form__recover-access__question').exists();
-        assert.dom('.authentication-login-form__recover-access .link--underlined').exists();
-        assert.dom('.authentication-login-form__recover-access__message').exists();
-      });
-    });
-  });
 });

--- a/orga/tests/integration/templates/authentication/login-test.gjs
+++ b/orga/tests/integration/templates/authentication/login-test.gjs
@@ -1,0 +1,48 @@
+import { render } from '@1024pix/ember-testing-library';
+import Login from 'pix-orga/templates/authentication/login';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Template | Authentication | login', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let domainService;
+
+  hooks.beforeEach(function () {
+    domainService = this.owner.lookup('service:currentDomain');
+  });
+
+  module('when domain is pix.org', function () {
+    test('does not display recovery link', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authentication/login');
+      sinon.stub(domainService, 'getExtension').returns('org');
+
+      // when
+      await render(<template><Login @controller={{controller}} /></template>);
+
+      // then
+      assert.dom('.authentication-login-form__recover-access__question').doesNotExist();
+      assert.dom('.authentication-login-form__recover-access .link--underlined').doesNotExist();
+      assert.dom('.authentication-login-form__recover-access__message').doesNotExist();
+    });
+  });
+
+  module('when domain is pix.fr', function () {
+    test('displays recovery link', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authentication/login');
+      sinon.stub(domainService, 'getExtension').returns('fr');
+
+      // when
+      await render(<template><Login @controller={{controller}} /></template>);
+
+      // then
+      assert.dom('.authentication-login__recover-access__question').exists();
+      assert.dom('.authentication-login__recover-access .link--underlined').exists();
+      assert.dom('.authentication-login__recover-access__message').exists();
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Le message destiné aux chefs d'établissement ne doit apparaître que dans une route / template, or il figure actuellement dans un composant (le formulaire de login) utilisé dans plusieurs routes.

“Vous êtes personnel de direction ou directeur d'école ?
Activez ou devenez l'administrateur de l'espace Pix Orga de votre établissement scolaire(https://orga.dev.pix.fr/demande-administration-sco)
(Réservé aux personnels de direction des établissements scolaires publics et privés sous contrat.)”

## 🛷 Proposition

Déplacer la gestion de l’affichage du message du composant `LoginForm` au template `orga/app/templates/authentication/login.js`, puisqu’il ne doit s’afficher que dans ce template et pas dans les autres cas.

## ☃️ Remarques

ras

## 🧑‍🎄 Pour tester

Les parties 1. et 2. peuvent être testées en RA (connexion simple, connexion sur invitation) mais la partie 3 (SSO) doit être testée en local.

1. tester la route `/connexion `
- Sur le domaine .fr, **le message doit être visible sous le bouton "Je me connecte"**. 
- Sur le domaine .org, le message ne doit pas apparaître

2. tester la route `/rejoindre?invitationId={id}&code={code}` 
- sur pix orga, connectez vous en tant qu'administrateur et invitez quelqu'un (n'importe quel email)
- récupérez le lien du mail
- allez sur la route à tester et vérifiez que le message n'apparaît pas

3. tester la route `/connexion/pro-connect/login`
- pour cela commencez une connexion via SSO avec invitation (même procédure d'invitation que 3., puis une authentification SSO). Après l'authentification par le fournisseur d'identité, le message ne doit pas apparaître sur le formulaire de login Pix 
- enfin commencez une connexion via SSO sans invitation : après l'authentification par le fournisseur d'identité, le message ne doit pas apparaître sur le formulaire de login Pix 
