### PR TITLE
[FEATURE] Utiliser des shorts ids au lieu des ids de modules pour créer un schéma de parcours combiné (PIX-20863)

### DIFF
--- a/api/src/devcomp/application/api/modules-api.js
+++ b/api/src/devcomp/application/api/modules-api.js
@@ -72,4 +72,11 @@ const getUserModuleStatuses = async ({ userId, moduleIds }) => {
   });
 };
 
-export { getModulesByIds, getUserModuleStatuses };
+const getModulesByShortIds = async ({ moduleShortIds }) => {
+  const modules = [];
+  for (const shortId of moduleShortIds) {
+    modules.push(await usecases.getModuleByShortId({ shortId }));
+  }
+  return modules.map((module) => new Module(module));
+};
+export { getModulesByIds, getModulesByShortIds, getUserModuleStatuses };

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -38,7 +38,7 @@ export class CombinedCourseBlueprint {
           campaignId,
         });
       } else if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
-        const module = modulesByShortId[requirement.value];
+        const [module] = modulesByShortId[requirement.value];
         return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
           moduleId: module.id,
         });
@@ -86,9 +86,9 @@ export class CombinedCourseBlueprint {
     }
   }
   static buildContentItems(items) {
-    return items.map(({ moduleId, targetProfileId }) =>
-      moduleId
-        ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleId }
+    return items.map(({ moduleShortId, targetProfileId }) =>
+      moduleShortId
+        ? { type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE, value: moduleShortId }
         : { type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION, value: targetProfileId },
     );
   }

--- a/api/src/quest/domain/models/CombinedCourseBlueprint.js
+++ b/api/src/quest/domain/models/CombinedCourseBlueprint.js
@@ -23,13 +23,13 @@ export class CombinedCourseBlueprint {
       .map(({ value }) => parseInt(value));
   }
 
-  get moduleIds() {
+  get moduleShortIds() {
     return this.content
       .filter((item) => item.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE)
       .map(({ value }) => value);
   }
 
-  toCombinedCourse(code, organizationId, campaigns) {
+  toCombinedCourse(code, organizationId, campaigns, modulesByShortId) {
     const successRequirements = this.content.map((requirement) => {
       if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION) {
         const requirementTargetProfileId = requirement.value;
@@ -38,8 +38,9 @@ export class CombinedCourseBlueprint {
           campaignId,
         });
       } else if (requirement.type === COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE) {
+        const module = modulesByShortId[requirement.value];
         return CombinedCourseBlueprint.buildRequirementForCombinedCourse({
-          moduleId: requirement.value,
+          moduleId: module.id,
         });
       } else {
         return requirement;

--- a/api/src/quest/domain/models/Module.js
+++ b/api/src/quest/domain/models/Module.js
@@ -1,9 +1,10 @@
 export class Module {
-  constructor({ id, title, slug, duration, image }) {
+  constructor({ id, title, slug, duration, image, shortId }) {
     this.id = id;
     this.title = title;
     this.slug = slug;
     this.duration = duration;
     this.image = image;
+    this.shortId = shortId;
   }
 }

--- a/api/src/quest/infrastructure/repositories/module-repository.js
+++ b/api/src/quest/infrastructure/repositories/module-repository.js
@@ -5,3 +5,9 @@ export const getByIds = async ({ moduleIds, modulesApi }) => {
 
   return modules.map((module) => new Module(module));
 };
+
+export const getByShortIds = async ({ moduleShortIds, modulesApi }) => {
+  const modules = await modulesApi.getModulesByShortIds({ moduleShortIds });
+
+  return modules.map((module) => new Module(module));
+};

--- a/api/tests/devcomp/integration/application/api/modules-api_test.js
+++ b/api/tests/devcomp/integration/application/api/modules-api_test.js
@@ -204,4 +204,41 @@ describe('Integration | Devcomp | Application | Api | Modules', function () {
       });
     });
   });
+
+  describe('#getModulesByShortIds', function () {
+    it('should return a list of Modules', async function () {
+      // given
+      nock('https://assets.pix.org').persist().head(/^.+$/).reply(200, {});
+      const existingModuleShortId1 = 'ecc13f55';
+      const existingModuleShortId2 = 'e074af34';
+      const moduleShortIds = [existingModuleShortId1, existingModuleShortId2];
+
+      // when
+      const result = await modulesApi.getModulesByShortIds({ moduleShortIds });
+
+      // then
+      // then
+      const expectedResult = [
+        {
+          duration: undefined,
+          id: '5df14039-803b-4db4-9778-67e4b84afbbd',
+          shortId: existingModuleShortId1,
+          slug: 'adresse-ip-publique-et-vous',
+          title: "L'adresse IP publique : ce qu'elle révèle sur vous !",
+          image: undefined,
+        },
+        {
+          id: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
+          shortId: existingModuleShortId2,
+          slug: 'au-dela-des-mots-de-passe',
+          title: 'Au-delà des mots de passe : comment s’authentifier ?',
+          duration: undefined,
+          image: undefined,
+        },
+      ];
+
+      expect(result).deep.equal(expectedResult);
+      expect(result[0]).instanceOf(Module);
+    });
+  });
 });

--- a/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
+++ b/api/tests/quest/acceptance/application/combined-course-blueprint-route_test.js
@@ -21,10 +21,10 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
         const adminUser = await insertUserWithRoleSuperAdmin();
 
         databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module' }]),
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }]),
         });
         databaseBuilder.factory.buildCombinedCourseBlueprint({
-          content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module-abc' }]),
+          content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module-abc' }]),
         });
         await databaseBuilder.commit();
 
@@ -57,7 +57,7 @@ describe('Quest | Acceptance | Application | Combined course blueprint Route ', 
               'internal-name': 'Mon schéma de parcours combiné',
               description: 'La description combinix',
               illustration: 'illustration.svg',
-              content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'modulox' }]),
+              content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulox' }]),
             },
           },
         };

--- a/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-course-blueprint_test.js
@@ -14,7 +14,7 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }, { targetProfileId }]),
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }, { targetProfileId }]),
     };
 
     await usecases.createCombinedCourseBlueprint({ combinedCourseBlueprint });
@@ -36,7 +36,7 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
       internalName: 'Une épure pour tel niveau',
       illustration: 'illustrations/mon-epure.png',
       description: 'Description',
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'abc-123' }, { targetProfileId: 123 }]),
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'abc-123' }, { targetProfileId: 123 }]),
     };
 
     const error = await catchErr(usecases.createCombinedCourseBlueprint)({ combinedCourseBlueprint });

--- a/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
+++ b/api/tests/quest/integration/domain/usecases/create-combined-courses_test.js
@@ -42,8 +42,8 @@ describe('Integration | Combined course | Domain | UseCases | create-combined-co
     await databaseBuilder.commit();
 
     const input = `Identifiant des organisations*;Json configuration for quest*;Identifiant du createur des campagnes*
-${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfile.id}},{""type"":""module"",""value"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a""},{""type"":""module"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
-${firstOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfileWithTraining.id}},{""type"":""module"",""value"":""eeeb4951-6f38-4467-a4ba-0c85ed71321a""},{""type"":""module"",""value"":""f32a2238-4f65-4698-b486-15d51935d335""}]}";${userId}
+${firstOrganizationId},${secondOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfile.id}},{""type"":""module"",""value"":""27d6ca4f""},{""type"":""module"",""value"":""df82ec66""}],""description"":""ma description"", ""illustration"":""mon_illu.svg""}";${userId}
+${firstOrganizationId};"{""name"":""Combinix"",""content"":[{""type"":""evaluation"",""value"":${targetProfileWithTraining.id}},{""type"":""module"",""value"":""27d6ca4f""},{""type"":""module"",""value"":""df82ec66""}]}";${userId}
 `;
 
     const payload = iconv.encode(input, 'UTF-8');

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -14,7 +14,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         illustration: 'illustration/ia.svg',
         createdAt: new Date(),
         updatedAt: new Date(),
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'modulix' }]),
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulix' }]),
       };
 
       // when
@@ -36,7 +36,7 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
         illustration: 'illustration/ia.svg',
         createdAt: new Date(),
         updatedAt: new Date(),
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'modulix' }]),
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'modulix' }]),
       };
 
       // when

--- a/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
+++ b/api/tests/quest/unit/domain/models/CombinedCourseBlueprint_test.js
@@ -3,6 +3,7 @@ import {
   COMBINED_COURSE_BLUEPRINT_ITEMS,
   CombinedCourseBlueprint,
 } from '../../../../../src/quest/domain/models/CombinedCourseBlueprint.js';
+import { Module } from '../../../../../src/quest/domain/models/Module.js';
 import {
   CRITERION_COMPARISONS,
   Quest,
@@ -21,7 +22,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         internalName: 'internaleName',
         description: 'description',
         illustration: 'illustration',
-        content: CombinedCourseBlueprint.buildContentItems([{ moduleId: '123' }]),
+        content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: '123' }]),
         createdAt: new Date('2024-01-25'),
         updatedAt: new Date('2024-01-26'),
       };
@@ -36,7 +37,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
     it('should build blueprint content items for targetProfileId and moduleId', function () {
       const requirements = CombinedCourseBlueprint.buildContentItems([
         { targetProfileId: 123 },
-        { moduleId: 'az-123' },
+        { moduleShortId: 'az-123' },
       ]);
 
       expect(requirements).deep.equal([
@@ -52,8 +53,8 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
     });
   });
 
-  describe('#moduleIds', function () {
-    it('should return module ids from passages success requirements', async function () {
+  describe('#moduleShortIds', function () {
+    it('should return module short ids from passages success requirements', async function () {
       const combinedCourseContent = [
         {
           type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
@@ -72,7 +73,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         name: 'combinix',
         content: combinedCourseContent,
       });
-      expect(combinedCourseBlueprint.moduleIds).to.deep.equal(['abcdef-555', 'abcdef-777']);
+      expect(combinedCourseBlueprint.moduleShortIds).to.deep.equal(['abcdef-555', 'abcdef-777']);
     });
 
     it('should return empty list of ids if template has not any campaignParticipations success requirements', async function () {
@@ -86,7 +87,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         name: 'combinix',
         content: combinedCourseContent,
       });
-      expect(combinedCourseBlueprint.moduleIds).to.deep.equal([]);
+      expect(combinedCourseBlueprint.moduleShortIds).to.deep.equal([]);
     });
   });
 
@@ -143,6 +144,9 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
           targetProfileId: secondTargetProfileId,
         },
       ];
+      const modulesByShortId = {
+        ecc13f55: [new Module({ id: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a' })],
+      };
       const combinedCourseContent = [
         {
           type: COMBINED_COURSE_BLUEPRINT_ITEMS.EVALUATION,
@@ -154,7 +158,7 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         },
         {
           type: COMBINED_COURSE_BLUEPRINT_ITEMS.MODULE,
-          value: 'eeeb4951-6f38-4467-a4ba-0c85ed71321a',
+          value: 'ecc13f55',
         },
       ];
       const description = 'bla bla bla';
@@ -167,7 +171,12 @@ describe('Quest | Unit | Domain | Models | CombinedCourseBlueprint ', function (
         description,
         illustration,
       });
-      const combinedCourse = combinedCourseBlueprint.toCombinedCourse(code, organizationId, campaigns);
+      const combinedCourse = combinedCourseBlueprint.toCombinedCourse(
+        code,
+        organizationId,
+        campaigns,
+        modulesByShortId,
+      );
 
       // then
       const quest = new Quest({

--- a/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/combined-course-blueprint-serializer_test.js
@@ -9,7 +9,7 @@ describe('Quest | Unit | Infrastructure | Serializers | combined-course-blueprin
   it('#serialize', function () {
     // given
     const combinedCourseBlueprint = domainBuilder.buildCombinedCourseBlueprint({
-      content: CombinedCourseBlueprint.buildContentItems([{ moduleId: 'mon-module' }, { targetProfileId: 123 }]),
+      content: CombinedCourseBlueprint.buildContentItems([{ moduleShortId: 'mon-module' }, { targetProfileId: 123 }]),
     });
 
     // when


### PR DESCRIPTION
## ❄️ Problème
On voudrait faciliter la création de schéma de parcours combiné en permettant d'ajouter des modules via leur short id, qui est dans l'URL donc + facile à vérifier (et plus court que l'id également).

## 🛷 Proposition
On crée une API interne côté Devcomp pour exposer la méthode getModuleByShortId.
On utilise cette API uniquement à la création du combined course blueprint. On continue d'utiliser le module Id dans les autres cas.

## 🧑‍🎄 Pour tester

Sur PixAdmin

Créer un schéma de parcours combiné avec un shortId existant.
Télécharger le schéma.
Le déployer sur une organisation existante dans la partie "Administration".
Vérifier que le parcours combiné existe en base.
